### PR TITLE
fix(streaming): crossfade buffer shape mismatch + audio duration truncation

### DIFF
--- a/src/immich_memories/audio/mixer.py
+++ b/src/immich_memories/audio/mixer.py
@@ -323,7 +323,11 @@ def _build_ducking_filter(
     filter_parts.extend(
         (
             sidechain_filter,
-            "[vamix][ducked_music]amix=inputs=2:duration=first:dropout_transition=2[mixed]",
+            # WHY: duration=longest ensures output matches music duration (which was
+            # pre-trimmed to video_duration). duration=first would truncate to
+            # [vamix]'s decoded stream length, which can be shorter than the video
+            # if audio padding metadata isn't fully honored by the decoder.
+            "[vamix][ducked_music]amix=inputs=2:duration=longest:dropout_transition=2[mixed]",
         )
     )
 

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -338,6 +338,21 @@ def _emit_body_frames(
     return frames_written
 
 
+def _match_blend_bufs(
+    ref: np.ndarray, blend_buf: np.ndarray, temp_buf: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create black frame and ensure blend buffers match actual frame shape.
+
+    WHY: HDR mode pre-allocates flat uint16 YUV buffers, but some clips
+    (title screens, FFmpeg filter fallback on Linux) may decode as 3D RGB.
+    """
+    black = np.zeros_like(ref)
+    if blend_buf.shape != ref.shape or blend_buf.dtype != ref.dtype:
+        blend_buf = np.zeros_like(ref)
+        temp_buf = np.zeros_like(ref)
+    return black, blend_buf, temp_buf
+
+
 def _emit_crossfade(
     active_iter: Iterator[np.ndarray],
     next_iter: Iterator[np.ndarray],
@@ -349,13 +364,19 @@ def _emit_crossfade(
     width: int,
 ) -> None:
     """Blend fade_frames from two iterators and write to encoder."""
-    black = np.zeros((height, width, 3), dtype=blend_buf.dtype)
+    black: np.ndarray | None = None
     for fade_idx in range(fade_frames):
         frame_a = next(active_iter, None)
         frame_b = next(next_iter, None)
 
         if frame_a is None is frame_b:
             break
+
+        if black is None:
+            ref = frame_a if frame_a is not None else frame_b
+            assert ref is not None  # noqa: S101
+            black, blend_buf, temp_buf = _match_blend_bufs(ref, blend_buf, temp_buf)
+
         if frame_a is None:
             frame_a = black
         if frame_b is None:


### PR DESCRIPTION
## Summary
Two Linux GPU integration test failures:

1. **Crossfade ValueError** — HDR mode pre-allocates flat YUV blend buffers but title screens may decode as RGB on Linux FFmpeg. New `_match_blend_bufs()` detects shape/dtype mismatch and reallocates.

2. **Audio/video duration mismatch** (audio=2.77s, video=5.67s) — `amix=duration=first` truncated output to `[vamix]`'s decoded stream length. Changed to `duration=longest` since music is pre-trimmed to `video_duration`.

## Test plan
- [x] `make test` passes (1908 tests)
- [x] Pre-commit hooks pass (cognitive complexity stays within limits)
- [ ] Needs GPU integration runner verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>