### PR TITLE
fix(audio): bound MLX memory during local ACE-Step generation

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -179,6 +179,17 @@ install ACE-Step's Gradio UI. CUDA hosts should use the pinned v0.1.8 release wi
 PyTorch wheels. `uv sync --inexact` preserves this manual installation. An exact `uv sync` removes
 packages not declared by this project, so rerun the ACE-Step commands afterward.
 
+### Memory on Apple Silicon
+
+In `lib` mode the app caps ACE-Step's MLX memory before loading models: the VAE decodes audio in
+~10 s chunks (`ACESTEP_MLX_VAE_CHUNK=256`) and the MLX buffer cache is limited to 4 GiB. Without
+this, ACE-Step's own heuristic picks an 82 s decode chunk on Macs with more than 64 GB and the
+process footprint grows by roughly 0.8 GiB per second of audio in that chunk — a 216 s track hit
+108 GB and macOS killed the UI. With the cap the same track peaks around 53 GB for the XL/4B profile
+(most of that is model weights) at a ~20% slower VAE decode. Set `ACESTEP_MLX_VAE_CHUNK` yourself
+to override the chunk size; ACE-Step's `ACESTEP_SAVE_MEMORY` and `MAX_MPS_VRAM` do not bound this
+allocation.
+
 For a hosted generator, leave ACE-Step out of the app environment and use `mode: "api"` with the
 server URL. For a desktop that normally runs locally but has a server available as backup, keep
 `mode: "lib"` and set `api_url`; the app uses the API only when the local package is unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -529,6 +529,7 @@ DEP001 = [
     "cv2", "Quartz", "Vision", "Metal", "CoreImage",   # Platform/alt-name imports
     "yaml", "acestep", "soundfile", "scipy",            # Optional deps imported conditionally
     "torchaudio", "demucs", "torchcodec", "loguru",      # Optional: local audio pipeline
+    "mlx",                                              # Optional: Apple Silicon ACE-Step path
     "PIL", "av", "freetype", "streamlit",               # Alt package names (Pillow→PIL, pyav→av)
     "starlette",                                        # Transitive via nicegui→fastapi→starlette
 ]

