### PR TITLE
ci: run the integration suites diff-cover needs, and stop advertising an impossible fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,15 @@ jobs:
       - name: Run tests with coverage
         run: make test-cov-xml
 
+      # WHY: diff-cover merges tests/*-coverage.xml, but those are gitignored and
+      # so can never arrive from a contributor's machine. Code only reachable
+      # through FFmpeg would therefore always read as uncovered. This job already
+      # installs FFmpeg, so the suites covering the changed paths run here -- and
+      # only those: an unrelated PR runs none of them.
+      - name: Integration coverage for changed paths
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        run: make integration-coverage-for-diff
+
       - name: Diff coverage (≥80% on changed lines)
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,17 +76,31 @@ FFmpeg. They skip gracefully if services aren't available.
 
 ### Integration tests and diff-cover
 
-If CI's diff-cover fails because changed lines aren't covered by unit tests:
+Every PR must have 80% coverage on the lines it changes. Code that can only run
+with real FFmpeg used to be impossible to cover: `tests/*-coverage.xml` is
+gitignored, so integration coverage produced on your machine could never reach
+CI, and the gate would fail no matter what you did.
+
+**CI now handles that for you.** Before checking diff-cover it runs the
+FFmpeg-only integration suites covering the paths you changed — and only those,
+so a PR touching nothing FFmpeg-reachable runs none of them. That job already
+has FFmpeg installed, so this costs no setup time.
+
+To reproduce locally exactly what CI will see:
 
 ```bash
-make test-integration   # Runs real FFmpeg + Immich tests, generates per-suite coverage XMLs
-git add tests/*-coverage.xml tests/integration-junit.xml
-git commit --amend      # Add coverage files to your commit
-git push
+make integration-coverage-for-diff   # runs only the suites your diff touches
+make diff-cover-local                # merges them with unit coverage, same as CI
 ```
 
-CI merges `coverage.xml` (unit, from CI) with the per-suite `tests/*-coverage.xml`
-files (integration, committed locally) when calculating diff-cover at 80% threshold.
+If diff-cover still fails, the uncovered lines are not reachable from an
+integration suite and need unit tests. Subprocess boundaries can be stubbed
+rather than run for real — `tests/test_ffmpeg_pipe.py` shows the pattern: patch
+`subprocess.Popen`, hand back a fake process, and assert on what the code does
+with it.
+
+Do not try to commit coverage XMLs. They are gitignored deliberately, and
+`git add -f` is not acceptable in this repo.
 
 **What integration tests cover that unit tests can't:**
 - FFmpeg filter graph construction and assembly

--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,19 @@ diff-cover-local:  ## Check diff-cover locally before pushing (runs tests + merg
 		if [ -f "$$f" ]; then COVERAGE_FILES="$$COVERAGE_FILES $$f"; fi; \
 	done; \
 	uvx diff-cover $$COVERAGE_FILES --compare-branch=origin/main --fail-under=80 \
-	|| (echo "" && echo "⚠️  Diff coverage below 80%." && echo "   Run: make test-integration" && echo "   Then: git add tests/*-coverage.xml" && exit 1)
+	|| (echo "" && echo "⚠️  Diff coverage below 80% on changed lines." && \
+		echo "" && \
+		echo "   CI runs the FFmpeg-only integration suites that cover your changed" && \
+		echo "   paths automatically (make integration-coverage-for-diff), so code" && \
+		echo "   reachable only through FFmpeg does not need extra work from you." && \
+		echo "" && \
+		echo "   To reproduce what CI will see:" && \
+		echo "     make integration-coverage-for-diff && make diff-cover-local" && \
+		echo "" && \
+		echo "   If the uncovered lines are NOT reachable from an integration suite," && \
+		echo "   add unit tests. Subprocess boundaries can be stubbed -- see" && \
+		echo "   tests/test_ffmpeg_pipe.py for the pattern." && \
+		exit 1)
 
 # Diff coverage for PRs — merges CI unit coverage with local integration coverage.
 # If coverage is low, run `make test-integration` locally and commit the updated

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-titles test-fast mutation benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
+.PHONY: help install dev dev-ci dev-test run preflight test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-titles test-fast mutation benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
 
 # Default target
 help:
