### PR TITLE
feat(titles): tighter globe zoom for short-distance trips

### DIFF
--- a/src/immich_memories/titles/globe_renderer.py
+++ b/src/immich_memories/titles/globe_renderer.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-# Close-up zoom for start/end of each segment
-_CLOSE_DISTANCE = 2.2
+# Close-up zoom for start/end — city-level tight (#28)
+_CLOSE_DISTANCE = 1.5
 
 
 @dataclass
@@ -110,11 +110,12 @@ def _segment_cruise_altitude(lat0: float, lon0: float, lat1: float, lon1: float)
     """Compute mid-flight camera distance based on segment arc length.
 
     Uses great-circle distance on the unit sphere (radians input).
-    Maps to camera distance:
-        ~100km  (0.016 rad) → 2.5  (barely zoom out)
-        ~800km  (0.125 rad) → 3.5  (moderate pull-back)
-        ~2500km (0.39 rad)  → 5.5  (high altitude, like a plane)
-        ~5000km+            → 7.0  (max pull-back)
+    Power-curve scaling keeps short trips tight while long trips still
+    pull back dramatically (#28):
+        ~120km  (0.019 rad) → ~1.8  (barely zoom out)
+        ~800km  (0.125 rad) → ~2.7  (moderate pull-back)
+        ~2800km (0.44 rad)  → ~4.2  (high altitude)
+        ~9500km (1.49 rad)  → ~6.5  (near max pull-back)
     """
     # Great-circle distance on unit sphere (haversine formula, radians)
     dlat = lat1 - lat0
@@ -122,6 +123,6 @@ def _segment_cruise_altitude(lat0: float, lon0: float, lat1: float, lon1: float)
     a = math.sin(dlat / 2) ** 2 + math.cos(lat0) * math.cos(lat1) * math.sin(dlon / 2) ** 2
     arc = 2 * math.asin(min(1.0, math.sqrt(a)))
 
-    # arc is in radians; π = half the globe (~20,000km)
-    # Map: 0 → _CLOSE_DISTANCE, π → 7.0
-    return min(7.0, _CLOSE_DISTANCE + arc * 3.0)
+    # Power curve: short arcs barely zoom out, long arcs pull back hard.
+    # arc**0.7 compresses small values → tighter short trips.
+    return min(7.0, _CLOSE_DISTANCE + (arc**0.7) * 5.0)

--- a/tests/test_globe_renderer.py
+++ b/tests/test_globe_renderer.py
@@ -100,6 +100,17 @@ class TestCameraKeyframes:
         distances = [kf.distance for kf in keyframes]
         assert all(d == distances[0] for d in distances)
 
+    def test_close_distance_is_city_level(self):
+        """Close zoom should be tight enough for city-level view (<2.0)."""
+        from immich_memories.titles.globe_renderer import generate_camera_keyframes
+
+        keyframes = generate_camera_keyframes(
+            home_lat=50.85,
+            home_lon=4.35,
+            destinations=[(51.22, 2.92)],
+        )
+        assert keyframes[0].distance < 2.0
+
     def test_multi_destination_produces_n_plus_1_keyframes(self):
         """Home → dest1 → dest2 → dest3 = 4 keyframes."""
         from immich_memories.titles.globe_renderer import generate_camera_keyframes
@@ -117,41 +128,44 @@ class TestCameraInterpolation:
 
     def test_interpolate_at_start_returns_first_keyframe(self):
         from immich_memories.titles.globe_renderer import (
+            _CLOSE_DISTANCE,
             GlobeCameraKeyframe,
             interpolate_camera,
         )
 
         kfs = [
-            GlobeCameraKeyframe(lat=0.5, lon=0.1, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=0.8, lon=0.3, distance=2.2, time=1.0),
+            GlobeCameraKeyframe(lat=0.5, lon=0.1, distance=_CLOSE_DISTANCE, time=0.0),
+            GlobeCameraKeyframe(lat=0.8, lon=0.3, distance=_CLOSE_DISTANCE, time=1.0),
         ]
         lat, lon, dist = interpolate_camera(kfs, 0.0)
         assert abs(lat - 0.5) < 0.01
