### PR TITLE
fix(ui): use unified selection pool in UI pipeline

### DIFF
--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -105,10 +105,13 @@ def _build_generation_params(state, selected_clips, output_path):
         subtitle=state.title_suggestion_subtitle,
         clip_segments=state.clip_segments,
         clip_rotations=state.clip_rotations,
-        include_photos=state.include_photos and bool(state.photo_assets),
-        photo_assets=_filter_selected_photos(state),
+        # WHY: Photos are already in selected_clips as IMAGE-type assets
+        # from the unified selection pool. Setting include_photos=False
+        # prevents _add_photos_if_enabled from re-adding them.
+        include_photos=False,
+        photo_assets=None,
         target_duration_seconds=state.target_duration * 60,
-        selected_photo_ids=state.selected_photo_ids if state.selected_photo_ids else None,
+        selected_photo_ids=None,
         # Music and upload handled separately by UI (AI gen, 4-stem ducking, NiceGUI progress)
         music_path=None,
         upload_enabled=False,

--- a/src/immich_memories/ui/pages/clip_pipeline.py
+++ b/src/immich_memories/ui/pages/clip_pipeline.py
@@ -183,10 +183,31 @@ def _run_pipeline_blocking(
                 analysis_config=app_config.analysis,
                 app_config=app_config,
             )
-            result = pipeline.run(
+
+            # Unified selection: analyze videos, score photos, merge, select
+            analyzed = pipeline.run_analysis(
                 clips=clips,
                 progress_callback=_make_progress_callback(progress_state),
             )
+
+            # Merge photos into the unified pool (same as CLI path)
+            all_candidates = analyzed
+            if state.include_photos and state.photo_assets:
+                from pathlib import Path
+
+                from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+
+                all_candidates = _merge_photos_into_pool(
+                    analyzed,
+                    photo_assets=state.photo_assets,
+                    include_photos=True,
+                    config=app_config,
+                    client=client,
+                    work_dir=Path(app_config.cache.cache_path) / "photo_scoring",
+                )
+
+            result = pipeline.run_selection(all_candidates)
+
             state.pipeline_result = {
                 "selected_clips": result.selected_clips,
                 "clip_segments": result.clip_segments,
@@ -196,42 +217,16 @@ def _run_pipeline_blocking(
             state.selected_clip_ids = {c.asset.id for c in result.selected_clips}
             state.clip_segments = result.clip_segments
 
-            # Score photos using unified budget (same logic as CLI)
+            # Photos are now in selected_clips as IMAGE-type assets
+            # Tell Step 4 not to re-add them via the old path
             if state.include_photos and state.photo_assets:
-                from pathlib import Path
+                from immich_memories.api.models import AssetType
 
-                from immich_memories.analysis.unified_budget import BudgetCandidate
-                from immich_memories.photos.photo_pipeline import score_and_select_photos
-
-                video_candidates = [
-                    BudgetCandidate(
-                        asset_id=c.asset.id,
-                        duration=c.duration_seconds,
-                        score=0.5,
-                        candidate_type="video",
-                        date=c.asset.file_created_at,
-                        is_favorite=c.asset.is_favorite,
-                    )
-                    for c in result.selected_clips
-                ]
-
-                photo_work_dir = Path(app_config.cache.cache_path) / "photo_scoring"
-                photo_work_dir.mkdir(parents=True, exist_ok=True)
-
-                photo_result = score_and_select_photos(
-                    photo_assets=state.photo_assets,
-                    video_candidates=video_candidates,
-                    config=app_config,
-                    target_duration=state.target_duration * 60,
-                    work_dir=photo_work_dir,
-                    download_fn=client.download_asset,
-                    thumbnail_fn=client.get_asset_thumbnail,
-                    memory_type=state.memory_type,
-                )
-
-                state.scored_photos = photo_result.scored_photos
-                state.selected_photo_ids = set(photo_result.selection.selected_photo_ids)
-                state.photo_budget_result = photo_result.selection
+                state.selected_photo_ids = {
+                    c.asset.id for c in result.selected_clips if c.asset.type == AssetType.IMAGE
+                }
+                state.scored_photos = []
+                state.photo_budget_result = None
 
             state.pipeline_running = False
             progress_state["done"] = True

--- a/tests/test_photo_selection.py
+++ b/tests/test_photo_selection.py
@@ -243,9 +243,11 @@ class TestAppStatePhotoFields:
 
 
 class TestStep4PassesPreSelectedPhotos:
-    """Step 4 passes selected_photo_ids from state to GenerationParams."""
+    """Step 4 disables old photo path — photos are in selected_clips via unified pool."""
 
-    def test_build_generation_params_includes_selected_photo_ids(self):
+    def test_build_generation_params_disables_photo_path(self):
+        """Photos are in selected_clips as IMAGE assets. The old _add_photos_if_enabled
+        path must be disabled to avoid double-adding them."""
         state = MagicMock()
         state.generation_options = {}
         state.selected_person = None
@@ -272,35 +274,9 @@ class TestStep4PassesPreSelectedPhotos:
 
             params = _build_generation_params(state, [], MagicMock())
 
-        assert params.selected_photo_ids == {"p1"}
-
-    def test_build_generation_params_none_when_empty_selection(self):
-        state = MagicMock()
-        state.generation_options = {}
-        state.selected_person = None
-        state.date_range = None
-        state.include_photos = True
-        state.photo_assets = [_make_asset("p1")]
-        state.photo_duration = 4.0
-        state.config = MagicMock()
-        state.config.photos.duration = 4.0
-        state.immich_url = "http://localhost:2283"
-        state.immich_api_key = "test-key"
-        state.demo_mode = False
-        state.memory_type = None
-        state.memory_preset_params = {}
-        state.title_suggestion_title = None
-        state.title_suggestion_subtitle = None
-        state.clip_segments = {}
-        state.clip_rotations = {}
-        state.target_duration = 10
-        state.selected_photo_ids = set()
-
-        with patch("immich_memories.api.immich.SyncImmichClient"):
-            from immich_memories.ui.pages._step4_generate import _build_generation_params
-
-            params = _build_generation_params(state, [], MagicMock())
-
+        # Unified pool: photos already in selected_clips, old path disabled
+        assert params.include_photos is False
+        assert params.photo_assets is None
         assert params.selected_photo_ids is None
 
 


### PR DESCRIPTION
## Summary

- UI pipeline now uses the same unified selection flow as CLI: `run_analysis()` → `_merge_photos_into_pool()` → `run_selection()`
- Removes the old separate `score_and_select_photos` path that ran after `pipeline.run()`
- Step 4 generation sets `include_photos=False` since photos are already in `selected_clips` as IMAGE-type assets

This ensures CLI and UI produce identical selection behavior — same temporal dedup, same coverage guarantees, same interleaving.

Closes #192

## Test plan

- [x] All 3450 unit tests pass
- [x] Full CI hooks pass
- [ ] Manual: run UI Step 2 → verify photo+video clips appear in unified grid


🤖 Generated with [Claude Code](https://claude.com/claude-code)