### PR TITLE
fix(audio): release ACE-Step memory between batches and run the MLX DiT in bf16

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -190,6 +190,13 @@ process footprint grows by roughly 0.8 GiB per second of audio in that chunk —
 to override the chunk size; ACE-Step's `ACESTEP_SAVE_MEMORY` and `MAX_MPS_VRAM` do not bound this
 allocation.
 
+The MLX DiT copy runs in bf16 — the same precision ACE-Step uses on CUDA — instead of the fp32
+ACE-Step converts it from on macOS (7.8 GB instead of 15.5 GB for the XL model). Set
+`IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32=1` to keep fp32. Once a music batch finishes, the models are
+dropped and both torch's and MLX's caches are released, so the process falls back to ~1 GB between
+generations instead of holding ~27 GB of parked GPU memory; the next batch reloads the models
+(~25 s).
+
 For a hosted generator, leave ACE-Step out of the app environment and use `mode: "api"` with the
 server URL. For a desktop that normally runs locally but has a server available as backup, keep
 `mode: "lib"` and set `api_url`; the app uses the API only when the local package is unavailable.

--- a/src/immich_memories/audio/generators/ace_step_backend.py
+++ b/src/immich_memories/audio/generators/ace_step_backend.py
@@ -69,6 +69,31 @@ def _bound_mlx_memory() -> int:
         return _MLX_VAE_CHUNK_FRAMES
 
 
+def _cast_mlx_decoder_to_bf16(handler: Any) -> None:
+    """Run the MLX DiT at ACE-Step's reference GPU precision.
+
+    ACE-Step keeps the torch model in fp32 on MPS (a torch-MPS workaround) and
+    converts the MLX decoder from that copy, so the 4B XL decoder costs 15.5 GB
+    instead of the 7.8 GB the CUDA path uses in bf16. Set
+    ``IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32=1`` to keep fp32.
+    """
+    decoder = getattr(handler, "mlx_decoder", None)
+    if decoder is None or os.environ.get("IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32") == "1":
+        return
+    with suppress(ImportError):
+        import mlx.core as mx  # type: ignore[import-not-found]
+        from mlx.utils import tree_map  # type: ignore[import-not-found]
+
+        def _to_bf16(value: Any) -> Any:
+            if isinstance(value, mx.array) and mx.issubdtype(value.dtype, mx.floating):
+                return value.astype(mx.bfloat16)
+            return value
+
+        decoder.update(tree_map(_to_bf16, decoder.parameters()))
+        mx.eval(decoder.parameters())
+        mx.clear_cache()
+
+
 def _release_mlx_cache() -> None:
     """Hand cached Metal buffers back to macOS once a generation finishes."""
     with suppress(ImportError):
@@ -76,6 +101,24 @@ def _release_mlx_cache() -> None:
 
         mx.clear_cache()
         mx.synchronize()
+
+
+def _release_runtime_memory() -> None:
+    """Return the dropped runtime's GPU memory to the OS.
+
+    WHY: dropping the handlers frees the tensors, but torch's MPS caching
+    allocator keeps the freed heaps (~26 GB for XL/4B) until empty_cache(),
+    so a UI process would sit at ~27 GB between generations instead of ~1 GB.
+    """
+    import gc
+
+    gc.collect()
+    with suppress(ImportError):
+        import torch
+
+        if torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+    _release_mlx_cache()
 
 
 def _is_ace_step_importable() -> bool:
@@ -204,6 +247,8 @@ def _initialize_dit_handler(
     )
     if not initialized:
         raise RuntimeError(f"ACE-Step DiT initialization failed: {status}")
+    if use_mlx_dit:
+        _cast_mlx_decoder_to_bf16(handler)
     return handler
 
 
@@ -822,5 +867,7 @@ class ACEStepBackend(MusicGenerator):
         return info
 
     async def __aexit__(self, *args):
-        # Release pipeline memory if loaded
+        had_runtime = self._pipeline is not None
         self._pipeline = None
+        if had_runtime:
+            _release_runtime_memory()

--- a/tests/test_ace_step_backend.py
+++ b/tests/test_ace_step_backend.py
@@ -345,8 +345,27 @@ class TestACEStepBackendV15Library:
         mlx_core.set_cache_limit = set_cache_limit
         mlx_core.clear_cache = lambda: captured.setdefault("clear_cache_calls", []).append(True)
         mlx_core.synchronize = lambda: captured.setdefault("synchronize_calls", []).append(True)
