### PR TITLE
docs: align docs with Stage 2 cleanup reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,7 +82,6 @@ src/immich_memories/
 │   ├── clip_analyzer.py        # ClipAnalyzer: download + analyze + score
 │   ├── clip_refiner.py         # ClipRefiner: final selection + distribution
 │   ├── clip_scaler.py          # ClipScaler: duration scaling + dedup
-│   ├── clip_refinement.py      # Standalone refinement functions
 │   ├── clip_scaling.py         # Duration scaling helpers
 │   ├── clip_selection.py       # Standalone clip selection functions
 │   ├── preview_builder.py      # PreviewBuilder: preview segment extraction
@@ -111,7 +110,7 @@ src/immich_memories/
 │   └── llm_query.py            # LLM query helpers
 │
 ├── processing/                 # Video processing & assembly
-│   ├── video_assembler.py      # VideoAssembler (composes 7 services)
+│   ├── video_assembler.py      # VideoAssembler (composes 6 services)
 │   ├── assembly_engine.py      # AssemblyEngine (composes ConcatService)
 │   ├── ffmpeg_filter_graph.py  # ConcatService: concat/xfade/batch ops
 │   ├── assembly_config.py      # Dataclasses: AssemblySettings, AssemblyClip, etc.
@@ -142,7 +141,7 @@ src/immich_memories/
 │   ├── panns_analysis.py       # PANNs (PyTorch AudioSet) helpers
 │   ├── energy_analysis.py      # Audio energy analysis
 │   ├── audio_models.py         # Audio data models
-│   ├── mixer.py                # Audio mixing & ducking (re-exports)
+│   ├── mixer.py                # Audio mixing & ducking
 │   ├── mixer_class.py          # AudioMixer class
 │   ├── mixer_helpers.py        # Mixing helper functions
 │   ├── mood_analyzer.py        # Mood detection for music matching
@@ -183,7 +182,7 @@ src/immich_memories/
 │   ├── globe_video.py          # Globe video creation
 │   ├── map_animation.py        # Map animation
 │   ├── map_renderer.py         # Map tile rendering (staticmap + PIL overlay)
-│   ├── backgrounds.py          # Background generation (re-exports)
+│   ├── backgrounds.py          # Background generation
 │   ├── backgrounds_animated.py # Animated gradient backgrounds
 │   ├── animations.py           # Text animations
 │   ├── styles.py               # Visual style presets
@@ -310,7 +309,7 @@ VideoAssembler.assemble_with_titles()
 
 ## Configuration
 
-- `Config` (config.py): loaded from `~/.immich-memories/config.yaml`
+- `Config` (config_loader.py): loaded from `~/.immich-memories/config.yaml`, tiered YAML (see above)
 - `AssemblySettings` (assembly_config.py): video assembly parameters
 - `PipelineConfig` (smart_pipeline.py): analysis pipeline parameters
 
@@ -322,13 +321,27 @@ Immich API → Asset models → ClipExtractor → VideoClipInfo
   → VideoAssembler → final .mp4
 ```
 
+## Configuration Tiers
+
+Config is organized in 3 tiers (see `config_loader.py`):
+
+- **Tier 1** (top-level YAML): `immich`, `defaults`, `output`, `audio`, `title_screens`, `cache`, `upload`, `trips`
+- **Tier 2** (under `advanced:` in YAML): `analysis`, `hardware`, `llm`, `musicgen`, `ace_step`, `content_analysis`, `audio_content`, `server`
+- **Tier 3** (internal): `scheduler`, `title_llm`
+
+At runtime, all sections are flat fields on `Config` (e.g. `config.analysis`).
+Both flat and nested YAML formats are accepted.
+
 ## Conventions
 
-- **Max file length**: 500 lines (enforced in CI via `make file-length`)
+- **Max file length**: 800 lines soft / 1000 hard (enforced in CI via `make file-length`)
 - **Max complexity**: Xenon grade C (<=20 cyclomatic complexity, `make complexity`)
+- **Cognitive complexity**: complexipy ≤15 per function (`make cognitive-complexity`)
 - **Makefile**: Single source of truth for all commands (CI, pre-commit, CLAUDE.md)
 - **Composition**: Top-level orchestrators compose service objects via constructor injection
-- **Re-export shims**: `mixer.py`, `config.py` etc. re-export from sub-modules for backwards compat
+- **Re-export shims**: Only in `__init__.py` — never in regular modules
+- **No `_`-prefixed overflow files**: All files have descriptive names
 - **Private helpers**: Prefixed with `_`, same package
 - **Tests**: `tests/` directory, run with `make test`
-- **Pre-commit**: Run `make check` before committing
+- **Integration tests**: Run locally via pre-commit hook on processing/titles changes (`make test-integration`)
+- **Pre-commit**: Run `make ci` before committing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 1. **Install dev dependencies first**: `make dev`
 2. Read `ARCHITECTURE.md` — it maps the full codebase structure, key classes,
-   data flow, and mixin architecture. This avoids needing to explore the repo.
+   data flow, and composition architecture. This avoids needing to explore the repo.
 
 > **Important**: Always run `make dev` before running any other make target.
 > This installs all dev tools (pytest, ruff, mypy, etc.) into the project venv.
@@ -148,6 +148,8 @@ locally, CI will pass too. Use conventional commit message format (see above).
 
 **Abstractions:**
 - Do NOT create re-export shims for a single consumer — import from the source
+- Re-export shims belong only in `__init__.py` — never in regular modules
+- No `_`-prefixed overflow files — give every file a descriptive name
 - Do NOT split files purely for line count — splits must follow cohesion boundaries
 - Do NOT use mixins — use composition with Protocol contracts
 - If you need state from another module, inject it via constructor
@@ -157,6 +159,7 @@ locally, CI will pass too. Use conventional commit message format (see above).
 - Do NOT mock more than 3 boundaries in a single test — if you need more, the code under test has too many dependencies
 - Every mock MUST have a `# WHY:` comment explaining what external boundary it replaces
 - Integration tests (`make test-integration`) must exist for any FFmpeg pipeline change
