### PR TITLE
feat(config): add config tiers with advanced: YAML namespace

### DIFF
--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -37,9 +37,34 @@ from immich_memories.config_models import (
 )
 from immich_memories.scheduling.models import SchedulerConfig
 
+# Tier 2 sections — grouped under `advanced:` in YAML, flat on Config at runtime.
+_TIER2_SECTIONS = frozenset(
+    {
+        "analysis",
+        "hardware",
+        "llm",
+        "musicgen",
+        "ace_step",
+        "content_analysis",
+        "audio_content",
+        "server",
+    }
+)
+
 
 class Config(BaseSettings):
-    """Main configuration for Immich Memories."""
+    """Main configuration for Immich Memories.
+
+    Config tiers (YAML layout):
+      Tier 1 (top level): immich, defaults, output, audio, title_screens,
+                           cache, upload, trips
+      Tier 2 (advanced:):  analysis, hardware, llm, musicgen, ace_step,
+                           content_analysis, audio_content, server
+      Tier 3 (internal):   scheduler, title_llm
+
+    At runtime, ALL sections are flat fields on Config (config.analysis, etc.).
+    The tier grouping only affects YAML serialization.
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="IMMICH_MEMORIES_",
@@ -70,20 +95,42 @@ class Config(BaseSettings):
 
     @classmethod
     def from_yaml(cls, path: Path) -> Config:
-        """Load configuration from a YAML file."""
+        """Load configuration from a YAML file.
+
+        Accepts both formats:
+          - Flat: all sections at top level (legacy)
+          - Tiered: tier 2 sections nested under ``advanced:``
+        """
         if not path.exists():
             return cls()
 
         with path.open() as f:
             data = yaml.safe_load(f) or {}
 
+        # Flatten advanced: namespace → top-level fields
+        if "advanced" in data and isinstance(data["advanced"], dict):
+            advanced = data.pop("advanced")
+            for key, value in advanced.items():
+                if key not in data:  # top-level keys take precedence
+                    data[key] = value
+
         return cls(**data)
 
     def save_yaml(self, path: Path) -> None:
-        """Save configuration to a YAML file."""
+        """Save configuration to a YAML file (tiered format)."""
         path.parent.mkdir(parents=True, exist_ok=True)
+        data = self.model_dump()
+
+        # Group tier 2 sections under advanced:
+        advanced: dict = {}
+        for key in _TIER2_SECTIONS:
+            if key in data:
+                advanced[key] = data.pop(key)
+        if advanced:
+            data["advanced"] = advanced
+
         with path.open("w") as f:
-            yaml.dump(self.model_dump(), f, default_flow_style=False, sort_keys=False)
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
         # Restrict config file permissions (contains API keys)
         with contextlib.suppress(OSError):
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600 - owner read/write only

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -293,3 +293,72 @@ class TestConfig:
         config_path.write_text("")
         loaded = Config.from_yaml(config_path)
         assert loaded.defaults.target_duration_minutes == 10
+
+    def test_tiered_yaml_loads_advanced_sections(self, tmp_path):
+        """Tier 2 sections under advanced: are flattened to top-level fields."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "immich:\n  url: https://example.com\n"
+            "advanced:\n"
+            "  analysis:\n    scene_threshold: 20.0\n"
+            "  server:\n    port: 9090\n"
+        )
+        loaded = Config.from_yaml(config_path)
+        assert loaded.immich.url == "https://example.com"
+        assert loaded.analysis.scene_threshold == 20.0
+        assert loaded.server.port == 9090
+
+    def test_flat_yaml_still_works(self, tmp_path):
+        """Legacy flat format (no advanced: namespace) still loads."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "immich:\n  url: https://flat.com\n"
+            "analysis:\n  scene_threshold: 25.0\n"
+            "server:\n  port: 8080\n"
+        )
+        loaded = Config.from_yaml(config_path)
+        assert loaded.immich.url == "https://flat.com"
+        assert loaded.analysis.scene_threshold == 25.0
+        assert loaded.server.port == 8080
+
+    def test_save_yaml_groups_tier2_under_advanced(self, tmp_path):
+        """save_yaml outputs tier 2 sections under advanced: namespace."""
+        config_path = tmp_path / "config.yaml"
+        config = Config(
+            immich=ImmichConfig(url="https://save.com"),
+            analysis=AnalysisConfig(scene_threshold=30.0),
+        )
+        config.save_yaml(config_path)
+
+        import yaml
+
+        with config_path.open() as f:
+            raw = yaml.safe_load(f)
+        # Tier 1 at top level
+        assert raw["immich"]["url"] == "https://save.com"
+        # Tier 2 under advanced:
+        assert "analysis" not in raw
+        assert raw["advanced"]["analysis"]["scene_threshold"] == 30.0
+
+    def test_tiered_roundtrip(self, tmp_path):
+        """Config survives save (tiered) → load cycle."""
+        config_path = tmp_path / "config.yaml"
+        original = Config(
+            immich=ImmichConfig(url="https://rt.com", api_key="key"),
+            analysis=AnalysisConfig(scene_threshold=22.0),
+            server=ServerConfig(port=7070),
+        )
+        original.save_yaml(config_path)
+        loaded = Config.from_yaml(config_path)
+        assert loaded.immich.url == "https://rt.com"
+        assert loaded.analysis.scene_threshold == 22.0
+        assert loaded.server.port == 7070
+
+    def test_top_level_overrides_advanced(self, tmp_path):
+        """If a section appears both at top level and under advanced:, top level wins."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "analysis:\n  scene_threshold: 99.0\nadvanced:\n  analysis:\n    scene_threshold: 1.0\n"
+        )
+        loaded = Config.from_yaml(config_path)
+        assert loaded.analysis.scene_threshold == 99.0


### PR DESCRIPTION
## Summary

PR D of the [codebase cleanup plan](docs/superpowers/specs/2026-03-16-codebase-cleanup-design.md).

15 config sections organized into 3 tiers:

| Tier | Sections | YAML location |
|------|----------|---------------|
| **1 (user-facing)** | immich, defaults, output, audio, title_screens, cache, upload, trips | Top level |
| **2 (advanced)** | analysis, hardware, llm, musicgen, ace_step, content_analysis, audio_content, server | Under `advanced:` |
| **3 (internal)** | scheduler, title_llm | Top level (rarely touched) |

### Key design: zero breaking changes

- `from_yaml()` accepts BOTH flat (legacy) and tiered (`advanced:`) YAML
- `save_yaml()` outputs tiered format
- Config class fields are unchanged — `config.analysis` still works everywhere
- Top-level keys override `advanced:` keys if both are present
- No consumer code changes needed

## Test plan

- [x] `make ci` passes (1159 tests, all gates green)
- [x] 5 new tests: tiered load, flat load, save groups tier 2, roundtrip, precedence
- [x] Existing config tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)