+        mlx_core.eval = lambda *_args: None
+        mlx_core.float32, mlx_core.bfloat16, mlx_core.floating = "float32", "bfloat16", "floating"
+        mlx_core.issubdtype = lambda dtype, _category: dtype in ("float32", "bfloat16")
+
+        class FakeArray:
+            def __init__(self, dtype):
+                self.dtype = dtype
+
+            def astype(self, dtype):
+                return FakeArray(dtype)
+
+        mlx_core.array = FakeArray
+        mlx_utils = ModuleType("mlx.utils")
+
+        def tree_map(fn, tree):
+            return {k: fn(v) for k, v in tree.items()}
+
+        mlx_utils.tree_map = tree_map
         mlx_package.core = mlx_core
-        return {"mlx": mlx_package, "mlx.core": mlx_core}
+        mlx_package.utils = mlx_utils
+        return {"mlx": mlx_package, "mlx.core": mlx_core, "mlx.utils": mlx_utils}
 
     def test_v15_library_bounds_mlx_memory_before_handler_init(self, tmp_path):
         """VAE chunk + MLX cache limit must be in place before ACE-Step builds handlers.
@@ -422,6 +441,90 @@ class TestACEStepBackendV15Library:
         assert captured.get("clear_cache_calls") == [True]
         assert captured.get("synchronize_calls") == [True]
 
+    def test_v15_library_exit_returns_gpu_memory_to_the_os(self, tmp_path):
+        """Leaving the context drops the runtime AND empties torch/MLX caches.
+
+        Dropping the models alone leaves ~26 GB parked in torch's MPS caching
+        allocator, so the UI would sit at 27 GB between generations.
+        """
+        captured = {}
+        modules, _ = self._fake_v15_modules(tmp_path, captured)
+        modules.update(self._fake_mlx_modules(captured))
+        backend = ACEStepBackend(ACEStepConfig(mode="lib", model_variant="turbo", use_lm=False))
+        backend._effective_mode = "lib"
+
+        async def _use_backend():
+            async with backend:
+                backend._init_pipeline()
+                assert backend._pipeline is not None
+
+        # WHY: replaces the torch MPS allocator boundary (torch is an optional
+        # GPU extra, absent in CI) — we assert the release call, not real GPU work.
+        fake_torch = ModuleType("torch")
+        fake_torch.backends = SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True))
+        fake_torch.mps = SimpleNamespace(
+            empty_cache=lambda: captured.setdefault("torch_empty_cache", []).append(True)
+        )
+        modules["torch"] = fake_torch
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch.dict(os.environ, {"ACESTEP_CHECKPOINTS_DIR": str(tmp_path / "ckpt")}),
+            patch("platform.system", return_value="Darwin"),
+        ):
+            asyncio.run(_use_backend())
+
+        assert backend._pipeline is None
+        assert captured.get("torch_empty_cache") == [True]
+        assert captured.get("clear_cache_calls") == [True]
+        assert captured.get("synchronize_calls") == [True]
+
+    def test_v15_library_casts_mlx_decoder_to_bf16_after_dit_init(self, tmp_path):
+        """ACE-Step converts the MLX DiT from its fp32 torch copy; we cast it to bf16."""
+        captured = {}
+        modules, _ = self._fake_v15_modules(tmp_path, captured)
+        modules.update(self._fake_mlx_modules(captured))
+        fake_array = modules["mlx.core"].array
+        base_handler = modules["acestep.handler"].AceStepHandler
+
+        class FakeDecoder:
+            def __init__(self):
+                self._params = {"weight": fake_array("float32"), "step": 3}
+
+            def parameters(self):
+                return dict(self._params)
+
+            def update(self, params):
+                self._params.update(params)
+
+        class HandlerWithMlxDecoder(base_handler):
+            def __init__(self):
+                self.mlx_decoder = FakeDecoder()
+
+        modules["acestep.handler"].AceStepHandler = HandlerWithMlxDecoder
+        backend = ACEStepBackend(ACEStepConfig(mode="lib", model_variant="turbo", use_lm=False))
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch.dict(os.environ, {"ACESTEP_CHECKPOINTS_DIR": str(tmp_path / "ckpt")}),
+            patch("platform.system", return_value="Darwin"),
+        ):
+            os.environ.pop("IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32", None)
+            backend._init_pipeline()
+            params = backend._pipeline.dit_handler.mlx_decoder.parameters()
+
+        assert params["weight"].dtype == "bfloat16"
+        assert params["step"] == 3  # non-array leaves untouched
+
+    def test_invalid_vae_chunk_override_falls_back_to_default(self, tmp_path):
+        from immich_memories.audio.generators.ace_step_backend import _bound_mlx_memory
+
+        with (
+            patch.dict(sys.modules, self._fake_mlx_modules({})),
+            patch.dict(os.environ, {"ACESTEP_MLX_VAE_CHUNK": "not-a-number"}),
+        ):
+            assert _bound_mlx_memory() == 256
+
     @pytest.mark.parametrize(
         ("variant", "expected_model", "expected_steps", "expected_shift"),
         [
@@ -471,6 +574,43 @@ class TestACEStepBackendV15Library:
         assert result.audio_path == request.output_dir / "ace_step_v2.wav"
         assert result.audio_path.exists()
         assert result.metadata["infer_step"] == expected_steps
+
+
+class TestMlxDecoderPrecision:
+    """The MLX DiT copy runs at ACE-Step's reference GPU precision (bf16), not fp32."""
+
+    @staticmethod
+    def _handler_with_fp32_decoder():
+        mx = pytest.importorskip("mlx.core")
+        nn = pytest.importorskip("mlx.nn")
+        decoder = nn.Linear(4, 4)
+        mx.eval(decoder.parameters())
+        assert decoder.weight.dtype == mx.float32
+        return SimpleNamespace(mlx_decoder=decoder), mx
+
+    def test_mlx_decoder_is_cast_to_bf16(self):
+        from immich_memories.audio.generators.ace_step_backend import _cast_mlx_decoder_to_bf16
+
+        handler, mx = self._handler_with_fp32_decoder()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32", None)
+            _cast_mlx_decoder_to_bf16(handler)
+        assert handler.mlx_decoder.weight.dtype == mx.bfloat16
+        assert handler.mlx_decoder.bias.dtype == mx.bfloat16
+
+    def test_fp32_escape_hatch_keeps_decoder_untouched(self):
+        from immich_memories.audio.generators.ace_step_backend import _cast_mlx_decoder_to_bf16
+
+        handler, mx = self._handler_with_fp32_decoder()
+        with patch.dict(os.environ, {"IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32": "1"}):
+            _cast_mlx_decoder_to_bf16(handler)
+        assert handler.mlx_decoder.weight.dtype == mx.float32
+
+    def test_handler_without_mlx_decoder_is_a_no_op(self):
+        from immich_memories.audio.generators.ace_step_backend import _cast_mlx_decoder_to_bf16
+
+        _cast_mlx_decoder_to_bf16(SimpleNamespace(mlx_decoder=None))
+        _cast_mlx_decoder_to_bf16(SimpleNamespace())
 
 
 class TestACEStepBackendAPIAvailability:


