### PR TITLE
fix: ffmpeg 6.1.1 compat — remove agamma, fix audio label reuse

### DIFF
--- a/src/immich_memories/audio/mixer.py
+++ b/src/immich_memories/audio/mixer.py
@@ -303,16 +303,16 @@ def _build_ducking_filter(
     filter_parts.append(music_filter)
 
     # Prepare video audio (normalize if requested)
-    # WHY: label "va" instead of "video_audio" — FFmpeg 6.x on Linux
-    # parses underscores in labels as stream specifier separators (type_index)
+    # WHY: Split into two copies — FFmpeg 6.x doesn't allow consuming a label twice.
+    # [va] feeds sidechaincompress (as sidechain input), [vamix] feeds amix.
     if config.normalize_audio:
-        filter_parts.append("[0:a]loudnorm=I=-16:TP=-1.5:LRA=11[vidaud]")
+        filter_parts.append("[0:a]loudnorm=I=-16:TP=-1.5:LRA=11,asplit=2[va][vamix]")
     else:
-        filter_parts.append("[0:a]acopy[vidaud]")
+        filter_parts.append("[0:a]asplit=2[va][vamix]")
 
     # Apply sidechain compression: duck music when video audio is present
     sidechain_filter = (
-        f"[music][vidaud]sidechaincompress="
+        f"[music][va]sidechaincompress="
         f"threshold={ducking.threshold}:"
         f"ratio={ducking.ratio}:"
         f"attack={ducking.attack_ms}:"
@@ -323,7 +323,7 @@ def _build_ducking_filter(
     filter_parts.extend(
         (
             sidechain_filter,
-            "[vidaud][ducked_music]amix=inputs=2:duration=first:dropout_transition=2[mixed]",
+            "[vamix][ducked_music]amix=inputs=2:duration=first:dropout_transition=2[mixed]",
         )
     )
 

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -393,7 +393,7 @@ def _resolve_clip_hdr(
             f"zscale=t={trc}:tin=iec61966-2-1"
             ":p=bt2020:pin=bt709"
             ":m=bt2020nc:min=bt709"
-            ":npl=203:agamma=false"
+            ":npl=203"
             ",format=yuv420p10le"
         )
 

--- a/tests/test_mixer_helpers.py
+++ b/tests/test_mixer_helpers.py
@@ -125,12 +125,14 @@ class TestBuildDuckingFilter:
         joined = ";".join(parts)
         assert "loudnorm" in joined
 
-    def test_no_normalize_uses_acopy(self):
+    def test_no_normalize_uses_asplit(self):
+        """Without loudnorm, audio still needs asplit for sidechaincompress + amix."""
         ducking = DuckingConfig()
         config = MixConfig(ducking=ducking, normalize_audio=False)
         parts = _build_ducking_filter(config, ducking, video_duration=30.0)
         joined = ";".join(parts)
-        assert "acopy" in joined
+        assert "asplit=2" in joined
+        assert "loudnorm" not in joined
 
     def test_output_is_mixed(self):
         ducking = DuckingConfig()


### PR DESCRIPTION
Fixes Linux CI failures from PR #101:

1. **zscale agamma**: `agamma=false` not supported on FFmpeg 6.1.1 (Ubuntu 24.04). Causes SDR→HDR filter to fail silently, producing rgb24 instead of yuv420p10le = shape mismatch crash. Removing it is safe — pixel difference is <3 mean values.

2. **Audio mixer label reuse**: `[vidaud]` was consumed by both `sidechaincompress` and `amix`. FFmpeg 6.x requires explicit `asplit` to feed one stream to two filters. Fixes `Invalid stream specifier: vidaud` error.