### PR TITLE
feat(ui): show photos in Step 2 clip review grid

### DIFF
--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -58,6 +58,13 @@ _FORMAT_MAP = {
 }
 
 
+def _filter_selected_photos(state) -> list | None:
+    """Return only photo assets whose IDs are in the selected set."""
+    if not state.include_photos or not state.photo_assets:
+        return None
+    return [p for p in state.photo_assets if p.id in state.selected_photo_ids]
+
+
 def _build_generation_params(state, selected_clips, output_path):
     """Build GenerationParams from UI AppState."""
     from immich_memories.api.immich import SyncImmichClient
@@ -99,7 +106,7 @@ def _build_generation_params(state, selected_clips, output_path):
         clip_segments=state.clip_segments,
         clip_rotations=state.clip_rotations,
         include_photos=state.include_photos and bool(state.photo_assets),
-        photo_assets=state.photo_assets if state.include_photos else None,
+        photo_assets=_filter_selected_photos(state),
         target_duration_seconds=state.target_duration * 60,
         # Music and upload handled separately by UI (AI gen, 4-stem ducking, NiceGUI progress)
         music_path=None,

--- a/src/immich_memories/ui/pages/clip_grid.py
+++ b/src/immich_memories/ui/pages/clip_grid.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import base64
 from collections import defaultdict
+from datetime import datetime
 
 from nicegui import ui
 
