### PR TITLE
fix(ci): harden GPU integration pipeline against fork abuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v5
         with:
           lfs: true

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,42 +1,56 @@
 # Mirror to private repo → triggers GPU integration tests → status callback
 #
+# SECURITY: Self-hosted GPU runners can't safely run on public repos (fork abuse).
+# This workflow mirrors code to a private repo where ARC GPU runners are scoped.
+#
+# Triggers:
+#   - push to main: automatic (post-merge integration regression check)
+#   - workflow_dispatch: manual (test a specific branch before merging)
+#
+# NEVER add pull_request trigger — any fork could push malicious code
+# (crypto miners, exfiltration) to the GPU runner. PRs only get unit tests
+# on GitHub-hosted runners.
+#
 # Flow:
-#   1. Push branch to private mirror
+#   1. Push branch to private mirror (SSH deploy key)
 #   2. Trigger integration workflow via repository_dispatch
 #   3. Post "pending" commit status on this repo
-#   4. Private repo runs FFmpeg + GPU tests
+#   4. Private repo runs FFmpeg + GPU tests on ARC K8s runner
 #   5. Private repo posts "success"/"failure" status back here
-#
-# The integration result shows as a separate PR check: "Integration (GPU)"
 
 name: Mirror to CI
 
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test (defaults to current)"
+        required: false
+        type: string
 
 jobs:
   mirror:
     name: Mirror & Trigger GPU Tests
     runs-on: ubuntu-latest
-    # Don't run on the private mirror repo
     if: github.repository == 'sam-dumont/immich-video-memory-generator'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          # WHY: pull_request checks out a merge commit by default.
-          # We need the actual branch head for mirroring.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.branch || github.sha }}
 
       - name: Push to private mirror
         env:
           SSH_KEY: ${{ secrets.MIRROR_SSH_KEY }}
         run: |
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          # SSH deploy key — more reliable than PAT for cross-repo push
+          BRANCH="${{ inputs.branch || github.ref_name }}"
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/mirror_key
           chmod 600 ~/.ssh/mirror_key
@@ -52,7 +66,7 @@ jobs:
           curl -sS -X POST \
             -H "Authorization: token ${{ secrets.CI_MIRROR_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }}" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
             -d '{
               "state": "pending",
               "context": "Integration (GPU)",
@@ -69,8 +83,8 @@ jobs:
             -d '{
               "event_type": "integration-test",
               "client_payload": {
-                "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
-                "branch": "${{ github.head_ref || github.ref_name }}",
+                "sha": "${{ github.sha }}",
+                "branch": "${{ inputs.branch || github.ref_name }}",
                 "public_repo": "${{ github.repository }}"
               }
             }'

--- a/docs/GPU_INTEGRATION_TESTS.md
+++ b/docs/GPU_INTEGRATION_TESTS.md
@@ -1,0 +1,78 @@
+# GPU Integration Tests — Architecture & Security
+
+## Why a private mirror?
+
+Self-hosted runners (with GPU access) **cannot safely run on public repos**. Anyone can
+fork the repo, submit a PR with a modified test file (crypto miner, data exfiltration),
+and the runner would execute it. GitHub's own docs warn against this.
+
+## Architecture
+
+```
+PUBLIC REPO (sam-dumont/immich-video-memory-generator)
+├── ci.yml ──► unit tests on GitHub-hosted runners (free, safe)
+│              harden-runner monitors network egress
+└── mirror.yml ──► git push to private mirror (SSH deploy key)
+                   triggers: push to main (automatic)
+                             workflow_dispatch (manual, for testing branches)
+                   NEVER triggers on: pull_request (fork abuse vector)
+                              │
+                              ▼
+PRIVATE REPO (sam-dumont/immich-memories-ci)
+└── integration.yml ──► GPU integration tests
+                        triggered by: repository_dispatch from mirror.yml
+                        runs-on: gpu (ARC K8s runner with NVIDIA GPU)
+                        posts status back to public repo: "Integration (GPU)" ✅/❌
+                              │
+                              ▼
+K8S CLUSTER (rancher-cluster/55-github-arc)
+└── ARC runner pods
+    ├── NVIDIA runtimeClass + time-sliced GPU
+    ├── PVC cache for uv packages (10Gi, survives pod restarts)
+    ├── emptyDir /tmp (20Gi, ephemeral per job)
+    ├── Scoped to private repo ONLY (not org-level)
+    └── Scale 0→2 on demand, ephemeral (pod dies after each job)
+```
+
+## Security layers
+
+| Layer | Protection |
+|-------|-----------|
+| No `pull_request` trigger | Fork PRs never reach GPU runner |
+| `workflow_dispatch` only for branches | Only repo owner can trigger manually |
+| `github.repository` guard | Extra check against fork execution |
+| ARC scoped to private repo | Runner only accepts jobs from `immich-memories-ci` |
+| Ephemeral pods | Each job gets a fresh container, no persistence |
+| SSH deploy key (not PAT) | Narrowly scoped: write access to one repo only |
+| `harden-runner` on public CI | Monitors network egress, detects supply chain attacks |
+
+## Running GPU tests
+
+**Automatic (post-merge):** Every push to `main` triggers integration tests automatically.
+
+**Manual (pre-merge):** Test a specific branch before merging:
+```bash
+gh workflow run mirror.yml -f branch=feat/my-feature
+```
+
+**Direct (on private repo):**
+```bash
+gh workflow run integration.yml -R sam-dumont/immich-memories-ci -f suite=assembly
+```
+
+## Config
+
+The runner gets `~/.immich-memories/config.yaml` from the `IMMICH_MEMORIES_CONFIG` secret
+(base64-encoded). Paths are overridden via env vars (pydantic-settings):
+
+- `IMMICH_MEMORIES_CACHE__DIRECTORY=/tmp/immich-cache`
+- `IMMICH_MEMORIES_CACHE__DATABASE=/tmp/immich-cache/cache.db`
+- `IMMICH_MEMORIES_OUTPUT__DIRECTORY=/tmp/immich-output`
+- `UV_CACHE_DIR=/home/runner/.cache/uv` (PVC-backed, persistent)
+
+## Updating config
+
+When your local config changes:
+```bash
+cat ~/.immich-memories/config.yaml | base64 | gh secret set IMMICH_MEMORIES_CONFIG -R sam-dumont/immich-memories-ci
+```


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from mirror.yml — fork PRs **never** reach GPU runner
- Add `workflow_dispatch` for manual branch testing: `gh workflow run mirror.yml -f branch=feat/my-branch`
- Add [harden-runner](https://github.com/step-security/harden-runner) (StepSecurity) to CI + mirror workflows — monitors network egress, detects crypto miners and supply chain attacks
- Document full architecture + security layers in `docs/GPU_INTEGRATION_TESTS.md`

## Test plan

- [x] `pull_request` trigger removed — verified in mirror.yml
- [x] harden-runner in audit mode (non-blocking, builds baseline)
- [ ] Push to main triggers mirror → GPU tests → status callback
- [ ] Manual dispatch works: `gh workflow run mirror.yml -f branch=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)