### PR TITLE
fix(ci): grant pull-requests:write to CI called from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
 
   # Create release (requires approval for major releases)
   release:


### PR DESCRIPTION
One-line fix: release.yml grants `pull-requests: read` but ci.yml needs `write` for diff-cover PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)