### PR TITLE
feat(speech): gate and orchestrate per-segment transcription

### DIFF
--- a/src/immich_memories/analysis/speech_analysis.py
+++ b/src/immich_memories/analysis/speech_analysis.py
@@ -16,13 +16,15 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from immich_memories.audio.audio_models import SPEECH_EVENT_CLASS
-from immich_memories.config_models import SpeechConfig
+from immich_memories.config_models import SpeechConfig, TranscriptionConfig
 from immich_memories.speech.models import SpeechRegion
+from immich_memories.speech.transcription import select_transcriber
 from immich_memories.speech.vad import VAD_SAMPLE_RATE, extract_audio_16k, select_detector
 
 if TYPE_CHECKING:
     from immich_memories.audio.audio_models import AudioAnalysisResult, AudioEvent
     from immich_memories.config_models import AudioContentConfig
+    from immich_memories.speech.transcription import Transcriber, Transcript
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +81,8 @@ class SpeechAnalysisService:
         speech_config: SpeechConfig | None = None,
         audio_content_enabled: bool = False,
         audio_analyzer: object | None = None,
+        transcription_config: TranscriptionConfig | None = None,
+        transcriber: Transcriber | None = None,
     ):
         """Initialize the speech analysis service.
 
@@ -87,6 +91,8 @@ class SpeechAnalysisService:
             speech_config: SpeechConfig controlling VAD-derived protected ranges.
             audio_content_enabled: Enable audio content analysis (laughter detection).
             audio_analyzer: Pre-built PANNs analyzer, or None to lazy-create.
+            transcription_config: TranscriptionConfig controlling speech transcription.
+            transcriber: Pre-built transcriber, or None to select one from config.
         """
         self._audio_content_config = audio_content_config
         self.speech_config = speech_config or SpeechConfig()
@@ -96,6 +102,12 @@ class SpeechAnalysisService:
         self._audio_analysis_cache: dict[str, AudioAnalysisResult] = {}
         self._vad_audio_cache: dict[str, np.ndarray | None] = {}
         self._vad_regions_cache: dict[str, list[SpeechRegion]] = {}
+        self.transcription_config = transcription_config or TranscriptionConfig()
+        self._transcriber = (
+            transcriber
+            if transcriber is not None
+            else select_transcriber(self.transcription_config)
+        )
 
     def clear_cache(self, release_audio_analyzer: bool = False) -> None:
         """Clear internal caches to free memory.
@@ -315,3 +327,42 @@ class SpeechAnalysisService:
                     audio, VAD_SAMPLE_RATE
                 )
         return self._vad_regions_cache[cache_key]
+
+    def transcribe_segment(self, video_path: Path, start: float, end: float) -> Transcript | None:
+        """Transcribe one segment, or decline.
+
+        Declining is the common case and is not an error: no transcriber
+        configured, too little voice activity, or a result the post-ASR gate
+        rejected. Nothing downstream scores on the outcome either way.
+
+        The transcriber receives a slice of the cached 16 kHz array, never the
+        whole video, so whisper is only ever asked what was said and never when.
+        """
+        if self._transcriber is None or not self.speech_config.enabled:
+            return None
+
+        regions = self.detect_regions_cached(video_path)
+        voiced = voiced_seconds(regions, start, end)
+        if voiced < self.transcription_config.min_voiced_seconds:
+            logger.debug(
+                "Skipping transcription of %.1fs-%.1fs: %.2fs voiced (floor %.2fs)",
+                start,
+                end,
+                voiced,
+                self.transcription_config.min_voiced_seconds,
+            )
+            return None
+
+        audio = self.extract_audio_cached(video_path)
+        if audio is None:
+            return None
+
+        segment_audio = audio[int(start * VAD_SAMPLE_RATE) : int(end * VAD_SAMPLE_RATE)]
+        if segment_audio.size == 0:
+            return None
+
+        try:
+            return self._transcriber.transcribe(segment_audio)
+        except (RuntimeError, ValueError, OSError) as exc:
+            logger.warning("Transcription failed for %s: %s", video_path.name, exc)
+            return None

--- a/src/immich_memories/analysis/speech_analysis.py
+++ b/src/immich_memories/analysis/speech_analysis.py
@@ -60,6 +60,11 @@ def non_speech_protected_ranges(
     ]
 
 
+def voiced_seconds(regions: list[SpeechRegion], start: float, end: float) -> float:
+    """Total voice-activity time inside [start, end]."""
+    return sum(max(0.0, min(region.end, end) - max(region.start, start)) for region in regions)
+
+
 class SpeechAnalysisService:
     """Audio-content (PANNs) and VAD speech-boundary analysis.
 
