### PR TITLE
perf(pipeline): reduce over-analysis + always use unified photo budget

### DIFF
--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -38,6 +38,30 @@ class JobCancelledException(Exception):
     pass
 
 
+def _cap_analysis_candidates(
+    selected: list[VideoClipInfo], target_clips: int
+) -> list[VideoClipInfo]:
+    """Cap selected clips at 1.5x target to prevent over-analysis.
+
+    Favorites are always preserved. Non-favorites are trimmed by resolution
+    (highest resolution kept first).
+    """
+    max_candidates = int(target_clips * 1.5)
+    if len(selected) <= max_candidates:
+        return selected
+
+    fav = [c for c in selected if c.asset.is_favorite]
+    non_fav = [c for c in selected if not c.asset.is_favorite]
+    non_fav.sort(
+        key=lambda c: c.width * c.height if c.width and c.height else 0,
+        reverse=True,
+    )
+    keep = max(0, max_candidates - len(fav))
+    result = fav + non_fav[:keep] if keep > 0 else fav[:max_candidates]
+    logger.info(f"Capped analysis candidates to {len(result)} (1.5x target {target_clips})")
+    return result
+
+
 @dataclass
 class PipelineConfig:
     """Configuration for the smart pipeline."""
@@ -379,9 +403,10 @@ class SmartPipeline:
         buckets = compute_density_budget(
             assets=entries,
             target_duration_seconds=target_seconds,
+            raw_multiplier=1.3,
         )
 
-        raw_budget = (target_seconds - 50) * 2.0
+        raw_budget = (target_seconds - 50) * 1.3
         log_budget_summary(buckets, raw_budget)
 
         # Collect selected asset IDs from budget
@@ -393,7 +418,11 @@ class SmartPipeline:
         # Build clip lists
         clip_map = {c.asset.id: c for c in clips}
         selected = [clip_map[aid] for aid in selected_ids if aid in clip_map]
-        self._available_non_favorites = [c for c in clips if c.asset.id not in selected_ids]
+        selected = _cap_analysis_candidates(selected, self.config.target_clips)
+
+        self._available_non_favorites = [
+            c for c in clips if c.asset.id not in {c.asset.id for c in selected}
+        ]
 
         fav_count = sum(1 for c in selected if c.asset.is_favorite)
         gap_count = len(selected) - fav_count

