### PR TITLE
fix(demo): resilient redaction + align assembly with Playwright segments (#213)

### DIFF
--- a/docs-site/scripts/assemble-demo.sh
+++ b/docs-site/scripts/assemble-demo.sh
@@ -25,11 +25,12 @@ ok()  { echo -e "${GREEN}[assemble]${NC} $*"; }
 # Verify inputs
 # ---------------------------------------------------------------------------
 
-SECTIONS=(section1-config section2-review section3-options section4-export)
+# Segments from Playwright recording (make demo-record)
+SEGMENTS=(segment1-config segment2-navigate segment3-grid segment4-options segment5-progress)
 
-for s in "${SECTIONS[@]}"; do
+for s in "${SEGMENTS[@]}"; do
     if [[ ! -f "$RAW_DIR/$s.webm" ]]; then
-        echo "ERROR: Missing $RAW_DIR/$s.webm — run record-demo.ts first"
+        echo "ERROR: Missing $RAW_DIR/$s.webm — run 'make demo-record' first"
         exit 1
     fi
 done
@@ -41,33 +42,39 @@ mkdir -p "$WORK_DIR"
 # ---------------------------------------------------------------------------
 log "Stage 1: Speed-ramping sections..."
 
-# Section 1 — Config: 2x speed (boring setup)
-ffmpeg -y -i "$RAW_DIR/section1-config.webm" \
-    -filter:v "setpts=0.5*PTS" -an \
+# Segment 1 — Config: 3x speed (boring setup)
+ffmpeg -y -i "$RAW_DIR/segment1-config.webm" \
+    -filter:v "setpts=0.33*PTS" -an \
     -c:v libx264 -crf 20 -preset fast \
     "$WORK_DIR/s1_fast.mp4" 2>/dev/null
-ok "  section1: 2x speed"
+ok "  segment1: 3x speed"
 
-# Section 2 — Clip review: 1.5x speed (interesting content)
-ffmpeg -y -i "$RAW_DIR/section2-review.webm" \
-    -filter:v "setpts=0.67*PTS" -an \
+# Segment 2 — Navigate: 3x speed (loading transition)
+ffmpeg -y -i "$RAW_DIR/segment2-navigate.webm" \
+    -filter:v "setpts=0.33*PTS" -an \
     -c:v libx264 -crf 20 -preset fast \
     "$WORK_DIR/s2_fast.mp4" 2>/dev/null
-ok "  section2: 1.5x speed"
+ok "  segment2: 3x speed"
 
-# Section 3 — Options: 1.5x speed (showing features)
-ffmpeg -y -i "$RAW_DIR/section3-options.webm" \
-    -filter:v "setpts=0.67*PTS" -an \
-    -c:v libx264 -crf 20 -preset fast \
+# Segment 3 — Clip grid: 1x speed (highlight: scrolling thumbnails)
+ffmpeg -y -i "$RAW_DIR/segment3-grid.webm" \
+    -an -c:v libx264 -crf 20 -preset fast \
     "$WORK_DIR/s3_fast.mp4" 2>/dev/null
-ok "  section3: 1.5x speed"
+ok "  segment3: 1x speed (highlight)"
 
-# Section 4 — Export: 2x speed (quick wrap-up)
-ffmpeg -y -i "$RAW_DIR/section4-export.webm" \
+# Segment 4 — Options: 2x speed (settings overview)
+ffmpeg -y -i "$RAW_DIR/segment4-options.webm" \
     -filter:v "setpts=0.5*PTS" -an \
     -c:v libx264 -crf 20 -preset fast \
     "$WORK_DIR/s4_fast.mp4" 2>/dev/null
-ok "  section4: 2x speed"
+ok "  segment4: 2x speed"
+
+# Segment 5 — Progress: 1.5x speed (highlight: progress bar)
+ffmpeg -y -i "$RAW_DIR/segment5-progress.webm" \
+    -filter:v "setpts=0.67*PTS" -an \
+    -c:v libx264 -crf 20 -preset fast \
+    "$WORK_DIR/s5_fast.mp4" 2>/dev/null
+ok "  segment5: 1.5x speed (highlight)"
 
 # ---------------------------------------------------------------------------
 # Stage 2: Add section title overlays (lower-third labels)
@@ -76,9 +83,10 @@ log "Stage 2: Adding section title overlays..."
 
 TITLES=(
     "Step 1 · Configuration"
+    "Step 1 · Loading Clips"
     "Step 2 · Review Clips"
     "Step 3 · Generation Options"
-    "Step 4 · Preview & Export"
+    "Step 4 · Generating"
 )
 
 # Use a system font that FFmpeg can find — fontfile path varies by OS
@@ -88,7 +96,7 @@ else
     FONT="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 fi
 
-for i in 1 2 3 4; do
+for i in 1 2 3 4 5; do
     title="${TITLES[$((i-1))]}"
     ffmpeg -y -i "$WORK_DIR/s${i}_fast.mp4" \
         -vf "drawtext=text='${title}':fontfile=${FONT}:fontsize=42:fontcolor=white:borderw=2:bordercolor=black@0.6:x=(w-tw)/2:y=h-80:enable='between(t,0,2.5)'" \
@@ -113,7 +121,7 @@ ok "  intro card (2.5s)"
 # Outro card: dark background with call-to-action (3 seconds)
 ffmpeg -y -f lavfi \
     -i "color=c=0x1a1a2e:s=1920x1080:d=3:r=30" \
-    -vf "drawtext=text='Try it yourself':fontfile=${FONT}:fontsize=56:fontcolor=white:x=(w-tw)/2:y=(h-th)/2-60,drawtext=text='github.com/samuelMusic/immich-memories':fontfile=${FONT}:fontsize=32:fontcolor=0x6C8EBF:x=(w-tw)/2:y=(h-th)/2+20,drawtext=text='Open source · Self-hosted · Privacy-first':fontfile=${FONT}:fontsize=24:fontcolor=0x888888:x=(w-tw)/2:y=(h-th)/2+80" \
+    -vf "drawtext=text='Try it yourself':fontfile=${FONT}:fontsize=56:fontcolor=white:x=(w-tw)/2:y=(h-th)/2-60,drawtext=text='github.com/sam-dumont/immich-video-memory-generator':fontfile=${FONT}:fontsize=32:fontcolor=0x6C8EBF:x=(w-tw)/2:y=(h-th)/2+20,drawtext=text='Open source · Self-hosted · Privacy-first':fontfile=${FONT}:fontsize=24:fontcolor=0x888888:x=(w-tw)/2:y=(h-th)/2+80" \
     -c:v libx264 -crf 18 -preset fast -pix_fmt yuv420p \
     "$WORK_DIR/outro.mp4" 2>/dev/null
 ok "  outro card (3s)"
@@ -135,6 +143,7 @@ INPUTS=(
     "$WORK_DIR/s2_titled.mp4"
     "$WORK_DIR/s3_titled.mp4"
     "$WORK_DIR/s4_titled.mp4"
+    "$WORK_DIR/s5_titled.mp4"
     "$WORK_DIR/outro.mp4"
 )
 

--- a/tests/e2e/redaction.py
+++ b/tests/e2e/redaction.py
@@ -77,23 +77,40 @@ _GENERIC_NAMES = [
 ]
 
 
+def _safe_evaluate(page: Page, expression: str, arg: object = None) -> None:
+    """Run page.evaluate with retry on context destruction.
+
+    NiceGUI's reactive rendering can destroy the JS execution context
+    mid-evaluation. We retry once after a short wait.
+    """
+    for attempt in range(3):
+        try:
+            if arg is not None:
+                page.evaluate(expression, arg)
+            else:
+                page.evaluate(expression)
+            return
+        except Exception as exc:
+            if "Execution context was destroyed" in str(exc) and attempt < 2:
+                page.wait_for_timeout(500)
+                continue
+            raise
+
+
 def redact_inputs(page: Page) -> None:
     """Replace sensitive input field values with fake data."""
+    # WHY: Use locator.fill() where possible — it auto-waits for element
+    # stability, avoiding the "execution context destroyed" crash that
+    # raw page.evaluate() hits during NiceGUI re-renders.
     for selector, value in _INPUT_REDACTIONS:
-        page.evaluate(
-            """({sel, val}) => {
-                const el = document.querySelector(sel);
-                if (el) {
-                    el.value = val;
-                    // Quasar wraps inputs — also set the inner control's value
-                    const native = el.closest('.q-field')?.querySelector('input');
-                    if (native && native !== el) native.value = val;
-                }
-            }""",
-            {"sel": selector, "val": value},
-        )
+        loc = page.locator(selector).first
+        if loc.is_visible(timeout=1000):
+            loc.fill(value)
+
     # Catch any remaining IP:port patterns in ALL input elements
-    page.evaluate("""() => {
+    _safe_evaluate(
+        page,
+        """() => {
         document.querySelectorAll('input').forEach(el => {
             if (/\\d+\\.\\d+\\.\\d+\\.\\d+/.test(el.value)) {
                 el.value = el.value.replace(
@@ -102,13 +119,15 @@ def redact_inputs(page: Page) -> None:
                 );
             }
         });
-    }""")
+    }""",
+    )
 
 
 def redact_text_nodes(page: Page) -> None:
     """Walk visible text nodes and replace patterns matching personal data."""
     for pattern, replacement in _TEXT_REDACTIONS:
-        page.evaluate(
+        _safe_evaluate(
+            page,
             """({pattern, repl}) => {
                 const regex = new RegExp(pattern);
                 const walker = document.createTreeWalker(
@@ -132,7 +151,8 @@ def redact_person_names(page: Page) -> None:
     The CSS approach hides real text (font-size: 0) and overlays fake names
     via ::after pseudo-elements, which Vue cannot clobber.
     """
-    page.evaluate(
+    _safe_evaluate(
+        page,
         """(names) => {
             let css = '';
             const options = document.querySelectorAll('[role="option"]');

--- a/tests/e2e/test_demo_recording.py
+++ b/tests/e2e/test_demo_recording.py
@@ -84,6 +84,12 @@ def _setup_step1(page: Page, app_url: str) -> None:
     redact_page(page)
 
 
+def _wait_for_stable(page: Page) -> None:
+    """Wait for NiceGUI to finish rendering before DOM manipulation."""
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(500)
+
+
 def _navigate_to_step2(page: Page) -> None:
     """Click Next to load clips."""
     next_btn = page.locator("button:has-text('Next')").first
@@ -91,6 +97,7 @@ def _navigate_to_step2(page: Page) -> None:
         next_btn.click()
     page.locator(".q-card, .clip-card, [class*='clip']").first.wait_for(timeout=_CLIP_LOAD_TIMEOUT)
     page.wait_for_timeout(1500)
+    _wait_for_stable(page)
     redact_page(page)
 
 
@@ -100,6 +107,7 @@ def _navigate_to_step3(page: Page) -> None:
     if next_btn.is_visible(timeout=3000):
         next_btn.click()
     page.wait_for_timeout(2000)
+    _wait_for_stable(page)
     redact_page(page)
 
 


### PR DESCRIPTION
## Summary

- Use `locator.fill()` for input redaction instead of raw `page.evaluate()` — auto-waits for DOM stability
- Add `_safe_evaluate()` wrapper with 3-retry on JS context destruction (NiceGUI reactive re-renders)
- Add `_wait_for_stable()` before `redact_page()` after step transitions
- Update `assemble-demo.sh` segment names to match Playwright test output (5 segments)
- Fix GitHub URL in outro card

## Test plan
- [x] `make demo-record` passes 5/6 segments (segment 6 is generation timeout, not redaction)
- [x] `make demo-assemble` produces 40.6s, 1.6MB demo.mp4
- [x] `make check` passes

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)