### PR TITLE
fix(ci): pin Python version in GPU integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -97,6 +97,8 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install ${{ env.PYTHON_VERSION }}
+      - name: Pin Python version for uv
+        run: echo "${{ env.PYTHON_VERSION }}" > .python-version
       - run: make dev
 
       - name: Restore config


### PR DESCRIPTION
Now that .python-version is gitignored (#180), the self-hosted GPU runner needs an explicit pin. Writes `PYTHON_VERSION` to `.python-version` before `make dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)