### PR TITLE
fix: Asset width/height from search API — fixes broken resolution filter

### DIFF
--- a/src/immich_memories/api/models.py
+++ b/src/immich_memories/api/models.py
@@ -163,6 +163,10 @@ class Asset(BaseModel):
     is_archived: bool = Field(default=False, alias="isArchived")
     is_trashed: bool = Field(default=False, alias="isTrashed")
     duration: str | None = None
+    # WHY: width/height from search API — needed for resolution filtering
+    # BEFORE download. Without these, all non-favorites report 0×0 and get dropped.
+    width: int = Field(default=0)
+    height: int = Field(default=0)
     exif_info: ExifInfo | None = Field(default=None, alias="exifInfo")
     people: list[Person] = Field(default_factory=list)
     faces: list[AssetFace] = Field(default_factory=list)

--- a/src/immich_memories/generate.py
+++ b/src/immich_memories/generate.py
@@ -789,5 +789,12 @@ def assets_to_clips(assets: list) -> list:
         duration = asset.duration_seconds or 0
         if duration < MIN_CLIP_DURATION:
             continue
-        clips.append(VideoClipInfo(asset=asset, duration_seconds=duration))
+        clips.append(
+            VideoClipInfo(
+                asset=asset,
+                duration_seconds=duration,
+                width=asset.width,
+                height=asset.height,
+            )
+        )
     return clips


### PR DESCRIPTION
## Summary

- Add `width`/`height` fields to `Asset` model (already in Immich search API response, just not parsed)
- Propagate to `VideoClipInfo` in `assets_to_clips()`

## The Bug

ALL non-favorites reported 0×0 resolution because the Asset model didn't parse `width`/`height` from the search API. The resolution filter (`min 1080px for 4K output`) dropped everything: `max(0, 0) < 1080 → true`.

**Real impact** (a person-spotlight library, 1320 clips):
- Before: 0/1100 non-favorites survived → only 220 favorites analyzed (17%)
- After: 985/1100 survive → 115 genuinely low-res dropped (correct behavior)

## Test plan

- [x] 1567 unit tests passing
- [x] Verified on real Immich library: resolution distribution now shows real values (720px-3840px)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
