### PR TITLE
fix(build): remove direct git reference blocking PyPI uploads

### DIFF
--- a/docs-site/docs/music/ace-step.md
+++ b/docs-site/docs/music/ace-step.md
@@ -28,7 +28,9 @@ ACE-Step runs in two modes:
 ## Local Setup (lib mode)
 
 ```bash
-pip install 'immich-memories[ace-step]'
+# ACE-Step is not on PyPI — install directly from GitHub
+pip install 'ace-step @ git+https://github.com/ace-step/ACE-Step.git'
+pip install 'torchcodec>=0.1'
 ```
 
 ```yaml

--- a/docs-site/docs/music/overview.md
+++ b/docs-site/docs/music/overview.md
@@ -49,14 +49,12 @@ musicgen:
 Install the packages:
 
 ```bash
-pip install 'immich-memories[local-audio]'
-```
+# Demucs (stem separation)
+pip install 'immich-memories[demucs]'
 
-Or separately:
-
-```bash
-pip install 'immich-memories[demucs]'       # Stem separation only
-pip install 'immich-memories[ace-step]'      # Music generation only
+# ACE-Step (music generation) — not on PyPI, install from GitHub
+pip install 'ace-step @ git+https://github.com/ace-step/ACE-Step.git'
+pip install 'torchcodec>=0.1'
 ```
 
 That's it. No Docker, no API servers. The pipeline auto-detects local Demucs for stem separation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,18 +82,9 @@ demucs = [
     "demucs>=4.0",
 ]
 # Local ACE-Step music generation (in-process, no API server needed)
-# ⚠️  Requires Python ≤3.12 (spacy 3.8.4 has no 3.13 wheels)
-# Model cache: ~/.cache/huggingface/hub/ (~2-10GB depending on lm_model_size)
-ace-step = [
-    "ace-step @ git+https://github.com/ace-step/ACE-Step.git ; python_version < '3.13'",
-    "torchcodec>=0.1 ; python_version < '3.13'",
-]
-# Full local audio pipeline: ACE-Step generation + Demucs stem separation
-# ⚠️  Requires Python ≤3.12 (ACE-Step dependency)
-local-audio = [
-    "immich-memories[demucs]",
-    "immich-memories[ace-step]",
-]
+# ⚠️  NOT a pip extra — ACE-Step is not published on PyPI.
+#     Install manually: pip install 'ace-step @ git+https://github.com/ace-step/ACE-Step.git'
+#     See docs-site/docs/music/ace-step.md for setup instructions.
 # GPU-accelerated title rendering with Taichi
 # Supports: Metal (macOS), CUDA (NVIDIA), Vulkan, OpenGL, CPU fallback
 gpu = [
@@ -149,9 +140,6 @@ Documentation = "https://sam-dumont.github.io/immich-video-memory-generator/"
 Repository = "https://github.com/sam-dumont/immich-video-memory-generator"
 Issues = "https://github.com/sam-dumont/immich-video-memory-generator/issues"
 Changelog = "https://github.com/sam-dumont/immich-video-memory-generator/releases"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
@@ -509,8 +497,6 @@ DEP002 = [
     "authlib",                                          # auth: used in upcoming OIDC client task
     "oidc-provider-mock",                               # auth: used in upcoming OIDC tests task
     "demucs",                                           # optional: local stem separation
-    "ace-step",                                         # optional: local music generation
-    "torchcodec",                                       # optional: ACE-Step audio saving
 ]
 DEP001 = [
     "cv2", "Quartz", "Vision", "Metal", "CoreImage",   # Platform/alt-name imports


### PR DESCRIPTION
## Summary

Fixes PyPI publish failures since v0.21.0 (releases #67-69).

The `ace-step` extra used `git+https://github.com/ace-step/ACE-Step.git` as a direct reference. PyPI rejects packages with direct URL dependencies with `400 Bad Request`.

- Remove `ace-step` and `local-audio` extras from `pyproject.toml`
- Remove `allow-direct-references = true` from hatch metadata
- Update docs: ACE-Step install is now a manual `pip install` from GitHub
- `demucs` extra remains unchanged (proper PyPI package)

ACE-Step is not published on PyPI (only a stale community upload at v0.1.0). API mode (`mode: "api"`) is unaffected — this only impacts local lib mode.

## Test plan

- [x] `uv build` succeeds
- [x] Built wheel metadata has no `git+` references
- [ ] Merge → release workflow should publish to PyPI successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)