### PR TITLE
fix(ci): pass secrets to CI workflow called from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
     needs: [analyze]
     if: needs.analyze.outputs.should_release == 'true'
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
One-line fix: `secrets: inherit` on the workflow_call in release.yml so Codecov gets the token on main branch runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)