### PR TITLE
fix(titles): drain FFmpeg stderr concurrently to prevent a pipe deadlock

### DIFF
--- a/src/immich_memories/titles/ending_service.py
+++ b/src/immich_memories/titles/ending_service.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 
 from immich_memories.processing.encoding_plan import EncodingPlan
+from immich_memories.titles.ffmpeg_pipe import StderrDrain
 
 from .encoding import title_color_filter, title_encoder_args
 from .styles import TitleStyle
@@ -118,6 +119,7 @@ class EndingService:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        stderr_drain = StderrDrain(process).start()
 
         with contextlib.suppress(BrokenPipeError):
             for i in range(total_frames):
@@ -145,12 +147,12 @@ class EndingService:
         # WHY: Python 3.12's communicate() calls stdin.flush() even after
         # stdin.close(), crashing with ValueError. Verified: FFmpeg succeeds
         # (returncode=0, output exists) but communicate() aborts the pipeline.
-        # Use direct stderr.read() + wait() to avoid the buggy code path.
+        # The background stderr drain plus wait() avoids that code path.
         if process.stdin and not process.stdin.closed:
             process.stdin.close()
 
-        stderr_bytes = process.stderr.read() if process.stderr else b""
         process.wait()
+        stderr_tail = stderr_drain.stop()
 
         if process.returncode != 0:
-            raise RuntimeError(f"FFmpeg failed: {stderr_bytes.decode()[-500:]}")
+            raise RuntimeError(f"FFmpeg failed: {stderr_tail[-500:]}")

