### PR TITLE
ci(perf): benchmark persistence across CI runs with manual submission

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,198 @@
+# Benchmark persistence — track performance across CI runs and local machines
+#
+# Uses github-action-benchmark with actions/cache for historical comparison.
+# Each runner (linux-ci, mac-local, synology, gpu-arc) gets its own cache
+# namespace so results are compared against the same hardware.
+#
+# Flow:
+#   CI (Linux):  push/PR → run benchmarks → compare against cache → PR comment
+#   Local (Mac/Synology/etc.): `make benchmark-json && make benchmark-submit`
+#       → workflow_dispatch → ingest results into runner-specific cache
+#
+# The benchmark-submit target dispatches results via GitHub API — no CI runner
+# needed for Mac/Synology. Results land in separate cache namespaces.
+
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/immich_memories/processing/**"
+      - "src/immich_memories/titles/**"
+      - "tests/integration/assembly/test_perf_*.py"
+      - "tests/integration/titles/test_perf_*.py"
+      - "tests/integration/assembly/perf_utils.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/immich_memories/processing/**"
+      - "src/immich_memories/titles/**"
+      - "tests/integration/assembly/test_perf_*.py"
+      - "tests/integration/titles/test_perf_*.py"
+      - "tests/integration/assembly/perf_utils.py"
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner name (e.g. mac-m4, synology-ds923, gpu-arc)"
+        required: true
+      suite:
+        description: "Benchmark suite"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - assembly
+          - titles
+      sha:
+        description: "Git SHA of the benchmarked commit"
+        required: false
+        default: ""
+      results:
+        description: "JSON benchmark results (from make benchmark-submit)"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: benchmark-${{ github.event.inputs.runner || 'linux-ci' }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.13"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # ── CI benchmarks (Linux only) ─────────────────────────────────────────────
+  bench-linux:
+    name: Benchmark (Linux CI)
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Create LFS cache key
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Cache LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: lfs-
+      - name: Pull LFS files
+        run: git lfs pull
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          prune-cache: false
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Install FFmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - run: make dev-test
+
+      - name: Run assembly benchmarks
+        run: make benchmark-assembly
+        continue-on-error: true
+
+      - name: Run title benchmarks
+        run: make benchmark-titles-json
+        continue-on-error: true
+
+      - name: Merge benchmark JSON files
+        run: |
+          python3 -c "
+          import json, glob, sys
+          merged = []
+          for f in sorted(glob.glob('tests/benchmark-*.json')):
+              try:
+                  merged.extend(json.loads(open(f).read()))
+              except Exception as e:
+                  print(f'WARN: skipping {f}: {e}', file=sys.stderr)
+          if not merged:
+              print('No benchmark results found', file=sys.stderr)
+              sys.exit(1)
+          out = 'tests/benchmark-results.json'
+          open(out, 'w').write(json.dumps(merged, indent=2))
+          print(f'Merged {len(merged)} entries to {out}')
+          "
+
+      # WHY: restore BEFORE benchmark-action so it has historical data to compare against
+      - name: Restore benchmark cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./cache
+          key: benchmark-linux-ci-main-
+          restore-keys: |
+            benchmark-linux-ci-main-
+
+      - name: Compare against baseline
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: tests/benchmark-results.json
+          external-data-json-path: ./cache/benchmark-data.json
+          alert-threshold: "150%"
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          comment-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save benchmark cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ./cache
+          key: benchmark-linux-ci-main-${{ github.run_id }}
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: benchmark-linux-ci
+          path: tests/benchmark-*.json
+          retention-days: 90
+
+  # ── Ingest results from local runners (Mac, Synology, GPU, etc.) ───────────
+  ingest:
+    name: Ingest (${{ github.event.inputs.runner }})
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Write results to file
+        run: |
+          cat <<'RESULTS_EOF' > tests/benchmark-results.json
+          ${{ github.event.inputs.results }}
+          RESULTS_EOF
+          echo "Ingesting ${{ github.event.inputs.suite }} results from ${{ github.event.inputs.runner }}"
+          echo "SHA: ${{ github.event.inputs.sha || 'not specified' }}"
+          python3 -c "import json; d=json.load(open('tests/benchmark-results.json')); print(f'{len(d)} benchmark entries')"
+
+      - name: Restore benchmark cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./cache
+          key: benchmark-${{ github.event.inputs.runner }}-main-
+          restore-keys: |
+            benchmark-${{ github.event.inputs.runner }}-main-
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: tests/benchmark-results.json
+          external-data-json-path: ./cache/benchmark-data.json
+          alert-threshold: "150%"
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save benchmark cache
+        uses: actions/cache/save@v4
+        with:
+          path: ./cache
+          key: benchmark-${{ github.event.inputs.runner }}-main-${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ config.yaml
 coverage.xml
 tests/integration-coverage.xml
 tests/*-junit.xml
+tests/benchmark-*.json
 tests/integration-junit.xml
 develop-eggs/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-titles test-fast mutation benchmark benchmark-perf lint format typecheck check clean clean-cache clean-all build build-check docker docker-run file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
+.PHONY: help install dev dev-ci dev-test run preflight test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-titles test-fast mutation benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check clean clean-cache clean-all build build-check docker docker-run file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
 
 # Default target
 help:
@@ -19,8 +19,12 @@ help:
 	@echo "  test         Run all tests"
 	@echo "  test-cov     Run tests with coverage report"
 	@echo "  test-fast    Run tests without slow integration tests"
-	@echo "  benchmark    Run performance benchmarks"
-	@echo "  benchmark-perf Run assembly performance benchmarks (requires FFmpeg)"
+	@echo "  benchmark         Run pytest-benchmark suite"
+	@echo "  benchmark-perf    Run assembly performance benchmarks (requires FFmpeg)"
+	@echo "  benchmark-assembly  Assembly benchmarks → tests/benchmark-assembly.json"
+	@echo "  benchmark-titles    Title benchmarks → tests/benchmark-titles.json"
+	@echo "  benchmark-json    Run all benchmarks, produce JSON for CI"
+	@echo "  benchmark-submit  Submit local benchmark results to GitHub"
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  lint         Run ruff linter"
@@ -126,6 +130,38 @@ benchmark-titles:  ## Title rendering drill-down: content-backed vs gradient (re
 benchmark-pipeline:  ## Full pipeline benchmark with Immich (requires FFmpeg + Immich)
 	uv run pytest tests/integration/pipeline/test_perf_pipeline.py -v -m integration \
 		--log-cli-level=INFO --tb=short
+
+benchmark-assembly:  ## Assembly benchmarks → tests/benchmark-assembly.json
+	uv run pytest tests/integration/assembly/test_perf_assembly.py -v -m integration \
+		--log-cli-level=INFO --tb=short
+
+benchmark-titles-json:  ## Title benchmarks → tests/benchmark-titles.json
+	uv run pytest tests/integration/titles/test_perf_titles.py -v -m integration \
+		--log-cli-level=INFO --tb=short
+
+benchmark-json: benchmark-assembly benchmark-titles-json  ## Run all benchmarks, produce JSON for CI
+	@echo ""
+	@echo "Benchmark JSON files:"
+	@ls -la tests/benchmark-*.json 2>/dev/null || echo "  (none found — benchmarks may have been skipped)"
+
+benchmark-submit:  ## Submit local benchmark results to GitHub (for non-CI runners)
+	@RUNNER_NAME=$${BENCHMARK_RUNNER:-$$(hostname)}; \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	SHA=$$(git rev-parse --short HEAD); \
+	echo "Submitting benchmarks from $$RUNNER_NAME ($$BRANCH@$$SHA)..."; \
+	for f in tests/benchmark-*.json; do \
+		[ -f "$$f" ] || continue; \
+		SUITE=$$(basename "$$f" .json | sed 's/benchmark-//'); \
+		echo "  Uploading $$SUITE results..."; \
+		gh api repos/:owner/:repo/actions/workflows/benchmark.yml/dispatches \
+			-f ref=main \
+			-f "inputs[runner]=$$RUNNER_NAME" \
+			-f "inputs[suite]=$$SUITE" \
+			-f "inputs[sha]=$$SHA" \
+			-f "inputs[results]=$$(cat $$f)" \
+		&& echo "    ✓ $$SUITE submitted" \
+		|| echo "    ✗ $$SUITE failed (is GH_TOKEN set?)"; \
+	done
 
 test-integration-live-photos:  ## Run ONLY live photo merge tests (~30s, needs Immich)
 	uv run pytest tests/integration/live_photos/ -v -s -m integration --log-cli-level=INFO --tb=short \

--- a/tests/integration/assembly/perf_utils.py
+++ b/tests/integration/assembly/perf_utils.py
@@ -113,3 +113,22 @@ def load_results(path: Path) -> list[PerfResult]:
         return []
     data = json.loads(path.read_text())
     return [PerfResult(**r) for r in data.get("results", [])]
+
+
+def save_benchmark_json(results: list[PerfResult], output_path: Path) -> None:
+    """Export results in github-action-benchmark's customSmallerIsBetter format.
+
+    Produces a JSON list where each entry has name, unit, value.
+    Wall time is the primary metric; peak memory (child RSS) is included
+    as a secondary metric with a `:peak-memory` suffix.
+    """
+    entries: list[dict[str, str | float]] = []
+    for r in results:
+        entries.append({"name": r.scenario, "unit": "seconds", "value": round(r.wall_seconds, 2)})
+        # WHY: child_peak_rss_mb captures FFmpeg subprocess memory, which is
+        # the dominant allocation — more useful than Python heap for regression tracking.
+        peak_mb = r.child_peak_rss_mb if r.child_peak_rss_mb > 0 else r.python_peak_mb
+        entries.append(
+            {"name": f"{r.scenario}:peak-memory", "unit": "MB", "value": round(peak_mb, 1)}
+        )
+    output_path.write_text(json.dumps(entries, indent=2) + "\n")

--- a/tests/integration/assembly/test_perf_assembly.py
+++ b/tests/integration/assembly/test_perf_assembly.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import pytest
 
 from tests.integration.assembly.conftest import make_n_clips
-from tests.integration.assembly.perf_utils import PerfResult, measure_resources, save_results
+from tests.integration.assembly.perf_utils import (
+    PerfResult,
+    measure_resources,
+    save_benchmark_json,
+    save_results,
+)
 from tests.integration.conftest import (
     ffprobe_json,
     get_duration,
@@ -141,3 +146,8 @@ def test_save_results(tmp_path):
     output = project_root / "tests" / "perf-results.json"
     save_results(_module_results, output)
     logger.info(f"Results saved to {output}")
+
+    # Save benchmark JSON for github-action-benchmark
+    bench_output = project_root / "tests" / "benchmark-assembly.json"
+    save_benchmark_json(_module_results, bench_output)
+    logger.info(f"Benchmark JSON saved to {bench_output}")

--- a/tests/integration/titles/test_perf_titles.py
+++ b/tests/integration/titles/test_perf_titles.py
@@ -1,0 +1,129 @@
+"""Performance benchmarks for title screen rendering.
+
+Measures wall time and memory for different title screen types.
+Run with: make benchmark-titles
+
+Results saved to tests/benchmark-titles.json in customSmallerIsBetter format.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from tests.integration.assembly.perf_utils import PerfResult, measure_resources, save_benchmark_json
+from tests.integration.conftest import requires_ffmpeg
+
+logger = logging.getLogger("test.perf.titles")
+
+pytestmark = [pytest.mark.integration, requires_ffmpeg, pytest.mark.perf]
+
+_module_results: list[PerfResult] = []
+
+
+class TestTitleScreenPerf:
+    """Benchmark title screen generation via convenience API."""
+
+    def test_gradient_720p(self, tmp_path: Path) -> None:
+        from immich_memories.titles.convenience import generate_title_screen
+        from immich_memories.titles.styles import TitleStyle
+
+        style = TitleStyle(
+            name="bench-gradient",
+            background_type="soft_gradient",
+            background_colors=["#1a1a2e", "#16213e"],
+        )
+        output = tmp_path / "gradient_720p.mp4"
+
+        with measure_resources("title-gradient-720p") as result:
+            generate_title_screen(
+                title="2024",
+                subtitle="Family Memories",
+                style=style,
+                output_path=output,
+                resolution="720p",
+                duration=3.5,
+                fps=30.0,
+                animated_background=True,
+            )
+
+        assert output.exists()
+        result.output_size_mb = output.stat().st_size / (1024 * 1024)
+        logger.info(result.summary_line)
+        _module_results.append(result)
+
+    def test_content_backed_720p(self, tmp_path: Path) -> None:
+        from immich_memories.titles.convenience import generate_title_screen
+        from immich_memories.titles.styles import TitleStyle
+
+        style = TitleStyle(
+            name="bench-content-backed",
+            background_type="content_backed",
+            background_colors=["#0a0a0a", "#1a1a1a"],
+        )
+        output = tmp_path / "content_backed_720p.mp4"
+
+        with measure_resources("title-content-backed-720p") as result:
+            generate_title_screen(
+                title="Summer Trip",
+                subtitle="July 2024",
+                style=style,
+                output_path=output,
+                resolution="720p",
+                duration=3.5,
+                fps=30.0,
+                animated_background=True,
+            )
+
+        assert output.exists()
+        result.output_size_mb = output.stat().st_size / (1024 * 1024)
+        logger.info(result.summary_line)
+        _module_results.append(result)
+
+
+class TestEndingScreenPerf:
+    """Benchmark ending screen generation."""
+
+    def test_ending_720p(self, tmp_path: Path) -> None:
+        from immich_memories.titles.convenience import generate_ending_screen
+        from immich_memories.titles.styles import TitleStyle
+
+        style = TitleStyle(
+            name="bench-ending",
+            background_colors=["#1a1a2e", "#16213e"],
+        )
+        output = tmp_path / "ending_720p.mp4"
+
+        with measure_resources("title-ending-720p") as result:
+            generate_ending_screen(
+                style=style,
+                output_path=output,
+                resolution="720p",
+                duration=4.0,
+                fps=30.0,
+            )
+
+        assert output.exists()
+        result.output_size_mb = output.stat().st_size / (1024 * 1024)
+        logger.info(result.summary_line)
+        _module_results.append(result)
+
+
+def test_save_title_benchmarks() -> None:
+    """Save collected title benchmark results."""
+    if not _module_results:
+        pytest.skip("No title perf results collected")
+
+    logger.info("=" * 60)
+    logger.info("TITLE PERFORMANCE SUMMARY")
+    logger.info("=" * 60)
+    for r in _module_results:
+        logger.info(r.summary_line)
+    logger.info("=" * 60)
+
+    project_root = Path(__file__).resolve().parents[3]
+    output = project_root / "tests" / "benchmark-titles.json"
+    save_benchmark_json(_module_results, output)
+    logger.info(f"Benchmark JSON saved to {output}")

--- a/tests/test_perf_utils.py
+++ b/tests/test_perf_utils.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from tests.integration.assembly.perf_utils import PerfResult, measure_resources
+import json
+from pathlib import Path
+
+from tests.integration.assembly.perf_utils import (
+    PerfResult,
+    measure_resources,
+    save_benchmark_json,
+)
 
 
 class TestMeasureResources:
@@ -39,3 +46,93 @@ class TestMeasureResources:
         assert "python_peak_mb=100" in line
         assert "child_peak_rss_mb=500" in line
         assert "wall_s=5.2" in line
+
+
+class TestBenchmarkJsonExport:
+    """Tests for customSmallerIsBetter JSON export used by github-action-benchmark."""
+
+    def _sample_results(self) -> list[PerfResult]:
+        return [
+            PerfResult(
+                scenario="assembly-720p-2clips",
+                python_peak_mb=50.0,
+                wall_seconds=4.8,
+                cpu_user_seconds=3.0,
+                cpu_sys_seconds=1.0,
+                child_peak_rss_mb=200.0,
+                clip_count=2,
+                resolution="720p",
+            ),
+            PerfResult(
+                scenario="assembly-1080p-5clips",
+                python_peak_mb=120.0,
+                wall_seconds=12.5,
+                cpu_user_seconds=8.0,
+                cpu_sys_seconds=2.0,
+                child_peak_rss_mb=400.0,
+                clip_count=5,
+                resolution="1080p",
+            ),
+        ]
+
+    def test_produces_valid_json_list(self, tmp_path: Path) -> None:
+        """Output must be a JSON list of benchmark entries."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json(self._sample_results(), output)
+
+        data = json.loads(output.read_text())
+        assert isinstance(data, list)
+        # 2 results × 2 metrics (wall time + peak memory) = 4 entries
+        assert len(data) == 4
+
+    def test_entries_have_required_fields(self, tmp_path: Path) -> None:
+        """Each entry must have name, unit, value per customSmallerIsBetter spec."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json(self._sample_results(), output)
+
+        data = json.loads(output.read_text())
+        for entry in data:
+            assert "name" in entry
+            assert "unit" in entry
+            assert "value" in entry
+            assert isinstance(entry["value"], (int, float))
+
+    def test_wall_time_entries(self, tmp_path: Path) -> None:
+        """Wall time entries should use scenario name and seconds unit."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json(self._sample_results(), output)
+
+        data = json.loads(output.read_text())
+        wall_entries = [e for e in data if e["unit"] == "seconds"]
+        assert len(wall_entries) == 2
+        assert wall_entries[0]["name"] == "assembly-720p-2clips"
+        assert wall_entries[0]["value"] == 4.8
+
+    def test_empty_results_produces_empty_list(self, tmp_path: Path) -> None:
+        """Empty input should produce an empty JSON list."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json([], output)
+
+        data = json.loads(output.read_text())
+        assert data == []
+
+    def test_extra_metrics_included(self, tmp_path: Path) -> None:
+        """Peak memory should be included as a separate metric."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json(self._sample_results()[:1], output)
+
+        data = json.loads(output.read_text())
+        names = {e["name"] for e in data}
+        # Wall time + memory metric
+        assert "assembly-720p-2clips" in names
+        assert "assembly-720p-2clips:peak-memory" in names
+
+    def test_memory_metric_uses_mb(self, tmp_path: Path) -> None:
+        """Memory entries should use MB unit."""
+        output = tmp_path / "bench.json"
+        save_benchmark_json(self._sample_results()[:1], output)
+
+        data = json.loads(output.read_text())
+        mem_entries = [e for e in data if e["unit"] == "MB"]
+        assert len(mem_entries) == 1
+        assert mem_entries[0]["value"] == 200.0


### PR DESCRIPTION
## Summary
- Add `benchmark.yml` workflow using `github-action-benchmark` + `actions/cache` for regression detection
- Linux-only CI benchmarks (assembly + titles) on push/PR to processing/titles paths
- Local runners (Mac, Synology, GPU) submit results via `make benchmark-submit` → `workflow_dispatch`
- Each runner gets its own cache namespace — no cross-hardware comparison
- 150% regression threshold with PR comment alerts

## New Makefile targets
- `make benchmark-assembly` — Assembly benchmarks → `tests/benchmark-assembly.json`
- `make benchmark-titles` — Title benchmarks → `tests/benchmark-titles.json`
- `make benchmark-json` — Run all benchmarks, produce JSON
- `make benchmark-submit` — Submit local results to GitHub (requires `gh auth`)

## Files changed
- `.github/workflows/benchmark.yml` — New workflow (CI + manual ingest)
- `tests/integration/assembly/perf_utils.py` — `save_benchmark_json()` for `customSmallerIsBetter` format
- `tests/integration/assembly/test_perf_assembly.py` — Emits benchmark JSON alongside existing perf-results
- `tests/integration/titles/test_perf_titles.py` — New title rendering benchmarks (gradient, content-backed, ending)
- `tests/test_perf_utils.py` — 6 unit tests for JSON export (TDD)
- `Makefile` — New benchmark targets
- `.gitignore` — Ignore generated benchmark JSON

## Test plan
- [x] `make ci` passes (2528 tests, all quality gates green)
- [x] Pre-commit hooks pass (including diff-cover ≥80%)
- [ ] Verify `benchmark.yml` triggers on push to main
- [ ] Run `make benchmark-json` locally → verify JSON output
- [ ] Run `make benchmark-submit` → verify workflow dispatch

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)