### PR DESCRIPTION
Closes #285. Stacked on #284 (base is `fix/acestep-mlx-memory`; retarget to `main` once #284 merges — GitHub does this automatically).

## What

Two more memory levers for local ACE-Step on Apple Silicon, on top of #284:

- **Release GPU memory between batches.** `ACEStepBackend.__aexit__` already dropped the runtime, but torch's MPS caching allocator kept ~26 GB of freed heaps (and MLX its cache), so a UI process sat at **27 GB** between generations. Now `gc.collect()` + `torch.mps.empty_cache()` + `mx.clear_cache()`/`synchronize()` on exit → **1.2 GB** (measured 40 GB → 1.2 GB after a batch, no manual intervention).
- **MLX DiT in bf16.** ACE-Step keeps its torch model in fp32 on MPS (torch-MPS workaround) and converts the MLX decoder from that copy, so the 4B XL decoder costs 15.5 GB instead of the 7.8 GB the CUDA path uses in bf16. Cast it after init; `IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32=1` keeps fp32.

## Measurements (M5 Max 128 GB, XL/4B, real weights)

| | before | after |
|---|---|---|
| runtime loaded (at rest) | 47 GB | **39 GB** |
| peak during 180 s generation | 55 GB | **48 GB** |
| between batches | 27 GB | **1.2 GB** |

Same-seed A/B without the planner (only the decoder precision differs): waveform correlation **0.998**, SNR **23.7 dB**, envelope correlation 0.997.

What's left in the 39 GB is mostly ACE-Step instantiating a 15.5 GB fp32 torch decoder that the MLX path never uses — an upstream change (freeing it later only recovers ~2 GB because the MPS heaps stay fragmented while the encoders live in them).

## Test plan

- [x] TDD: exit releases caches (fake torch/MLX boundaries); bf16 cast (real MLX on macOS + fake MLX for CI); env escape hatch; invalid chunk env fallback
- [x] `make ci` green (4436 tests), `make docs-build` green, diff-cover 86.7%
- [x] End-to-end 180 s XL/4B through the modified backend: peak 48 GB, 1.2 GB after the batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTVApDqT1TP91KCsJM2T8w