--- a/src/immich_memories/titles/ffmpeg_pipe.py
+++ b/src/immich_memories/titles/ffmpeg_pipe.py
@@ -32,8 +32,8 @@ def drain_stderr_tail(stream, tail: bytearray, *, limit: int = STDERR_TAIL_BYTES
 class StderrDrain:
     """Drains `process.stderr` on a background thread for the process lifetime.
 
-    Usable as a context manager, or with explicit start/stop where the frame
-    loop already owns the function body.
+    Explicit start/stop rather than a context manager, because every caller's
+    frame loop already owns its function body.
     """
 
     def __init__(
@@ -65,12 +65,6 @@ class StderrDrain:
             self._reader.join(timeout=self._join_timeout)
             self._reader = None
         return stderr_text(self.tail)
-
-    def __enter__(self) -> StderrDrain:
-        return self.start()
-
-    def __exit__(self, *_exc: object) -> None:
-        self.stop()
 
 
 def stderr_text(tail: bytearray) -> str:

--- a/src/immich_memories/titles/ffmpeg_pipe.py
+++ b/src/immich_memories/titles/ffmpeg_pipe.py
@@ -1,0 +1,78 @@
+"""Shared plumbing for feeding raw frames to FFmpeg over a pipe.
+
+Writing frames to FFmpeg's stdin while its stderr is piped and unread
+deadlocks: once FFmpeg fills the stderr pipe buffer it blocks on that write,
+stops draining stdin, and the producer blocks in turn. The render then hangs
+forever at 0% CPU with no output — indistinguishable from a crash.
+
+Draining stderr concurrently for the whole process lifetime is the fix. Only
+the newest bytes are kept, because FFmpeg can emit unbounded progress output
+and the tail is wanted for diagnostics, not archival.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+
+STDERR_TAIL_BYTES = 8192
+_READ_CHUNK_BYTES = 65536
+
+
+def drain_stderr_tail(stream, tail: bytearray, *, limit: int = STDERR_TAIL_BYTES) -> None:
+    """Drain a byte stream to EOF, retaining only its newest `limit` bytes."""
+    if stream is None:
+        return
+    while chunk := stream.read(_READ_CHUNK_BYTES):
+        tail.extend(chunk)
+        if len(tail) > limit:
+            del tail[:-limit]
+
+
+class StderrDrain:
+    """Drains `process.stderr` on a background thread for the process lifetime.
+
+    Usable as a context manager, or with explicit start/stop where the frame
+    loop already owns the function body.
+    """
+
+    def __init__(
+        self,
+        process: subprocess.Popen,
+        *,
+        limit: int = STDERR_TAIL_BYTES,
+        join_timeout: float = 10.0,
+    ) -> None:
+        self._process = process
+        self._limit = limit
+        self._join_timeout = join_timeout
+        self._reader: threading.Thread | None = None
+        self.tail = bytearray()
+
+    def start(self) -> StderrDrain:
+        self._reader = threading.Thread(
+            target=drain_stderr_tail,
+            args=(self._process.stderr, self.tail),
+            kwargs={"limit": self._limit},
+            daemon=True,
+        )
+        self._reader.start()
+        return self
+
+    def stop(self) -> str:
+        """Join the reader and return the decoded tail."""
+        if self._reader is not None:
+            self._reader.join(timeout=self._join_timeout)
+            self._reader = None
+        return stderr_text(self.tail)
+
+    def __enter__(self) -> StderrDrain:
+        return self.start()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+
+def stderr_text(tail: bytearray) -> str:
+    """Decode a drained tail for an error message."""
+    return bytes(tail).decode(errors="replace").strip()

--- a/src/immich_memories/titles/globe_video.py
+++ b/src/immich_memories/titles/globe_video.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import numpy as np
 
 from immich_memories.processing.encoding_plan import EncodingPlan
+from immich_memories.titles.ffmpeg_pipe import StderrDrain
 
 from .encoding import standalone_title_encoding_plan, title_color_filter, title_encoder_args
 from .globe_renderer import GlobeCameraKeyframe, interpolate_camera
@@ -62,6 +63,7 @@ def create_globe_animation_video(
 
     process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     assert process.stdin is not None
+    stderr_drain = StderrDrain(process).start()
     frame_buffer = np.zeros((height, width, 3), dtype=np.float32)
 
     # Time mapping: hold → animate → hold
@@ -91,10 +93,10 @@ def create_globe_animation_video(
         process.stdin.close()
 
     process.wait()
-    stderr = process.stderr.read() if process.stderr else b""
+    stderr_tail = stderr_drain.stop()
 
     if process.returncode != 0:
-        raise RuntimeError(f"Globe FFmpeg failed: {stderr.decode()[-500:]}")
+        raise RuntimeError(f"Globe FFmpeg failed: {stderr_tail[-500:]}")
 
     logger.info(f"Globe animation generated: {output_path}")
     return output_path

--- a/src/immich_memories/titles/map_animation.py
+++ b/src/immich_memories/titles/map_animation.py
@@ -16,6 +16,7 @@ from PIL import Image, ImageDraw
 from staticmap import CircleMarker, StaticMap
 
 from immich_memories.processing.encoding_plan import EncodingPlan
+from immich_memories.titles.ffmpeg_pipe import StderrDrain
 
 from .encoding import standalone_title_encoding_plan, title_color_filter, title_encoder_args
 from .map_renderer import _draw_gradient_band, _overlay_composite, _wrap_text
@@ -435,6 +436,7 @@ def _pipe_frames(
         stderr=subprocess.PIPE,
     )
     assert proc.stdin is not None  # noqa: S101
+    stderr_drain = StderrDrain(proc).start()
 
     cached: list[Image.Image | None] = [None, None]
     z = float(_CITY_ZOOM)
@@ -455,9 +457,9 @@ def _pipe_frames(
 
     proc.stdin.close()
     proc.wait()
-    err = proc.stderr.read() if proc.stderr else b""
+    stderr_tail = stderr_drain.stop()
     if proc.returncode != 0:
-        raise RuntimeError(f"Map fly FFmpeg failed: {err.decode()[-500:]}")
+        raise RuntimeError(f"Map fly FFmpeg failed: {stderr_tail[-500:]}")
 
 
 def _title_alpha(p: float) -> float:

--- a/src/immich_memories/titles/video_encoding.py
+++ b/src/immich_memories/titles/video_encoding.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from immich_memories.processing.encoding_plan import EncodingPlan
+from immich_memories.titles.ffmpeg_pipe import StderrDrain
 
 from .animations import get_animation_preset, reverse_preset
 from .encoding import standalone_title_encoding_plan, title_color_filter, title_encoder_args
@@ -186,6 +187,7 @@ def create_title_video(
     process = subprocess.Popen(
         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
+    stderr_drain = StderrDrain(process).start()
     writer_thread = threading.Thread(target=write_frames_to_ffmpeg, args=(process,))
     writer_thread.start()
 
@@ -219,12 +221,12 @@ def create_title_video(
     frame_queue.put(None)
     writer_thread.join()
 
-    stderr = process.stderr.read() if process.stderr else b""
     process.wait()
+    stderr_tail = stderr_drain.stop()
 
     if write_error:
         raise RuntimeError(f"Write error: {write_error[0]}")
     if process.returncode != 0:
-        raise RuntimeError(f"FFmpeg failed: {stderr.decode()}")
+        raise RuntimeError(f"FFmpeg failed: {stderr_tail}")
 
     return output_path

--- a/tests/test_ffmpeg_pipe.py
+++ b/tests/test_ffmpeg_pipe.py
@@ -14,8 +14,13 @@ from __future__ import annotations
 import subprocess
 import sys
 import threading
+from pathlib import Path
+
+import pytest
+from PIL import Image
 
 from immich_memories.titles.ffmpeg_pipe import drain_stderr_tail
+from immich_memories.titles.styles import TitleStyle
 
 # Child that floods stderr *before* reading any stdin. Without a concurrent
 # drain the parent's stdin write blocks as soon as the stderr buffer fills.
@@ -96,3 +101,135 @@ class TestDrainStderrTail:
 
         assert len(tail) <= 1024
         assert bytes(tail).endswith(b"TAIL")
+
+
+class TestDrainGuards:
+    def test_missing_stream_is_a_no_op(self) -> None:
+        """Popen without stderr=PIPE leaves process.stderr as None."""
+        tail = bytearray()
+
+        drain_stderr_tail(None, tail)
+
+        assert tail == bytearray()
+
+
+class TestFailuresCarryStderrTail:
+    """Every rewritten call site must surface FFmpeg's drained stderr in its error.
+
+    These also pin the drain lifecycle: without start()/stop() around the frame
+    loop the tail would be empty and these assertions would fail.
+    """
+
+    @staticmethod
+    def _failing_process(message: bytes = b"ffmpeg exploded"):
+        from unittest.mock import MagicMock
+
+        process = MagicMock()
+        process.stdin = MagicMock()
+        process.stdin.closed = False
+        process.stderr = MagicMock()
+        # Drained in a loop until it yields b"", mirroring a real pipe reaching EOF.
+        process.stderr.read.side_effect = [message, b""]
+        process.returncode = 1
+        return process
+
+    def test_globe_video_failure_reports_stderr(self) -> None:
+        from unittest.mock import patch
+
+        import numpy as np
+
+        from immich_memories.titles.globe_renderer import GlobeCameraKeyframe
+        from immich_memories.titles.globe_video import create_globe_animation_video
+
+        keyframes = [
+            GlobeCameraKeyframe(lat=0.0, lon=0.0, distance=2.2, time=0.0),
+            GlobeCameraKeyframe(lat=0.5, lon=0.3, distance=2.2, time=1.0),
+        ]
+
+        with (
+            # WHY: replaces the FFmpeg subprocess
+            patch("immich_memories.titles.globe_video.subprocess.Popen") as popen,
+            # WHY: replaces the Taichi/numpy globe projection kernel
+            patch("immich_memories.titles.globe_video.project_globe_frame"),
+        ):
+            popen.return_value = self._failing_process()
+            with pytest.raises(RuntimeError, match="ffmpeg exploded"):
+                create_globe_animation_video(
+                    texture=np.full((18, 36, 3), 0.5, dtype=np.float32),
+                    keyframes=keyframes,
+                    output_path=Path("/tmp/globe_fail.mp4"),
+                    width=32,
+                    height=18,
+                    duration=0.2,
+                    fps=10.0,
+                    hold_start=0.0,
+                    hold_end=0.0,
+                )
+
+    def test_video_encoding_failure_reports_stderr(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from immich_memories.titles.video_encoding import create_title_video
+
+        with (
+            # WHY: replaces the FFmpeg subprocess
+            patch("immich_memories.titles.video_encoding.subprocess.Popen") as popen,
+            # WHY: replaces the frame renderer, which needs fonts and a real canvas
+            patch("immich_memories.titles.video_encoding._render_frame_with_animation") as render,
+        ):
+            popen.return_value = self._failing_process()
+            render.return_value = Image.new("RGB", (32, 18))
+            with pytest.raises(RuntimeError, match="ffmpeg exploded"):
+                create_title_video(
+                    title="t",
+                    subtitle=None,
+                    style=TitleStyle(),
+                    output_path=tmp_path / "title.mp4",
+                    width=32,
+                    height=18,
+                    duration=0.2,
+                    fps=10.0,
+                )
+
+    def test_ending_service_failure_reports_stderr(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from immich_memories.titles.encoding import standalone_title_encoding_plan
+        from immich_memories.titles.ending_service import EndingService
+
+        with patch("subprocess.Popen") as popen:  # WHY: replaces the FFmpeg subprocess
+            popen.return_value = self._failing_process()
+            with pytest.raises(RuntimeError, match="ffmpeg exploded"):
+                EndingService(TitleStyle()).create_ending_video(
+                    output_path=tmp_path / "ending.mp4",
+                    fade_to_color=(0, 0, 0),
+                    width=32,
+                    height=18,
+                    duration=0.2,
+                    fps=10.0,
+                    encoding_plan=standalone_title_encoding_plan(),
+                )
+
+    def test_map_animation_failure_reports_stderr(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from immich_memories.titles.map_animation import _FlyConfig, _pipe_frames
+
+        with (
+            # WHY: replaces the FFmpeg subprocess
+            patch("immich_memories.titles.map_animation.subprocess.Popen") as popen,
+            # WHY: replaces map tile rendering, which would fetch tiles over the network
+            patch("immich_memories.titles.map_animation._get_frame_at") as get_frame,
+        ):
+            popen.return_value = self._failing_process()
+            get_frame.return_value = (Image.new("RGB", (32, 18)), 9.0)
+            with pytest.raises(RuntimeError, match="ffmpeg exploded"):
+                _pipe_frames(
+                    _FlyConfig(width=32, height=18),
+                    tmp_path / "map.mp4",
+                    duration=0.2,
+                    fps=10.0,
+                    hold_start=0.0,
+                    hold_end=0.0,
+                    encoding_plan=None,
+                )

--- a/tests/test_ffmpeg_pipe.py
+++ b/tests/test_ffmpeg_pipe.py
@@ -1,0 +1,98 @@
+"""Tests for the FFmpeg stdin/stderr pipe plumbing.
+
+Writing frames to a subprocess's stdin while its stderr is piped and unread is
+a classic deadlock: once the child fills the stderr pipe buffer it blocks on
+that write, stops draining stdin, and the producer blocks in turn. Neither side
+can progress and the render hangs forever at 0% CPU.
+
+These tests use a real child process rather than a mock, because the deadlock
+lives in OS pipe buffering — a fake would not reproduce it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+
+from immich_memories.titles.ffmpeg_pipe import drain_stderr_tail
+
+# Child that floods stderr *before* reading any stdin. Without a concurrent
+# drain the parent's stdin write blocks as soon as the stderr buffer fills.
+_NOISY_CHILD = (
+    "import sys;"
+    "sys.stderr.buffer.write(b'x' * 400000);"
+    "sys.stderr.buffer.flush();"
+    "data = sys.stdin.buffer.read();"
+    "sys.stderr.buffer.write(b'read %d bytes' % len(data));"
+    "sys.stderr.buffer.flush()"
+)
+
+
+class TestDrainStderrTail:
+    def test_concurrent_drain_prevents_deadlock(self) -> None:
+        """The whole point: a noisy child must not be able to stall the writer."""
+        process = subprocess.Popen(
+            [sys.executable, "-c", _NOISY_CHILD],
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        tail = bytearray()
+        reader = threading.Thread(target=drain_stderr_tail, args=(process.stderr, tail))
+        reader.start()
+
+        assert process.stdin is not None
+        process.stdin.write(b"f" * 300000)
+        process.stdin.close()
+
+        assert process.wait(timeout=30) == 0
+        reader.join(timeout=10)
+        assert not reader.is_alive()
+        assert b"read 300000 bytes" in bytes(tail)
+
+    def test_without_drain_the_writer_actually_deadlocks(self) -> None:
+        """Proves the child reproduces the bug, so the test above means something.
+
+        The blocking write is done on a daemon thread: without a stderr drain it
+        never returns, so it cannot be awaited on the main thread.
+        """
+        process = subprocess.Popen(
+            [sys.executable, "-c", _NOISY_CHILD],
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        finished = threading.Event()
+
+        def _write_without_draining() -> None:
+            try:
+                assert process.stdin is not None
+                process.stdin.write(b"f" * 300000)
+                process.stdin.flush()
+            except OSError:
+                pass
+            finally:
+                finished.set()
+
+        writer = threading.Thread(target=_write_without_draining, daemon=True)
+        writer.start()
+        try:
+            assert not finished.wait(timeout=5.0), (
+                "the write completed without a stderr drain, so this child no "
+                "longer reproduces the deadlock and the test above proves nothing"
+            )
+        finally:
+            process.kill()
+            process.wait(timeout=10)
+            finished.wait(timeout=5)
+
+    def test_tail_is_bounded_to_the_newest_bytes(self) -> None:
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.stderr.buffer.write(b'a'*50000 + b'TAIL')"],
+            stderr=subprocess.PIPE,
+        )
+        tail = bytearray()
+        drain_stderr_tail(process.stderr, tail, limit=1024)
+        process.wait(timeout=30)
+
+        assert len(tail) <= 1024
+        assert bytes(tail).endswith(b"TAIL")


### PR DESCRIPTION
Closes #279

## The deadlock

Four title-rendering paths wrote frames to FFmpeg's stdin while its stderr was piped and unread until the writer finished:

```python
writer_thread.join()               # blocks until every frame is written
stderr = process.stderr.read()     # only read afterwards
```

Once FFmpeg fills the stderr pipe buffer (~64 KiB) it blocks on that write and stops draining stdin. The frame write then blocks, `join()` never returns, and `read()` is never reached. The render hangs forever at 0% CPU with no output — indistinguishable from a crash.

Affected: `video_encoding.py`, `globe_video.py`, `map_animation.py`, `ending_service.py`.

## The fix

`taichi_video.py` already did this correctly — presumably from #273. Its approach is extracted as `StderrDrain` in a new `titles/ffmpeg_pipe.py` and applied to the other four, so there is one implementation rather than five.

Only the newest 8 KiB of stderr is retained: FFmpeg emits unbounded progress output and the tail is wanted for diagnostics, not archival. Error messages keep their bounded FFmpeg detail.

## Testing

The deadlock lives in OS pipe buffering, so the tests use a **real child process rather than a mock** — a fake cannot reproduce it.

- one test asserts the drain prevents the deadlock
- a second asserts the *same child still deadlocks without* the drain, so the first cannot silently stop testing anything if the child changes
- a third asserts the tail stays bounded to its newest bytes

The blocking write in the second test runs on a daemon thread, because without a drain it never returns and cannot be awaited on the main thread.

`make ci` green (4571 passed). The **136 title integration tests** exercise all four rewritten paths against real FFmpeg.

## Acceptance criteria

- [x] Drain FFmpeg stderr concurrently for the entire process lifetime
- [x] Keep only a bounded diagnostic tail rather than unbounded output
- [x] Preserve the full producer/writer error and process return-code semantics
- [x] Close stdin and join worker resources on success and failure
- [x] Prove with a deterministic fake process that stderr pressure cannot deadlock the writer
- [x] Preserve useful bounded FFmpeg diagnostics in raised errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3