### PR TITLE
fix(pipeline): density budget divider overhead caused negative budget (#151)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: gpu
     # Only runs on the private mirror — never on the public repo
     if: github.repository == 'sam-dumont/immich-memories-ci'
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Resolve params
         id: params

--- a/src/immich_memories/analysis/density_budget.py
+++ b/src/immich_memories/analysis/density_budget.py
@@ -100,9 +100,11 @@ def compute_density_budget(
         key = _bucket_key(a.date, bucket_mode)
         buckets[key].append(a)
 
-    # Estimate month divider overhead
+    # WHY: dividers are pre-rendered at exact duration — don't multiply by
+    # raw_multiplier (that's for raw footage needing trimming, not titles).
+    # Cap to 30% of budget so divider overhead can't starve content selection.
     divider_overhead = len(buckets) * 2.0
-    raw_budget -= divider_overhead * raw_multiplier
+    raw_budget -= min(divider_overhead, raw_budget * 0.3)
 
     total_assets = len(assets)
 

--- a/tests/test_scoring_calibration.py
+++ b/tests/test_scoring_calibration.py
@@ -459,6 +459,272 @@ class TestScoringVersion:
         assert needs is True
 
 
+class TestDensityBudgetNegativeBudget:
+    """Regression: divider overhead must not cause negative budget (#151)."""
+
+    def test_many_buckets_small_target_still_selects_clips(self):
+        """12 monthly buckets with target_clips=5 should not produce 0 clips.
+
+        WHY: The old code multiplied divider overhead by raw_multiplier,
+        causing 12 * 2.0 * 1.3 = 31.2s to be subtracted from a 26s budget.
+        """
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = []
+        for month in range(1, 13):
+            for i in range(50):
+                entries.append(
+                    AssetEntry(
+                        asset_id=f"m{month}_c{i}",
+                        asset_type="video",
+                        date=datetime(2025, month, 1 + i % 28),
+                        duration=10.0,
+                        is_favorite=(i == 0),
+                        width=1920,
+                        height=1080,
+                        is_camera_original=True,
+                    )
+                )
+
+        # target_clips=5 * avg_clip_duration=5.0 = 25s target
+        buckets = compute_density_budget(entries, target_duration_seconds=25.0, raw_multiplier=1.3)
+        total_selected = sum(len(b.favorite_ids) + len(b.gap_fill_ids) for b in buckets)
+
+        assert total_selected > 0, (
+            f"Budget selected 0 clips from {len(entries)} — "
+            f"divider overhead likely caused negative budget"
+        )
+        # Should select at least the 12 favorites (1 per month)
+        total_favorites = sum(len(b.favorite_ids) for b in buckets)
+        assert total_favorites >= 5, (
+            f"Only {total_favorites} favorites selected — budget too restrictive"
+        )
+
+    def test_budget_never_negative(self):
+        """Bucket quotas should never be negative regardless of bucket count."""
+        from datetime import datetime, timedelta
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        base = datetime(2025, 1, 1)
+        entries = [
+            AssetEntry(
+                asset_id=f"w{w}_c{i}",
+                asset_type="video",
+                date=base + timedelta(weeks=w, days=i),
+                duration=5.0,
+                is_favorite=False,
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for w in range(52)
+            for i in range(3)
+        ]
+
+        buckets = compute_density_budget(
+            entries, target_duration_seconds=30.0, raw_multiplier=1.3, bucket_mode="week"
+        )
+
+        for b in buckets:
+            assert b.quota_seconds >= 0, f"Bucket {b.key} has negative quota {b.quota_seconds:.1f}s"
+
+
+class TestDensityBudgetEdgeCases:
+    """Edge cases and adversarial inputs for density budget."""
+
+    def test_single_bucket_gets_full_budget(self):
+        """All clips in one month with month mode → single bucket gets entire budget."""
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = [
+            AssetEntry(
+                asset_id=f"c{i}",
+                asset_type="video",
+                date=datetime(2025, 6, 1 + i),
+                duration=10.0,
+                is_favorite=False,
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for i in range(20)
+        ]
+        # WHY: force month mode — auto would pick "week" for <180 day span
+        buckets = compute_density_budget(
+            entries,
+            target_duration_seconds=60.0,
+            bucket_mode="month",
+        )
+        assert len(buckets) == 1
+        assert buckets[0].quota_seconds > 0
+
+    def test_very_small_target_still_selects(self):
+        """target=10s with 500 clips should still select something."""
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = [
+            AssetEntry(
+                asset_id=f"c{i}",
+                asset_type="video",
+                date=datetime(2025, (i % 12) + 1, 1 + i % 28),
+                duration=8.0,
+                is_favorite=(i % 50 == 0),
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for i in range(500)
+        ]
+        buckets = compute_density_budget(
+            entries,
+            target_duration_seconds=10.0,
+            raw_multiplier=1.3,
+        )
+        total = sum(len(b.favorite_ids) + len(b.gap_fill_ids) for b in buckets)
+        assert total > 0, "10s target with 500 clips selected nothing"
+
+    def test_all_favorites_always_included(self):
+        """Favorites must be selected even when budget is tight."""
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = [
+            AssetEntry(
+                asset_id=f"fav{i}",
+                asset_type="video",
+                date=datetime(2025, 6, 1 + i),
+                duration=5.0,
+                is_favorite=True,
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for i in range(10)
+        ]
+        buckets = compute_density_budget(
+            entries,
+            target_duration_seconds=15.0,
+            raw_multiplier=1.3,
+        )
+        fav_ids = set()
+        for b in buckets:
+            fav_ids.update(b.favorite_ids)
+        # Should get at least some favorites even with tight budget
+        assert len(fav_ids) > 0, "No favorites selected despite all clips being favorites"
+
+    def test_empty_assets_returns_empty(self):
+        from immich_memories.analysis.density_budget import compute_density_budget
+
+        assert compute_density_budget([], target_duration_seconds=60.0) == []
+
+    def test_dense_month_gets_more_quota(self):
+        """Month with 3x clips should get ~3x the quota of a sparse month."""
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = []
+        # January: 10 clips
+        for i in range(10):
+            entries.append(
+                AssetEntry(
+                    asset_id=f"jan{i}",
+                    asset_type="video",
+                    date=datetime(2025, 1, 1 + i),
+                    duration=10.0,
+                    is_favorite=False,
+                    width=1920,
+                    height=1080,
+                    is_camera_original=True,
+                )
+            )
+        # July: 30 clips (3x density)
+        for i in range(30):
+            entries.append(
+                AssetEntry(
+                    asset_id=f"jul{i}",
+                    asset_type="video",
+                    date=datetime(2025, 7, 1 + i % 28),
+                    duration=10.0,
+                    is_favorite=False,
+                    width=1920,
+                    height=1080,
+                    is_camera_original=True,
+                )
+            )
+
+        buckets = compute_density_budget(entries, target_duration_seconds=120.0)
+        jan = next(b for b in buckets if b.key == "2025-01")
+        jul = next(b for b in buckets if b.key == "2025-07")
+
+        # July has 3x clips → should get ~3x quota
+        assert jul.quota_seconds > jan.quota_seconds * 2, (
+            f"July ({jul.quota_seconds:.1f}s) should get ~3x January ({jan.quota_seconds:.1f}s)"
+        )
+
+    def test_gap_fillers_selected_when_no_favorites(self):
+        """With no favorites, gap-fillers should fill the quota."""
+        from datetime import datetime
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        entries = [
+            AssetEntry(
+                asset_id=f"c{i}",
+                asset_type="video",
+                date=datetime(2025, 6, 1 + i),
+                duration=5.0,
+                is_favorite=False,
+                score=float(i) / 20,
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for i in range(20)
+        ]
+        buckets = compute_density_budget(entries, target_duration_seconds=30.0)
+        gap_ids = set()
+        for b in buckets:
+            gap_ids.update(b.gap_fill_ids)
+        assert len(gap_ids) > 0, "No gap-fillers selected despite no favorites"
+
+    def test_week_mode_creates_weekly_buckets(self):
+        """bucket_mode='week' should create weekly buckets."""
+        from datetime import datetime, timedelta
+
+        from immich_memories.analysis.density_budget import AssetEntry, compute_density_budget
+
+        base = datetime(2025, 6, 1)
+        entries = [
+            AssetEntry(
+                asset_id=f"c{i}",
+                asset_type="video",
+                date=base + timedelta(days=i),
+                duration=5.0,
+                is_favorite=False,
+                width=1920,
+                height=1080,
+                is_camera_original=True,
+            )
+            for i in range(28)  # 4 weeks
+        ]
+        buckets = compute_density_budget(
+            entries,
+            target_duration_seconds=60.0,
+            bucket_mode="week",
+        )
+        assert len(buckets) >= 4, f"Expected 4+ weekly buckets, got {len(buckets)}"
+        assert all("-W" in b.key for b in buckets), "Weekly bucket keys should contain -W"
+
+
 class TestDensityBudgetQualityGate:
     """Non-camera and low-res clips must be filtered BEFORE entering density budget."""
 


### PR DESCRIPTION
## Summary

Fixes #151 — density budget selected 0 clips from 1265 candidates for full-year targets.

### Root cause
Line 105 in `density_budget.py`:
```python
raw_budget -= divider_overhead * raw_multiplier  # BUG
```
Dividers are pre-rendered at exact duration — multiplying by `raw_multiplier` (1.3) caused 12 monthly buckets × 2.0s × 1.3 = 31.2s to be subtracted from a 26s budget, making it negative.

### Fix
- Don't multiply divider overhead by raw_multiplier
- Cap divider overhead to 30% of budget to prevent starvation

### Tests (9 new)
- `test_many_buckets_small_target_still_selects_clips` — the exact regression case
- `test_budget_never_negative` — 52 weekly buckets, no negative quotas
- `test_single_bucket_gets_full_budget` — single month gets everything
- `test_very_small_target_still_selects` — 10s target with 500 clips
- `test_all_favorites_always_included` — favorites survive tight budgets
- `test_empty_assets_returns_empty`
- `test_dense_month_gets_more_quota` — proportional distribution verified
- `test_gap_fillers_selected_when_no_favorites`
- `test_week_mode_creates_weekly_buckets`

### Also
- Bumps Linux integration CI timeout from 45 → 90 minutes

## Test plan
- [x] 2522 tests pass, `make check` green
- [x] Regression test reproduces the exact bug scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)