### PR TITLE
ci: run semgrep in make ci and ignore the bandit report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ complexipy_results_*.json
 build/
 config.yaml
 coverage.xml
+bandit-report.json
 tests/*-coverage.xml
 tests/*-junit.xml
 tests/benchmark-*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ make critique
 - **Cognitive complexity**: complexipy ≤15 per function (`make cognitive-complexity`)
 - **Dead code**: Vulture must pass (`make dead-code`)
 - **Security**: Bandit must pass with no HIGH findings (`make security-lint`)
+- **Security (cross-file)**: Semgrep must pass with no ERROR findings (`make semgrep`)
 - **Modernization**: refurb must pass (`make refurb`)
 - **Dependency hygiene**: deptry must pass (`make dep-check`)
 - **Tests**: all tests must pass (`make test`)

--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ launch-check: check build build-check docs-check e2e
 	@echo "Launch readiness checks passed!"
 
 # Full CI-equivalent pipeline (locally)
-ci: ensure-dev lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint refurb dep-check arch-check duplication critique test
+ci: ensure-dev lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint semgrep refurb dep-check arch-check duplication critique test
 	@echo "Full CI pipeline passed!"
 
 # Self-critique for AI code smells


### PR DESCRIPTION
Two small gaps found while working on #293's follow-ups.

**`make ci` did not run semgrep.** Its contract is "if it passes locally, CI will pass
too", but the CI Security Scan job runs both bandit and semgrep while `make ci` ran only
bandit. That is why a PR went red on a check that had passed locally. Adding it costs
about 30 seconds.

**`make bandit-ci` writes `bandit-report.json` into the repo root**, untracked and not
ignored, so every local security run left a stray file in `git status`.

Also documents semgrep in `CLAUDE.md`'s enforced-gates list, which omitted it.

## Not a bug, checked

While looking at this I suspected the `SEMGREP_APP_TOKEN` conditional in `ci.yml` was
dead code, because both steps reference `env.SEMGREP_APP_TOKEN` and the value is set at
step level. It is fine — a successful run shows `Semgrep (local, no token): success`, so
step-level `env` is visible to that step's own `if`. No change made.

## Verification

`make ci` green (4586 passed) with semgrep now inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016veDe6HjnoTgbYaxGmRojY