--- a/src/immich_memories/generate.py
+++ b/src/immich_memories/generate.py
@@ -349,11 +349,14 @@ def _add_photos_if_enabled(
 
     _report(params, "photos", 0.5, "Selecting and rendering photos...")
 
-    if params.target_duration_seconds:
-        video_clips, photo_clips = _apply_unified_budget(assembly_clips, params, run_output_dir)
-    else:
-        video_clips = assembly_clips
-        photo_clips = _render_photos(params, run_output_dir, len(assembly_clips))
+    # WHY: always use unified budget to avoid rendering photos that get discarded
+    effective_duration = params.target_duration_seconds
+    if effective_duration is None:
+        effective_duration = sum(c.duration for c in assembly_clips) * 1.25
+
+    video_clips, photo_clips = _apply_unified_budget(
+        assembly_clips, params, run_output_dir, target_override=effective_duration
+    )
 
     return _merge_by_date(video_clips, photo_clips)
 
@@ -406,6 +409,7 @@ def _apply_unified_budget(
     assembly_clips: list[AssemblyClip],
     params: GenerationParams,
     output_dir: Path,
+    target_override: float | None = None,
 ) -> tuple[list[AssemblyClip], list[AssemblyClip]]:
     """Apply unified budget: score photos, select within budget, render selected.
 
@@ -418,7 +422,8 @@ def _apply_unified_budget(
     )
     from immich_memories.photos.photo_pipeline import render_photo_clips, score_photos
 
-    assert params.target_duration_seconds is not None
+    target = target_override or params.target_duration_seconds
+    assert target is not None
     photo_dir = output_dir / "photos"
     photo_dir.mkdir(exist_ok=True)
 
@@ -469,15 +474,15 @@ def _apply_unified_budget(
     overhead = estimate_title_overhead(
         clip_dates=clip_dates,
         title_settings=title_settings,
-        target_duration=params.target_duration_seconds,
+        target_duration=target,
         memory_type=params.memory_type,
         num_clips=len(assembly_clips),
         transition_duration=transition_dur,
     )
-    content_budget = params.target_duration_seconds - overhead
+    content_budget = target - overhead
 
     logger.info(
-        f"Unified budget: target={params.target_duration_seconds:.0f}s, "
+        f"Unified budget: target={target:.0f}s, "
         f"overhead={overhead:.1f}s, content_budget={content_budget:.1f}s"
     )
 

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -100,6 +100,7 @@ def _build_generation_params(state, selected_clips, output_path):
         clip_rotations=state.clip_rotations,
         include_photos=state.include_photos and bool(state.photo_assets),
         photo_assets=state.photo_assets if state.include_photos else None,
+        target_duration_seconds=state.target_duration * 60,
         # Music and upload handled separately by UI (AI gen, 4-stem ducking, NiceGUI progress)
         music_path=None,
         upload_enabled=False,

--- a/tests/test_pipeline_efficiency.py
+++ b/tests/test_pipeline_efficiency.py
@@ -1,0 +1,198 @@
+"""Tests for pipeline efficiency: density budget tightening + unified photo budget."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+
+class TestDensityBudgetCap:
+    """Phase 2 filtering should cap analysis candidates at 1.5x target_clips."""
+
+    def _make_clip(
+        self, asset_id: str, is_favorite: bool = False, width: int = 1920, height: int = 1080
+    ):
+        from immich_memories.api.models import Asset, VideoClipInfo
+
+        now = datetime.now(tz=UTC)
+        asset = Asset(
+            id=asset_id,
+            type="VIDEO",
+            fileCreatedAt=now,
+            fileModifiedAt=now,
+            updatedAt=now,
+            isFavorite=is_favorite,
+            exifInfo={"make": "Apple", "model": "iPhone"},
+        )
+        return VideoClipInfo(
+            asset=asset,
+            duration_seconds=5.0,
+            width=width,
+            height=height,
+        )
+
+    def test_caps_at_1_5x_target_clips(self):
+        """With 200 clips and target_clips=40, returns at most 60."""
+        from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+
+        config = PipelineConfig(target_clips=40)
+        # WHY: mock services — we're testing _phase_filter logic, not Immich
+        pipeline = SmartPipeline(
+            client=MagicMock(),
+            analysis_cache=MagicMock(),
+            thumbnail_cache=MagicMock(),
+            config=config,
+            analysis_config=MagicMock(min_segment_duration=1.5),
+            app_config=MagicMock(),
+        )
+
+        clips = [self._make_clip(f"clip{i}") for i in range(200)]
+        result = pipeline._phase_filter(clips)
+        assert len(result) <= 60  # 1.5x cap
+
+    def test_favorites_preserved_when_cap_hit(self):
+        """All favorites should survive the cap."""
+        from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+
+        config = PipelineConfig(target_clips=20)
+        pipeline = SmartPipeline(
+            client=MagicMock(),
+            analysis_cache=MagicMock(),
+            thumbnail_cache=MagicMock(),
+            config=config,
+            analysis_config=MagicMock(min_segment_duration=1.5),
+            app_config=MagicMock(),
+        )
+
+        favorites = [self._make_clip(f"fav{i}", is_favorite=True) for i in range(15)]
+        non_favorites = [self._make_clip(f"nonfav{i}") for i in range(100)]
+        clips = favorites + non_favorites
+
+        result = pipeline._phase_filter(clips)
+        fav_ids = {c.asset.id for c in result if c.asset.is_favorite}
+        assert len(fav_ids) == 15  # All favorites kept
+
+    def test_analyze_all_mode_bypasses_cap(self):
+        """analyze_all=True should return all clips, no cap."""
+        from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+
+        config = PipelineConfig(target_clips=20, analyze_all=True)
+        pipeline = SmartPipeline(
+            client=MagicMock(),
+            analysis_cache=MagicMock(),
+            thumbnail_cache=MagicMock(),
+            config=config,
+            analysis_config=MagicMock(min_segment_duration=1.5),
+            app_config=MagicMock(),
+        )
+
+        clips = [self._make_clip(f"clip{i}") for i in range(100)]
+        result = pipeline._phase_filter(clips)
+        assert len(result) == 100
+
+    def test_reduced_multiplier_selects_fewer(self):
+        """With raw_multiplier=1.3, fewer clips selected than with 2.0."""
+        from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+
+        config = PipelineConfig(target_clips=40)
+        pipeline = SmartPipeline(
+            client=MagicMock(),
+            analysis_cache=MagicMock(),
+            thumbnail_cache=MagicMock(),
+            config=config,
+            analysis_config=MagicMock(min_segment_duration=1.5),
+            app_config=MagicMock(),
+        )
+
+        clips = [self._make_clip(f"clip{i}") for i in range(200)]
+        result = pipeline._phase_filter(clips)
+        # With 1.3x multiplier + 1.5x cap, should be well under 200
+        assert len(result) < 100
+
+
+class TestUnifiedPhotoBudget:
+    """Photo rendering should always use unified budget, never legacy render-all."""
+
+    def test_add_photos_without_target_duration_uses_unified(self):
+        """Even without target_duration_seconds, unified budget is used."""
+        from immich_memories.generate import _add_photos_if_enabled
+        from immich_memories.processing.assembly_config import AssemblyClip
+
+        clips = [
+            AssemblyClip(
+                path="/fake/clip.mp4",
+                duration=5.0,
+                asset_id="a1",
+                date="2025-01-15",
+            ),
+        ]
+
+        params = MagicMock()
+        params.include_photos = True
+        params.photo_assets = [MagicMock()]
+        params.target_duration_seconds = None  # Not set (UI path before fix)
+        params.progress_callback = None
+
+        with patch(
+            "immich_memories.generate._apply_unified_budget",
+            return_value=(clips, []),
+        ) as mock_unified:
+            _add_photos_if_enabled(clips, params, MagicMock())
+
+        mock_unified.assert_called_once()
+
+    def test_add_photos_with_target_duration_uses_unified(self):
+        """With target_duration_seconds set, unified budget is used."""
+        from immich_memories.generate import _add_photos_if_enabled
+        from immich_memories.processing.assembly_config import AssemblyClip
+
+        clips = [
+            AssemblyClip(
+                path="/fake/clip.mp4",
+                duration=5.0,
+                asset_id="a1",
+                date="2025-01-15",
+            ),
+        ]
+
+        params = MagicMock()
+        params.include_photos = True
+        params.photo_assets = [MagicMock()]
+        params.target_duration_seconds = 120.0
+        params.progress_callback = None
+
+        with patch(
+            "immich_memories.generate._apply_unified_budget",
+            return_value=(clips, []),
+        ) as mock_unified:
+            _add_photos_if_enabled(clips, params, MagicMock())
+
+        mock_unified.assert_called_once()
+
+    def test_ui_sets_target_duration_seconds(self):
+        """UI _build_generation_params should set target_duration_seconds."""
+        from immich_memories.ui.pages._step4_generate import _build_generation_params
+
+        state = MagicMock()
+        state.target_duration = 5  # 5 minutes
+        state.generation_options = {}
+        state.selected_person = None
+        state.date_range = None
+        state.memory_type = None
+        state.memory_preset_params = {}
+        state.title_suggestion_title = None
+        state.title_suggestion_subtitle = None
+        state.clip_segments = {}
+        state.clip_rotations = {}
+        state.include_photos = False
+        state.photo_assets = None
+        state.photo_duration = 4.0
+        state.demo_mode = False
+        state.immich_url = "http://fake:2283"
+        state.immich_api_key = "fake-key"
+        state.config = MagicMock()
+
+        with patch("immich_memories.api.immich.SyncImmichClient"):
+            params = _build_generation_params(state, [], MagicMock())
+
+        assert params.target_duration_seconds == 300  # 5 min * 60


### PR DESCRIPTION
## Summary

- Density budget `raw_multiplier` reduced from 2.0 to 1.3 — downloads/analyzes ~40% fewer clips
- Hard cap at 1.5x `target_clips` after density budget selection (favorites always preserved)
- Legacy "render ALL photos then discard" path removed — always uses unified budget from PR #108
- UI now sets `target_duration_seconds` in `GenerationParams` (was missing, causing legacy path)

## Test plan

- [x] 7 unit tests covering cap behavior, favorites preservation, analyze-all bypass, unified budget
- [x] `make ci` passes (2083 tests, 0 failures)
- [ ] Manual: generate with large library — verify pipeline log shows capped candidates
- [ ] Manual: UI with photos enabled — verify "Unified budget" in logs (not legacy render-all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)