-        assert abs(dist - 2.2) < 0.01
+        assert abs(dist - _CLOSE_DISTANCE) < 0.01
 
     def test_interpolate_at_end_returns_last_keyframe(self):
         from immich_memories.titles.globe_renderer import (
+            _CLOSE_DISTANCE,
             GlobeCameraKeyframe,
             interpolate_camera,
         )
 
         kfs = [
-            GlobeCameraKeyframe(lat=0.5, lon=0.1, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=0.8, lon=0.3, distance=2.2, time=1.0),
+            GlobeCameraKeyframe(lat=0.5, lon=0.1, distance=_CLOSE_DISTANCE, time=0.0),
+            GlobeCameraKeyframe(lat=0.8, lon=0.3, distance=_CLOSE_DISTANCE, time=1.0),
         ]
         lat, lon, dist = interpolate_camera(kfs, 1.0)
         assert abs(lat - 0.8) < 0.01
-        assert abs(dist - 2.2) < 0.01
+        assert abs(dist - _CLOSE_DISTANCE) < 0.01
 
     def test_interpolate_midpoint_is_between_keyframes(self):
         from immich_memories.titles.globe_renderer import (
+            _CLOSE_DISTANCE,
             GlobeCameraKeyframe,
             interpolate_camera,
         )
 
         kfs = [
-            GlobeCameraKeyframe(lat=0.0, lon=0.0, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=1.0, lon=1.0, distance=2.2, time=1.0),
+            GlobeCameraKeyframe(lat=0.0, lon=0.0, distance=_CLOSE_DISTANCE, time=0.0),
+            GlobeCameraKeyframe(lat=1.0, lon=1.0, distance=_CLOSE_DISTANCE, time=1.0),
         ]
         lat, lon, dist = interpolate_camera(kfs, 0.5)
         # Cosine easing at t=0.5 gives exactly the midpoint
@@ -161,45 +175,72 @@ class TestCameraInterpolation:
     def test_endpoints_return_close_distance(self):
         """Both t=0 and t=1 should be at the keyframe's close distance."""
         from immich_memories.titles.globe_renderer import (
+            _CLOSE_DISTANCE,
             GlobeCameraKeyframe,
             interpolate_camera,
         )
 
         kfs = [
-            GlobeCameraKeyframe(lat=0.887, lon=0.076, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=0.607, lon=0.576, distance=2.2, time=1.0),
+            GlobeCameraKeyframe(lat=0.887, lon=0.076, distance=_CLOSE_DISTANCE, time=0.0),
+            GlobeCameraKeyframe(lat=0.607, lon=0.576, distance=_CLOSE_DISTANCE, time=1.0),
         ]
         _, _, dist_start = interpolate_camera(kfs, 0.0)
         _, _, dist_end = interpolate_camera(kfs, 1.0)
-        assert abs(dist_start - 2.2) < 0.01
-        assert abs(dist_end - 2.2) < 0.01
+        assert abs(dist_start - _CLOSE_DISTANCE) < 0.01
+        assert abs(dist_end - _CLOSE_DISTANCE) < 0.01
 
     def test_midpoint_pulls_back_proportional_to_distance(self):
         """Mid-flight should zoom out, more for longer distances."""
         from immich_memories.titles.globe_renderer import (
-            GlobeCameraKeyframe,
+            generate_camera_keyframes,
             interpolate_camera,
         )
 