--- a/src/immich_memories/audio/generators/ace_step_backend.py
+++ b/src/immich_memories/audio/generators/ace_step_backend.py
@@ -39,6 +39,44 @@ from immich_memories.audio.generators.base import (
 
 logger = logging.getLogger(__name__)
 
+# WHY: ACE-Step's MLX VAE decode grows the MLX buffer cache by ~0.8 GiB per
+# second of audio inside one decode chunk, and on >64 GB Macs upstream picks an
+# 82 s chunk (2048 latent frames). MLX only trims that cache near its default
+# limit (~recommendedMaxWorkingSetSize, ~120 GiB on a 128 GB machine), so a
+# 216 s track pushed the host process past 100 GiB and macOS killed it. A small
+# chunk plus a hard cache limit keeps the same request around 50 GiB (measured:
+# 108 GB -> 53 GB peak footprint). Peak *active* memory stays a few GiB either
+# way, so the limit costs ~20% on VAE decode and nothing elsewhere.
+_MLX_VAE_CHUNK_FRAMES = 256  # 25 latent frames/s -> ~10 s of audio per decode
+_MLX_CACHE_LIMIT_BYTES = 4 * 1024**3
+
+
+def _bound_mlx_memory() -> int:
+    """Cap MLX allocator growth before ACE-Step constructs its handlers.
+
+    Must run before ``AceStepHandler()``: ACE-Step reads the chunk override
+    into a process-wide cached GPU config on first handler construction.
+    Returns the VAE chunk size in latent frames that ACE-Step should use.
+    """
+    os.environ.setdefault("ACESTEP_MLX_VAE_CHUNK", str(_MLX_VAE_CHUNK_FRAMES))
+    with suppress(ImportError):
+        import mlx.core as mx  # type: ignore[import-not-found]
+
+        mx.set_cache_limit(_MLX_CACHE_LIMIT_BYTES)
+    try:
+        return max(192, int(os.environ["ACESTEP_MLX_VAE_CHUNK"]))
+    except ValueError:
+        return _MLX_VAE_CHUNK_FRAMES
+
+
+def _release_mlx_cache() -> None:
+    """Hand cached Metal buffers back to macOS once a generation finishes."""
+    with suppress(ImportError):
+        import mlx.core as mx  # type: ignore[import-not-found]
+
+        mx.clear_cache()
+        mx.synchronize()
+
 
 def _is_ace_step_importable() -> bool:
     """Check if the ACE-Step 1.5 library API is importable."""
@@ -79,17 +117,18 @@ def _validate_torchcodec() -> None:
 
 
 def _run_with_suppressed_output(pipeline_fn, **kwargs):
-    """Run ACE-Step pipeline with loguru, tqdm, and FutureWarnings suppressed.
+    """Run the ACE-Step pipeline with loguru and FutureWarnings suppressed.
 
-    ACE-Step uses loguru (not stdlib logging) and tqdm progress bars that
-    bypass our logging config. Suppress them at the FD level during generation.
+    ACE-Step logs through loguru, which ignores stdlib logging config. Its tqdm
+    bars are disabled via ``ACESTEP_DISABLE_TQDM`` (set in ``_init_pipeline``).
+    The process's stderr is deliberately left alone: a native MLX/Metal failure
+    prints its only diagnostic there.
     """
     import warnings
 
     # WHY: torch.nn.utils.weight_norm emits a FutureWarning on every model load
     warnings.filterwarnings("ignore", category=FutureWarning, module="torch")
 
-    # WHY: ACE-Step uses loguru, which ignores stdlib logging config
     try:
         from loguru import logger as loguru_logger  # type: ignore[import-not-found]
 
@@ -97,16 +136,9 @@ def _run_with_suppressed_output(pipeline_fn, **kwargs):
     except ImportError:
         loguru_logger = None  # type: ignore[assignment]
 
-    # WHY: tqdm writes progress bars to stderr, bypassing Python logging
-    devnull_fd = os.open(os.devnull, os.O_WRONLY)
-    saved_err = os.dup(2)
     try:
-        os.dup2(devnull_fd, 2)
         return pipeline_fn(**kwargs)
     finally:
-        os.dup2(saved_err, 2)
-        os.close(saved_err)
-        os.close(devnull_fd)
         if loguru_logger is not None:
             loguru_logger.enable("acestep")
 
@@ -151,9 +183,14 @@ def _initialize_dit_handler(
     device: str,
     offload: bool,
     use_mlx_dit: bool,
+    mlx_vae_chunk: int | None = None,
 ) -> Any:
     """Initialize and validate the ACE-Step 1.5 DiT handler."""
     handler = handler_type()
+    if mlx_vae_chunk is not None and hasattr(handler, "mlx_vae_chunk_size"):
+        # WHY: belt and braces — the env override is ignored if ACE-Step's
+        # global GPU config was already cached earlier in this process.
+        handler.mlx_vae_chunk_size = mlx_vae_chunk
     status, initialized = handler.initialize_service(
         project_root=str(project_root),
         config_path=dit_model,
@@ -272,6 +309,27 @@ def _mood_to_structured_prompt(
     )
 
 
+def _run_v15_generation(
+    runtime: _ACEStepV15Runtime,
+    params: Any,
+    generation_config: Any,
+    output_dir: Path,
+) -> Any:
+    """Run one ACE-Step 1.5 generation on the worker thread and release MLX buffers after."""
+    try:
+        return _run_with_suppressed_output(
+            runtime.generate_music,
+            dit_handler=runtime.dit_handler,
+            llm_handler=runtime.llm_handler,
+            params=params,
+            config=generation_config,
+            save_dir=str(output_dir),
+        )
+    finally:
+        if runtime.device == "mps":
+            _release_mlx_cache()
+
+
 class ACEStepBackend(MusicGenerator):
     """ACE-Step 1.5 music generation backend.
 
@@ -370,6 +428,9 @@ class ACEStepBackend(MusicGenerator):
             from acestep.model_downloader import ensure_lm_model  # type: ignore[import-not-found]
 
             os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+            # WHY: tqdm bars were the reason stderr used to be redirected to
+            # /dev/null; upstream honours this switch, so stderr stays visible.
+            os.environ.setdefault("ACESTEP_DISABLE_TQDM", "1")
             os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
             os.environ.setdefault(
                 "ACESTEP_CHECKPOINTS_DIR",
@@ -384,6 +445,7 @@ class ACEStepBackend(MusicGenerator):
             checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
             device, lm_backend, use_mlx_dit = _local_runtime_target()
+            mlx_vae_chunk = _bound_mlx_memory() if use_mlx_dit else None
             dit_model = _dit_model_name(self.config.model_variant)
             lm_model = _lm_model_name(self.config.lm_model_size) if self.config.use_lm else None
             offload = bool(self.config.extra_args.get("cpu_offload", False)) and not (
@@ -404,6 +466,7 @@ class ACEStepBackend(MusicGenerator):
                 device=device,
                 offload=offload,
                 use_mlx_dit=use_mlx_dit,
+                mlx_vae_chunk=mlx_vae_chunk,
             )
             llm_handler = _initialize_lm_handler(
                 LLMHandler,
@@ -489,41 +552,39 @@ class ACEStepBackend(MusicGenerator):
         infer_step = 8 if is_turbo else 50
         timestep_shift = 3.0 if is_turbo else 1.0
 
-        def _run_pipeline():
-            runtime = self._pipeline
-            assert isinstance(runtime, _ACEStepV15Runtime)
-            params = runtime.generation_params_type(
-                caption=caption_result.caption,
-                lyrics="[Instrumental]",
-                instrumental=True,
-                bpm=caption_result.bpm,
-                keyscale=caption_result.key_scale,
-                timesignature=caption_result.time_signature,
-                duration=float(duration),
-                inference_steps=infer_step,
-                guidance_scale=1.0 if is_turbo else 7.0,
-                shift=timestep_shift,
-                thinking=self.config.use_lm,
-                use_cot_metas=self.config.use_lm,
-                use_cot_caption=self.config.use_lm,
-                use_cot_language=False,
-            )
-            generation_config = runtime.generation_config_type(
-                batch_size=1,
-                use_random_seed=True,
-                audio_format="wav",
-            )
-            return _run_with_suppressed_output(
-                runtime.generate_music,
-                dit_handler=runtime.dit_handler,
-                llm_handler=runtime.llm_handler,
-                params=params,
-                config=generation_config,
-                save_dir=str(request.output_dir),
-            )
+        runtime = self._pipeline
+        assert isinstance(runtime, _ACEStepV15Runtime)
+        params = runtime.generation_params_type(
+            caption=caption_result.caption,
+            lyrics="[Instrumental]",
+            instrumental=True,
+            bpm=caption_result.bpm,
+            keyscale=caption_result.key_scale,
+            timesignature=caption_result.time_signature,
+            duration=float(duration),
+            inference_steps=infer_step,
+            guidance_scale=1.0 if is_turbo else 7.0,
+            shift=timestep_shift,
+            thinking=self.config.use_lm,
+            use_cot_metas=self.config.use_lm,
+            use_cot_caption=self.config.use_lm,
+            use_cot_language=False,
+        )
+        generation_config = runtime.generation_config_type(
+            batch_size=1,
+            use_random_seed=True,
+            audio_format="wav",
+        )
 
         loop = asyncio.get_running_loop()
-        upstream_result = await loop.run_in_executor(None, _run_pipeline)
+        upstream_result = await loop.run_in_executor(
+            None,
+            _run_v15_generation,
+            runtime,
+            params,
+            generation_config,
+            request.output_dir,
+        )
 
         if not getattr(upstream_result, "success", False):
             error = getattr(upstream_result, "error", "unknown ACE-Step error")

--- a/tests/test_ace_step_backend.py
+++ b/tests/test_ace_step_backend.py
@@ -331,6 +331,97 @@ class TestACEStepBackendV15Library:
             "dtype": None,
         }
 
+    @staticmethod
+    def _fake_mlx_modules(captured: dict) -> dict:
+        # WHY: replaces the real MLX runtime — the test asserts allocator policy
+        # calls, not GPU work.
+        mlx_package = ModuleType("mlx")
+        mlx_core = ModuleType("mlx.core")
+
+        def set_cache_limit(limit: int) -> int:
+            captured.setdefault("cache_limits", []).append(limit)
+            return 0
+
+        mlx_core.set_cache_limit = set_cache_limit
+        mlx_core.clear_cache = lambda: captured.setdefault("clear_cache_calls", []).append(True)
+        mlx_core.synchronize = lambda: captured.setdefault("synchronize_calls", []).append(True)
+        mlx_package.core = mlx_core
+        return {"mlx": mlx_package, "mlx.core": mlx_core}
+
+    def test_v15_library_bounds_mlx_memory_before_handler_init(self, tmp_path):
+        """VAE chunk + MLX cache limit must be in place before ACE-Step builds handlers.
+
+        ACE-Step caches its GPU config on first handler construction, so a
+        chunk override applied afterwards is ignored.
+        """
+        captured = {}
+        modules, _ = self._fake_v15_modules(tmp_path, captured)
+        modules.update(self._fake_mlx_modules(captured))
+        base_handler = modules["acestep.handler"].AceStepHandler
+
+        class ObservingHandler(base_handler):
+            def __init__(self):
+                self.mlx_vae_chunk_size = 2048  # upstream default on >64 GB Macs
+                captured["env_at_handler_init"] = {
+                    "chunk": os.environ.get("ACESTEP_MLX_VAE_CHUNK"),
+                    "tqdm": os.environ.get("ACESTEP_DISABLE_TQDM"),
+                    "cache_limits": list(captured.get("cache_limits", [])),
+                }
+
+        modules["acestep.handler"].AceStepHandler = ObservingHandler
+        backend = ACEStepBackend(
+            ACEStepConfig(mode="lib", model_variant="acestep-v15-xl-turbo", use_lm=False)
+        )
+        env = {"ACESTEP_CHECKPOINTS_DIR": str(tmp_path / "checkpoints")}
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch.dict(os.environ, env, clear=False),
+            patch("platform.system", return_value="Darwin"),
+        ):
+            for key in ("ACESTEP_MLX_VAE_CHUNK", "ACESTEP_DISABLE_TQDM"):
+                os.environ.pop(key, None)
+            backend._init_pipeline()
+            handler = backend._pipeline.dit_handler
+
+        seen = captured["env_at_handler_init"]
+        assert seen["chunk"] == "256"
+        assert seen["tqdm"] == "1"
+        assert seen["cache_limits"] == [4 * 1024**3]
+        assert handler.mlx_vae_chunk_size == 256
+
+    @pytest.mark.parametrize("upstream_fails", [False, True])
+    def test_v15_library_releases_mlx_cache_after_generation(self, tmp_path, upstream_fails):
+        """Cached Metal buffers go back to the OS after every generation, even a failed one."""
+        captured = {}
+        modules, _ = self._fake_v15_modules(tmp_path, captured)
+        modules.update(self._fake_mlx_modules(captured))
+        if upstream_fails:
+
+            def failing_generate(**_kwargs):
+                raise RuntimeError("metal blew up")
+
+            modules["acestep.inference"].generate_music = failing_generate
+        backend = ACEStepBackend(ACEStepConfig(mode="lib", model_variant="turbo", use_lm=False))
+        backend._effective_mode = "lib"
+        request = GenerationRequest(
+            prompt="calm", duration_seconds=10, output_dir=tmp_path / "music"
+        )
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch.dict(os.environ, {"ACESTEP_CHECKPOINTS_DIR": str(tmp_path / "ckpt")}),
+            patch("platform.system", return_value="Darwin"),
+        ):
+            if upstream_fails:
+                with pytest.raises(RuntimeError, match="metal blew up"):
+                    asyncio.run(backend.generate(request))
+            else:
+                asyncio.run(backend.generate(request))
+
+        assert captured.get("clear_cache_calls") == [True]
+        assert captured.get("synchronize_calls") == [True]
+
     @pytest.mark.parametrize(
         ("variant", "expected_model", "expected_steps", "expected_shift"),
         [

--- a/tests/test_privacy_pipeline.py
+++ b/tests/test_privacy_pipeline.py
@@ -56,18 +56,20 @@ class TestValidateTorchcodec:
 
 
 class TestRunWithSuppressedOutput:
-    """Output suppression actually suppresses stderr."""
+    """Upstream chatter is silenced without hiding the process's own stderr."""
 
-    def test_suppresses_stderr(self):
+    def test_keeps_process_stderr_visible(self, capfd):
+        # WHY: the previous fd-2 redirect swallowed the only diagnostic when
+        # a native MLX failure killed the UI process; stderr must stay visible.
         from immich_memories.audio.generators.ace_step_backend import _run_with_suppressed_output
 
         def _noisy_fn(**kwargs):
-            # This writes to stderr — should be suppressed
-            os.write(2, b"SHOULD NOT APPEAR")
+            os.write(2, b"NATIVE DIAGNOSTIC")
             return kwargs.get("value", 42)
 
         result = _run_with_suppressed_output(_noisy_fn, value=99)
         assert result == 99
+        assert "NATIVE DIAGNOSTIC" in capfd.readouterr().err
 
     def test_returns_function_result(self):
         from immich_memories.audio.generators.ace_step_backend import _run_with_suppressed_output


### PR DESCRIPTION
Closes #283

## What

Local ACE-Step 1.5 (`mode: lib`, MLX path on Apple Silicon) could push the host process past 100 GiB on a long track and get the whole UI killed by macOS (`vm-compressor-space-shortage`), losing all in-memory wizard state. This bounds the MLX allocator before ACE-Step builds its handlers and stops hiding stderr during generation.

- `_bound_mlx_memory()` — sets `ACESTEP_MLX_VAE_CHUNK=256` and `mx.set_cache_limit(4 GiB)` **before** `AceStepHandler()` (upstream caches its GPU config on first handler construction), and mirrors the chunk onto the handler.
- `_release_mlx_cache()` after every generation (also on failure) so Metal buffers go back to the OS.
- `_run_with_suppressed_output` no longer `dup2`s fd 2 to `/dev/null` for the whole process; tqdm is disabled via `ACESTEP_DISABLE_TQDM` instead. The old redirect swallowed the only diagnostic when the process died.
- Docs: "Memory on Apple Silicon" note in `audio-and-music.md`.

## Why (root cause, verified)

ACE-Step's MLX VAE decode grows the MLX buffer cache by ~0.8 GiB per second of audio inside one decode chunk. On Macs with >64 GB unified memory upstream auto-selects `mlx_vae_chunk_size=2048` (82 s of audio) and only calls `mx.clear_cache()` every 4 chunks; MLX's default cache limit on a 128 GB machine is ~121 GiB, so nothing trims it. DiT/LM are small (~2 GiB at 216 s). `ACESTEP_SAVE_MEMORY` / `MAX_MPS_VRAM` do not touch this allocation.

Measured (bounded probes + the guarded benchmark, real XL/4B models, 216 s request):

| | peak footprint | result |
|---|---|---|
| before | 108 GB (jetsam) | UI process killed |
| after (this PR, real code path) | 53–56 GB | success, 79–89 s |

Note: `psutil` RSS on macOS excludes Metal buffers — use `footprint`/system-available when benchmarking this.

## Test plan

- [x] TDD: 3 new unit tests (bounds applied before handler init; cache released after success and failure; stderr stays visible)
- [x] `make ci` passes locally (4434 tests)
- [x] `make docs-build` passes
- [x] End-to-end: XL/4B 216 s through the modified backend on M5 Max 128 GB → 56 GB peak footprint, success

## Follow-ups (not in this PR)

- Pre-flight headroom check on system-available memory before local music generation
- Run local ACE-Step in a worker process so a native crash can't take the UI down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTVApDqT1TP91KCsJM2T8w
