### PR TITLE
fix(ci): update publisher and trim GPU dependencies

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,7 +105,7 @@ jobs:
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - name: Pin Python version for uv
         run: echo "${{ env.PYTHON_VERSION }}" > .python-version
-      - run: make dev
+      - run: make dev-test
 
       - name: Restore config
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1.14
 
   # Deploy docs after release (GITHUB_TOKEN events don't trigger other workflows,
   # so we call the docs workflow directly instead of relying on release:published)

--- a/docs/superpowers/plans/2026-08-15-release-and-arc-storage-hardening.md
+++ b/docs/superpowers/plans/2026-08-15-release-and-arc-storage-hardening.md
@@ -1,0 +1,140 @@
+# Release and ARC Storage Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the PyPI release incompatibility and prevent the self-hosted GPU job from consuming unrequested node ephemeral storage, using repository changes only.
+
+**Architecture:** Keep the application fix small and test it as workflow configuration: upgrade the publisher action and install the existing CI-specific dependency set. In the cluster repo, keep the reusable uv cache persistent but move runner work and temporary data to dynamically provisioned, per-pod PVCs on a dedicated `Delete` storage class; declare honest container ephemeral-storage resources for whatever remains on the node.
+
+**Tech Stack:** GitHub Actions YAML, pytest/PyYAML, Terraform HCL, ARC Helm values, Kubernetes generic ephemeral volumes, Python `unittest`.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-release-and-arc-storage-hardening-design.md`
+
+## Global Constraints
+
+- [ ] Change only `/Users/sam/Code/perso/immich-video-memory-generator` and `/Users/sam/Code/perso/rancher-cluster` source files.
+- [ ] Do not mutate live Kubernetes resources, workers, RKE2 agent configuration, Terraform state, GitHub workflows, releases, or branches.
+- [ ] Do not run `kubectl` mutations, SSH commands, `terraform apply`, workflow reruns, publishing, pushes, or service restarts.
+- [ ] Preserve unrelated untracked files in both repositories.
+- [ ] Stage and commit only the files named in each task.
+
+---
+
+### Task 1: Pin the metadata-2.5-compatible PyPI publisher
+
+**Files:**
+- Modify: `tests/test_docker_contract.py`
+- Modify: `.github/workflows/release.yml:341`
+
+- [ ] Add this workflow contract beside the existing release workflow test:
+
+```python
+def test_release_publisher_supports_core_metadata_2_5() -> None:
+    """The PyPI publisher must understand metadata emitted by current build tooling."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "release.yml").read_text())
+    steps = workflow["jobs"]["pypi-publish"]["steps"]
+    publish_step = next(step for step in steps if step.get("name") == "Publish to PyPI")
+
+    assert publish_step["uses"] == (
+        "pypa/gh-action-pypi-publish@"
+        "dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+    )
+```
+
+- [ ] Run `uv run pytest tests/test_docker_contract.py::test_release_publisher_supports_core_metadata_2_5 -q` and confirm it fails because the workflow still pins `cef2210...`.
+- [ ] Change the action pin to `pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1.14`.
+- [ ] Run the same targeted test and confirm it passes.
+
+### Task 2: Stop the GPU integration job from downloading unused CUDA/audio packages
+
+**Files:**
+- Modify: `tests/test_docker_contract.py`
+- Modify: `.github/workflows/integration.yml:108`
+
+- [ ] Add this contract test:
+
+```python
+def test_gpu_integration_uses_ci_dependency_set() -> None:
+    """GPU integration needs Taichi, not the full Torch and audio-ML stack."""
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "integration.yml").read_text()
+    )
+    run_commands = [
+        step.get("run")
+        for step in workflow["jobs"]["integration"]["steps"]
+        if "run" in step
+    ]
+
+    assert "make dev-test" in run_commands
+    assert "make dev" not in run_commands
+```
+
+- [ ] Confirm the job key from the parsed workflow, then run `uv run pytest tests/test_docker_contract.py::test_gpu_integration_uses_ci_dependency_set -q`; expected failure is missing `make dev-test`.
+- [ ] Change only the dependency-install command from `make dev` to the existing `make dev-test` target.
+- [ ] Run the same targeted test and confirm it passes.
+- [ ] Run `uv run ruff check tests/test_docker_contract.py` and `uv run pytest tests/test_docker_contract.py -q`.
+- [ ] Commit only `.github/workflows/release.yml`, `.github/workflows/integration.yml`, and `tests/test_docker_contract.py` with `fix(ci): update publisher and trim GPU dependencies`.
+
+### Task 3: Specify the ARC storage contract before changing Terraform
+
+**Files:**
+- Create: `/Users/sam/Code/perso/rancher-cluster/55-github-arc/tests/test_storage_contract.py`
+
+- [ ] Add a dependency-free `unittest.TestCase` that reads `arc.tf`, `cache.tf`, `../04-storage/storage_class.tf`, and checks all of these exact contracts:
+  - the `proxmox-ephemeral-xfs` resource uses the Proxmox CSI provisioner, XFS/local/SSD/no-cache parameters, expansion, `Delete`, and `WaitForFirstConsumer`;
+  - `arc.tf` defines generic ephemeral `work` and `tmp` volumes with 40Gi and 30Gi claims on that class;
+  - the runner mounts them at `/home/runner/_work` and `/tmp`;
+  - the runner requests 8Gi and limits 16Gi of `ephemeral-storage`;
+  - `cache.tf` requests 50Gi for the persistent uv cache;
+  - `Dockerfile.runner` does not exist.
+- [ ] Prefer narrow multiline snippet assertions over generic word-count assertions so the test proves the values are attached to the intended resources.
+- [ ] Run `python3 -m unittest 55-github-arc/tests/test_storage_contract.py -v` from the cluster repo and confirm failures cover the absent storage class/volumes/resources, old 30Gi cache, and dead Dockerfile.
+
+### Task 4: Add disposable runner storage and expand the persistent cache
+
+**Files:**
+- Modify: `/Users/sam/Code/perso/rancher-cluster/04-storage/storage_class.tf`
+- Modify: `/Users/sam/Code/perso/rancher-cluster/55-github-arc/arc.tf`
+- Modify: `/Users/sam/Code/perso/rancher-cluster/55-github-arc/cache.tf`
+- Delete: `/Users/sam/Code/perso/rancher-cluster/55-github-arc/Dockerfile.runner`
+
+- [ ] Add `kubernetes_storage_class_v1.proxmox_ephemeral_xfs` named `proxmox-ephemeral-xfs`, copying the existing Proxmox XFS parameters but omitting the default-class annotation and setting `reclaim_policy = "Delete"`.
+- [ ] In `local.arc_gpu_values`, replace the node-backed `tmp` `emptyDir` with these Kubernetes generic ephemeral volumes:
+  - `work`: 40Gi RWO claim on `proxmox-ephemeral-xfs`;
+  - `tmp`: 30Gi RWO claim on `proxmox-ephemeral-xfs`.
+- [ ] Mount `work` at `/home/runner/_work` and keep `tmp` at `/tmp`.
+- [ ] Add `ephemeral-storage: "8Gi"` to runner requests and `ephemeral-storage: "16Gi"` to limits.
+- [ ] Expand the shared `arc-uv-cache` PVC request from 30Gi to 50Gi; the existing class already has `allow_volume_expansion = true`.
+- [ ] Delete the unused `Dockerfile.runner`; no build or Helm value references it.
+- [ ] Run `python3 -m unittest 55-github-arc/tests/test_storage_contract.py -v` and confirm all contract tests pass.
+- [ ] Run `terraform fmt -check 04-storage/storage_class.tf 55-github-arc/arc.tf 55-github-arc/cache.tf` from the cluster repo.
+- [ ] Run `terraform -chdir=04-storage validate` and `terraform -chdir=55-github-arc validate` using only the existing initialized provider directories. Do not initialize providers or access the cluster; if either command requires that, report it instead of widening scope.
+- [ ] Commit only the four Terraform/Dockerfile paths plus the new contract test with `fix(arc): provision runner work storage`.
+
+### Task 5: Final local verification and scope audit
+
+**Files:**
+- Verify only; no new files expected.
+
+- [ ] In the app repo, run:
+
+```bash
+uv run pytest \
+  tests/test_docker_contract.py::test_release_publisher_supports_core_metadata_2_5 \
+  tests/test_docker_contract.py::test_gpu_integration_uses_ci_dependency_set -q
+uv run ruff check tests/test_docker_contract.py
+git status --short --branch
+git diff HEAD~1 --check
+```
+
+- [ ] In the cluster repo, run:
+
+```bash
+python3 -m unittest 55-github-arc/tests/test_storage_contract.py -v
+terraform fmt -check 04-storage/storage_class.tf 55-github-arc/arc.tf 55-github-arc/cache.tf
+git status --short --branch
+git diff HEAD~1 --check
+```
+
+- [ ] Inspect the two commits and confirm no live-operation script, worker/RKE2 file, Terraform state, generated provider directory, or unrelated user file was changed.
+- [ ] Report the exact passing commands, any validation that was safely skipped, both commit IDs, and the required deployment order (`04-storage` before `55-github-arc`) without applying or pushing anything.

--- a/docs/superpowers/specs/2026-08-15-release-and-arc-storage-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-15-release-and-arc-storage-hardening-design.md
@@ -1,0 +1,81 @@
+# Release and ARC Storage Hardening Design
+
+## Goal
+
+Fix the failed PyPI publication and stop GPU integration runners from being evicted when a job installs or generates more data than the Kubernetes node can safely hold.
+
+## Scope
+
+Only checked-in files in these repositories may change:
+
+- `immich-video-memory-generator`
+- `rancher-cluster`
+
+No command may mutate the live Kubernetes cluster. Do not apply Terraform, run mutating `kubectl` commands, SSH to workers, edit RKE2 configuration, restart `rke2-agent`, rerun GitHub workflows, publish packages, or push branches as part of this work.
+
+## Observed Failures
+
+The PyPI job rejected the `0.38.0` wheel because it uses core metadata 2.5 while the pinned `pypa/gh-action-pypi-publish` revision contains Twine 6.1, which supports metadata through 2.4.
+
+The GPU integration runner was evicted after using roughly 9.6 GiB of ephemeral storage. The current ARC values mount a persistent volume only at `/home/runner/.cache/uv`; the checkout and `.venv` under `/home/runner/_work` remain on nodefs. `/tmp` is also node-backed through an `emptyDir`.
+
+## Application Repository Changes
+
+Update `.github/workflows/release.yml` to pin `pypa/gh-action-pypi-publish` to commit `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`, the `release/v1.14` revision that includes Twine 7 and metadata 2.5 support.
+
+Update `.github/workflows/integration.yml` to install dependencies with `make dev-test` instead of `make dev`. The integration workflow does not run the optional Demucs/audio-ML suite, so installing every extra only pulls several gigabytes of unused PyTorch and CUDA packages.
+
+Add repository-level regression checks that parse the workflows and assert both pins. The checks must fail against the old workflow text and pass after the edits.
+
+## Cluster Repository Changes
+
+### Ephemeral StorageClass
+
+Add a non-default `proxmox-ephemeral-xfs` StorageClass beside `proxmox-data-xfs` in `04-storage/storage_class.tf`. It uses the same Proxmox CSI provisioner, XFS filesystem, local storage parameters, `WaitForFirstConsumer`, and volume expansion support. Its reclaim policy is `Delete`, so generic ephemeral runner volumes are removed when their owning pods disappear.
+
+The existing default `proxmox-data-xfs` StorageClass remains unchanged with `Retain` semantics for durable application data.
+
+### Per-runner volumes
+
+Replace the runner's node-backed `tmp` `emptyDir` in `55-github-arc/arc.tf` with two generic ephemeral volumes:
+
+- `work`: a 40 GiB claim using `proxmox-ephemeral-xfs`, mounted at `/home/runner/_work`.
+- `tmp`: a 30 GiB claim using `proxmox-ephemeral-xfs`, mounted at `/tmp`.
+
+Each runner receives separate claims through `volumeClaimTemplate`; concurrent runners cannot share or corrupt a workspace.
+
+Declare an 8 GiB `ephemeral-storage` request and a 16 GiB limit for the remaining writable image layer and logs. The large, variable job data belongs on the two CSI volumes rather than in this allowance.
+
+Expand `arc-uv-cache` in `55-github-arc/cache.tf` from 30 GiB to 50 GiB. The existing StorageClass supports online expansion. This is a declarative change only; applying it is outside this task.
+
+Delete `55-github-arc/Dockerfile.runner`. Nothing builds or references it, and introducing a private runner-image publishing and authentication path is unrelated to the storage failure.
+
+## Deployment Ordering
+
+When the owner later deploys these changes, `04-storage` must be applied before `55-github-arc` because the runner claims reference the new StorageClass by name. Deployment itself is explicitly outside this task.
+
+## Validation
+
+Application validation:
+
+- Run the targeted regression checks for the two workflow changes.
+- Parse all GitHub workflow YAML files.
+- Run the repository's relevant CI/workflow validation target if one exists.
+
+Cluster validation:
+
+- Run `terraform fmt -check -recursive` in the affected Terraform modules.
+- Run `terraform validate` in `04-storage` and `55-github-arc` when their existing initialized provider caches permit offline validation.
+- Render or inspect the Helm values and assert the two ephemeral claims, mount paths, sizes, and container storage resources.
+- Confirm the default durable StorageClass still uses `Retain` and the new runner StorageClass uses `Delete`.
+
+Validation must not contact or mutate the live cluster. A local validation blocked by missing provider initialization or backend credentials must be reported rather than bypassed with a live apply.
+
+## Success Criteria
+
+- The publisher action supports metadata 2.5.
+- GPU integration no longer installs unused audio-ML dependencies.
+- Runner checkout, virtual environment, and temporary media files no longer consume nodefs.
+- Per-job volumes are automatically reclaimed.
+- The uv cache has 50 GiB capacity in source configuration.
+- No live worker or cluster state is changed.

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -245,6 +245,28 @@ def test_release_images_receive_one_explicit_build_identity() -> None:
     assert "SOURCE_URL=https://github.com/${{ github.repository }}" in build_args
 
 
+def test_release_publisher_supports_core_metadata_2_5() -> None:
+    """The PyPI publisher must understand metadata emitted by current build tooling."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "release.yml").read_text())
+    steps = workflow["jobs"]["pypi-publish"]["steps"]
+    publish_step = next(step for step in steps if step.get("name") == "Publish to PyPI")
+
+    assert publish_step["uses"] == (
+        "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+    )
+
+
+def test_gpu_integration_uses_ci_dependency_set() -> None:
+    """GPU integration needs Taichi, not the full Torch and audio-ML stack."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "integration.yml").read_text())
+    run_commands = [
+        step.get("run") for step in workflow["jobs"]["integration"]["steps"] if "run" in step
+    ]
+
+    assert "make dev-test" in run_commands
+    assert "make dev" not in run_commands
+
+
 def test_pull_request_images_receive_required_build_arguments() -> None:
     """Every PR image build must satisfy the Dockerfile's fail-closed arguments."""
     workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())


### PR DESCRIPTION
## Description

- Pin `pypa/gh-action-pypi-publish` to the v1.14 commit that supports Core Metadata 2.5.
- Use the existing `make dev-test` dependency set in GPU integration CI instead of downloading the full Torch/CUDA/audio stack.
- Add workflow contract tests for both regressions.
- Document the related ARC storage hardening design and implementation plan.

The release failed because the older publisher bundled Twine 6.1, which rejected the package's Metadata-Version 2.5. The self-hosted GPU job was evicted after using roughly 10 GiB of node ephemeral storage with a request of zero; avoiding unused dependencies reduces that pressure. The companion cluster-side storage fix is [dropbars/rancher-cluster@4beb6f8](https://github.com/dropbars/rancher-cluster/commit/4beb6f86f7f4ca26e90147e305797bd843846d8a).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that causes existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test update
- [x] 🏗️ CI/Build changes

## Related Issues

None.

## Checklist

- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] I have run `make check` locally and all checks pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validation completed locally:

- `uv run pytest -q`: 4,433 passed, 7 skipped, 662 deselected
- `uv run ruff check tests/test_docker_contract.py`: passed
- Workflow contract suite: 21 passed