### PR TITLE
feat: disk space preflight check before assembly

### DIFF
--- a/.nicegui/storage-user-40ac797c-c78a-4bdc-90c6-7078c38f39f8.json
+++ b/.nicegui/storage-user-40ac797c-c78a-4bdc-90c6-7078c38f39f8.json
@@ -1,0 +1,1 @@
+{"authenticated":true,"username":"Sam Dumont","auth_provider":"oidc","email":"samuel@dumont.info","authenticated_at":"2026-03-19T18:42:50.369624+00:00","session_id":"38e20b79-3c35-441f-8646-93d05f6ac8f5"}

--- a/.nicegui/storage-user-455de4d8-70ed-495f-bc72-b11b6dbec5e3.json
+++ b/.nicegui/storage-user-455de4d8-70ed-495f-bc72-b11b6dbec5e3.json
@@ -1,0 +1,1 @@
+{"session_id":"9bc3ef4d-0c9c-4631-9297-a80d9fb7a997","theme":"light"}

--- a/.nicegui/storage-user-702d5fc1-2342-44cc-a78c-0d92c07ded54.json
+++ b/.nicegui/storage-user-702d5fc1-2342-44cc-a78c-0d92c07ded54.json
@@ -1,0 +1,1 @@
+{"authenticated":true,"username":"admin","auth_provider":"basic","email":"","authenticated_at":"2026-03-19T18:31:28.525597+00:00"}

--- a/src/immich_memories/generate.py
+++ b/src/immich_memories/generate.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import io
 import logging
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date
@@ -133,6 +134,18 @@ class PipelineLock:
             self._fd = None
 
 
+# Minimum free disk space before starting generation
+_MIN_FREE_BYTES = 1024 * 1024 * 1024  # 1 GB
+
+
+def check_disk_space(output_dir: Path) -> None:
+    """Abort early if disk space is critically low."""
+    usage = shutil.disk_usage(output_dir)
+    if usage.free < _MIN_FREE_BYTES:
+        free_gb = usage.free / (1024**3)
+        raise GenerationError(f"Insufficient disk space: {free_gb:.1f} GB free, need at least 1 GB")
+
+
 def _report(params: GenerationParams, phase: str, progress: float, msg: str) -> None:
     if params.progress_callback:
         params.progress_callback(phase, progress, msg)
@@ -172,6 +185,9 @@ def _generate_memory_inner(params: GenerationParams) -> Path:
     dir_slug = params.output_path.stem
     run_output_dir = params.output_path.parent / f"{dir_slug}_{run_id}"
     run_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Preflight: abort early if disk is critically low
+    check_disk_space(run_output_dir)
     result_output_path = run_output_dir / sanitize_filename(params.output_path.name)
 
     run_tracker.start_run(

--- a/tests/test_disk_space.py
+++ b/tests/test_disk_space.py
@@ -1,0 +1,70 @@
+"""Tests for disk space preflight check before assembly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from immich_memories.generate import GenerationError
+
+
+class TestCheckDiskSpace:
+    """check_disk_space should raise GenerationError when free space < 1GB."""
+
+    def test_raises_when_disk_full(self, tmp_path: Path):
+        from immich_memories.generate import check_disk_space
+
+        # Simulate <1GB free (500MB)
+        fake_usage = type("Usage", (), {"free": 500 * 1024 * 1024})()
+        with (
+            patch("shutil.disk_usage", return_value=fake_usage),
+            pytest.raises(GenerationError, match="Insufficient disk space"),
+        ):
+            check_disk_space(tmp_path)
+
+    def test_passes_when_enough_space(self, tmp_path: Path):
+        from immich_memories.generate import check_disk_space
+
+        # 5GB free — should not raise
+        fake_usage = type("Usage", (), {"free": 5 * 1024 * 1024 * 1024})()
+        with patch("shutil.disk_usage", return_value=fake_usage):
+            check_disk_space(tmp_path)  # Should not raise
+
+    def test_passes_at_exactly_1gb(self, tmp_path: Path):
+        from immich_memories.generate import check_disk_space
+
+        fake_usage = type("Usage", (), {"free": 1024 * 1024 * 1024})()
+        with patch("shutil.disk_usage", return_value=fake_usage):
+            check_disk_space(tmp_path)  # Should not raise (>= threshold)
+
+    def test_error_message_includes_free_space(self, tmp_path: Path):
+        from immich_memories.generate import check_disk_space
+
+        fake_usage = type("Usage", (), {"free": 200 * 1024 * 1024})()
+        with (
+            patch("shutil.disk_usage", return_value=fake_usage),
+            pytest.raises(GenerationError, match="0.2 GB free"),
+        ):
+            check_disk_space(tmp_path)
+
+
+class TestDiskSpaceWiredInPipeline:
+    """check_disk_space is called early in generate_memory()."""
+
+    def test_check_disk_space_called_before_extraction(self, tmp_path: Path):
+        """generate_memory should check disk space before starting extraction."""
+        import immich_memories.generate as gen_mod
+
+        assert hasattr(gen_mod, "check_disk_space"), (
+            "check_disk_space must be defined in generate.py"
+        )
+
+        # Verify the function is called in the pipeline (may be in inner function)
+        import inspect
+
+        # check_disk_space is in _generate_memory_inner (called by generate_memory under lock)
+        pipeline_fn = getattr(gen_mod, "_generate_memory_inner", gen_mod.generate_memory)
+        source = inspect.getsource(pipeline_fn)
+        assert "check_disk_space" in source, "pipeline must call check_disk_space"


### PR DESCRIPTION
## Summary
- Adds `check_disk_space()` that runs `shutil.disk_usage()` before clip extraction
- Aborts with clear `GenerationError` if < 1GB free on the output filesystem
- Error message shows exact free space (e.g., "0.2 GB free, need at least 1 GB")

Closes #52

## Test plan
- [x] Test raises when disk is full (500MB)
- [x] Test passes with enough space (5GB)
- [x] Test passes at exactly 1GB threshold
- [x] Test error message includes free space amount
- [x] Verify wired into `generate_memory()` before extraction phase
- [x] `make ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)