### PR TITLE
fix(ci): disable carryforward on integration-linux flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ locally, CI will pass too. Use conventional commit message format (see above).
 
 **Coverage upload flow:**
 - Public CI uploads unit coverage (`coverage.xml`) as `unittests` flag
-- GPU runner uploads integration coverage as `integration-linux` flag (carryforward enabled)
+- GPU runner uploads integration coverage as `integration-linux` flag
 - Codecov merges both flags for total coverage
 
 **Integration test folders:**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,10 @@
 comment: false
 
 codecov:
-  # WHY: Integration coverage XMLs (tests/*-coverage.xml) are generated locally
-  # and committed — their timestamps are stale. CI freshens them before upload,
-  # but this disables the server-side check as a safety net.
   max_report_age: off
 
-# Unit tests run in public CI (every commit). Integration tests run on GPU
-# runner (triggered by mirror). carryforward keeps integration coverage
-# between GPU runs so it's not lost when only unit tests re-upload.
+# Both flags upload fresh on every commit (public CI + GPU runner mirror).
+# carryforward OFF — no stale data from different Python versions.
 flags:
   unittests:
     paths:
@@ -17,7 +13,7 @@ flags:
   integration-linux:
     paths:
       - src/immich_memories/
-    carryforward: true
+    carryforward: false
 
 coverage:
   status:


### PR DESCRIPTION
## Summary

Disable `carryforward: true` on `integration-linux` Codecov flag.

The GPU runner runs for every push to main, so carryforward is unnecessary. The carried-forward data from the previous Python 3.13 run has inflated line counts (24,682 vs 21,333) that dilute the coverage percentage.

Part of #210

## Test plan

- [x] Config-only change