-        # Short hop: Brussels (0.887, 0.076) → Amsterdam (0.912, 0.085) ~170km
-        kfs_short = [
-            GlobeCameraKeyframe(lat=0.887, lon=0.076, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=0.912, lon=0.085, distance=2.2, time=1.0),
-        ]
+        # Short hop: Brussels → Ostend ~120km
+        kfs_short = generate_camera_keyframes(50.85, 4.35, [(51.22, 2.92)])
+        close = kfs_short[0].distance
         _, _, dist_short = interpolate_camera(kfs_short, 0.5)
 
-        # Long hop: Brussels (0.887, 0.076) → Cyprus (0.607, 0.576) ~2800km
-        kfs_long = [
-            GlobeCameraKeyframe(lat=0.887, lon=0.076, distance=2.2, time=0.0),
-            GlobeCameraKeyframe(lat=0.607, lon=0.576, distance=2.2, time=1.0),
-        ]
+        # Long hop: Brussels → Cyprus ~2800km
+        kfs_long = generate_camera_keyframes(50.85, 4.35, [(34.71, 33.02)])
         _, _, dist_long = interpolate_camera(kfs_long, 0.5)
 
         # Both should pull back beyond the close distance
-        assert dist_short > 2.2
-        assert dist_long > 2.2
+        assert dist_short > close
+        assert dist_long > close
         # Long hop should pull back significantly more
         assert dist_long > dist_short + 0.5
+
+    def test_short_trip_barely_pulls_back(self):
+        """Short trip (<200km) should barely zoom out at midpoint (#28)."""
+        from immich_memories.titles.globe_renderer import (
+            generate_camera_keyframes,
+            interpolate_camera,
+        )
+
+        # Brussels → Ostend ~120km
+        kfs = generate_camera_keyframes(50.85, 4.35, [(51.22, 2.92)])
+        close = kfs[0].distance
+        _, _, dist_mid = interpolate_camera(kfs, 0.5)
+
+        # Pull-back should be minimal for a short trip
+        pullback = dist_mid - close
+        assert pullback < 0.3
+
+    def test_long_trip_still_has_strong_pullback(self):
+        """Long trip should still pull back substantially (#28)."""
+        from immich_memories.titles.globe_renderer import (
+            generate_camera_keyframes,
+            interpolate_camera,
+        )
+
+        # Brussels → Tokyo ~9500km
+        kfs = generate_camera_keyframes(50.85, 4.35, [(35.68, 139.69)])
+        close = kfs[0].distance
+        _, _, dist_mid = interpolate_camera(kfs, 0.5)
+
+        # Should pull back at least 3.0 units above close
+        assert dist_mid - close > 3.0
 
 
 class TestGlobeVideo:


### PR DESCRIPTION
## Summary

- Closes #28 — Globe fly-over intro zoomed out too far for short-distance trips (e.g., Brussels → Ostend, ~120km)
- Lowered `_CLOSE_DISTANCE` from 2.2 → 1.5 for city-level start/end zoom
- Switched cruise altitude from linear (`arc * 3.0`) to power-curve (`arc^0.7 * 5.0`) so short trips barely pull back while long trips still get dramatic fly-overs

**Before / After:**

| Trip | Before (close=2.2) | After (close=1.5) |
|------|------|------|
| 120km (Brussels→Ostend) | mid=2.25, pullback=0.05 | mid=1.79, pullback=0.29 |
| 2800km (Brussels→Cyprus) | mid=3.57, pullback=1.37 | mid=4.39, pullback=2.89 |
| 9500km (Brussels→Tokyo) | mid=6.65, pullback=4.45 | mid=7.00, pullback=5.50 |

## Test plan

- [x] New test: `test_close_distance_is_city_level` — close distance < 2.0
- [x] New test: `test_short_trip_barely_pulls_back` — short trip pullback < 0.3
- [x] New test: `test_long_trip_still_has_strong_pullback` — long trip pullback > 3.0
- [x] Updated existing tests to use `_CLOSE_DISTANCE` instead of hardcoded 2.2
- [x] All 17 globe tests pass (including Taichi GPU kernel tests)
- [x] Full CI pipeline passes (2525 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)