### PR TITLE
fix(test): use GenerationParams.output_resolution instead of non-existent TitleScreenConfig fields

### DIFF
--- a/tests/integration/pipeline/test_full_pipeline.py
+++ b/tests/integration/pipeline/test_full_pipeline.py
@@ -280,11 +280,6 @@ class TestFullPipelineWithTitles:
         config.title_screens.title_duration = 2.0  # Shorter for test speed
         config.title_screens.ending_duration = 2.0
         config.title_screens.month_divider_duration = 1.5
-        # WHY: Force 720p@30fps — 4K PIL title rendering takes 2.5min per
-        # screen on CPU (no Taichi on Linux CI). At 720p@30fps, it's ~5s.
-        config.title_screens.resolution = "720p"
-        config.title_screens.fps = 30.0
-
         output = tmp_path / "full_titles.mp4"
         progress_phases = []
 
@@ -295,6 +290,9 @@ class TestFullPipelineWithTitles:
             client=client,
             transition="smart",  # TransitionType.SMART — mix of cut and crossfade
             transition_duration=0.3,
+            # WHY: Force 720p — 4K PIL title rendering takes 2.5min per
+            # screen on CPU (no Taichi on Linux CI). At 720p, it's ~5s.
+            output_resolution="720p",
             person_name="Test Person",
             date_start=date(2024, 1, 1),
             date_end=date(2025, 12, 31),


### PR DESCRIPTION
## Summary

- Remove `config.title_screens.resolution` and `config.title_screens.fps` assignments that don't exist on the Pydantic `TitleScreenConfig` model
- Use `GenerationParams(output_resolution="720p")` which is the correct API to control output resolution

Fixes the CI failure: `ValueError: "TitleScreenConfig" object has no field "resolution"`

## Note

Title screens still render at source resolution and get downscaled during assembly. Filed #159 to track rendering at target resolution upfront across the full pipeline.

## Test plan

- [x] `pytest tests/integration/pipeline/test_full_pipeline.py::TestFullPipelineWithTitles::test_full_pipeline_with_titles_and_transitions` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)