### PR TITLE
ci: upgrade GitHub Actions to latest versions across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -65,7 +65,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for secret scanning
 
@@ -134,7 +134,7 @@ jobs:
           failure-threshold: error
 
       - name: Upload Bandit report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: bandit-report
@@ -144,7 +144,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -171,7 +171,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -217,7 +217,7 @@ jobs:
             extras: "dev,mac,audio,audio-ml,face,gpu"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -252,7 +252,7 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for version detection
 
@@ -276,7 +276,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-ci
           path: dist/
@@ -297,7 +297,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - uses: actions/labeler@v5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
 
   # Validate PR title follows conventional commits
@@ -80,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for breaking changes
         id: check
@@ -114,10 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'opened'
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             Thanks for your first contribution to Immich Memories! 🎉
 
             A maintainer will review your PR soon. In the meantime, please make sure:
@@ -126,7 +125,7 @@ jobs:
             - [ ] You've added tests for new functionality
 
             Need help? Check out our [contributing guide](CONTRIBUTING.md).
-          issue-message: |
+          issue_message: |
             Thanks for opening your first issue! 🙌
 
             We'll look into this as soon as possible. If you'd like to help fix this issue,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       next_version: ${{ steps.analyze.outputs.next_version }}
       release_type: ${{ steps.analyze.outputs.release_type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -260,7 +260,7 @@ jobs:
           prerelease: false
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-release
           path: dist/
@@ -297,7 +297,7 @@ jobs:
             slug: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -330,7 +330,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-${{ matrix.slug }}
           path: /tmp/digests/*
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: /tmp/digests
           pattern: digests-*


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` v4 → v5, `actions/upload-artifact` v4 → v5, `actions/download-artifact` v4 → v5 across all workflows
- Upgrades `actions/first-interaction` v1 → v2 and fixes input names (hyphens → underscores) in pr-automation.yml
- Removes deprecated `repo-token` input from `actions/labeler`
- Fixes 4 Node.js 20 deprecation warnings from PR #12's CI run

Third-party actions (semgrep, gitleaks, hadolint, codelytv, amannn) are at their latest majors — Node.js 24 support depends on upstream releases.

## Test plan
- [ ] PR automation workflow runs without Node.js 20 warnings for `actions/*` owned actions
- [ ] CI workflow runs successfully
- [ ] Welcome message uses correct input names (`repo_token`, `pr_message`, `issue_message`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)