### PR TITLE
fix(tracking): handle FK constraint failure gracefully in phase stats

### DIFF
--- a/src/immich_memories/tracking/run_database.py
+++ b/src/immich_memories/tracking/run_database.py
@@ -146,29 +146,40 @@ class RunDatabase:
             conn.commit()
 
     def save_phase_stats(self, run_id: str, stats: PhaseStats) -> None:
-        """Save phase timing statistics."""
-        with self._get_connection() as conn:
-            conn.execute(
-                """
-                INSERT INTO phase_stats (
-                    run_id, phase_name, started_at, completed_at,
-                    duration_seconds, items_processed, items_total,
-                    errors, extra_metrics
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    run_id,
-                    stats.phase_name,
-                    stats.started_at.isoformat(),
-                    stats.completed_at.isoformat() if stats.completed_at else None,
-                    stats.duration_seconds,
-                    stats.items_processed,
-                    stats.items_total,
-                    json.dumps(stats.errors) if stats.errors else None,
-                    json.dumps(stats.extra_metrics) if stats.extra_metrics else None,
-                ),
+        """Save phase timing statistics.
+
+        Gracefully handles missing run_id (e.g. DB was deleted mid-run).
+        Phase stats are observability data — losing them is acceptable.
+        """
+        try:
+            with self._get_connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO phase_stats (
+                        run_id, phase_name, started_at, completed_at,
+                        duration_seconds, items_processed, items_total,
+                        errors, extra_metrics
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        stats.phase_name,
+                        stats.started_at.isoformat(),
+                        stats.completed_at.isoformat() if stats.completed_at else None,
+                        stats.duration_seconds,
+                        stats.items_processed,
+                        stats.items_total,
+                        json.dumps(stats.errors) if stats.errors else None,
+                        json.dumps(stats.extra_metrics) if stats.extra_metrics else None,
+                    ),
+                )
+                conn.commit()
+        except sqlite3.IntegrityError:
+            logger.warning(
+                "Phase stats lost for '%s' — run_id '%s' may no longer exist in database",
+                stats.phase_name,
+                run_id,
             )
-            conn.commit()
 
     def get_run(self, run_id: str) -> RunMetadata | None:
         """Get a single run by ID."""

--- a/src/immich_memories/tracking/run_tracker.py
+++ b/src/immich_memories/tracking/run_tracker.py
@@ -154,7 +154,10 @@ class RunTracker:
             extra_metrics=extra_metrics or {},
         )
 
-        self.db.save_phase_stats(self.run_id, stats)
+        try:
+            self.db.save_phase_stats(self.run_id, stats)
+        except Exception as exc:
+            logger.warning("Failed to save phase stats for '%s': %s", stats.phase_name, exc)
 
         logger.debug(
             f"Completed phase: {self._current_phase} "

--- a/tests/test_run_database_fk.py
+++ b/tests/test_run_database_fk.py
@@ -1,0 +1,89 @@
+"""Tests for RunDatabase FK constraint handling when run_id is missing."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from immich_memories.tracking.models import PhaseStats
+from immich_memories.tracking.run_database import RunDatabase
+from immich_memories.tracking.run_tracker import RunTracker
+
+
+@pytest.fixture
+def db(tmp_path):
+    return RunDatabase(db_path=tmp_path / "test.db")
+
+
+def _make_phase_stats() -> PhaseStats:
+    return PhaseStats(
+        phase_name="analysis",
+        started_at=datetime(2026, 3, 27, 10, 0),
+        completed_at=datetime(2026, 3, 27, 10, 5),
+        duration_seconds=300.0,
+        items_processed=42,
+        items_total=42,
+        errors=[],
+        extra_metrics={},
+    )
+
+
+class TestCompletePhaseDBResilience:
+    """RunTracker.complete_phase must not crash when DB write fails."""
+
+    # WHY: RunDatabase opens a SQLite connection — isolate tracker logic from disk I/O
+    @patch("immich_memories.tracking.run_tracker.RunDatabase")
+    def test_complete_phase_survives_db_exception(self, mock_db_cls, caplog):
+        """complete_phase logs a warning and continues if DB raises any exception."""
+        tracker = RunTracker(db_path=Path("/tmp/test.db"))
+        tracker.start_phase("analysis", total_items=10)
+
+        # Simulate DB failure (e.g. DB deleted, corruption, etc.)
+        tracker.db.save_phase_stats.side_effect = RuntimeError("disk I/O error")
+
+        with caplog.at_level(logging.WARNING):
+            tracker.complete_phase(items_processed=10)
+
+        # Phase state should be reset even after failure
+        assert tracker._current_phase is None
+        assert any("phase stats" in r.message.lower() for r in caplog.records)
+
+
+class TestSavePhaseStatsFKConstraint:
+    """save_phase_stats must not crash when run_id is missing from pipeline_runs."""
+
+    def test_nonexistent_run_id_does_not_raise(self, db):
+        """Inserting phase stats for a missing run_id logs a warning instead of raising."""
+        stats = _make_phase_stats()
+        # Should NOT raise sqlite3.IntegrityError
+        db.save_phase_stats("nonexistent_run_id", stats)
+
+    def test_nonexistent_run_id_logs_warning(self, db, caplog):
+        """A warning is logged when phase stats are lost due to missing run_id."""
+        stats = _make_phase_stats()
+        with caplog.at_level(logging.WARNING):
+            db.save_phase_stats("nonexistent_run_id", stats)
+        assert any("run_id" in record.message.lower() for record in caplog.records)
+
+    def test_valid_run_id_saves_normally(self, db):
+        """Phase stats with a valid run_id are saved successfully."""
+        from immich_memories.tracking.models import RunMetadata
+
+        run = RunMetadata(
+            run_id="valid_run_001",
+            created_at=datetime(2026, 3, 27, 10, 0),
+            status="running",
+        )
+        db.save_run(run)
+
+        stats = _make_phase_stats()
+        db.save_phase_stats("valid_run_001", stats)
+
+        # Verify the stats were actually persisted
+        retrieved = db.get_phase_stats("valid_run_001")
+        assert len(retrieved) == 1
+        assert retrieved[0].phase_name == "analysis"


### PR DESCRIPTION
## Summary
- `save_phase_stats()` now catches `sqlite3.IntegrityError` and logs a warning instead of crashing the pipeline
- `RunTracker.complete_phase()` has a broad safety net for any DB exception
- Phase stats are observability data — losing them is acceptable; crashing video generation is not

Fixes #190

## Test plan
- [x] Unit test: `save_phase_stats()` with non-existent `run_id` does NOT raise, logs warning
- [x] Unit test: `save_phase_stats()` with valid `run_id` still saves normally
- [x] Unit test: `RunTracker.complete_phase()` survives arbitrary DB exceptions
- [x] `make ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)