### PR TITLE
fix(ffmpeg): fallback to SDR when zscale filter unavailable

### DIFF
--- a/src/immich_memories/photos/animator.py
+++ b/src/immich_memories/photos/animator.py
@@ -537,12 +537,18 @@ class PhotoAnimator:
 
         # Gain-mapped source is linear light — add zscale PQ conversion
         if gain_map_hdr:
-            vf += (
-                ",zscale=transfer=smpte2084:transferin=linear"
-                ":primaries=bt2020:primariesin=bt709"
-                ":matrix=bt2020nc:matrixin=bt709"
-                ",format=yuv420p10le"
-            )
+            from immich_memories.processing.hdr_utilities import check_zscale_available
+
+            if check_zscale_available():
+                vf += (
+                    ",zscale=transfer=smpte2084:transferin=linear"
+                    ":primaries=bt2020:primariesin=bt709"
+                    ":matrix=bt2020nc:matrixin=bt709"
+                    ",format=yuv420p10le"
+                )
+            else:
+                logger.warning("zscale not available — HDR gain map photo rendered as SDR")
+                vf += ",format=yuv420p"
 
         return self._build_vf_command(source_path, output_path, duration, encoder_args, vf)
 

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -465,29 +465,42 @@ def _stream_render_to_mp4(
 
     Streams one frame at a time — O(1) memory.
     """
-    encoder_args = _get_photo_encoder_args()
+    from immich_memories.processing.hdr_utilities import check_zscale_available
+
+    has_zscale = check_zscale_available()
+    encoder_args = _get_photo_encoder_args() if has_zscale else _get_sdr_encoder_args()
 
     if gain_map_hdr:
-        # Gain-mapped source: 16-bit linear light → HLG
-        # npl must match the peak baked into the uint16 normalization
         pix_fmt = "rgb48le"
-        vf = (
-            f"zscale=t=arib-std-b67:tin=linear"
-            f":p=bt2020:pin=bt709"
-            f":m=bt2020nc:min=bt709"
-            f":npl={peak_nits}"
-            f",format=yuv420p10le"
-        )
+        if has_zscale:
+            vf = (
+                f"zscale=t=arib-std-b67:tin=linear"
+                f":p=bt2020:pin=bt709"
+                f":m=bt2020nc:min=bt709"
+                f":npl={peak_nits}"
+                f",format=yuv420p10le"
+            )
+        else:
+            # WHY: Without zscale, HDR gain map data can't be properly
+            # converted. Fall back to SDR: drop to 8-bit, skip HDR metadata.
+            logger.warning("zscale not available — rendering photo as SDR (HDR gain map ignored)")
+            pix_fmt = "rgb24"
+            vf = "format=yuv420p"
     else:
-        # SDR source: 8-bit sRGB → HLG
         pix_fmt = "rgb24"
-        vf = (
-            "zscale=t=arib-std-b67:tin=iec61966-2-1"
-            ":p=bt2020:pin=bt709"
-            ":m=bt2020nc:min=bt709"
-            ":npl=203"
-            ",format=yuv420p10le"
-        )
+        if has_zscale:
+            vf = (
+                "zscale=t=arib-std-b67:tin=iec61966-2-1"
+                ":p=bt2020:pin=bt709"
+                ":m=bt2020nc:min=bt709"
+                ":npl=203"
+                ",format=yuv420p10le"
+            )
+        else:
+            # WHY: Without zscale, render as plain SDR. Colors are correct
+            # but no HDR metadata — the photo won't match HDR video clips.
+            logger.warning("zscale not available — rendering photo as SDR")
+            vf = "format=yuv420p"
 
     proc = subprocess.Popen(
         [
@@ -525,8 +538,9 @@ def _stream_render_to_mp4(
     )
 
     assert proc.stdin is not None
+    use_16bit = pix_fmt == "rgb48le"
     for frame in render_ken_burns_streaming(img, target_w, target_h, params):
-        if gain_map_hdr:
+        if use_16bit:
             frame_bytes = (np.clip(frame * 65535, 0, 65535).astype(np.uint16)).tobytes()
         else:
             frame_bytes = (np.clip(frame * 255, 0, 255).astype(np.uint8)).tobytes()
@@ -593,3 +607,8 @@ def _get_photo_encoder_args() -> list[str]:
         "-x265-params",
         "hdr-opt=1:repeat-headers=1:colorprim=bt2020:transfer=arib-std-b67:colormatrix=bt2020nc",
     ]
+
+
+def _get_sdr_encoder_args() -> list[str]:
+    """SDR encoder args for when zscale is unavailable."""
+    return ["-c:v", "libx264", "-preset", "medium", "-crf", "18", "-pix_fmt", "yuv420p"]

--- a/src/immich_memories/processing/hdr_utilities.py
+++ b/src/immich_memories/processing/hdr_utilities.py
@@ -175,17 +175,28 @@ def _get_colorspace_filter(hdr_type: str) -> str:
     return ",setparams=colorspace=bt2020nc:color_primaries=bt2020:color_trc=arib-std-b67"
 
 
-def _check_zscale_available() -> bool:
-    """Return True if FFmpeg has the zscale filter available."""
+_zscale_cache: bool | None = None
+
+
+def check_zscale_available() -> bool:
+    """Return True if FFmpeg has the zscale filter available. Result is cached."""
+    global _zscale_cache  # noqa: PLW0603
+    if _zscale_cache is not None:
+        return _zscale_cache
     try:
         result = subprocess.run(
             ["ffmpeg", "-hide_banner", "-filters"],
             capture_output=True,
             text=True,
         )
-        return "zscale" in result.stdout
+        _zscale_cache = "zscale" in result.stdout
     except Exception:
-        return False
+        _zscale_cache = False
+    return _zscale_cache
+
+
+# Keep private alias for backward compat within this module
+_check_zscale_available = check_zscale_available
 
 
 def _get_sdr_to_hdr_filter(

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -1443,6 +1443,12 @@ class TestGetGpuEncoderArgs:
 
 
 class TestCheckZscaleAvailable:
+    def setup_method(self):
+        # WHY: check_zscale_available caches its result — reset between tests
+        import immich_memories.processing.hdr_utilities as hdr_mod
+
+        hdr_mod._zscale_cache = None
+
     def test_available(self):
         # WHY: subprocess.run checks ffmpeg filters
         with patch("immich_memories.processing.hdr_utilities.subprocess.run") as mock_run:
@@ -1457,3 +1463,105 @@ class TestCheckZscaleAvailable:
     def test_error_returns_false(self):
         with patch("immich_memories.processing.hdr_utilities.subprocess.run", side_effect=OSError):
             assert _check_zscale_available() is False
+
+
+class TestZscaleFallbackBehavior:
+    """When zscale is unavailable, photo rendering falls back to SDR."""
+
+    def setup_method(self):
+        import immich_memories.processing.hdr_utilities as hdr_mod
+
+        hdr_mod._zscale_cache = None
+
+    def test_photo_sdr_encoder_args_are_h264(self):
+        """SDR fallback should use H.264 (not HEVC HDR)."""
+        from immich_memories.photos.photo_pipeline import _get_sdr_encoder_args
+
+        args = _get_sdr_encoder_args()
+        assert "-c:v" in args
+        assert "libx264" in args
+        assert "yuv420p" in args
+
+    def test_photo_pipeline_uses_sdr_when_no_zscale(self):
+        """Without zscale, _stream_render_to_mp4 should use SDR filter (not crash)."""
+        from immich_memories.photos.photo_pipeline import _get_sdr_encoder_args
+
+        # WHY: mock check_zscale_available — we're testing the fallback decision
+        with patch("immich_memories.processing.hdr_utilities.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="scale only")
+            from immich_memories.processing.hdr_utilities import check_zscale_available
+
+            assert check_zscale_available() is False
+
+        # Verify SDR args don't include HDR metadata
+        args = _get_sdr_encoder_args()
+        assert "bt2020" not in " ".join(args)
+        assert "arib-std-b67" not in " ".join(args)
+
+    def test_photo_stream_render_sdr_fallback_for_gain_map(self):
+        """HDR gain map photo should fall back to SDR pix_fmt when no zscale."""
+        import immich_memories.processing.hdr_utilities as hdr_mod
+
+        hdr_mod._zscale_cache = False  # Force no-zscale
+
+        from immich_memories.photos.photo_pipeline import _stream_render_to_mp4
+
+        # WHY: mock subprocess.Popen — we're testing filter selection, not FFmpeg
+        with (
+            patch("immich_memories.photos.photo_pipeline.subprocess.Popen") as mock_popen,
+            patch(
+                "immich_memories.photos.photo_pipeline.render_ken_burns_streaming", return_value=[]
+            ),
+        ):
+            mock_proc = MagicMock()
+            mock_proc.returncode = 0
+            mock_proc.stdin = MagicMock()
+            mock_popen.return_value = mock_proc
+
+            import numpy as np
+
+            from immich_memories.photos.renderer import KenBurnsParams
+
+            img = np.zeros((100, 100, 3), dtype=np.uint8)
+            params = KenBurnsParams(duration=1.0, fps=1)
+
+            _stream_render_to_mp4(img, params, Path("/tmp/test.mp4"), 100, 100, gain_map_hdr=True)
+
+            call_args = mock_popen.call_args[0][0]
+            # Should use rgb24 (SDR) not rgb48le (HDR) and format=yuv420p not yuv420p10le
+            assert "rgb24" in call_args
+            assert "format=yuv420p" in call_args
+
+    def test_photo_stream_render_sdr_fallback_for_sdr_source(self):
+        """SDR photo should use simple format filter when no zscale."""
+        import immich_memories.processing.hdr_utilities as hdr_mod
+
+        hdr_mod._zscale_cache = False
+
+        from immich_memories.photos.photo_pipeline import _stream_render_to_mp4
+
+        with (
+            patch("immich_memories.photos.photo_pipeline.subprocess.Popen") as mock_popen,
+            patch(
+                "immich_memories.photos.photo_pipeline.render_ken_burns_streaming", return_value=[]
+            ),
+        ):
+            mock_proc = MagicMock()
+            mock_proc.returncode = 0
+            mock_proc.stdin = MagicMock()
+            mock_popen.return_value = mock_proc
+
+            import numpy as np
+
+            from immich_memories.photos.renderer import KenBurnsParams
+
+            img = np.zeros((100, 100, 3), dtype=np.uint8)
+            params = KenBurnsParams(duration=1.0, fps=1)
+
+            _stream_render_to_mp4(img, params, Path("/tmp/test.mp4"), 100, 100, gain_map_hdr=False)
+
+            call_args = mock_popen.call_args[0][0]
+            assert "rgb24" in call_args
+            assert "format=yuv420p" in call_args
+            # Must NOT contain zscale
+            assert not any("zscale" in str(a) for a in call_args)


### PR DESCRIPTION
## Summary

When FFmpeg is built without `libzimg` (e.g. Homebrew FFmpeg 8.1 dropped it), photo rendering crashed with "Broken pipe". Now falls back to SDR gracefully.

- `check_zscale_available()` made public + cached in `hdr_utilities.py`
- `photo_pipeline.py`: detects missing zscale, uses H.264/yuv420p instead of HEVC/HLG
- `animator.py`: skips HDR gain map zscale conversion, renders as SDR

Photos/titles still render correctly — just without HDR metadata when zscale is missing.

Closes #208

## Test plan

- [x] All unit tests pass
- [x] Diff coverage >= 80%
- [x] All CI hooks pass
- [ ] Manual: install FFmpeg without zimg, verify photo rendering works


🤖 Generated with [Claude Code](https://claude.com/claude-code)