### PR TITLE
fix(audio): force output duration metadata with apad+atrim after amix

### DIFF
--- a/src/immich_memories/audio/mixer.py
+++ b/src/immich_memories/audio/mixer.py
@@ -327,11 +327,13 @@ def _build_ducking_filter(
     filter_parts.extend(
         (
             sidechain_filter,
-            # WHY: duration=longest ensures output matches music duration (which was
-            # pre-trimmed to video_duration). duration=first would truncate to
-            # [vamix]'s decoded stream length, which can be shorter than the video
-            # if audio padding metadata isn't fully honored by the decoder.
-            "[vamix][ducked_music]amix=inputs=2:duration=longest:dropout_transition=2[mixed]",
+            # WHY: duration=longest + final apad/atrim = belt-and-suspenders for
+            # correct output duration. amix duration=longest should produce full
+            # length, but some FFmpeg versions write incorrect stream duration
+            # metadata. The final apad/atrim guarantees both the actual samples
+            # AND the metadata match video_duration.
+            "[vamix][ducked_music]amix=inputs=2:duration=longest:dropout_transition=2,"
+            f"apad=whole_dur={video_duration},atrim=0:{video_duration}[mixed]",
         )
     )
 


### PR DESCRIPTION
## Summary
Follow-up to #128 — `apad` on `[0:a]` before amix still didn't fix it because the issue is in the OUTPUT stream metadata, not the input.

Root cause: `amix=duration=longest` produces correct audio samples but FFmpeg 6.x writes incorrect stream-level duration metadata. `ffprobe` reads per-stream `duration` tag which shows 2.79s (first input's original duration) instead of the actual decoded length (5.67s).

Fix: Apply `apad=whole_dur={video_duration},atrim=0:{video_duration}` AFTER `amix` output, before the `[mixed]` label. This forces both the actual samples AND the output stream metadata to match `video_duration`.

## Test plan
- [x] `make test` passes (1908 tests)
- [x] Mac integration tests pass (assembly + pipeline)
- [ ] Needs GPU integration runner verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>