+- Integration tests run locally via pre-commit hook (not in CI) when processing/titles code changes
 
 **Comments:**
 - Do NOT write comments that describe what the next line does
@@ -165,7 +168,9 @@ locally, CI will pass too. Use conventional commit message format (see above).
 
 **Config:**
 - New config options MUST have a sane default
-- User-facing options go in Tier 1 (~20 options). Everything else is Tier 2 (advanced)
+- User-facing options go in Tier 1 (top-level YAML). Everything else in Tier 2 (`advanced:`)
+- Tier 2 sections: analysis, hardware, llm, musicgen, ace_step, content_analysis, audio_content, server
+- At runtime, all sections are flat on Config (`config.analysis`, not `config.advanced.analysis`)
 - Do NOT add migration/compat shims for renamed fields — deprecate, document, remove
 
 ### Documentation Freshness

--- a/docs-site/docs/configuration/advanced.md
+++ b/docs-site/docs/configuration/advanced.md
@@ -7,6 +7,20 @@ title: Advanced Configuration
 
 These options have sane defaults and most users don't need to change them. Add any of these to your `~/.immich-memories/config.yaml` to override.
 
+:::tip Config tiers
+These advanced sections can be placed under an `advanced:` key in your config file for organization:
+
+```yaml
+advanced:
+  analysis:
+    scene_threshold: 25.0
+  hardware:
+    backend: "videotoolbox"
+```
+
+Or kept at the top level (both formats work).
+:::
+
 ## Video analysis
 
 ```yaml

--- a/docs-site/docs/features/architecture.md
+++ b/docs-site/docs/features/architecture.md
@@ -35,7 +35,7 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 - Dead code detection (Vulture)
 - Cyclomatic complexity (Xenon grade C)
 - Cognitive complexity checks
-- File length enforcement (500 lines max)
+- File length enforcement (800 lines max)
 - Refurb modernization checks
 - Dependency vulnerability audit (pip-audit)
 - Docstring coverage
@@ -67,7 +67,7 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 | Lint + format | Ruff | Style issues, import ordering, unused imports |
 | Type check | mypy | Type mismatches, missing annotations |
 | Complexity | Xenon | Functions too complex to reason about (grade C max) |
-| File length | Custom script | Files over 500 lines (split into services) |
+| File length | Custom script | Files over 800 lines (split into services) |
 | Dead code | Vulture | Unused functions, variables, imports |
 | Duplication | Custom | Copy-pasted code blocks |
 | Security | Bandit + Semgrep | Common vulnerability patterns |
@@ -83,7 +83,7 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 ### Adding a new processing capability
 
 1. Create a service class in the relevant package (e.g., `processing/my_service.py`)
-2. Keep it under 500 lines. If it needs more, split into a service + helpers file
+2. Keep it under 800 lines. If it needs more, split into a service + helpers file
 3. Inject it into the orchestrator's `__init__` in `video_assembler.py`
 4. Add tests in `tests/test_my_service.py`
 5. Run `make check` before committing


### PR DESCRIPTION
## Summary

PR E of the [codebase cleanup plan](docs/superpowers/specs/2026-03-16-codebase-cleanup-design.md) — **final Stage 2 PR**.

### ARCHITECTURE.md
- VideoAssembler: 7→6 services (TransitionRenderer deleted)
- Removed `clip_refinement.py` from listing
- Removed "re-exports" labels from `mixer.py`, `backgrounds.py`
- Added Configuration Tiers section
- Fixed file length limit (500→800)
- Updated conventions (cognitive complexity, integration tests, re-export rules)

### CLAUDE.md
- Fixed "mixin architecture" → "composition architecture"
- Added rules: no `_`-prefixed files, re-exports only in `__init__.py`
- Added: integration tests via pre-commit hook
- Updated config rules with tier 2 section list

### docs-site
- Fixed file length limit in architecture feature page
- Added config tiers tip to advanced.md

### Docs audit findings (for later)
13 screenshots referenced but missing — tracked for future work:
`demo-hero.gif`, `trip-memory-example.png`, `memory-presets.png`, `step3-preview.png`, `llm-title-step3.png`, `llm-title-regenerate.png`, `trip-preset.png`, `trip-step3-title.png`, `trip-detection.png`, `privacy-toggle.png`, `privacy-blur.png`, `map-animation-frame.png`, `map-pan-close.png`

## Test plan

- [x] `make ci` passes
- [x] `make docs-check` passes (docs build clean)
- [x] All CLI commands verified accurate
- [x] All config options verified against `config_models.py`
- [x] Zero stale references to deleted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)