### PR TITLE
fix(titles): remove ghost text + mood-based styling for location cards

### DIFF
--- a/src/immich_memories/titles/generator.py
+++ b/src/immich_memories/titles/generator.py
@@ -13,6 +13,8 @@ from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     pass
 
@@ -457,8 +459,53 @@ class TitleScreenGenerator:
         self,
         location_name: str,
     ) -> GeneratedScreen:
-        """Generate a location interstitial card (delegates to TripService)."""
-        return self._trip.generate_location_card_screen(location_name)
+        """Generate a location interstitial card with mood-based styling.
+
+        Uses the same title pipeline as month dividers for visual
+        consistency. The background comes from TripService (dark gradient
+        or satellite map), text is rendered by the title video pipeline.
+        """
+        from .map_renderer import render_location_card
+
+        width, height = self.config.output_resolution
+        card_img = render_location_card(location_name, width, height)
+        bg_array = np.array(card_img, dtype=np.float32) / 255.0
+
+        divider_style = TitleStyle(
+            name=f"{self.style.name}_location",
+            font_family=self.style.font_family,
+            font_weight="medium",
+            title_size_ratio=0.10,
+            text_color=self.style.text_color,
+            background_type=self.style.background_type,
+            background_colors=self.style.background_colors,
+            animation_preset="slow_fade",
+            use_line_accent=False,
+        )
+
+        safe_name = location_name.replace(" ", "_").replace(",", "")[:30]
+        output_path = self.output_dir / f"location_{safe_name}.mp4"
+
+        self._rendering.create_title_video(
+            title=location_name,
+            subtitle=None,
+            style=divider_style,
+            output_path=output_path,
+            width=width,
+            height=height,
+            duration=self.config.month_divider_duration,
+            fps=self.config.fps,
+            animated_background=self.config.animated_background,
+            fade_from_white=True,
+            background_image=bg_array,
+        )
+
+        logger.info(f"Location card generated: {location_name}")
+        return GeneratedScreen(
+            path=output_path,
+            duration=self.config.month_divider_duration,
+            screen_type="location_card",
+        )
 
     def generate_all_screens(
         self,

--- a/src/immich_memories/titles/map_renderer.py
+++ b/src/immich_memories/titles/map_renderer.py
@@ -86,10 +86,13 @@ def render_location_card(
     lon: float | None = None,
     map_style: str = DEFAULT_MAP_STYLE,
 ) -> Image.Image:
-    """Render a location interstitial card with map background.
+    """Render a location card background (no text).
 
-    If lat/lon provided, renders a zoomed satellite map behind the name.
+    If lat/lon provided, renders a zoomed satellite map.
     Otherwise falls back to dark gradient.
+
+    Text is rendered by the title video pipeline, not baked into the
+    background — baking text caused a ghost echo (#83).
     """
     if lat is not None and lon is not None:
         img, _sm = _render_base_map([(lat, lon)], width, height, map_style)
@@ -100,17 +103,6 @@ def render_location_card(
     else:
         img = Image.new("RGB", (width, height), color=(30, 30, 35))
 
-    draw = ImageDraw.Draw(img)
-    font_size = int(height * 0.10)
-    font = _get_font(font_size, bold=True)
-
-    bbox = draw.textbbox((0, 0), location_name, font=font)
-    text_w = bbox[2] - bbox[0]
-    text_h = bbox[3] - bbox[1]
-    x = (width - text_w) // 2
-    y = (height - text_h) // 2
-
-    draw.text((x, y), location_name, fill=_TEXT_COLOR, font=font)
     return img
 
 

--- a/src/immich_memories/titles/trip_service.py
+++ b/src/immich_memories/titles/trip_service.py
@@ -12,8 +12,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 if TYPE_CHECKING:
     from .generator import GeneratedScreen, TitleScreenConfig
     from .rendering_service import RenderingService
@@ -123,37 +121,4 @@ class TripService:
             path=output_path,
             duration=self.config.title_duration,
             screen_type="trip_map",
-        )
-
-    def generate_location_card_screen(
-        self,
-        location_name: str,
-    ) -> GeneratedScreen:
-        """Generate a location interstitial card."""
-        from .generator import GeneratedScreen
-        from .map_renderer import render_location_card
-
-        width, height = self.config.output_resolution
-        card_img = render_location_card(location_name, width, height)
-        card_array = np.array(card_img, dtype=np.float32) / 255.0
-
-        safe_name = location_name.replace(" ", "_").replace(",", "")[:30]
-        output_path = self.output_dir / f"location_{safe_name}.mp4"
-
-        self._rendering.create_map_video(
-            title=location_name,
-            subtitle=None,
-            background_array=card_array,
-            output_path=output_path,
-            width=width,
-            height=height,
-            duration=self.config.month_divider_duration,
-            fps=self.config.fps,
-        )
-
-        logger.info(f"Location card generated: {location_name}")
-        return GeneratedScreen(
-            path=output_path,
-            duration=self.config.month_divider_duration,
-            screen_type="location_card",
         )

--- a/tests/test_trip_maps.py
+++ b/tests/test_trip_maps.py
@@ -243,6 +243,30 @@ class TestLocationCardWithMap:
         assert result.size == (1920, 1080)
 
 
+class TestLocationCardNoGhostText:
+    """Location cards must not bake text into the background (#83)."""
+
+    def test_location_card_background_has_no_text(self):
+        """render_location_card should produce a background without baked text.
+
+        Text rendering is handled by the title video pipeline, not the
+        background image. Baking text into the background creates a ghost
+        echo when the video renderer adds text on top.
+        """
+        from immich_memories.titles.map_renderer import render_location_card
+
+        # Dark fallback card — center region should be uniform dark
+        result = render_location_card("Charente-Maritime, France", width=1920, height=1080)
+        assert result.size == (1920, 1080)
+
+        # Sample center pixels — should be uniform background, no text
+        pixels = [result.getpixel((x, 540)) for x in range(860, 1060, 10)]
+        # All center pixels should be identical (no text = uniform color)
+        assert len(set(pixels)) == 1, (
+            f"Center pixels vary — text is baked into the background: {set(pixels)}"
+        )
+
+
 class TestEquirectangularMap:
     """Equirectangular map fetching for globe projection texture."""
 


### PR DESCRIPTION
## Summary

- Closes #83 — Location card interstitials had ghost text echo and plain styling
- **Ghost text fix:** `render_location_card()` no longer bakes text into the background image. Text was being rendered twice: once faintly in the dimmed background (55% opacity) and once sharply on top by the video renderer.
- **Consistent styling:** Location cards now route through `create_title_video()` with a divider-style that inherits mood-based colors/fonts from the video's style — same as month dividers. No more hardcoded plain dark gradient.
- Removed unused `TripService.generate_location_card_screen()` — logic moved to `TitleScreenGenerator` where it has access to `self.style`

## Test plan

- [x] New test: `test_location_card_background_has_no_text` — center pixels are uniform (no baked text)
- [x] All 28 trip map tests pass
- [x] Full CI passes (2523 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)