### PR TITLE
feat(speech): add transcription config and whisper.cpp adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,14 @@ speech = [
     "onnxruntime>=1.17",
     "kaldi-native-fbank>=1.20",
 ]
+# Speech transcription (whisper.cpp via pywhispercpp)
+# Prebuilt wheels exist for macOS arm64 (with Metal), manylinux x86_64/aarch64,
+# musllinux and Windows -- nothing compiles at install time. Linux wheels are
+# CPU-only. ggml model weights are NOT vendored (a base model is ~148 MB) and are
+# downloaded from HuggingFace on first use.
+transcribe = [
+    "pywhispercpp>=1.5",
+]
 # OIDC authentication (only needed for SSO login)
 auth = [
     "authlib>=1.6.12",
@@ -115,6 +123,7 @@ all = [
     "immich-memories[demucs]",
     "immich-memories[gpu]",
     "immich-memories[speech]",
+    "immich-memories[transcribe]",
 ]
 # All features for macOS (includes Apple Vision framework)
 all-mac = [
@@ -125,6 +134,7 @@ all-mac = [
     "immich-memories[mac]",
     "immich-memories[gpu]",
     "immich-memories[speech]",
+    "immich-memories[transcribe]",
 ]
 dev = [
     "pytest>=9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,6 +345,11 @@ module = [
     "onnxruntime.*",
     "kaldi_native_fbank",
     "kaldi_native_fbank.*",
+    # whisper.cpp bindings (optional, transcribe extra). CI installs only the dev
+    # extra, so the import must be ignorable or the type check fails there while
+    # passing on any machine that has the extra.
+    "pywhispercpp",
+    "pywhispercpp.*",
     # smart-turn's Hub download + log-mel extractor (not in any extra)
     "transformers",
     "transformers.*",

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -37,6 +37,7 @@ from immich_memories.config_models import (
     ServerConfig,
     SpeechConfig,
     TitleScreenConfig,
+    TranscriptionConfig,
     TripsConfig,
     UploadConfig,
 )
@@ -54,6 +55,7 @@ _TIER2_SECTIONS = frozenset(
         "content_analysis",
         "audio_content",
         "speech",
+        "transcription",
         "server",
         "auth",
         "automation",
@@ -101,7 +103,8 @@ class Config(BaseSettings):
       Tier 1 (top level): immich, defaults, output, audio, title_screens,
                            cache, upload, trips, photos
       Tier 2 (advanced:):  analysis, hardware, llm, musicgen, ace_step,
-                           content_analysis, audio_content, speech, server
+                           content_analysis, audio_content, speech, transcription,
+                           server
       Tier 3 (internal):   scheduler, title_llm
 
     At runtime, ALL sections are flat fields on Config (config.analysis, etc.).
@@ -131,6 +134,7 @@ class Config(BaseSettings):
     content_analysis: ContentAnalysisConfig = Field(default_factory=ContentAnalysisConfig)
     audio_content: AudioContentConfig = Field(default_factory=AudioContentConfig)
     speech: SpeechConfig = Field(default_factory=SpeechConfig)
+    transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
     title_screens: TitleScreenConfig = Field(default_factory=TitleScreenConfig)
     upload: UploadConfig = Field(default_factory=UploadConfig)
     photos: PhotoConfig = Field(default_factory=PhotoConfig)

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -803,6 +803,57 @@ class SpeechConfig(BaseModel):
     )
 
 
+class TranscriptionConfig(BaseModel):
+    """Settings for speech transcription of candidate clips.
+
+    Transcription is gated on voice activity, so it needs `speech.enabled`. With
+    speech off there are no VAD regions, so there is no gate, so nothing is
+    transcribed.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Transcribe speech in the top candidate clips",
+    )
+    languages: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Languages the library actually contains, e.g. ['fr', 'en']. One entry "
+            "forces that language and skips detection; several restrict detection to "
+            "that set. Empty means no transcription -- automatic detection across all "
+            "99 languages put French audio in Japanese and in German, twice out of two"
+        ),
+    )
+    model: str = Field(
+        default="base",
+        description="ggml model name (tiny/base/small/medium/large) or a path to a model file",
+    )
+    min_voiced_seconds: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=10.0,
+        description=(
+            "Voice activity required inside a clip before it is transcribed. Unmeasured "
+            "starting value: VAD already returns no regions at all on roughly half a "
+            "real library, which is where most of the saving comes from"
+        ),
+    )
+    min_confidence: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Mean token probability below which a transcript is discarded. Unmeasured "
+            "starting value. whisper.cpp exposes no per-segment no_speech_prob, so this "
+            "and the voice-activity floor are the whole gate"
+        ),
+    )
+    use_gpu: bool = Field(
+        default=True,
+        description="Use GPU when the installed whisper.cpp build supports it (Metal on macOS)",
+    )
+
+
 class ScoringPriorityConfig(BaseModel):
     """User-facing scoring knobs (Tier 1)."""
 

--- a/src/immich_memories/speech/transcription.py
+++ b/src/immich_memories/speech/transcription.py
@@ -12,10 +12,12 @@ import logging
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     import numpy as np
+
+    from immich_memories.config_models import TranscriptionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +39,19 @@ class Transcriber(Protocol):
     def transcribe(self, audio: np.ndarray) -> Transcript | None: ...
 
 
+# The injected whisper model is typed `Any` rather than given a Protocol.
+# pywhispercpp ships a stub that no honest Protocol matches: its audio parameter
+# is `str | ndarray[..., dtype[float32]]`, narrower than `np.ndarray`, so a
+# precise annotation fails contravariance; a blanket `**params: Any` promises any
+# keyword of any type, which the stub does not offer; and naming the keywords
+# individually trips Vulture, which reads a Protocol's keyword-only parameters as
+# unused variables. Three gates disagreeing about one seam is not worth a fourth
+# workaround -- the two methods used are `transcribe(audio, language=...,
+# extract_probability=True)` and `auto_detect_language(audio)`, and the tests pin
+# both.
+WhisperModel = Any
+
+
 def resolve_language(lang_probs: Mapping[str, float], configured: Sequence[str]) -> str | None:
     """Most probable language among the ones the library actually contains.
 
@@ -53,3 +68,122 @@ def resolve_language(lang_probs: Mapping[str, float], configured: Sequence[str])
 def strip_non_speech_markers(text: str) -> str:
     """Drop whisper's bracketed non-speech annotations and normalise whitespace."""
     return " ".join(_MARKER_RE.sub(" ", text).split())
+
+
+def _mean_probability(segments: list) -> float:
+    """Unweighted mean of the per-segment token probabilities.
+
+    Unweighted because weighting by duration would mean reading t0/t1. A three-to-
+    five second slice usually returns one segment, so there is little to weight.
+    """
+    values = [
+        float(segment.probability)
+        for segment in segments
+        if segment.probability == segment.probability  # NaN when not extracted
+    ]
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+class WhisperCppTranscriber:
+    """Transcriber backed by whisper.cpp through pywhispercpp.
+
+    The model is injected so tests never import pywhispercpp, matching how
+    SpeechAnalysisService takes its audio analyzer.
+    """
+
+    def __init__(self, config: TranscriptionConfig, model: WhisperModel | None = None):
+        self._config = config
+        self._model = model
+
+    def _load_model(self) -> WhisperModel:
+        model = self._model
+        if model is None:
+            from pywhispercpp.model import Model
+
+            model = Model(
+                self._config.model,
+                context_params={"use_gpu": self._config.use_gpu},
+                # Each of these is set against a pywhispercpp default that is wrong
+                # here: print_progress defaults to True and would write a progress
+                # line per segment per video, and no_context off lets whisper fall
+                # into repetition loops.
+                print_progress=False,
+                no_context=True,
+                temperature=0.0,
+            )
+            self._model = model
+        return model
+
+    def _resolve(self, model: WhisperModel, audio: np.ndarray) -> str | None:
+        configured = self._config.languages
+        if not configured:
+            return None
+        if len(configured) == 1:
+            return configured[0]
+        _, lang_probs = model.auto_detect_language(audio)
+        return resolve_language(lang_probs, configured)
+
+    def transcribe(self, audio: np.ndarray) -> Transcript | None:
+        model = self._load_model()
+        language = self._resolve(model, audio)
+        if language is None:
+            return None
+
+        segments = model.transcribe(audio, language=language, extract_probability=True)
+        if not segments:
+            return None
+
+        text = strip_non_speech_markers(" ".join(segment.text for segment in segments))
+        if not text:
+            return None
+
+        confidence = _mean_probability(segments)
+        if confidence < self._config.min_confidence:
+            logger.debug(
+                "Discarding transcript at confidence %.2f (floor %.2f)",
+                confidence,
+                self._config.min_confidence,
+            )
+            return None
+
+        return Transcript(text=text, language=language, confidence=confidence)
+
+
+def select_transcriber(config: TranscriptionConfig) -> Transcriber | None:
+    """A whisper.cpp transcriber, or `None` when transcription cannot run.
+
+    `None` is the null implementation: callers skip transcription entirely rather
+    than holding an object that always declines.
+    """
+    if not config.enabled:
+        return None
+
+    if not config.languages:
+        logger.warning(
+            "transcription.enabled is true but transcription.languages is empty -- "
+            "no transcripts will be produced. Set the languages your library contains, "
+            "e.g. languages: [fr, en]"
+        )
+        return None
+
+    try:
+        from pywhispercpp.model import Model
+    except ImportError:
+        logger.info(
+            "pywhispercpp is not installed -- transcription unavailable "
+            "(pip install 'immich-memories[transcribe]')"
+        )
+        return None
+
+    known = set(Model.available_languages())
+    languages = [lang for lang in config.languages if lang in known]
+    unknown = [lang for lang in config.languages if lang not in known]
+    if unknown:
+        logger.warning("Ignoring unknown language codes: %s", ", ".join(unknown))
+    if not languages:
+        logger.warning("No usable language codes configured -- transcription disabled")
+        return None
+
+    return WhisperCppTranscriber(config.model_copy(update={"languages": languages}))

--- a/src/immich_memories/speech/transcription.py
+++ b/src/immich_memories/speech/transcription.py
@@ -1,0 +1,55 @@
+"""Speech transcription for candidate clips.
+
+Transcription consumes an audio *slice* for one segment, never the whole video,
+so whisper is only ever asked what was said and never when. Its word timestamps
+measured as unusable -- zero inter-word gaps across 30 words, one word spanning
+1.56 to 11.66 seconds -- and slicing means no code path can depend on them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# whisper.cpp writes its non-speech annotations in brackets or parentheses:
+# [Music], [BLANK_AUDIO], (sighs). A result made of nothing else is not speech.
+_MARKER_RE = re.compile(r"[\[(][^\])]*[\])]")
+
+
+@dataclass(frozen=True)
+class Transcript:
+    """What was said in one segment, in one language, with one confidence."""
+
+    text: str
+    language: str
+    confidence: float
+
+
+class Transcriber(Protocol):
+    def transcribe(self, audio: np.ndarray) -> Transcript | None: ...
+
+
+def resolve_language(lang_probs: Mapping[str, float], configured: Sequence[str]) -> str | None:
+    """Most probable language among the ones the library actually contains.
+
+    Whisper's own top choice is never consulted. Detection across all 99
+    languages put French audio in Japanese and in German, twice out of two, so
+    the languages the library does not contain are not candidates at all.
+    """
+    candidates = [lang for lang in configured if lang in lang_probs]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda lang: lang_probs[lang])
+
+
+def strip_non_speech_markers(text: str) -> str:
+    """Drop whisper's bracketed non-speech annotations and normalise whitespace."""
+    return " ".join(_MARKER_RE.sub(" ", text).split())

--- a/tests/test_speech_transcription.py
+++ b/tests/test_speech_transcription.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from immich_memories.config_loader import Config
 from immich_memories.config_models import TranscriptionConfig
+from immich_memories.speech.transcription import (
+    resolve_language,
+    strip_non_speech_markers,
+)
 
 
 def test_transcription_defaults_to_off_with_no_languages():
@@ -30,3 +34,33 @@ def test_transcription_reads_from_the_advanced_block(tmp_path):
 
     assert config.transcription.enabled is True
     assert config.transcription.languages == ["fr", "en"]
+
+
+def test_resolve_language_ignores_the_global_winner_outside_the_configured_set():
+    """The reason the language config exists.
+
+    Whisper's own top-1 detection put French audio in Japanese and in German, two
+    attempts out of two. Restricting the argmax to the languages the library
+    actually contains turns a 99-way guess into a two-way decision.
+    """
+    lang_probs = {"ja": 0.55, "de": 0.20, "fr": 0.15, "en": 0.10}
+
+    assert resolve_language(lang_probs, ["fr", "en"]) == "fr"
+
+
+def test_resolve_language_returns_none_when_nothing_is_configured():
+    assert resolve_language({"fr": 0.9}, []) is None
+
+
+def test_resolve_language_ignores_codes_the_model_never_scored():
+    """A configured code absent from the probability mapping is not a candidate."""
+    assert resolve_language({"fr": 0.4, "en": 0.6}, ["xx", "fr"]) == "fr"
+
+
+def test_strip_non_speech_markers_removes_bracketed_annotations():
+    assert strip_non_speech_markers("[Music] hello there (sighs)") == "hello there"
+
+
+def test_strip_non_speech_markers_empties_a_marker_only_transcript():
+    """whisper.cpp answers [BLANK_AUDIO] on silence; that is not a transcript."""
+    assert strip_non_speech_markers("[BLANK_AUDIO]") == ""

--- a/tests/test_speech_transcription.py
+++ b/tests/test_speech_transcription.py
@@ -1,0 +1,32 @@
+"""Speech transcription: config, language resolution, and the whisper.cpp adapter."""
+
+from __future__ import annotations
+
+from immich_memories.config_loader import Config
+from immich_memories.config_models import TranscriptionConfig
+
+
+def test_transcription_defaults_to_off_with_no_languages():
+    """The feature ships inert: no languages configured means no transcripts."""
+    config = TranscriptionConfig()
+
+    assert config.enabled is False
+    assert config.languages == []
+
+
+def test_transcription_is_a_tier2_section_on_config():
+    """advanced.transcription in YAML must land flat on Config at runtime."""
+    config = Config()
+
+    assert isinstance(config.transcription, TranscriptionConfig)
+
+
+def test_transcription_reads_from_the_advanced_block(tmp_path):
+    """A Tier 2 section is written under `advanced:` and flattened on load."""
+    path = tmp_path / "config.yaml"
+    path.write_text("advanced:\n  transcription:\n    enabled: true\n    languages: [fr, en]\n")
+
+    config = Config.from_yaml(path)
+
+    assert config.transcription.enabled is True
+    assert config.transcription.languages == ["fr", "en"]

--- a/tests/test_speech_transcription.py
+++ b/tests/test_speech_transcription.py
@@ -2,12 +2,51 @@
 
 from __future__ import annotations
 
+import math
+import sys
+from unittest.mock import patch
+
+import numpy as np
+
 from immich_memories.config_loader import Config
 from immich_memories.config_models import TranscriptionConfig
 from immich_memories.speech.transcription import (
+    Transcript,
+    WhisperCppTranscriber,
     resolve_language,
+    select_transcriber,
     strip_non_speech_markers,
 )
+
+
+class FakeSegment:
+    def __init__(self, text: str, probability: float):
+        self.text = text
+        self.probability = probability
+
+
+class FakeModel:
+    """# WHY: replaces the pywhispercpp Model, an external ML model that would
+    otherwise download ~148 MB of weights and run inference in a unit test."""
+
+    def __init__(self, segments=None, lang_probs=None):
+        self._segments = segments if segments is not None else [FakeSegment("bonjour", 0.9)]
+        self._lang_probs = lang_probs or {"fr": 0.7, "en": 0.2, "ja": 0.1}
+        self.transcribe_calls: list[dict] = []
+        self.detect_calls = 0
+
+    def transcribe(self, audio, **params):
+        self.transcribe_calls.append(params)
+        return self._segments
+
+    def auto_detect_language(self, audio):
+        self.detect_calls += 1
+        best = max(self._lang_probs, key=lambda k: self._lang_probs[k])
+        return (best, self._lang_probs[best]), self._lang_probs
+
+
+def _audio(seconds: float = 3.0) -> np.ndarray:
+    return np.zeros(int(16000 * seconds), dtype=np.float32)
 
 
 def test_transcription_defaults_to_off_with_no_languages():
@@ -64,3 +103,81 @@ def test_strip_non_speech_markers_removes_bracketed_annotations():
 def test_strip_non_speech_markers_empties_a_marker_only_transcript():
     """whisper.cpp answers [BLANK_AUDIO] on silence; that is not a transcript."""
     assert strip_non_speech_markers("[BLANK_AUDIO]") == ""
+
+
+def test_single_configured_language_is_forced_without_detection():
+    """One language is a property of the library, not a question for the model."""
+    model = FakeModel()
+    transcriber = WhisperCppTranscriber(
+        TranscriptionConfig(enabled=True, languages=["fr"]), model=model
+    )
+
+    result = transcriber.transcribe(_audio())
+
+    assert model.detect_calls == 0, "detection must be skipped entirely"
+    assert model.transcribe_calls[0]["language"] == "fr"
+    assert result == Transcript(text="bonjour", language="fr", confidence=0.9)
+
+
+def test_several_configured_languages_detect_within_the_set():
+    model = FakeModel(lang_probs={"ja": 0.6, "fr": 0.3, "en": 0.1})
+    transcriber = WhisperCppTranscriber(
+        TranscriptionConfig(enabled=True, languages=["fr", "en"]), model=model
+    )
+
+    result = transcriber.transcribe(_audio())
+
+    assert model.detect_calls == 1
+    assert model.transcribe_calls[0]["language"] == "fr"
+    assert result is not None
+    assert result.language == "fr"
+
+
+def test_low_confidence_transcript_is_discarded():
+    """whisper.cpp exposes no no_speech_prob, so mean token probability is the gate."""
+    model = FakeModel(segments=[FakeSegment("mmm", 0.3)])
+    transcriber = WhisperCppTranscriber(
+        TranscriptionConfig(enabled=True, languages=["fr"], min_confidence=0.6), model=model
+    )
+
+    assert transcriber.transcribe(_audio()) is None
+
+
+def test_marker_only_transcript_is_discarded():
+    model = FakeModel(segments=[FakeSegment("[BLANK_AUDIO]", 0.95)])
+    transcriber = WhisperCppTranscriber(
+        TranscriptionConfig(enabled=True, languages=["fr"]), model=model
+    )
+
+    assert transcriber.transcribe(_audio()) is None
+
+
+def test_confidence_is_the_unweighted_mean_of_segment_probabilities():
+    """Weighting by duration would mean reading t0/t1, which this design refuses."""
+    model = FakeModel(segments=[FakeSegment("un", 0.8), FakeSegment("deux", 1.0)])
+    transcriber = WhisperCppTranscriber(
+        TranscriptionConfig(enabled=True, languages=["fr"]), model=model
+    )
+
+    result = transcriber.transcribe(_audio())
+
+    assert result is not None
+    assert math.isclose(result.confidence, 0.9)
+    assert result.text == "un deux"
+
+
+def test_select_transcriber_returns_none_when_disabled():
+    assert select_transcriber(TranscriptionConfig(enabled=False, languages=["fr"])) is None
+
+
+def test_select_transcriber_returns_none_without_languages():
+    assert select_transcriber(TranscriptionConfig(enabled=True, languages=[])) is None
+
+
+def test_select_transcriber_returns_none_without_pywhispercpp():
+    """The extra is optional: absent means no transcripts, not a crash."""
+    # WHY: replaces the pywhispercpp import itself. A None entry in sys.modules
+    # makes `from pywhispercpp.model import Model` raise ImportError, which is what
+    # a machine without the extra installed produces.
+    with patch.dict(sys.modules, {"pywhispercpp": None, "pywhispercpp.model": None}):
+        assert select_transcriber(TranscriptionConfig(enabled=True, languages=["fr"])) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1782,6 +1782,7 @@ all = [
     { name = "mutagen", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "onnxruntime", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "panns-inference", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pywhispercpp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "taichi", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'linux') or sys_platform == 'darwin' or sys_platform == 'win32'" },
     { name = "torch", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -1798,6 +1799,7 @@ all-mac = [
     { name = "pyobjc-framework-metal", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "pywhispercpp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "taichi", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'linux') or sys_platform == 'darwin' or sys_platform == 'win32'" },
     { name = "torch", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -1854,6 +1856,9 @@ mac = [
 speech = [
     { name = "kaldi-native-fbank", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "onnxruntime", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+transcribe = [
+    { name = "pywhispercpp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -1922,6 +1927,9 @@ requires-dist = [
     { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=9.0" },
+    { name = "pywhispercpp", marker = "extra == 'all'", specifier = ">=1.5" },
+    { name = "pywhispercpp", marker = "extra == 'all-mac'", specifier = ">=1.5" },
+    { name = "pywhispercpp", marker = "extra == 'transcribe'", specifier = ">=1.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "refurb", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -1940,7 +1948,7 @@ requires-dist = [
     { name = "videohash", specifier = ">=3.0" },
     { name = "watchdog", specifier = ">=3.0" },
 ]
-provides-extras = ["all", "all-mac", "audio", "audio-ml", "auth", "demucs", "dev", "face", "gpu", "mac", "speech"]
+provides-extras = ["all", "all-mac", "audio", "audio-ml", "auth", "demucs", "dev", "face", "gpu", "mac", "speech", "transcribe"]
 
 [[package]]
 name = "import-linter"
@@ -4344,6 +4352,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/5e/90b39adff710d698c00ba9c3125e2bec99dad7c5f1a3ba37c73a78a6689f/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9950eb7c8b942e9bfa53d87c7e45a420dcddbd835c4c5f1aca045a3f775c6113", size = 4477378, upload-time = "2025-08-04T16:19:58.162Z" },
     { url = "https://files.pythonhosted.org/packages/f1/1a/89f5f4ebcb9d34d9b7b2ac0a868c8b6d8c78d699a36f54407a060cea0566/pywavelets-1.9.0-cp314-cp314t-win32.whl", hash = "sha256:097f157e07858a1eb370e0d9c1bd11185acdece5cca10756d6c3c7b35b52771a", size = 4209132, upload-time = "2025-08-04T16:20:00.371Z" },
     { url = "https://files.pythonhosted.org/packages/68/d2/a8065103f5e2e613b916489e6c85af6402a1ec64f346d1429e2d32cb8d03/pywavelets-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b6ff6ba4f625d8c955f68c2c39b0a913776d406ab31ee4057f34ad4019fb33b", size = 4306793, upload-time = "2025-08-04T16:20:02.934Z" },
+]
+
+[[package]]
+name = "pywhispercpp"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "platformdirs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/8778f0685a4d32d74efdfa78fc5f745ca9998d96f8121dbf7793db2da5d3/pywhispercpp-1.5.0.tar.gz", hash = "sha256:5aa54c73ec96617d97aa519dbbf817e44255eddd9bd52ee1243be61028dbd018", size = 2333262, upload-time = "2026-05-30T03:43:37.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/d4/a0519c6e8ca2020c46d93870fbf901793e2624ac5c1b71d710aff0a27fb4/pywhispercpp-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d92eec44b49595ab1454cff1d10faa83b0b27779db8d8f00592ed363f0c5a262", size = 3961932, upload-time = "2026-05-30T03:42:41.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/be/e2d4c0d04d36679a9e525959163c7a87aa5dd97730da6e8a130a90104a0b/pywhispercpp-1.5.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b43ddd44e65ca53d5ab1f62b623bc3edc64019bbe06b9641fff2dfef704c990", size = 3962091, upload-time = "2026-05-30T03:42:43Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c3/079908901f25db85e2b1ed11b5bacd0aa7652ff87887f277209dc205a29d/pywhispercpp-1.5.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f895cbbf5ba71a9e3f0e6afb4b6ae49bae5c716dc6a8a4d905eb789d9fe2238", size = 4434882, upload-time = "2026-05-30T03:42:44.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1c/085db38c0cf10b944bf7871574006843790a9bf993fbf3c35b9375a85e8f/pywhispercpp-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:70e925fad2c48554d3f5baf79e2746540268d2974b5cf40a4880887e4a065c2f", size = 4736877, upload-time = "2026-05-30T03:42:45.943Z" },
+    { url = "https://files.pythonhosted.org/packages/24/6a/eab565086cd200f65b5e6f99e09ec41fa32df3e034bbb95dea9d214fa0bc/pywhispercpp-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b592011cd992a5bcd36d0923477fb4cfdd338a0c7ce58997de195a14ab2b6d9a", size = 5208795, upload-time = "2026-05-30T03:42:47.501Z" },
+    { url = "https://files.pythonhosted.org/packages/46/67/698d430788da7da92932b3313466f5e43f3e7e7bee88ddaa22caeb0da157/pywhispercpp-1.5.0-cp311-cp311-win32.whl", hash = "sha256:c35c16f5da31d79be604dfd082b8bb67d5d46ba2f7f59bf5ab13857d5cd6ec6b", size = 1169400, upload-time = "2026-05-30T03:42:48.774Z" },
+    { url = "https://files.pythonhosted.org/packages/72/16/7795546c6fd65056c0818165280c7da84c0dae7c5cd39dd2d7759496d2ee/pywhispercpp-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:1bc31f684b6a38000e397824155bda3b45b61af6acc9f7e0f3bfa70e20b574e3", size = 1317016, upload-time = "2026-05-30T03:42:49.803Z" },
+    { url = "https://files.pythonhosted.org/packages/78/22/e944ab33c3daf6c78f30d6dd943d84ececf3eb4625da2a3eedacff5590cd/pywhispercpp-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:24602b8d0329a224fe6eb1c1e455853e983a5e04a63d4cb759ae2f275e254f5f", size = 3963140, upload-time = "2026-05-30T03:42:50.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a3/e1daeb58fc76b9cd5f108708ecbeb4e1175ee9d366502033066eae71c51b/pywhispercpp-1.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839b738936a8cd72cdd55c59a83a462820532bee78e233241bf9a3503e92144", size = 3962387, upload-time = "2026-05-30T03:42:52.536Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a7/d8b196d1fa83ec6072c32e021f1987079bbeb25009a4fe7a10967d02b249/pywhispercpp-1.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ad4071772eb9dad59a741611e44e3819e6249c46e295ab8468609d03c6e4232", size = 4437117, upload-time = "2026-05-30T03:42:53.842Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/28069ac89a08ebc3e56616a07a36c1628d61fa679a45ea3f507da7f5cb13/pywhispercpp-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:22f9ddf12f6fb0fe3c43465d976b554e8928fcc113c902127e94c792d85f0631", size = 4736369, upload-time = "2026-05-30T03:42:55.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c8/2e63aaf0c1c6f9a3e4f05db9c2c6f8f922937f0b508f5f9e338b2ac5e58a/pywhispercpp-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f825942067da3b0c48fc5b552b816fcee1761e955b9fdfdc911f0ab2d6fff11", size = 5211824, upload-time = "2026-05-30T03:42:56.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/15/bf1ff8b4fbc777fa2bfc89ff8cddff103ee251807f3f440a518184da7570/pywhispercpp-1.5.0-cp312-cp312-win32.whl", hash = "sha256:03025227d0da211e382db6b6b16d910a267c663b6b2c57092b1200965ec45393", size = 1170123, upload-time = "2026-05-30T03:42:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/88/fb11006f84b0af46cedf1f66a6190bb78cafb29c0d89d5a73d5ba25ffc43/pywhispercpp-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9b1cd9dd4c3eb7fb2b777529eb62618e58a6bb05be20f82b7b1afe3d0b12274", size = 1318389, upload-time = "2026-05-30T03:42:59.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d1/0fa142a92fd89bde6b05c8af4f4f48caae64ae1087771b61a43aa5e4a7c7/pywhispercpp-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:64415b7687c0b39e66652b38683983ef7f23e174d7b3b05caa539955da8b088e", size = 3963201, upload-time = "2026-05-30T03:43:00.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7b/aacf3166d890bc6efe73ad35f5de32e96ce69706878486b50d92567e7554/pywhispercpp-1.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:649af3ae0f9dc0d0dd757d8c2adfc6d929b1b203ac1ba85d5ac453015ddd6e63", size = 3962374, upload-time = "2026-05-30T03:43:01.812Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/58/8e651f7210eeb64721562406a69c769e72fdd4560fa8d5ca4895cab5b4e2/pywhispercpp-1.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ea8fa7f5ce602d3e986fb11c4c2973b471f1b14e0fe75e01a66f1a60aecbfbf", size = 4437279, upload-time = "2026-05-30T03:43:03.09Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/50fc2a47a80ac9464e5e17cf0144a80a1764426277240b6bb8ffe930541b/pywhispercpp-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4363fa893e398d1f18a5775374109aa310022b9f4fc777a89329b12963f3149d", size = 4736450, upload-time = "2026-05-30T03:43:04.249Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cd/645214d9161fc50f6b7ba2a44897b9cadcc0358f9cdcaa36e913472def4d/pywhispercpp-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c9498eb9f4c38ea121da2435b5275c267486a5e14dddf5e72ec54a480b1fb44e", size = 5211883, upload-time = "2026-05-30T03:43:05.391Z" },
+    { url = "https://files.pythonhosted.org/packages/26/50/90365a2aae2ad8fc7eedbc89321537dd7eee1e8ba37397ce9f5ec4f26f71/pywhispercpp-1.5.0-cp313-cp313-win32.whl", hash = "sha256:d2805f15361247ada04a34b51c556514527b984f9b089a4e32f1b2a4abbc5367", size = 1170165, upload-time = "2026-05-30T03:43:06.661Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/42/8926c7ffe918c82a574fb63b15b252fd6c8569e7cd45077f6cb98b1af0fa/pywhispercpp-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:57dd5111d4dd9fe3f0e784a03a3337df5abd514260a7d16656733d110316d2f0", size = 1318418, upload-time = "2026-05-30T03:43:07.715Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/391d4585b61d35dd8fe2b90328f46bec1205ba0706438ec385c51a914838/pywhispercpp-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1f94300f2fa1748f67f63a9240b526e8542b2dad1ceca5ea87ec2e9e15a939a", size = 3963952, upload-time = "2026-05-30T03:43:09.054Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8c/58786b3fe14d68cdba055922c8c2b7503588b01f46701a5cc36dd58f9ce1/pywhispercpp-1.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c393c01a0a77007a17d17cb706e08cba97f0e35ea0268733af1792949d03ceb", size = 3963344, upload-time = "2026-05-30T03:43:10.25Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/de/e324e88c2a4dfa985eb078bcb3d4f9f4cf7f8777d0653371f10110af4ce7/pywhispercpp-1.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6777b5d40c0679952ded7934f7119d5fbfd606ec348293f869f430795609bae", size = 4437634, upload-time = "2026-05-30T03:43:11.713Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/273c2e6d73a746a5f2efada5886ca532da3cc312a267a7c0bd5e629e53a4/pywhispercpp-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a2fe9312fe3c08f832da392296118cc8cc1fc901753289132253f2066d911357", size = 4737949, upload-time = "2026-05-30T03:43:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0c/077f0649f40179a04b69d54ad5a57ce5229f92fa0d17f9c512bb051fbba5/pywhispercpp-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ea34ae824a6f934ba7736e6440f93cc467a7ec98b9c8fb2e5a37bb439ffa93b9", size = 5212029, upload-time = "2026-05-30T03:43:14.274Z" },
+    { url = "https://files.pythonhosted.org/packages/08/88/a92e632999d26b410bea6244e24f2606467cd88e6980098e134b1ccbb1dc/pywhispercpp-1.5.0-cp314-cp314-win32.whl", hash = "sha256:f5d13b4a7e34b9f4eebf70bff150ec36f4145c580bd5d812b9a3139611e7433c", size = 1203706, upload-time = "2026-05-30T03:43:15.478Z" },
+    { url = "https://files.pythonhosted.org/packages/51/62/2e331213b3a211d79dcbfaa1abb6f05dc20df2e9aa49dc787b9b65e7b47b/pywhispercpp-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:77d4d0ff382b5bc1369e9f77a851b45659edf5974e0903ffb15b981a043d216b", size = 1358500, upload-time = "2026-05-30T03:43:16.732Z" },
+    { url = "https://files.pythonhosted.org/packages/00/6b/d1c9cacc56b4a2064e3f71ac14d4ba848cd4653724ee4431b77e39d8a1c7/pywhispercpp-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4bb409027566b473100e43f07fac48f9c8bdb6cba1ac0fbff5594a6f5a0e1b7e", size = 3979612, upload-time = "2026-05-30T03:43:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/ab215917094403ee3255b9c52b495525fca809697364e4c247324de86803/pywhispercpp-1.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbdbb1bb236f4481ff6ea475aed9ed091393ddb02271df309645d71de207778d", size = 3964093, upload-time = "2026-05-30T03:43:19.227Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d4/ca6ba9b20beac14d80bc10d9bd5e826e4d3efedd5e6ac41f389d7801aeb9/pywhispercpp-1.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:568669bae45bd879bba1e35401cefc89d572428bd17326ce8437107ab80003d0", size = 4437185, upload-time = "2026-05-30T03:43:20.9Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e5/ad59d5979e63ac9455491d3c1fd219e4bebd486bec97765b6a33ec5f013b/pywhispercpp-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:358261055c56a96a04f6b0ff419633ffc61ef61027788b2bb2c6e7dca69abdb7", size = 4738540, upload-time = "2026-05-30T03:43:22.282Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e7/4c6ab180c30e02ddb4e49e2c27ea2e82950598c3abc681db6841f109798b/pywhispercpp-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:24da0c0bd33068f4c9c3f45eae3e6b7fb31d9b5d3487e4e1e1323b4253288d62", size = 5210500, upload-time = "2026-05-30T03:43:23.977Z" },
+    { url = "https://files.pythonhosted.org/packages/93/85/c15aa8ec8c1a43c7097e7a437f10aaffd8db3eb12ff27fff030688d0e407/pywhispercpp-1.5.0-cp314-cp314t-win32.whl", hash = "sha256:9806e084ebf956c7e492c76ea31c708e894849024772b3c3a57f85c342afc341", size = 1219916, upload-time = "2026-05-30T03:43:25.134Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/56/00dcf7627eb0a0b5db4d1d36c9a3d91d86b92e13fd53f4f3e72304ab53b6/pywhispercpp-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:dc8dbcb6033db306e9ec450d835c005dd491c457937c79ef2673ea8797cbb93c", size = 1381519, upload-time = "2026-05-30T03:43:26.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part 1 of 3 for #293. **Nothing calls any of this yet** — it is the transcription
machinery with no caller, so the diff cannot change a single frame of output.

Parts 2 and 3 follow: the voice-activity gate and `transcribe_segment` (PR B), then
persistence and the pipeline step (PR C).

## What's here

- a Tier 2 `transcription:` config section
- `resolve_language`, which takes the argmax over **the configured languages only**
- `strip_non_speech_markers`, for whisper's `[Music]` / `[BLANK_AUDIO]` / `(sighs)`
- `Transcriber` Protocol + `WhisperCppTranscriber` + `select_transcriber`
- a `transcribe` extra pinning `pywhispercpp>=1.5`

16 unit tests, none of which import pywhispercpp — the model is injected.

## Why `languages` is required rather than optional

```yaml
advanced:
  transcription:
    enabled: false
    languages: []          # e.g. [fr, en]; empty means no transcription
```

An empty list means **no transcripts**, not "fall back to auto-detection". #293's own
measurement found whisper's 99-way detection put French audio in Japanese and in
German, two attempts out of two. A transcript in the wrong language is worse than no
transcript for every downstream consumer, so the failure mode of forgetting to
configure this is an empty column rather than a confident wrong answer.

With one language it is forced and detection never runs. With several,
`auto_detect_language()` produces probabilities for all 99 and the argmax is taken
**within the configured set** — a two-way decision instead of a 99-way guess, at the
cost of one mel pass rather than a second decode.

## Two departures from the issue text

**`no_speech_prob` is not reachable.** #293 specifies rejecting a transcript on
`no_speech_prob > 0.6` regardless of `avg_logprob`. The getter exists in the C API
(`whisper.h`, `whisper_full_get_segment_no_speech_prob`) but no usable surface exposes
it: `whisper-cli --output-json-full` emits only token `p` and `t_dtw`, and
pywhispercpp binds the `no_speech_thold` *input* parameter without binding the getter.
That criterion came from OpenAI's Python reference implementation, where
`no_speech_prob` is in the result dict.

The post-ASR gate is therefore the mean of `Segment.probability` (from
`extract_probability=True`) plus the marker-only check. The pre-ASR half — voice
activity — arrives in PR B, and it is the one that does most of the work, since VAD
already returns no regions at all on roughly half a real library.

**`min_voiced_seconds: 1.0` and `min_confidence: 0.6` are guesses**, not measurements,
and both field descriptions say so. They are calibratable against the 44 labelled
clips from #292 later; that is a separate exercise from landing the plumbing.

## Why pywhispercpp rather than shelling out to whisper-cli

Checked rather than assumed:

- prebuilt wheels for cp39–cp314 on macOS arm64, manylinux x86_64/aarch64, musllinux
  and Windows — **nothing compiles at install**. The macOS arm64 wheel bundles
  `libggml-metal.dylib`; Linux wheels are CPU-only (`-DGGML_NATIVE=OFF`, no CUDA),
  which is fine for three-second slices.
- `Model.transcribe()` accepts a **numpy array**, so PR B feeds it the 16 kHz mono
  float32 that `SpeechAnalysisService` already caches — no temp WAV, no second FFmpeg
  pass.
- `Model.auto_detect_language()` returns probabilities for **all** languages, not just
  the winner, which is what constrained detection needs.

Verified against the real 1.5.0 wheel: `available_languages()` returns 100 codes,
`transcribe` takes `extract_probability` plus `**params`, and `__init__` takes
`context_params`.

Since neither backend exposes `no_speech_prob`, the subprocess route had no remaining
advantage.

## Degradation

`content_analysis.enabled` and `audio_content.enabled` are irrelevant to all of it.

| pywhispercpp | `transcription.enabled` | `languages` | result |
|---|---|---|---|
| absent | true | `[fr]` | no transcriber, one INFO line, nothing else changes |
| present | false | — | no transcriber |
| present | true | `[]` | no transcriber, one WARNING naming the fix |
| present | true | `[fr]` | forced language |
| present | true | `[fr, en]` | constrained detection |

Unknown language codes are dropped with a warning rather than passed to the model.

## One thing worth a reviewer's eye

`WhisperModel` is aliased to `Any` rather than declared as a Protocol, with a comment
explaining why. Three gates disagreed about typing that seam precisely: pywhispercpp's
stub types its audio parameter `str | ndarray[..., dtype[float32]]`, narrower than
`np.ndarray`, so a precise Protocol fails contravariance; a blanket `**params: Any`
promises any keyword of any type, which the stub does not offer; and naming the
keywords individually trips Vulture, which reads a Protocol's keyword-only parameters
as unused variables. The behaviour is pinned by tests instead. Happy to revisit if you
prefer a different trade.

## Verification

`make ci` green (4543 passed, 9 skipped) and `make semgrep` clean — the latter because
it is **not** part of `make ci` but *is* part of the CI Security Scan job, which is a
gap worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016veDe6HjnoTgbYaxGmRojY
