### PR TITLE
fix(auth): expand env vars in issuer_url and client_id

### DIFF
--- a/src/immich_memories/config_models_auth.py
+++ b/src/immich_memories/config_models_auth.py
@@ -33,7 +33,7 @@ class AuthConfig(BaseModel):
     email_header: str = "Remote-Email"
     trusted_proxies: list[str] = Field(default_factory=list)
 
-    @field_validator("password", "client_secret", mode="before")
+    @field_validator("password", "client_secret", "issuer_url", "client_id", mode="before")
     @classmethod
     def expand_env(cls, v: str) -> str:
         if isinstance(v, str):


### PR DESCRIPTION
## Summary
- `AuthConfig.expand_env` field validator only covered `password` and `client_secret`
- `issuer_url` and `client_id` with `${VAR}` placeholders (standard for K8s ConfigMaps) stayed as literal strings
- Caused `UnsupportedProtocol: URL is missing protocol` on OIDC login

One-line fix: added `issuer_url` and `client_id` to the `@field_validator` decorator.

## Test plan
- [x] All 3481 tests pass
- [ ] OIDC login works on K8s deployment with env var config

🤖 Generated with [Claude Code](https://claude.com/claude-code)