### PR TITLE
fix(analysis): clear stale LLM display fields between clips

### DIFF
--- a/src/immich_memories/analysis/progress.py
+++ b/src/immich_memories/analysis/progress.py
@@ -197,7 +197,11 @@ class ProgressTracker:
         llm_quality: float | None,
         audio_categories: list[str] | None,
     ) -> None:
-        """Update 'Last Analyzed' display fields if any displayable data is present."""
+        """Update 'Last Analyzed' display fields if any displayable data is present.
+
+        All fields are set unconditionally so that stale data from a previous
+        clip never leaks into the current display (fixes #121).
+        """
         has_display_data = (
             preview_path is not None or llm_description is not None or audio_categories is not None
         )
@@ -206,18 +210,12 @@ class ProgressTracker:
         self.progress.last_completed_asset_id = item_id
         self.progress.last_completed_segment = segment
         self.progress.last_completed_score = score
-        if preview_path is not None:
-            self.progress.last_completed_video_path = preview_path
-        if llm_description is not None:
-            self.progress.last_completed_llm_description = llm_description
-        if llm_emotion is not None:
-            self.progress.last_completed_llm_emotion = llm_emotion
-        if llm_interestingness is not None:
-            self.progress.last_completed_llm_interestingness = llm_interestingness
-        if llm_quality is not None:
-            self.progress.last_completed_llm_quality = llm_quality
-        if audio_categories is not None:
-            self.progress.last_completed_audio_categories = audio_categories
+        self.progress.last_completed_video_path = preview_path
+        self.progress.last_completed_llm_description = llm_description
+        self.progress.last_completed_llm_emotion = llm_emotion
+        self.progress.last_completed_llm_interestingness = llm_interestingness
+        self.progress.last_completed_llm_quality = llm_quality
+        self.progress.last_completed_audio_categories = audio_categories
 
     def complete_item(
         self,

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -580,8 +580,8 @@ class TestProgressTrackerDisplayFields:
         assert tracker.progress.last_completed_score == 0.7
 
     @patch("immich_memories.analysis.progress.time")
-    def test_partial_display_data_only_updates_provided_fields(self, mock_time: object) -> None:
-        """Only preview_path triggers display update; missing LLM fields stay None."""
+    def test_partial_display_data_clears_unprovided_fields(self, mock_time: object) -> None:
+        """When a new clip has display data, unprovided LLM fields reset to None."""
         mock_time.time.return_value = 1.0  # type: ignore[union-attr]
         tracker = ProgressTracker()
         tracker.start_phase(PipelinePhase.ANALYZING, total_items=5)
@@ -592,9 +592,53 @@ class TestProgressTrackerDisplayFields:
         p = tracker.progress
         assert p.last_completed_asset_id == "vid1"
         assert p.last_completed_video_path == "/tmp/p.mp4"
-        # LLM fields not provided → stay None
+        # LLM fields not provided → should be None
         assert p.last_completed_llm_description is None
         assert p.last_completed_llm_emotion is None
+
+    @patch("immich_memories.analysis.progress.time")
+    def test_llm_description_does_not_leak_between_clips(self, mock_time: object) -> None:
+        """Regression test for #121: stale LLM description from clip A must not
+        persist when clip B completes without LLM data."""
+        mock_time.time.return_value = 1.0  # type: ignore[union-attr]
+        tracker = ProgressTracker()
+        tracker.start_phase(PipelinePhase.ANALYZING, total_items=3)
+
+        # Clip A: has full LLM analysis
+        tracker.start_item("clip_a", asset_id="asset-a")
+        mock_time.time.return_value = 2.0  # type: ignore[union-attr]
+        tracker.complete_item(
+            "clip_a",
+            preview_path="/tmp/a.mp4",
+            llm_description="A young child in a snowy yard",
+            llm_emotion="joyful",
+            llm_interestingness=0.9,
+            llm_quality=0.8,
+            audio_categories=["speech"],
+        )
+        assert tracker.progress.last_completed_llm_description == "A young child in a snowy yard"
+
+        # Clip B: no LLM analysis, but has audio categories (triggers display update)
+        mock_time.time.return_value = 3.0  # type: ignore[union-attr]
+        tracker.start_item("clip_b", asset_id="asset-b")
+        mock_time.time.return_value = 4.0  # type: ignore[union-attr]
+        tracker.complete_item(
+            "clip_b",
+            audio_categories=["laughter"],
+        )
+
+        p = tracker.progress
+        # Asset ID must update to clip B
+        assert p.last_completed_asset_id == "clip_b"
+        # LLM fields must NOT leak from clip A — they should be None
+        assert p.last_completed_llm_description is None
+        assert p.last_completed_llm_emotion is None
+        assert p.last_completed_llm_interestingness is None
+        assert p.last_completed_llm_quality is None
+        # Audio categories should reflect clip B
+        assert p.last_completed_audio_categories == ["laughter"]
+        # Preview path should be cleared (clip B has no preview)
+        assert p.last_completed_video_path is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #121 — LLM description from a previous clip leaked into the "Last Analyzed" UI card when the next clip had no LLM analysis
- **Root cause:** `_update_display_fields()` always updated `last_completed_asset_id` but conditionally updated LLM/preview/audio fields (only when non-None), so stale data from a previous clip persisted
- **Fix:** Set all display fields unconditionally — when a new clip becomes "last completed," its fields replace everything (including clearing to None)

## Test plan

- [x] Regression test reproducing the exact scenario (clip A with LLM → clip B without → verify no leak)
- [x] All 62 progress tracker tests pass
- [x] Full CI pipeline passes (2523 tests, all quality gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)