@@ -90,6 +95,7 @@ class SpeechAnalysisService:
         self._audio_analyzer = audio_analyzer  # Injected or lazy-created
         self._audio_analysis_cache: dict[str, AudioAnalysisResult] = {}
         self._vad_audio_cache: dict[str, np.ndarray | None] = {}
+        self._vad_regions_cache: dict[str, list[SpeechRegion]] = {}
 
     def clear_cache(self, release_audio_analyzer: bool = False) -> None:
         """Clear internal caches to free memory.
@@ -100,6 +106,7 @@ class SpeechAnalysisService:
         """
         self._audio_analysis_cache.clear()
         self._vad_audio_cache.clear()
+        self._vad_regions_cache.clear()
         if release_audio_analyzer and self._audio_analyzer is not None:
             if hasattr(self._audio_analyzer, "cleanup"):
                 self._audio_analyzer.cleanup()
@@ -109,6 +116,7 @@ class SpeechAnalysisService:
         """Release current-video state while retaining reusable configuration and models."""
         self._audio_analysis_cache.clear()
         self._vad_audio_cache.clear()
+        self._vad_regions_cache.clear()
 
     def run_audio_content_analysis(
         self,
@@ -256,12 +264,12 @@ class SpeechAnalysisService:
         if not self.speech_config.enabled or self._speech_detector is None:
             return result
 
-        audio = self.extract_audio_cached(video_path)
-        if audio is None:
+        regions = self.detect_regions_cached(video_path)
+        if not regions:
             return result
 
-        regions = self._speech_detector.detect(audio, VAD_SAMPLE_RATE)
-        if not regions:
+        audio = self.extract_audio_cached(video_path)
+        if audio is None:
             return result
 
         duration = video_duration or (len(audio) / VAD_SAMPLE_RATE)
@@ -290,3 +298,20 @@ class SpeechAnalysisService:
         if cache_key not in self._vad_audio_cache:
             self._vad_audio_cache[cache_key] = extract_audio_16k(video_path)
         return self._vad_audio_cache[cache_key]
+
+    def detect_regions_cached(self, video_path: Path) -> list[SpeechRegion]:
+        """VAD regions for a video, computed once and reused.
+
+        Both boundary placement and the transcription gate need them; running
+        FireRedVAD twice over one cached array buys nothing.
+        """
+        cache_key = str(video_path)
+        if cache_key not in self._vad_regions_cache:
+            audio = self.extract_audio_cached(video_path)
+            if audio is None or self._speech_detector is None:
+                self._vad_regions_cache[cache_key] = []
+            else:
+                self._vad_regions_cache[cache_key] = self._speech_detector.detect(
+                    audio, VAD_SAMPLE_RATE
+                )
+        return self._vad_regions_cache[cache_key]

--- a/tests/test_speech_transcription_gate.py
+++ b/tests/test_speech_transcription_gate.py
@@ -8,8 +8,9 @@ from unittest.mock import patch
 import numpy as np
 
 from immich_memories.analysis.speech_analysis import SpeechAnalysisService, voiced_seconds
-from immich_memories.config_models import AudioContentConfig, SpeechConfig
+from immich_memories.config_models import AudioContentConfig, SpeechConfig, TranscriptionConfig
 from immich_memories.speech.models import SpeechRegion
+from immich_memories.speech.transcription import Transcript
 
 
 def test_voiced_seconds_counts_only_the_overlap_with_the_segment():
@@ -48,3 +49,116 @@ def test_regions_are_detected_once_per_video():
     assert first == second
     assert detect.call_count == 1
     assert extract.call_count == 1
+
+
+class RecordingTranscriber:
+    """# WHY: replaces the whisper.cpp model so the gate's decision to call or not
+    call it is observable without running inference."""
+
+    def __init__(self, result: Transcript | None = None):
+        self.result = result or Transcript(text="bonjour", language="fr", confidence=0.9)
+        self.calls: list[int] = []
+
+    def transcribe(self, audio):
+        self.calls.append(len(audio))
+        return self.result
+
+
+def _service(transcriber, **overrides) -> SpeechAnalysisService:
+    return SpeechAnalysisService(
+        audio_content_config=AudioContentConfig(),
+        speech_config=SpeechConfig(enabled=True),
+        transcription_config=TranscriptionConfig(enabled=True, languages=["fr"], **overrides),
+        transcriber=transcriber,
+    )
+
+
+def _patched(service, regions):
+    # WHY: replaces extract_audio_16k, the FFmpeg boundary.
+    audio = patch(
+        "immich_memories.analysis.speech_analysis.extract_audio_16k",
+        return_value=np.zeros(16000 * 10, dtype=np.float32),
+    )
+    # WHY: replaces the FireRedVAD ONNX model with fixed regions.
+    detect = patch.object(service._speech_detector, "detect", return_value=regions)
+    return audio, detect
+
+
+def test_thin_voice_activity_never_reaches_the_model():
+    """The pre-ASR gate is the whole point: half a real library has no VAD regions."""
+    transcriber = RecordingTranscriber()
+    service = _service(transcriber, min_voiced_seconds=1.0)
+    audio, detect = _patched(service, [SpeechRegion(start=2.0, end=2.4)])
+
+    with audio, detect:
+        result = service.transcribe_segment(Path("/fake.mov"), 2.0, 5.0)
+
+    assert result is None
+    assert transcriber.calls == [], "whisper must not be called at all"
+
+
+def test_sufficient_voice_activity_transcribes_the_segment_slice():
+    transcriber = RecordingTranscriber()
+    service = _service(transcriber, min_voiced_seconds=1.0)
+    audio, detect = _patched(service, [SpeechRegion(start=2.0, end=4.0)])
+
+    with audio, detect:
+        result = service.transcribe_segment(Path("/fake.mov"), 2.0, 5.0)
+
+    assert result is not None
+    assert result.text == "bonjour"
+    assert transcriber.calls == [16000 * 3], "must receive the 3s slice, not the whole video"
+
+
+def test_no_transcriber_means_no_transcription():
+    """Disabled transcription yields no transcriber, so nothing is attempted.
+
+    Note `transcriber=None` does NOT mean "no transcriber" -- it means "select one
+    from config", which on a machine with the extra installed builds a real one and
+    lazily loads whisper weights. Any test that does not want a model must disable
+    transcription in config or inject a double.
+    """
+    service = SpeechAnalysisService(
+        audio_content_config=AudioContentConfig(),
+        speech_config=SpeechConfig(enabled=True),
+        transcription_config=TranscriptionConfig(enabled=False, languages=["fr"]),
+    )
+    audio, detect = _patched(service, [SpeechRegion(start=0.0, end=8.0)])
+
+    with audio, detect:
+        assert service.transcribe_segment(Path("/fake.mov"), 0.0, 5.0) is None
+
+
+def test_transcription_is_disabled_when_speech_is_disabled():
+    """The VAD regions are the gate, so no VAD means no safe transcription."""
+    transcriber = RecordingTranscriber()
+    service = SpeechAnalysisService(
+        audio_content_config=AudioContentConfig(),
+        speech_config=SpeechConfig(enabled=False),
+        transcription_config=TranscriptionConfig(enabled=True, languages=["fr"]),
+        transcriber=transcriber,
+    )
+
+    with patch(
+        # WHY: replaces extract_audio_16k, the FFmpeg boundary.
+        "immich_memories.analysis.speech_analysis.extract_audio_16k",
+        return_value=np.zeros(16000 * 10, dtype=np.float32),
+    ):
+        result = service.transcribe_segment(Path("/fake.mov"), 0.0, 5.0)
+
+    assert result is None
+    assert transcriber.calls == []
+
+
+def test_a_failing_model_leaves_the_segment_untranscribed():
+    class ExplodingTranscriber:
+        """# WHY: replaces the whisper.cpp model to exercise the failure path."""
+
+        def transcribe(self, audio):
+            raise RuntimeError("model died")
+
+    service = _service(ExplodingTranscriber())
+    audio, detect = _patched(service, [SpeechRegion(start=0.0, end=8.0)])
+
+    with audio, detect:
+        assert service.transcribe_segment(Path("/fake.mov"), 0.0, 5.0) is None

--- a/tests/test_speech_transcription_gate.py
+++ b/tests/test_speech_transcription_gate.py
@@ -1,0 +1,50 @@
+"""The confidence gate around transcription, and the region cache that feeds it."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from immich_memories.analysis.speech_analysis import SpeechAnalysisService, voiced_seconds
+from immich_memories.config_models import AudioContentConfig, SpeechConfig
+from immich_memories.speech.models import SpeechRegion
+
+
+def test_voiced_seconds_counts_only_the_overlap_with_the_segment():
+    regions = [SpeechRegion(start=0.0, end=2.0), SpeechRegion(start=5.0, end=6.0)]
+
+    assert voiced_seconds(regions, 1.0, 5.5) == 1.5
+
+
+def test_voiced_seconds_is_zero_without_regions():
+    assert voiced_seconds([], 0.0, 10.0) == 0.0
+
+
+def test_regions_are_detected_once_per_video():
+    """Two candidates in one video must not each run the VAD model."""
+    service = SpeechAnalysisService(
+        audio_content_config=AudioContentConfig(),
+        speech_config=SpeechConfig(enabled=True),
+    )
+
+    # WHY: replaces extract_audio_16k, the FFmpeg boundary, so no real file is needed.
+    with (
+        patch(
+            "immich_memories.analysis.speech_analysis.extract_audio_16k",
+            return_value=np.zeros(16000 * 8, dtype=np.float32),
+        ) as extract,
+        # WHY: replaces the FireRedVAD ONNX model so the call count is observable.
+        patch.object(
+            service._speech_detector,
+            "detect",
+            return_value=[SpeechRegion(start=1.0, end=3.0)],
+        ) as detect,
+    ):
+        first = service.detect_regions_cached(Path("/fake.mov"))
+        second = service.detect_regions_cached(Path("/fake.mov"))
+
+    assert first == second
+    assert detect.call_count == 1
+    assert extract.call_count == 1


### PR DESCRIPTION
Part 2 of 3 for #293, on top of #296. **Nothing calls `transcribe_segment` yet** —
the pipeline step arrives in PR C, so this diff still cannot change a frame of output.

## What's here

- `voiced_seconds(regions, start, end)` — overlap of voice activity with a segment
- `detect_regions_cached` on `SpeechAnalysisService`, so the VAD detector runs once
  per video instead of once per consumer
- `transcribe_segment(video_path, start, end)` — the pre-ASR gate, the audio slice,
  and failure containment

8 tests, all sub-second.

## The gate is where the cost saving lives

VAD returns **zero regions on roughly half** the clips in a real library. Those never
reach whisper at all, because the gate runs before it:

```
voiced_seconds(regions, start, end) < transcription.min_voiced_seconds  ->  decline
```

Declining is the common case and is not an error. The three ways to decline — no
transcriber configured, too little voice activity, or a result the post-ASR gate in
#296 rejected — all return `None`, and nothing downstream scores on the outcome.

## Why the region cache

`apply_vad_ranges` computed the VAD regions and threw them away. The gate needs the
same regions for the same video, and re-running FireRedVAD over an array that is
already cached buys nothing. `_vad_regions_cache` sits beside the existing
`_vad_audio_cache` and is cleared by both `clear_cache` and `reset_for_video`.

`apply_vad_ranges` now reads through that cache. Its behaviour is unchanged — the
existing speech suites (`test_speech_analysis`, `test_speech_boundaries_independent`,
`test_speech_vad`, `test_speech_fireredvad`) are the regression check and all pass.

## No whisper timestamp is ever read

The transcriber receives `audio[int(start * 16000):int(end * 16000)]` — a numpy slice
of the array `extract_audio_cached` already holds. Slicing is free, and it means
whisper is only ever asked *what* was said, never *when*.

That matters because #293's measurement found whisper's word timestamps unusable:
zero inter-word gaps across 30 words, one word spanning 1.56 to 11.66 seconds. Slicing
turns "do not trust the timestamps" from a rule someone has to remember into something
the code structurally cannot do.

## Transcription depends on `speech.enabled`

The VAD regions **are** the gate, so with `speech.enabled: false` there is no gate and
`transcribe_segment` declines. This is the one place the feature is not independent of
another, and it is a dependency rather than a coupling: the gate is the safety
mechanism, not a garnish. `content_analysis.enabled` and `audio_content.enabled`
remain irrelevant to all of it.

## One trap worth knowing about

`transcriber=None` does **not** mean "no transcriber" — the constructor reads it as
"select one from config". On a machine with the `transcribe` extra installed, an
enabled config therefore builds a real `WhisperCppTranscriber`, and the first
`transcribe_segment` call lazily loads whisper weights.

A unit test of mine did exactly that and took 39 seconds while printing
`whisper_init_state: compute buffer`. The behaviour is correct; the test was
expressing the wrong thing. It now disables transcription in config, which is what
"no transcriber" actually means, and the file runs in 0.13s.

Every existing caller is safe today because `TranscriptionConfig()` defaults to
`enabled=False`. PR C changes that for anything built from a `Config` with
transcription on, so the same trap is written into the plan for that task.

## Verification

`make ci` green (4551 passed, 9 skipped) and `make semgrep` clean — the latter run
separately because it is not part of `make ci` but is part of the CI Security Scan job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016veDe6HjnoTgbYaxGmRojY
