### PR TITLE
feat(benchmarks): export pipeline timing as benchmark JSON (#182)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo "  benchmark         Run pytest-benchmark suite"
 	@echo "  benchmark-perf    Run assembly performance benchmarks (requires FFmpeg)"
 	@echo "  benchmark-assembly  Assembly benchmarks → tests/benchmark-assembly.json"
+	@echo "  benchmark-pipeline  Pipeline benchmarks → tests/benchmark-pipeline.json (Immich)"
 	@echo "  benchmark-titles    Title benchmarks → tests/benchmark-titles.json"
 	@echo "  benchmark-json    Run all benchmarks, produce JSON for CI"
 	@echo "  benchmark-submit  Submit local benchmark results to GitHub"
@@ -139,7 +140,9 @@ benchmark-titles-json:  ## Title benchmarks → tests/benchmark-titles.json
 	uv run pytest tests/integration/titles/test_perf_titles.py -v -m integration \
 		--log-cli-level=INFO --tb=short
 
-benchmark-json: benchmark-assembly benchmark-titles-json  ## Run all benchmarks, produce JSON for CI
+benchmark-json: benchmark-assembly benchmark-titles-json  ## Run all benchmarks, produce JSON for CI (no Immich)
+
+benchmark-json-full: benchmark-assembly benchmark-titles-json benchmark-pipeline  ## All benchmarks including pipeline (requires Immich)
 	@echo ""
 	@echo "Benchmark JSON files:"
 	@ls -la tests/benchmark-*.json 2>/dev/null || echo "  (none found — benchmarks may have been skipped)"

--- a/tests/integration/pipeline/test_perf_pipeline.py
+++ b/tests/integration/pipeline/test_perf_pipeline.py
@@ -17,7 +17,12 @@ from subprocess import run as sp_run
 import numpy as np
 import pytest
 
-from tests.integration.assembly.perf_utils import PerfResult, measure_resources, save_results
+from tests.integration.assembly.perf_utils import (
+    PerfResult,
+    measure_resources,
+    save_benchmark_json,
+    save_results,
+)
 from tests.integration.conftest import (
     ffprobe_json,
     get_duration,
@@ -234,4 +239,9 @@ def test_save_pipeline_results(tmp_path):
     project_root = Path(__file__).resolve().parents[3]
     output = project_root / "tests" / "perf-results-pipeline.json"
     save_results(_pipeline_results, output)
+
+    # Export in github-action-benchmark format for CI comparison
+    benchmark_output = project_root / "tests" / "benchmark-pipeline.json"
+    save_benchmark_json(_pipeline_results, benchmark_output)
     logger.info(f"Results saved to {output}")
+    logger.info(f"Benchmark JSON saved to {benchmark_output}")


### PR DESCRIPTION
## Summary
- `test_perf_pipeline.py` now exports `tests/benchmark-pipeline.json` in `customSmallerIsBetter` format for github-action-benchmark
- Add `make benchmark-json-full` target (includes pipeline benchmarks, requires Immich)
- Add pipeline benchmark to Makefile help text
- `make benchmark-submit` already picks up all `tests/benchmark-*.json` files

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)