@@ -448,9 +448,28 @@ diff-cover-local:  ## Check diff-cover locally before pushing (runs tests + merg
 		echo "   tests/test_ffmpeg_pipe.py for the pattern." && \
 		exit 1)
 
-# Diff coverage for PRs — merges CI unit coverage with local integration coverage.
-# If coverage is low, run `make test-integration` locally and commit the updated
-# per-suite coverage XMLs (tests/*-coverage.xml) before pushing.
+integration-coverage-for-diff:  ## Run only the FFmpeg-only integration suites the diff touches (used by CI before diff-cover)
+	@CHANGED=$$(git diff --name-only origin/main...HEAD -- 'src/immich_memories/**/*.py' 2>/dev/null); \
+	SUITES=""; \
+	case "$$CHANGED" in *src/immich_memories/titles/*) SUITES="$$SUITES titles";; esac; \
+	case "$$CHANGED" in *src/immich_memories/processing/*) SUITES="$$SUITES processing assembly";; esac; \
+	case "$$CHANGED" in *src/immich_memories/photos/*) SUITES="$$SUITES photos";; esac; \
+	case "$$CHANGED" in *src/immich_memories/generate*) SUITES="$$SUITES assembly";; esac; \
+	SUITES=$$(echo $$SUITES | tr ' ' '\n' | sort -u | tr '\n' ' '); \
+	if [ -z "$$(echo $$SUITES | tr -d ' ')" ]; then \
+		echo "No FFmpeg-reachable source changed -- skipping integration coverage."; \
+	else \
+		echo "Changed source touches: $$SUITES"; \
+		for s in $$SUITES; do \
+			echo "Running integration suite: $$s"; \
+			$(MAKE) test-integration-$$s || exit 1; \
+		done; \
+	fi
+
+# Diff coverage for PRs. CI runs integration-coverage-for-diff first, so the
+# FFmpeg-only suites covering the changed paths have written their XMLs here.
+# tests/*-coverage.xml is gitignored and can never arrive from a contributor's
+# machine, which is why CI produces it rather than asking them to commit it.
 diff-cover-ci:
 	@SRC_CHANGED=$$(git diff --numstat origin/main...HEAD -- '*.py' 2>/dev/null | grep '^' | grep -v 'tests/' | awk '{s+=$$1+$$2} END {print s+0}'); \
 	echo "Changed source lines (excl tests): $${SRC_CHANGED}"; \


### PR DESCRIPTION
Closes #303

## The trap

`make diff-cover-ci` merges `tests/*-coverage.xml` when present. Those files are **gitignored** (`.gitignore:93`), and CI never runs integration tests — so integration coverage produced on a contributor's machine can never reach CI.

Any change to code only reachable through FFmpeg therefore reads as uncovered, and the 80% gate fails whatever the contributor does. Both the failure message and `CONTRIBUTING.md` told them to fix it with:

```bash
make test-integration
git add tests/*-coverage.xml
```

`git add` on an ignored file is a **silent no-op**. The only thing that makes it work is `git add -f`, which this repo forbids. So the documented instructions produce no error, no coverage, and an unpassable gate.

I hit this on #279: `make diff-cover-local` passed locally and CI failed at 74%, for exactly this reason.

## Fix

**CI runs the suites the diff actually touches.** New `make integration-coverage-for-diff` maps changed source paths to the FFmpeg-only suites that cover them:

| Changed path | Suite(s) run |
|---|---|
| `titles/` | titles |
| `processing/` | processing, assembly |
| `photos/` | photos |
| `generate*` | assembly |
| anything else | none |

A PR touching nothing FFmpeg-reachable runs nothing extra. The diff-cover job (3.12 / ubuntu / PR only) **already installs FFmpeg** for its unit tests, so there is no new setup cost — only the runtime of the one or two suites that apply.

**The guidance now matches reality.** The failure message and `CONTRIBUTING.md` explain what CI does, how to reproduce it locally, and what to do when a line genuinely is not reachable from any integration suite — with `tests/test_ffmpeg_pipe.py` as the worked example of stubbing `subprocess.Popen`.

## Verification

- With no FFmpeg-reachable change: `No FFmpeg-reachable source changed — skipping integration coverage.`
- With a `titles/` change: `Changed source touches: titles` → runs only that suite
- `make ci` green (4568 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3