### PR TITLE
fix(ci): cache LFS objects to avoid bandwidth exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,21 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          lfs: true
           fetch-depth: 0  # Full history for diff-cover
+
+      # WHY: LFS bandwidth is metered — caching avoids re-downloading 13MB of
+      # fixtures on every CI run (~9 LFS checkouts/push was burning 1GB/month).
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
+
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
@@ -351,8 +364,16 @@ jobs:
             extras: "dev,mac,audio,audio-ml,face,gpu"
     steps:
       - uses: actions/checkout@v5
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
         with:
-          lfs: true
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
@@ -432,8 +453,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
         with:
-          lfs: true
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
       - uses: actions/setup-node@v5
         with:
           node-version: '22'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,8 +33,16 @@ jobs:
     if: github.repository == 'sam-dumont/immich-video-memory-generator'
     steps:
       - uses: actions/checkout@v5
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
         with:
-          lfs: true
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ steps.params.outputs.branch }}
-          lfs: true
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
 
       - name: Post "in_progress" status
         if: github.event_name == 'repository_dispatch'

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -45,7 +45,16 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.sha }}
-          lfs: true
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
 
       - name: Push to private mirror
         env:


### PR DESCRIPTION
## Summary
Every CI checkout was downloading ~13MB of LFS fixtures. With 9+ LFS checkouts per push across 4 workflows, active development burned through GitHub's 1GB/month LFS bandwidth in days.

Replace `lfs: true` with `actions/cache` keyed on LFS object hashes. First run downloads from GitHub LFS; subsequent runs restore from GitHub Actions cache (free, unlimited bandwidth).

**Workflows updated:** ci.yml (test, test-extras, docs jobs), docs.yml, mirror.yml, integration.yml

## Test plan
- [x] Pattern matches [recommended approach](https://github.com/actions/checkout/issues/165#issuecomment-657673315) for LFS caching
- [x] Cache key based on `git lfs ls-files -l` hash — invalidates only when LFS files change
- [x] `restore-keys: lfs-` allows partial cache hits when only some files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>