### PR TITLE
ci(release): add PyPI publishing via trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,16 @@ jobs:
           name: dist-release
           path: dist/
 
+      - name: Summary
+        if: inputs.dry_run != 'true'
+        env:
+          NEXT_VERSION: ${{ needs.analyze.outputs.next_version }}
+        run: |
+          echo "## Release v$NEXT_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Published packages:" >> $GITHUB_STEP_SUMMARY
+          ls -la dist/ >> $GITHUB_STEP_SUMMARY
+
       - name: Dry run summary
         if: inputs.dry_run == 'true'
         run: |
@@ -275,6 +285,28 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Built packages:" >> $GITHUB_STEP_SUMMARY
           ls -la dist/ >> $GITHUB_STEP_SUMMARY
+
+  # Publish to PyPI using Trusted Publishers (OIDC — no API tokens needed)
+  pypi-publish:
+    name: Publish to PyPI
+    needs: [analyze, release]
+    if: inputs.dry_run != 'true' && needs.analyze.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/immich-memories/
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-release
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   # Deploy docs after release (GITHUB_TOKEN events don't trigger other workflows,
   # so we call the docs workflow directly instead of relying on release:published)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ token = { env = "GH_TOKEN" }
 
 [tool.semantic_release.publish]
 upload_to_vcs_release = true
-upload_to_pypi = false  # Don't publish to PyPI
+upload_to_pypi = false  # PyPI publishing handled by GitHub Actions trusted publishers
 
 # Commitizen configuration for conventional commits
 [tool.commitizen]


### PR DESCRIPTION
Add pypi-publish job to release workflow using OIDC trusted publishers
(pypa/gh-action-pypi-publish). This enables `uvx immich-memories` once
the package is registered on PyPI.

https://claude.ai/code/session_01GZAJ2GgTKqrEjFzb9h7X4d