### PR TITLE
fix(test): add missing date params to title screen integration test

### DIFF
--- a/tests/integration/pipeline/test_generate_real.py
+++ b/tests/integration/pipeline/test_generate_real.py
@@ -8,6 +8,7 @@ No mocks. Real FFmpeg, real Immich, real data.
 from __future__ import annotations
 
 import logging
+from datetime import date
 
 import pytest
 
@@ -66,6 +67,8 @@ class TestGenerateMemoryRealImmich:
             transition="crossfade",
             output_resolution="720p",
             person_name="Test Person",
+            date_start=date(2025, 1, 1),
+            date_end=date(2025, 12, 31),
         )
         result = generate_memory(params)
 


### PR DESCRIPTION
## Summary
- Fix `test_pipeline_with_title_screens` failing with `ValueError: Year required for calendar year selection`
- The title generator requires `date_start`/`date_end` when title screens are enabled — test was missing them

One-line fix: add `date_start=date(2025, 1, 1), date_end=date(2025, 12, 31)` to the test's `GenerationParams`.

## Test plan
- [x] All 5 `test_generate_real.py` tests pass locally with real Immich
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)