-from immich_memories.api.models import VideoClipInfo
+from immich_memories.api.models import Asset, VideoClipInfo
 from immich_memories.ui.components import im_badge
 from immich_memories.ui.pages.step2_helpers import (
     format_duration,
@@ -16,6 +17,23 @@ from immich_memories.ui.pages.step2_helpers import (
 from immich_memories.ui.state import get_app_state
 
 CLIPS_PER_PAGE = 20
+
+# Union type for items in the mixed grid
+GridItem = VideoClipInfo | Asset
+
+
+def grid_item_date(item: GridItem) -> datetime:
+    """Extract file_created_at from either a VideoClipInfo or an Asset."""
+    if isinstance(item, VideoClipInfo):
+        return item.asset.file_created_at
+    return item.file_created_at
+
+
+def grid_item_id(item: GridItem) -> str:
+    """Extract the asset ID from either a VideoClipInfo or an Asset."""
+    if isinstance(item, VideoClipInfo):
+        return item.asset.id
+    return item.id
 
 
 def clip_quality_score(c: VideoClipInfo) -> tuple[int, int, int, int]:
@@ -280,6 +298,102 @@ def _render_clip_card(
         checkbox.on_value_change(make_toggle_handler(clip.asset.id))
 
 
+def _render_photo_card(
+    photo: Asset,
+    state,
+    all_clips: list[VideoClipInfo],
+    summary_container: ui.element,
+) -> None:
+    """Render a single photo card in the list view."""
+    is_selected = photo.id in state.selected_photo_ids
+
+    with (
+        ui.card()
+        .classes("p-2 rounded-xl")
+        .style("background-color: var(--im-bg-elevated); border: 1px solid var(--im-border)")
+    ):
+        _render_clip_thumbnail(photo.id)
+
+        with ui.row().classes("gap-1 flex-wrap"):
+            im_badge("Photo", variant="analysis")
+            if photo.is_favorite:
+                ui.icon("star").classes("text-xs").style("color: var(--im-warning)")
+
+        date_str = photo.file_created_at.strftime("%b %d %H:%M")
+        ui.label(date_str).classes("font-semibold text-sm").style("color: var(--im-text)")
+
+        filename = photo.original_file_name or "Unknown"
+        if len(filename) > 20:
+            filename = filename[:17] + "..."
+        ui.label(filename).classes("text-xs truncate").style("color: var(--im-text-secondary)")
+
+        def make_photo_toggle(photo_id: str):
+            def toggle(e):
+                value = e.value if hasattr(e, "value") else e
+                if value:
+                    state.selected_photo_ids.add(photo_id)
+                else:
+                    state.selected_photo_ids.discard(photo_id)
+                _update_duration_summary(all_clips, summary_container)
+
+            return toggle
+
+        checkbox = ui.checkbox("Include", value=is_selected)
+        checkbox.on_value_change(make_photo_toggle(photo.id))
+
+
+def _render_compact_photo_thumbnail(
+    photo: Asset,
+    state,
+    all_clips: list[VideoClipInfo],
+    summary_container: ui.element,
+) -> None:
+    """Render a single compact photo thumbnail cell with selection overlay."""
+    is_selected = photo.id in state.selected_photo_ids
+    tooltip = f"Photo | {photo.file_created_at.strftime('%b %d, %Y %H:%M')}"
+
+    def make_click_handler(photo_id: str):
+        def toggle():
+            if photo_id in state.selected_photo_ids:
+                state.selected_photo_ids.discard(photo_id)
+            else:
+                state.selected_photo_ids.add(photo_id)
+            _update_duration_summary(all_clips, summary_container)
+            ui.navigate.to("/step2")
+
+        return toggle
+
+    border = "2px solid var(--im-primary)" if is_selected else "1px solid var(--im-border)"
+    with (
+        ui.element("div")
+        .classes("relative cursor-pointer aspect-video rounded-lg overflow-hidden")
+        .style(f"border: {border}")
+        .tooltip(tooltip)
+        .on("click", make_click_handler(photo.id))
+    ):
+        thumb = get_thumbnail(photo.id)
+        if thumb:
+            b64 = base64.b64encode(thumb).decode()
+            ui.image(f"data:image/jpeg;base64,{b64}").classes("w-full h-full object-cover")
+        else:
+            ui.element("div").classes("w-full h-full flex items-center justify-center").style(
+                "background-color: var(--im-bg-surface)"
+            )
+
+        # Camera icon badge in top-left to distinguish from videos
+        ui.icon("photo_camera", color="white", size="16px").classes("absolute top-1 left-1").style(
+            "filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5))"
+        )
+
+        if is_selected:
+            ui.element("div").classes("absolute inset-0").style(
+                "background: rgba(66, 80, 175, 0.25)"
+            )
+            ui.icon("check_circle", color="white", size="20px").classes(
+                "absolute top-1 right-1"
+            ).style("filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5))")
+
+
 def _build_clip_tooltip(clip: VideoClipInfo) -> str:
     """Build hover tooltip text for compact grid view."""
     parts = []
@@ -447,6 +561,133 @@ def _render_clip_grid_paginated(
                         summary_container,
                     )
                 still_remaining = remaining_clips[page_size:]
+                if still_remaining:
+                    with btn_ctr:
+                        ui.button(
+                            f"Show more ({len(still_remaining)} remaining)",
+                            on_click=lambda sr=still_remaining: load_more(sr, parent, btn_ctr),
+                        ).props("outline")
+
+            ui.button(
+                f"Show more ({len(remaining)} remaining)",
+                on_click=load_more,
+            ).props("outline")
+
+
+def _render_mixed_grid(
+    items: list[GridItem],
+    duplicate_ids: set[str],
+    lower_quality_ids: set[str],
+    summary_container: ui.element,
+) -> None:
+    """Render a mixed grid of video clips and photos, sorted chronologically."""
+    state = get_app_state()
+    all_clips = state.clips
+
+    with ui.element("div").classes(
+        "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4"
+    ):
+        for item in items:
+            if isinstance(item, VideoClipInfo):
+                _render_clip_card(
+                    item, state, all_clips, duplicate_ids, lower_quality_ids, summary_container
+                )
+            else:
+                _render_photo_card(item, state, all_clips, summary_container)
+
+
+def _render_mixed_grid_paginated(
+    items: list[GridItem],
+    duplicate_ids: set[str],
+    lower_quality_ids: set[str],
+    summary_container: ui.element,
+    page_size: int = CLIPS_PER_PAGE,
+) -> None:
+    """Render a paginated mixed grid of video clips and photos."""
+    if len(items) <= page_size:
+        _render_mixed_grid(items, duplicate_ids, lower_quality_ids, summary_container)
+        return
+
+    grid_container = ui.column().classes("w-full")
+    with grid_container:
+        _render_mixed_grid(items[:page_size], duplicate_ids, lower_quality_ids, summary_container)
+
+    remaining = items[page_size:]
+    if remaining:
+        btn_container = ui.row().classes("w-full justify-center mt-2")
+        with btn_container:
+
+            def load_more(
+                remaining_items=remaining,
+                parent=grid_container,
+                btn_ctr=btn_container,
+            ):
+                btn_ctr.clear()
+                with parent:
+                    _render_mixed_grid(
+                        remaining_items[:page_size],
+                        duplicate_ids,
+                        lower_quality_ids,
+                        summary_container,
+                    )
+                still_remaining = remaining_items[page_size:]
+                if still_remaining:
+                    with btn_ctr:
+                        ui.button(
+                            f"Show more ({len(still_remaining)} remaining)",
+                            on_click=lambda sr=still_remaining: load_more(sr, parent, btn_ctr),
+                        ).props("outline")
+
+            ui.button(
+                f"Show more ({len(remaining)} remaining)",
+                on_click=load_more,
+            ).props("outline")
+
+
+def _render_compact_mixed_grid(
+    items: list[GridItem],
+    summary_container: ui.element,
+) -> None:
+    """Render a compact mixed grid of video clips and photos."""
+    state = get_app_state()
+    all_clips = state.clips
+
+    with ui.element("div").classes("grid grid-cols-4 sm:grid-cols-5 lg:grid-cols-6 gap-2"):
+        for item in items:
+            if isinstance(item, VideoClipInfo):
+                _render_compact_thumbnail(item, state, all_clips, summary_container)
+            else:
+                _render_compact_photo_thumbnail(item, state, all_clips, summary_container)
+
+
+def _render_compact_mixed_grid_paginated(
+    items: list[GridItem],
+    summary_container: ui.element,
+    page_size: int = CLIPS_PER_PAGE,
+) -> None:
+    """Render a paginated compact mixed grid."""
+    if len(items) <= page_size:
+        _render_compact_mixed_grid(items, summary_container)
+        return
+
+    grid_container = ui.column().classes("w-full")
+    with grid_container:
+        _render_compact_mixed_grid(items[:page_size], summary_container)
+
+    remaining = items[page_size:]
+    if remaining:
+        btn_container = ui.row().classes("w-full justify-center mt-2")
+        with btn_container:
+
+            def load_more(
+                remaining_items=remaining,
+                parent=grid_container,
+                btn_ctr=btn_container,
+            ):
+                btn_ctr.clear()
+                with parent:
+                    _render_compact_mixed_grid(remaining_items[:page_size], summary_container)
+                still_remaining = remaining_items[page_size:]
                 if still_remaining:
                     with btn_ctr:
                         ui.button(

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -171,6 +171,7 @@ def _load_clips() -> None:
                 status_label.set_text("Fetching photos...")
                 photo_assets = await run.io_bound(_fetch_photos, state, date_range)
                 state.photo_assets = photo_assets
+                state.selected_photo_ids = {a.id for a in photo_assets}
                 if photo_assets:
                     logger.info(f"Found {len(photo_assets)} photos")
 
@@ -178,9 +179,16 @@ def _load_clips() -> None:
             state.clips = clips
             _set_initial_selection(clips, state)
 
-            status_label.set_text(f"Found {len(clips)} videos. Loading thumbnails...")
+            photo_count = len(state.photo_assets) if state.include_photos else 0
+            total_msg = f"Found {len(clips)} videos"
+            if photo_count:
+                total_msg += f" and {photo_count} photos"
+            status_label.set_text(f"{total_msg}. Loading thumbnails...")
             progress_bar.value = 0.1
             await _load_thumbnails_and_metadata_async(clips, status_label, progress_bar)
+
+            if state.include_photos and state.photo_assets:
+                await _load_photo_thumbnails_async(state.photo_assets, status_label)
 
             loading_dialog.close()
             ui.navigate.to("/step2")
@@ -348,6 +356,39 @@ def _probe_and_cache_metadata(clip, client, state, analysis_cache) -> None:
             )
     except Exception as e:
         logger.debug(f"Failed to probe video metadata: {e}")
+
+
+async def _load_photo_thumbnails_async(
+    photo_assets: list,
+    status_label: ui.label,
+) -> None:
+    """Load thumbnails for photo assets from Immich."""
+    state = get_app_state()
+    thumbnail_cache = state.thumbnail_cache
+    if thumbnail_cache is None:
+        return
+
+    photo_ids = [a.id for a in photo_assets]
+    cached = set(thumbnail_cache.get_batch(photo_ids, "preview").keys())
+    need = [a for a in photo_assets if a.id not in cached]
+
+    if not need:
+        return
+
+    batch_size = 10
+    for i in range(0, len(need), batch_size):
+        batch = need[i : i + batch_size]
+
+        def fetch_batch(assets_batch=batch):
+            with SyncImmichClient(state.immich_url, state.immich_api_key) as client:
+                for asset in assets_batch:
+                    with contextlib.suppress(Exception):
+                        thumb = client.get_asset_thumbnail(asset.id, size="preview")
+                        if thumb:
+                            thumbnail_cache.put(asset.id, "preview", thumb)
+
+        await run.io_bound(fetch_batch)
+        status_label.set_text(f"Photo thumbnails: {min(i + batch_size, len(need))}/{len(need)}")
 
 
 def _render_cached_analysis_summary(clips: list[VideoClipInfo]) -> None:

--- a/src/immich_memories/ui/pages/step2_review.py
+++ b/src/immich_memories/ui/pages/step2_review.py
@@ -15,11 +15,15 @@ from immich_memories.ui.components import (
     im_separator,
 )
 from immich_memories.ui.pages.clip_grid import (
+    GridItem,
     _detect_duplicates,
     _group_clips_by_datetime,
     _render_clip_grid_paginated,
     _render_compact_grid_paginated,
+    _render_compact_mixed_grid_paginated,
+    _render_mixed_grid_paginated,
     _update_duration_summary,
+    grid_item_date,
 )
 from immich_memories.ui.pages.clip_pipeline import (
     _render_pipeline_progress_ui,
@@ -273,15 +277,21 @@ def _render_step2_controls(state, clips: list[VideoClipInfo]) -> None:
 
         def select_all():
             state.selected_clip_ids = {c.asset.id for c in clips}
+            if state.include_photos and state.photo_assets:
+                state.selected_photo_ids = {a.id for a in state.photo_assets}
             ui.navigate.to("/step2")
 
         def deselect_all():
             state.selected_clip_ids = set()
+            state.selected_photo_ids = set()
             ui.navigate.to("/step2")
 
         def invert_selection():
             all_ids = {c.asset.id for c in clips}
             state.selected_clip_ids = all_ids - state.selected_clip_ids
+            if state.include_photos and state.photo_assets:
+                all_photo_ids = {a.id for a in state.photo_assets}
+                state.selected_photo_ids = all_photo_ids - state.selected_photo_ids
             ui.navigate.to("/step2")
 
         im_button("Select All", variant="secondary", on_click=select_all)
@@ -379,13 +389,30 @@ def _render_view_toggle(state) -> None:
         list_btn.tooltip("Detailed list view")
 
 
+def _build_header_label(clips: list[VideoClipInfo], state) -> str:
+    """Build the header label showing video and photo counts."""
+    photo_count = len(state.photo_assets) if state.include_photos and state.photo_assets else 0
+    if photo_count:
+        return f"{len(clips)} Videos, {photo_count} Photos Found"
+    return f"{len(clips)} Videos Found"
+
+
+def _build_mixed_items(clips: list[VideoClipInfo], state) -> list[GridItem]:
+    """Merge clips and photos into a single chronologically sorted list."""
+    if not state.include_photos or not state.photo_assets:
+        return clips.copy()  # type: ignore[return-value]
+    items: list[GridItem] = [*clips, *state.photo_assets]
+    items.sort(key=grid_item_date)
+    return items
+
+
 def _render_step2_content(
     state,
     clips: list[VideoClipInfo],
     summary_container: ui.element,
 ) -> None:
     """Render the clip grid and navigation section."""
-    im_section_header(f"{len(clips)} Videos Found", icon="video_library")
+    im_section_header(_build_header_label(clips, state), icon="video_library")
 
     duplicate_ids, lower_quality_ids = _detect_duplicates(clips)
     _auto_deselect_duplicates(state, lower_quality_ids)
@@ -402,7 +429,17 @@ def _render_step2_content(
 
     _render_view_toggle(state)
 
-    if state.clip_view_mode == "grid":
+    has_photos = state.include_photos and bool(state.photo_assets)
+
+    if has_photos:
+        mixed_items = _build_mixed_items(clips, state)
+        if state.clip_view_mode == "grid":
+            _render_compact_mixed_grid_paginated(mixed_items, summary_container)
+        else:
+            _render_mixed_grid_paginated(
+                mixed_items, duplicate_ids, lower_quality_ids, summary_container
+            )
+    elif state.clip_view_mode == "grid":
         _render_compact_grid_paginated(clips, summary_container)
     else:
         _render_period_expansions(clips, duplicate_ids, lower_quality_ids, summary_container)
@@ -416,11 +453,11 @@ def _render_step2_content(
             ui.navigate.to("/")
 
         def go_next():
-            if state.selected_clip_ids:
+            if state.selected_clip_ids or (has_photos and state.selected_photo_ids):
                 state.review_selected_mode = True
                 ui.navigate.to("/step2")
             else:
-                ui.notify("Please select at least one clip", type="warning")
+                ui.notify("Please select at least one clip or photo", type="warning")
 
         im_button("Back to Configuration", variant="secondary", on_click=go_back, icon="arrow_back")
         im_button("Next: Refine Moments", variant="primary", on_click=go_next, icon="arrow_forward")

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -85,6 +85,7 @@ class AppState:
     include_live_photos: bool = False
     include_photos: bool = False
     photo_assets: list[Any] = field(default_factory=list)
+    selected_photo_ids: set[str] = field(default_factory=set)
     photo_duration: float = 4.0
 
     # Analysis depth (fast or thorough)
@@ -131,6 +132,7 @@ class AppState:
         """Reset clip-related state when changing configuration."""
         self.clips = []
         self.selected_clip_ids = set()
+        self.selected_photo_ids = set()
         self.clip_segments = {}
         self.clip_rotations = {}
         self.pipeline_result = None

--- a/tests/test_photo_review.py
+++ b/tests/test_photo_review.py
@@ -1,0 +1,213 @@
+"""Tests for photo review in Step 2 clip grid (issue #191)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+from immich_memories.ui.pages.clip_grid import grid_item_date, grid_item_id
+from immich_memories.ui.state import AppState
+
+
+def make_photo_asset(
+    asset_id: str = "photo-001",
+    *,
+    file_created_at: datetime | None = None,
+    is_favorite: bool = False,
+) -> Asset:
+    """Create a photo Asset for testing."""
+    now = file_created_at or datetime.now(tz=UTC)
+    return Asset(
+        id=asset_id,
+        type=AssetType.IMAGE,
+        fileCreatedAt=now,
+        fileModifiedAt=now,
+        updatedAt=now,
+        isFavorite=is_favorite,
+        originalFileName=f"{asset_id}.heic",
+    )
+
+
+class TestPhotoSelectionState:
+    """Photo selection state management."""
+
+    def test_selected_photo_ids_populated_from_photo_assets(self):
+        """When photo_assets are set, selected_photo_ids should contain all IDs."""
+        state = AppState()
+        photos = [make_photo_asset("p1"), make_photo_asset("p2"), make_photo_asset("p3")]
+        state.photo_assets = photos
+        state.selected_photo_ids = {a.id for a in photos}
+        assert state.selected_photo_ids == {"p1", "p2", "p3"}
+
+    def test_deselecting_photo_removes_from_set(self):
+        state = AppState()
+        state.selected_photo_ids = {"p1", "p2", "p3"}
+        state.selected_photo_ids.discard("p2")
+        assert state.selected_photo_ids == {"p1", "p3"}
+
+    def test_get_selected_photos_filters_by_ids(self):
+        """Filtering photo_assets by selected_photo_ids yields correct subset."""
+        state = AppState()
+        photos = [make_photo_asset("p1"), make_photo_asset("p2"), make_photo_asset("p3")]
+        state.photo_assets = photos
+        state.selected_photo_ids = {"p1", "p3"}
+        selected = [p for p in state.photo_assets if p.id in state.selected_photo_ids]
+        assert len(selected) == 2
+        assert {p.id for p in selected} == {"p1", "p3"}
+
+
+class TestGridItemHelpers:
+    """Test grid_item_date and grid_item_id with both types."""
+
+    def test_grid_item_date_for_clip(self):
+        from tests.conftest import make_clip
+
+        dt = datetime(2024, 6, 15, tzinfo=UTC)
+        clip = make_clip("v1", file_created_at=dt)
+        assert grid_item_date(clip) == dt
+
+    def test_grid_item_date_for_photo(self):
+        dt = datetime(2024, 6, 15, tzinfo=UTC)
+        photo = make_photo_asset("p1", file_created_at=dt)
+        assert grid_item_date(photo) == dt
+
+    def test_grid_item_id_for_clip(self):
+        from tests.conftest import make_clip
+
+        clip = make_clip("v1")
+        assert grid_item_id(clip) == "v1"
+
+    def test_grid_item_id_for_photo(self):
+        photo = make_photo_asset("p1")
+        assert grid_item_id(photo) == "p1"
+
+
+class TestPhotoGridItemSorting:
+    """Chronological interleaving of photos and video clips."""
+
+    def test_mixed_items_sort_by_date(self):
+        """Photos and video clips sort together by file_created_at."""
+        from tests.conftest import make_clip
+
+        early = datetime(2024, 1, 1, tzinfo=UTC)
+        mid = datetime(2024, 6, 15, tzinfo=UTC)
+        late = datetime(2024, 12, 31, tzinfo=UTC)
+
+        clip1 = make_clip("v1", file_created_at=early)
+        photo1 = make_photo_asset("p1", file_created_at=mid)
+        clip2 = make_clip("v2", file_created_at=late)
+
+        items: list[VideoClipInfo | Asset] = [clip2, photo1, clip1]
+        sorted_items = sorted(items, key=grid_item_date)
+
+        assert isinstance(sorted_items[0], VideoClipInfo)
+        assert sorted_items[0].asset.id == "v1"
+        assert isinstance(sorted_items[1], Asset)
+        assert sorted_items[1].id == "p1"
+        assert isinstance(sorted_items[2], VideoClipInfo)
+        assert sorted_items[2].asset.id == "v2"
+
+
+class TestBuildMixedItems:
+    """Test _build_mixed_items helper for merging clips and photos."""
+
+    def test_no_photos_returns_clips_only(self):
+        from immich_memories.ui.pages.step2_review import _build_mixed_items
+        from tests.conftest import make_clip
+
+        state = AppState()
+        clips = [make_clip("v1")]
+        state.include_photos = False
+        result = _build_mixed_items(clips, state)
+        assert len(result) == 1
+        assert isinstance(result[0], VideoClipInfo)
+
+    def test_with_photos_returns_sorted_mix(self):
+        from immich_memories.ui.pages.step2_review import _build_mixed_items
+        from tests.conftest import make_clip
+
+        early = datetime(2024, 1, 1, tzinfo=UTC)
+        late = datetime(2024, 12, 31, tzinfo=UTC)
+
+        state = AppState()
+        state.include_photos = True
+        state.photo_assets = [make_photo_asset("p1", file_created_at=late)]
+        clips = [make_clip("v1", file_created_at=early)]
+        result = _build_mixed_items(clips, state)
+
+        assert len(result) == 2
+        assert isinstance(result[0], VideoClipInfo)
+        assert isinstance(result[1], Asset)
+
+
+class TestBuildHeaderLabel:
+    """Test header label shows both video and photo counts."""
+
+    def test_videos_only(self):
+        from immich_memories.ui.pages.step2_review import _build_header_label
+        from tests.conftest import make_clip
+
+        state = AppState()
+        state.include_photos = False
+        clips = [make_clip("v1"), make_clip("v2")]
+        assert _build_header_label(clips, state) == "2 Videos Found"
+
+    def test_videos_and_photos(self):
+        from immich_memories.ui.pages.step2_review import _build_header_label
+        from tests.conftest import make_clip
+
+        state = AppState()
+        state.include_photos = True
+        state.photo_assets = [make_photo_asset("p1"), make_photo_asset("p2")]
+        clips = [make_clip("v1")]
+        assert _build_header_label(clips, state) == "1 Videos, 2 Photos Found"
+
+
+class TestFilterSelectedPhotos:
+    """Photos filtered by selected_photo_ids before passing to generation."""
+
+    def test_only_selected_photos_passed(self):
+        from immich_memories.ui.pages._step4_generate import _filter_selected_photos
+
+        state = AppState()
+        photos = [make_photo_asset("p1"), make_photo_asset("p2"), make_photo_asset("p3")]
+        state.photo_assets = photos
+        state.selected_photo_ids = {"p1", "p3"}
+        state.include_photos = True
+
+        filtered = _filter_selected_photos(state)
+        assert filtered is not None
+        assert len(filtered) == 2
+        assert {p.id for p in filtered} == {"p1", "p3"}
+
+    def test_empty_selection_yields_empty_list(self):
+        from immich_memories.ui.pages._step4_generate import _filter_selected_photos
+
+        state = AppState()
+        state.photo_assets = [make_photo_asset("p1")]
+        state.selected_photo_ids = set()
+        state.include_photos = True
+
+        filtered = _filter_selected_photos(state)
+        assert filtered is not None
+        assert filtered == []
+
+    def test_photos_disabled_yields_none(self):
+        from immich_memories.ui.pages._step4_generate import _filter_selected_photos
+
+        state = AppState()
+        state.photo_assets = [make_photo_asset("p1")]
+        state.include_photos = False
+
+        result = _filter_selected_photos(state)
+        assert result is None
+
+    def test_no_photo_assets_yields_none(self):
+        from immich_memories.ui.pages._step4_generate import _filter_selected_photos
+
+        state = AppState()
+        state.include_photos = True
+        state.photo_assets = []
+
+        result = _filter_selected_photos(state)
+        assert result is None

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -106,6 +106,16 @@ class TestAppStateIncludePhotos:
         state = AppState()
         assert state.photo_assets == []
 
+    def test_selected_photo_ids_starts_empty(self):
+        state = AppState()
+        assert state.selected_photo_ids == set()
+
+    def test_reset_clips_clears_selected_photo_ids(self):
+        state = AppState()
+        state.selected_photo_ids = {"p1", "p2"}
+        state.reset_clips()
+        assert state.selected_photo_ids == set()
+
 
 class TestAppStateGetSelectedClips:
     """Test get_selected_clips() method."""


### PR DESCRIPTION
## Summary
- Photos now appear interleaved chronologically alongside video clips in the Step 2 review grid
- Photo cards have a camera icon badge, no duration display, and checkbox for include/exclude
- Photo thumbnails are batch-loaded from Immich alongside video thumbnails
- Selected photos are filtered through `state.selected_photo_ids` before passing to generation
- Select all/deselect all/invert controls work for both videos and photos

Fixes #191

## Test plan
- [x] Unit tests for `selected_photo_ids` state field (default, reset)
- [x] Unit tests for grid item helpers (`grid_item_date`, `grid_item_id`)
- [x] Unit tests for chronological sorting of mixed video+photo items
- [x] Unit tests for header label formatting with photo counts
- [x] Unit tests for photo filtering before generation
- [x] `make ci` passes (2684 tests, all quality gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)