### PR TITLE
fix: launch blockers — Docker output volume + UID 1000, media auth bypass, health disclosure, encoder stderr deadlock

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3218,79 +3218,79 @@
       {
         "name": "streaming_assemble_full",
         "complexity": 16,
-        "line_start": 840,
-        "line_end": 937,
+        "line_start": 855,
+        "line_end": 952,
         "line_complexities": [
           {
-            "line": 859,
+            "line": 874,
             "complexity": 1
           },
           {
-            "line": 860,
-            "complexity": 0
-          },
-          {
-            "line": 863,
-            "complexity": 0
-          },
-          {
-            "line": 864,
-            "complexity": 0
-          },
-          {
-            "line": 865,
-            "complexity": 0
-          },
-          {
-            "line": 869,
-            "complexity": 2
-          },
-          {
             "line": 875,
-            "complexity": 3
-          },
-          {
-            "line": 876,
-            "complexity": 0
-          },
-          {
-            "line": 877,
             "complexity": 0
           },
           {
             "line": 878,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 879,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 880,
             "complexity": 0
           },
           {
-            "line": 881,
-            "complexity": 0
+            "line": 884,
+            "complexity": 2
           },
           {
             "line": 890,
+            "complexity": 3
+          },
+          {
+            "line": 891,
             "complexity": 0
           },
           {
-            "line": 908,
+            "line": 892,
+            "complexity": 0
+          },
+          {
+            "line": 893,
+            "complexity": 3
+          },
+          {
+            "line": 894,
+            "complexity": 3
+          },
+          {
+            "line": 895,
+            "complexity": 0
+          },
+          {
+            "line": 896,
+            "complexity": 0
+          },
+          {
+            "line": 905,
+            "complexity": 0
+          },
+          {
+            "line": 923,
             "complexity": 2
-          },
-          {
-            "line": 914,
-            "complexity": 0
           },
           {
             "line": 929,
+            "complexity": 0
+          },
+          {
+            "line": 944,
             "complexity": 2
           },
           {
-            "line": 935,
+            "line": 950,
             "complexity": 0
           }
         ]
@@ -3298,131 +3298,87 @@
       {
         "name": "assemble_streaming",
         "complexity": 24,
-        "line_start": 604,
-        "line_end": 729,
+        "line_start": 619,
+        "line_end": 744,
         "line_complexities": [
           {
-            "line": 626,
-            "complexity": 1
-          },
-          {
-            "line": 627,
-            "complexity": 0
-          },
-          {
-            "line": 629,
-            "complexity": 0
-          },
-          {
-            "line": 630,
-            "complexity": 0
-          },
-          {
-            "line": 631,
-            "complexity": 1
-          },
-          {
-            "line": 632,
-            "complexity": 1
-          },
-          {
-            "line": 633,
-            "complexity": 0
-          },
-          {
-            "line": 634,
-            "complexity": 0
-          },
-          {
-            "line": 636,
-            "complexity": 0
-          },
-          {
-            "line": 639,
-            "complexity": 3
-          },
-          {
-            "line": 640,
-            "complexity": 0
-          },
-          {
             "line": 641,
+            "complexity": 1
+          },
+          {
+            "line": 642,
             "complexity": 0
+          },
+          {
+            "line": 644,
+            "complexity": 0
+          },
+          {
+            "line": 645,
+            "complexity": 0
+          },
+          {
+            "line": 646,
+            "complexity": 1
           },
           {
             "line": 647,
-            "complexity": 0
-          },
-          {
-            "line": 668,
             "complexity": 1
           },
           {
-            "line": 669,
+            "line": 648,
             "complexity": 0
           },
           {
-            "line": 670,
+            "line": 649,
+            "complexity": 0
+          },
+          {
+            "line": 651,
+            "complexity": 0
+          },
+          {
+            "line": 654,
+            "complexity": 3
+          },
+          {
+            "line": 655,
+            "complexity": 0
+          },
+          {
+            "line": 656,
+            "complexity": 0
+          },
+          {
+            "line": 662,
+            "complexity": 0
+          },
+          {
+            "line": 683,
+            "complexity": 1
+          },
+          {
+            "line": 684,
+            "complexity": 0
+          },
+          {
+            "line": 685,
             "complexity": 2
           },
           {
-            "line": 671,
+            "line": 686,
             "complexity": 0
           },
           {
-            "line": 672,
+            "line": 687,
             "complexity": 0
-          },
-          {
-            "line": 695,
-            "complexity": 1
-          },
-          {
-            "line": 696,
-            "complexity": 0
-          },
-          {
-            "line": 698,
-            "complexity": 0
-          },
-          {
-            "line": 699,
-            "complexity": 2
-          },
-          {
-            "line": 700,
-            "complexity": 0
-          },
-          {
-            "line": 701,
-            "complexity": 0
-          },
-          {
-            "line": 702,
-            "complexity": 1
-          },
-          {
-            "line": 703,
-            "complexity": 0
-          },
-          {
-            "line": 705,
-            "complexity": 0
-          },
-          {
-            "line": 709,
-            "complexity": 1
           },
           {
             "line": 710,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 711,
-            "complexity": 2
-          },
-          {
-            "line": 712,
             "complexity": 0
           },
           {
@@ -3430,35 +3386,79 @@
             "complexity": 0
           },
           {
-            "line": 715,
-            "complexity": 1
-          },
-          {
-            "line": 721,
-            "complexity": 0
-          },
-          {
-            "line": 722,
-            "complexity": 1
-          },
-          {
-            "line": 723,
+            "line": 714,
             "complexity": 2
           },
           {
-            "line": 724,
+            "line": 715,
             "complexity": 0
           },
           {
-            "line": 725,
-            "complexity": 3
+            "line": 716,
+            "complexity": 0
           },
           {
-            "line": 727,
+            "line": 717,
             "complexity": 1
           },
           {
-            "line": 729,
+            "line": 718,
+            "complexity": 0
+          },
+          {
+            "line": 720,
+            "complexity": 0
+          },
+          {
+            "line": 724,
+            "complexity": 1
+          },
+          {
+            "line": 725,
+            "complexity": 0
+          },
+          {
+            "line": 726,
+            "complexity": 2
+          },
+          {
+            "line": 727,
+            "complexity": 0
+          },
+          {
+            "line": 728,
+            "complexity": 0
+          },
+          {
+            "line": 730,
+            "complexity": 1
+          },
+          {
+            "line": 736,
+            "complexity": 0
+          },
+          {
+            "line": 737,
+            "complexity": 1
+          },
+          {
+            "line": 738,
+            "complexity": 2
+          },
+          {
+            "line": 739,
+            "complexity": 0
+          },
+          {
+            "line": 740,
+            "complexity": 3
+          },
+          {
+            "line": 742,
+            "complexity": 1
+          },
+          {
+            "line": 744,
             "complexity": 0
           }
         ]

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,11 +1,14 @@
-# Immich Memories - Environment Variables
+# Immich Memories - Environment Variables (docker compose reads this file)
 
-# Immich server connection
+# Immich server connection (required)
 IMMICH_URL=https://photos.example.com
 IMMICH_API_KEY=your-api-key-here
 
-# Optional: Custom output directory
-# OUTPUT_DIR=/path/to/output
+# Optional: override any config key with IMMICH_MEMORIES_<SECTION>__<KEY>.
+# The image already sets the output directory to the mounted /app/output.
+# IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output
+# IMMICH_MEMORIES_CACHE__DIRECTORY=/home/immich/.immich-memories/cache
 
-# Optional: Cache settings
-# CACHE_DIR=/path/to/cache
+# Optional: basic auth (both required to enable)
+# IMMICH_MEMORIES_AUTH_USERNAME=admin
+# IMMICH_MEMORIES_AUTH_PASSWORD=change-me

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,8 +64,11 @@ COPY --from=builder /wheels /wheels
 RUN pip install --no-cache-dir /wheels/*.whl && \
     rm -rf /wheels
 
-# Create non-root user for security
-RUN groupadd -r immich && useradd -r -g immich -d /home/immich -m immich
+# Create non-root user for security. UID/GID 1000 on purpose: it matches the first
+# Linux user on most home servers (bind mounts of ./output and ./config are
+# writable without chown) and the shipped Kubernetes/Terraform manifests
+# (runAsUser: 1000).
+RUN groupadd -g 1000 immich && useradd -u 1000 -g immich -d /home/immich -m immich
 
 # Create config, cache, and NiceGUI state directories with correct ownership
 RUN mkdir -p /home/immich/.immich-memories/cache /app/output /app/.nicegui && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,9 @@ RUN mkdir -p /home/immich/.immich-memories/cache /app/output /app/.nicegui && \
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 ENV HOME=/home/immich
+# Generated videos must land on the volume the compose quickstart mounts;
+# the app default (~/Videos/Memories) would resolve inside the container.
+ENV IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output
 
 # Switch to non-root user
 USER immich

--- a/scripts/test_llm_titles.py
+++ b/scripts/test_llm_titles.py
@@ -170,7 +170,7 @@ async def test_trip(trip_name: str, assets, bases: list[OvernightBase]) -> None:
 async def test_person_memory() -> None:
     """Test a person memory title."""
     print(f"\n{'=' * 70}")
-    print("  PERSON MEMORY: Alice & Emile")
+    print("  PERSON MEMORY: Alice & Noah")
     print(f"{'=' * 70}")
 
     for temp in TEMPERATURES:
@@ -181,7 +181,7 @@ async def test_person_memory() -> None:
                 start_date="2019-01-01",
                 end_date="2025-12-31",
                 duration_days=2556,
-                person_names=["Alice", "Emile"],
+                person_names=["Alice", "Noah"],
             )
             raw = await query_llm(prompt, LLM_CFG, temperature=temp)
             result = parse_title_response(raw)

--- a/src/immich_memories/filename_builder.py
+++ b/src/immich_memories/filename_builder.py
@@ -32,8 +32,8 @@ def build_output_filename(
     """Build a human-readable output filename from memory context.
 
     Uses memory type, person names, and date range to produce filenames like:
-    - sam_emile_march_2026_memories.mp4 (multi-person, single month)
-    - emile_summer_2025_memories.mp4 (season preset)
+    - sam_noah_march_2026_memories.mp4 (multi-person, single month)
+    - noah_summer_2025_memories.mp4 (season preset)
     - sam_2025_memories.mp4 (year in review)
 
     Args:

--- a/src/immich_memories/processing/ffmpeg_runner.py
+++ b/src/immich_memories/processing/ffmpeg_runner.py
@@ -20,7 +20,30 @@ __all__ = [
     "_parse_ffmpeg_time",
     "_parse_ffmpeg_progress",
     "_run_ffmpeg_with_progress",
+    "drain_stderr_tail",
 ]
+
+FFMPEG_STDERR_TAIL_BYTES = 64 * 1024
+
+
+def drain_stderr_tail(
+    stream: IO[bytes],
+    tail: bytearray,
+    *,
+    limit: int = FFMPEG_STDERR_TAIL_BYTES,
+) -> None:
+    """Read a pipe to EOF, keeping only its newest bytes.
+
+    Run this on a thread for any FFmpeg process whose stdin is fed frame by
+    frame: FFmpeg writes stats/warnings to stderr from its transcode loop and
+    stops reading stdin once the 64 KB OS pipe is full, which deadlocks the
+    frame writer. Draining continuously keeps the pipe empty and still leaves
+    the error tail available for diagnostics.
+    """
+    while chunk := stream.read(65536):
+        tail.extend(chunk)
+        if len(tail) > limit:
+            del tail[:-limit]
 
 
 @dataclass

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -6,7 +6,8 @@ import contextlib
 import logging
 import shutil
 import subprocess
-from collections.abc import Callable, Iterator
+import threading
+from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -21,6 +22,7 @@ from immich_memories.processing.encoding_plan import (
     software_fallback_plan,
     uses_hardware_encoder,
 )
+from immich_memories.processing.ffmpeg_runner import drain_stderr_tail
 from immich_memories.processing.hdr_utilities import (
     _detect_color_primaries,
     _detect_hdr_type,
@@ -278,6 +280,7 @@ class StreamingEncoder:
         height: int,
         fps: int,
         encoding_plan: EncodingPlan | None = None,
+        ffmpeg_command: Sequence[str] = ("ffmpeg",),
     ) -> None:
         self._output_path = output_path
         self._width = width
@@ -288,7 +291,10 @@ class StreamingEncoder:
         # WHY: Frames arrive as rgb24 (sRGB). For HDR output, zscale converts
         # sRGB → HLG/PQ on the encoder side. Same pattern as photo pipeline.
         self._target_transfer = self._encoding_plan.target_transfer
+        self._ffmpeg_command = tuple(ffmpeg_command)
         self._proc: subprocess.Popen[bytes] | None = None
+        self._stderr_tail = bytearray()
+        self._stderr_reader: threading.Thread | None = None
 
     def start(self) -> None:
         """Start the FFmpeg encode process."""
@@ -328,8 +334,9 @@ class StreamingEncoder:
         input_pix_fmt = "yuv420p10le" if self._encoding_plan.hdr else "rgb24"
 
         cmd = [
-            "ffmpeg",
+            *self._ffmpeg_command,
             "-y",
+            "-nostats",
             "-f",
             "rawvideo",
             "-pix_fmt",
@@ -353,6 +360,17 @@ class StreamingEncoder:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
+        # WHY: FFmpeg <= 6.1 prints stats/warnings from the transcode thread and
+        # stops reading stdin once the 64 KB stderr pipe is full — draining
+        # only in finish() deadlocks any encode longer than a few minutes.
+        self._stderr_tail = bytearray()
+        self._stderr_reader = threading.Thread(
+            target=drain_stderr_tail,
+            args=(self._proc.stderr, self._stderr_tail),
+            name="streaming-encoder-stderr",
+            daemon=True,
+        )
+        self._stderr_reader.start()
 
     def write_frame(self, frame: np.ndarray) -> None:
         """Write one frame to the encoder. Uses memoryview for zero-copy."""
@@ -371,14 +389,11 @@ class StreamingEncoder:
         assert self._proc.stdin is not None  # noqa: S101
         with contextlib.suppress(BrokenPipeError):
             self._proc.stdin.close()
-        # WHY: Popen.wait() with stderr=PIPE deadlocks when FFmpeg fills the
-        # 64KB OS pipe buffer with progress/warnings. Drain stderr first —
-        # read() blocks until FFmpeg exits and closes its end of the pipe,
-        # which is fine since stdin is already closed (FFmpeg will finish).
-        stderr_bytes = self._proc.stderr.read() if self._proc.stderr else b""
         self._proc.wait(timeout=3600)
+        if self._stderr_reader is not None:
+            self._stderr_reader.join(timeout=30)
         if self._proc.returncode != 0:
-            stderr = stderr_bytes.decode(errors="replace")
+            stderr = bytes(self._stderr_tail).decode(errors="replace")
             raise RuntimeError(
                 f"Streaming encode failed (exit {self._proc.returncode}): {stderr[-500:]}"
             )

--- a/src/immich_memories/titles/taichi_video.py
+++ b/src/immich_memories/titles/taichi_video.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import numpy as np
 
 from immich_memories.processing.encoding_plan import EncodingPlan, HdrTransfer
+from immich_memories.processing.ffmpeg_runner import drain_stderr_tail
 
 from .encoding import standalone_title_encoding_plan, title_color_filter, title_encoder_args
 from .renderer_taichi import TaichiTitleConfig, TaichiTitleRenderer
@@ -25,19 +26,6 @@ logger = logging.getLogger(__name__)
 
 _FFMPEG_STDERR_TAIL_BYTES = 8192
 _FRAME_QUEUE_POLL_SECONDS = 0.1
-
-
-def _drain_stderr_tail(
-    stream,
-    tail: bytearray,
-    *,
-    limit: int = _FFMPEG_STDERR_TAIL_BYTES,
-) -> None:
-    """Drain a byte stream to EOF while retaining only its newest bytes."""
-    while chunk := stream.read(65536):
-        tail.extend(chunk)
-        if len(tail) > limit:
-            del tail[:-limit]
 
 
 def _pipe_writer(
@@ -265,8 +253,9 @@ def create_title_video_taichi(
     process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     stderr_tail = bytearray()
     stderr_reader = threading.Thread(
-        target=_drain_stderr_tail,
+        target=drain_stderr_tail,
         args=(process.stderr, stderr_tail),
+        kwargs={"limit": _FFMPEG_STDERR_TAIL_BYTES},
         name="title-ffmpeg-stderr",
         daemon=True,
     )

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from immich_memories.config_loader import Config
     from immich_memories.config_models_auth import AuthConfig
 
 import httpx
@@ -414,6 +415,52 @@ def _redact_health_value(value: Any, secrets_to_redact: tuple[str, ...]) -> Any:
     return value
 
 
+def _health_detail_allowed(config: Config) -> bool:
+    """Return whether the current request may see automation/run detail."""
+    if not is_auth_enabled(config.auth):
+        return True
+    try:
+        return bool(app.storage.user.get("authenticated"))
+    except RuntimeError:
+        # No request/session context (e.g. called outside an HTTP request).
+        return False
+
+
+def _operational_detail(
+    config: Config, secrets_to_redact: tuple[str, ...]
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return (automation status, last successful run) for the health payload.
+
+    WHY: /health is public so probes work, but automation detail carries person
+    names (memory keys) and host paths. With auth on, only a logged-in session
+    gets the detail; probes and other LAN devices get status + version.
+    """
+    if not _health_detail_allowed(config):
+        return None, None
+
+    automation: dict[str, Any] | None = None
+    try:
+        automation = _get_automation_status(config)
+    except Exception as exc:
+        logger.warning(
+            "Could not read automation status for readiness (%s)",
+            type(exc).__name__,
+        )
+
+    last_successful_run: str | None = None
+    try:
+        last_successful_run = _get_last_successful_run(config)
+    except Exception as exc:
+        logger.warning(
+            "Could not read run status for readiness (%s)",
+            type(exc).__name__,
+        )
+
+    if automation is not None:
+        automation = _redact_health_value(automation, secrets_to_redact)
+    return automation, last_successful_run
+
+
 async def _build_health_snapshot() -> dict[str, Any]:
     """Build the shared detailed health payload for readiness and compatibility."""
     try:
@@ -449,26 +496,7 @@ async def _build_health_snapshot() -> dict[str, Any]:
     else:
         immich = _ImmichDependency(status="missing_configuration", reachable=False)
 
-    automation: dict[str, Any] | None = None
-    try:
-        automation = _get_automation_status(config)
-    except Exception as exc:
-        logger.warning(
-            "Could not read automation status for readiness (%s)",
-            type(exc).__name__,
-        )
-
-    last_successful_run: str | None = None
-    try:
-        last_successful_run = _get_last_successful_run(config)
-    except Exception as exc:
-        logger.warning(
-            "Could not read run status for readiness (%s)",
-            type(exc).__name__,
-        )
-
-    if automation is not None:
-        automation = _redact_health_value(automation, secrets_to_redact)
+    automation, last_successful_run = _operational_detail(config, secrets_to_redact)
 
     ready = configured and immich.status == "ready"
     api_version_policy = getattr(config.immich.api_version, "value", config.immich.api_version)

--- a/src/immich_memories/ui/auth.py
+++ b/src/immich_memories/ui/auth.py
@@ -13,6 +13,8 @@ import threading
 from collections.abc import MutableMapping
 from datetime import UTC, datetime
 
+import nicegui
+
 from immich_memories.config_models_auth import AuthConfig
 
 logger = logging.getLogger(__name__)
@@ -64,7 +66,10 @@ def reset_rate_limiter() -> None:
         _failed_attempts.clear()
 
 
-_BYPASS_PREFIXES = ("/_nicegui/",)
+# WHY: only NiceGUI's versioned framework assets (JS/CSS the login page needs) and
+# the app's own /static (fonts) are public. "/_nicegui/auto/{media,static}/..." serves
+# every locally previewed video/audio file and must stay behind the login.
+_BYPASS_PREFIXES = (f"/_nicegui/{nicegui.__version__}/", "/static/")
 _HEALTH_BYPASS_EXACT = frozenset({"/health", "/health/live", "/health/ready"})
 _BYPASS_EXACT = (
     frozenset(

--- a/tests/integration/cli/test_generate.py
+++ b/tests/integration/cli/test_generate.py
@@ -1108,7 +1108,7 @@ class TestPipelineRunner:
             clip_segments={clip.asset.id: (0.0, 8.0) for clip in clips},
             errors=[],
         )
-        output_path = tmp_path / "emile-preview.mp4"
+        output_path = tmp_path / "noah-preview.mp4"
 
         with (
             patch("immich_memories.generate.assets_to_clips", return_value=clips),
@@ -1128,7 +1128,7 @@ class TestPipelineRunner:
                 no_music=True,
                 output_path=output_path,
                 memory_type="person_spotlight",
-                person_names=["Emile"],
+                person_names=["Noah"],
                 date_range=DateRange(
                     start=datetime(2026, 1, 1), end=datetime(2026, 12, 31, 23, 59, 59)
                 ),

--- a/tests/integration/cli/test_generate_e2e.py
+++ b/tests/integration/cli/test_generate_e2e.py
@@ -271,7 +271,7 @@ class TestPipelinePixels:
 class TestPipelineWithTitles:
     """Verify title screen rendering in the full pipeline.
 
-    Title screens have been the source of most regressions (Emile crash,
+    Title screens have been the source of most regressions (Noah crash,
     divider count changes, pink HDR). These tests enable titles and verify
     the output includes them.
     """

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nicegui
 import pytest
 
 from immich_memories.config_loader import Config
@@ -36,8 +37,9 @@ class TestBypassPaths:
             "/logout",
             "/auth/callback",
             "/auth/authorize",
-            "/_nicegui/auto/test",
-            "/_nicegui/static/foo.js",
+            f"/_nicegui/{nicegui.__version__}/static/foo.js",
+            f"/_nicegui/{nicegui.__version__}/components/abc.js",
+            "/static/fonts/Montserrat.woff2",
         ],
     )
     def test_bypass_paths_return_true(self, path: str):
@@ -45,7 +47,17 @@ class TestBypassPaths:
 
     @pytest.mark.parametrize(
         "path",
-        ["/", "/step2", "/protected", "/settings/config", "/api/something"],
+        [
+            "/",
+            "/step2",
+            "/protected",
+            "/settings/config",
+            "/api/something",
+            # WHY: NiceGUI serves every locally previewed video/audio file under
+            # /_nicegui/auto/{media,static}; those must stay behind the login.
+            "/_nicegui/auto/media/0123456789abcdef/family_2025_memories.mp4",
+            "/_nicegui/auto/static/0123456789abcdef/track.wav",
+        ],
     )
     def test_protected_paths_return_false(self, path: str):
         assert is_bypass_path(path) is False

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -200,11 +200,11 @@ class TestCheckAnalysisCache:
                 start=2.0,
                 end=7.0,
                 score=0.94,
-                llm_description="Emile building a sandcastle",
+                llm_description="Noah building a sandcastle",
                 llm_emotion="delighted",
                 llm_setting="beach",
                 llm_activities=["playing"],
-                llm_subjects=["Emile"],
+                llm_subjects=["Noah"],
                 llm_interestingness=0.91,
                 llm_quality=0.88,
                 audio_categories=["laughter", "waves"],
@@ -218,11 +218,11 @@ class TestCheckAnalysisCache:
 
         assert len(result) == 1
         assert (result[0].start_time, result[0].end_time, result[0].score) == (2.0, 7.0, 0.94)
-        assert clip.llm_description == "Emile building a sandcastle"
+        assert clip.llm_description == "Noah building a sandcastle"
         assert clip.llm_emotion == "delighted"
         assert clip.llm_setting == "beach"
         assert clip.llm_activities == ["playing"]
-        assert clip.llm_subjects == ["Emile"]
+        assert clip.llm_subjects == ["Noah"]
         assert clip.llm_interestingness == 0.91
         assert clip.llm_quality == 0.88
         assert clip.audio_categories == ["laughter", "waves"]

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -303,3 +303,15 @@ def test_image_default_output_directory_is_the_compose_output_mount() -> None:
     assert image_output_dir in mount_targets, (
         f"{image_output_dir} is not a compose mount target: {sorted(mount_targets)}"
     )
+
+
+def test_image_runs_as_uid_1000() -> None:
+    """Bind mounts (./output, ./config) and the K8s manifests assume the common host UID.
+
+    A system UID from `useradd -r` (~999) cannot write a host directory owned by
+    the first Linux user, and the shipped manifests pin `runAsUser: 1000`.
+    """
+    dockerfile = _logical_instructions(_dockerfile())
+    assert re.search(r"groupadd\s+(-r\s+)?-g\s+1000\s+immich", dockerfile), "group must be GID 1000"
+    assert re.search(r"useradd\s+[^&]*-u\s+1000\s+", dockerfile), "user must be UID 1000"
+    assert "useradd -r" not in dockerfile

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -284,3 +284,22 @@ def test_pull_request_images_receive_required_build_arguments() -> None:
         assert "INSTALL_EXTRAS=all" in build_args
         assert "VCS_REF=${{ github.sha }}" in build_args
         assert "SOURCE_URL=https://github.com/${{ github.repository }}" in build_args
+
+
+def test_image_default_output_directory_is_the_compose_output_mount() -> None:
+    """Videos generated in the container must land on the volume the quickstart mounts.
+
+    Without this, the default `~/Videos/Memories` resolves inside the container's
+    home and `docker compose pull && up -d` silently discards every generated video.
+    """
+    dockerfile = _logical_instructions(_dockerfile())
+    match = re.search(r"ENV IMMICH_MEMORIES_OUTPUT__DIRECTORY=(\S+)", dockerfile)
+    assert match, "Dockerfile must pin the default output directory to a mounted path"
+    image_output_dir = match.group(1)
+
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text())
+    volumes = compose["services"]["immich-memories"]["volumes"]
+    mount_targets = {str(v).split(":")[1] for v in volumes if ":" in str(v)}
+    assert image_output_dir in mount_targets, (
+        f"{image_output_dir} is not a compose mount target: {sorted(mount_targets)}"
+    )

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -579,3 +579,70 @@ class TestHealthEndpoint:
             result = _get_last_successful_run(Config())
 
         assert result is None
+
+
+class TestHealthDisclosure:
+    """Detailed operational state must not leak to unauthenticated LAN clients."""
+
+    @pytest.mark.parametrize("path", ["/health", "/health/ready"])
+    def test_unauthenticated_health_omits_automation_detail_when_auth_enabled(self, path: str):
+        from immich_memories.ui.app import _ImmichDependency, app
+
+        config = Config(
+            immich={"url": "http://immich.test", "api_key": "health-secret"},
+            auth={"enabled": True, "provider": "basic", "username": "u", "password": "p"},
+        )
+        automation = {
+            "last_attempt": {"memory_key": "person_spotlight:2024:Alice", "outcome": "completed"},
+            "last_completed_auto_run": {
+                "memory_key": "person_spotlight:2024:Alice",
+                "output_path": "/data/output/alice_2024_memories.mp4",
+            },
+            "pending_delivery_count": 0,
+            "oldest_pending_delivery": None,
+            "notification_health": None,
+        }
+        client = TestClient(app, raise_server_exceptions=False)
+        with (
+            # WHY: config and Immich probe are external boundaries; the test is about payload shape.
+            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch(
+                "immich_memories.ui.app._check_immich_dependency",
+                new_callable=AsyncMock,
+                return_value=_ImmichDependency(status="ready", reachable=True),
+            ),
+            patch("immich_memories.ui.app._get_automation_status", return_value=automation),
+            patch("immich_memories.ui.app._get_last_successful_run", return_value="run-123"),
+        ):
+            response = client.get(path)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] in {"ok", "ready"}
+        assert body["version"] == immich_memories.__version__
+        assert "Alice" not in response.text
+        assert "alice_2024_memories" not in response.text
+        assert body["automation"] is None
+        assert body["last_successful_run"] is None
+
+    def test_health_keeps_detail_when_auth_disabled(self):
+        from immich_memories.ui.app import _ImmichDependency, app
+
+        config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
+        automation = {"last_attempt": {"memory_key": "year_in_review:2024"}}
+        client = TestClient(app, raise_server_exceptions=False)
+        with (
+            # WHY: same boundaries as above; auth disabled means a trusted LAN deployment.
+            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch(
+                "immich_memories.ui.app._check_immich_dependency",
+                new_callable=AsyncMock,
+                return_value=_ImmichDependency(status="ready", reachable=True),
+            ),
+            patch("immich_memories.ui.app._get_automation_status", return_value=automation),
+            patch("immich_memories.ui.app._get_last_successful_run", return_value="run-123"),
+        ):
+            response = client.get("/health")
+
+        assert response.json()["last_automation_attempt"] == {"memory_key": "year_in_review:2024"}
+        assert response.json()["last_successful_run"] == "run-123"

--- a/tests/test_llm_titles.py
+++ b/tests/test_llm_titles.py
@@ -95,11 +95,11 @@ class TestBuildTitlePrompt:
             start_date="2019-01-01",
             end_date="2025-12-31",
             duration_days=2556,
-            person_names=["Alice", "Emile"],
+            person_names=["Alice", "Noah"],
             clip_descriptions=["playing in park", "birthday party"],
         )
         assert "Alice" in prompt
-        assert "Emile" in prompt
+        assert "Noah" in prompt
         assert "French" in prompt
 
     def test_includes_rules(self):

--- a/tests/test_output_filename.py
+++ b/tests/test_output_filename.py
@@ -60,14 +60,14 @@ class TestBuildOutputFilename:
         result = build_output_filename(
             memory_type="multi_person",
             preset_params={
-                "person_names": ["sam", "emile"],
+                "person_names": ["sam", "noah"],
                 "year": 2026,
             },
             person_name=None,
             date_start=date(2026, 3, 1),
             date_end=date(2026, 3, 31),
         )
-        assert result == "sam_emile_march_2026_memories.mp4"
+        assert result == "sam_noah_march_2026_memories.mp4"
 
     def test_multi_person_with_many_names_truncates(self):
         """More than 3 person names: truncate and add 'and_others'."""
@@ -110,22 +110,22 @@ class TestBuildOutputFilename:
         result = build_output_filename(
             memory_type="season",
             preset_params={"year": 2025, "season": "summer"},
-            person_name="emile",
+            person_name="noah",
             date_start=date(2025, 6, 1),
             date_end=date(2025, 8, 31),
         )
-        assert result == "emile_summer_2025_memories.mp4"
+        assert result == "noah_summer_2025_memories.mp4"
 
     def test_person_spotlight(self):
         """Person Spotlight: use person name from preset params."""
         result = build_output_filename(
             memory_type="person_spotlight",
-            preset_params={"person_names": ["emile"], "year": 2025},
-            person_name="emile",
+            preset_params={"person_names": ["noah"], "year": 2025},
+            person_name="noah",
             date_start=date(2025, 1, 1),
             date_end=date(2025, 12, 31),
         )
-        assert result == "emile_2025_memories.mp4"
+        assert result == "noah_2025_memories.mp4"
 
     def test_monthly_highlights(self):
         """Monthly Highlights: person + month + year."""

--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -1463,3 +1463,48 @@ class TestFramePreviewCallback:
             fps=10,
         )
         assert output.exists()
+
+
+def test_streaming_encoder_survives_noisy_ffmpeg_stderr(tmp_path: Path) -> None:
+    """A chatty encoder must not deadlock the frame writer.
+
+    FFmpeg <= 6.1 prints -stats/warnings from the transcode thread; once the 64 KB
+    stderr pipe is full it stops reading stdin and the encode hangs forever.
+    """
+    import sys
+    import threading
+
+    from immich_memories.processing.streaming_assembler import StreamingEncoder
+
+    fake_ffmpeg = tmp_path / "noisy_ffmpeg.py"
+    fake_ffmpeg.write_text(
+        "import sys\n"
+        "sys.stderr.write('x' * 200_000)\n"  # > pipe capacity, before touching stdin
+        "sys.stderr.flush()\n"
+        "data = sys.stdin.buffer.read()\n"
+        "open(sys.argv[-1], 'wb').write(b'fake' + len(data).to_bytes(4, 'big'))\n"
+    )
+    output = tmp_path / "out.mp4"
+    encoder = StreamingEncoder(
+        output,
+        width=64,
+        height=64,
+        fps=1,
+        encoding_plan=_h264_plan(),
+        ffmpeg_command=(sys.executable, str(fake_ffmpeg)),
+    )
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)  # 12 KB per frame
+
+    def run() -> None:
+        encoder.start()
+        for _ in range(20):  # 240 KB > 64 KB stdin pipe
+            encoder.write_frame(frame)
+        encoder.finish()
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(timeout=20)
+    if worker.is_alive() and encoder._proc is not None:
+        encoder._proc.kill()
+    assert not worker.is_alive(), "frame writer deadlocked on an undrained stderr pipe"
+    assert output.read_bytes().startswith(b"fake")

--- a/tests/test_taichi_video_lifecycle.py
+++ b/tests/test_taichi_video_lifecycle.py
@@ -179,12 +179,12 @@ def test_stderr_is_drained_while_frame_writer_is_active(
 
 
 def test_stderr_tail_is_bounded_and_keeps_latest_bytes() -> None:
-    from immich_memories.titles.taichi_video import _drain_stderr_tail
+    from immich_memories.processing.ffmpeg_runner import drain_stderr_tail
 
     stream = _FakeStderr(b"oldest-", b"middle-", b"latest")
     tail = bytearray()
 
-    _drain_stderr_tail(stream, tail, limit=13)
+    drain_stderr_tail(stream, tail, limit=13)
 
     assert bytes(tail) == b"middle-latest"
 

--- a/tests/test_titles_audio_coverage.py
+++ b/tests/test_titles_audio_coverage.py
@@ -1392,12 +1392,12 @@ class TestBuildOutputFilename:
 
         result = build_output_filename(
             "multi_person",
-            {"person_names": ["Sam", "Emile"]},
+            {"person_names": ["Sam", "Noah"]},
             None,
             date(2025, 3, 1),
             date(2025, 3, 31),
         )
-        assert "sam_emile" in result
+        assert "sam_noah" in result
 
     def test_multi_person_many_names_truncated(self):
         from immich_memories.filename_builder import build_output_filename


### PR DESCRIPTION
## Why

Pre-launch review (docs/reviews/2026-08-18-launch-review.md) found four operational problems that would have shown up in launch week:

1. **Docker: generated videos were written inside the container.** Default `output.directory` is `~/Videos/Memories`, which resolves to `/home/immich/Videos/Memories`; the quickstart's `./output:/app/output` mount was never used, so `docker compose pull && up -d` discarded every video not downloaded first.
2. **Auth: previewed videos were reachable without login.** The middleware bypassed everything under `/_nicegui/`, which includes NiceGUI's `add_media_file` routes (`/_nicegui/auto/media/<hash>/<file>`) that serve the family videos previewed in the UI.
3. **`/health` leaked person names and host paths** (automation memory keys, output paths) to any LAN device, auth or not.
4. **Streaming encoder deadlock on long CPU encodes.** `StreamingEncoder` opened `stderr=PIPE` and drained it only after the last frame. On FFmpeg ≤ 6.1 (Debian/Ubuntu/NAS packages) default `-stats` alone fills the 64 KB pipe in ~5 min of wall-clock encode; FFmpeg then stops reading stdin and the run hangs with the lock held.

## What

- `docker/Dockerfile`: `ENV IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output` + contract test that the image default is a compose mount target. `docker/.env.example` now lists real env vars (the old `OUTPUT_DIR`/`CACHE_DIR` were read by nothing).
- `ui/auth.py`: bypass only `/_nicegui/<nicegui version>/` (framework assets the login page needs) and `/static/` (bundled fonts). Tests assert `/_nicegui/auto/media/...` and `/_nicegui/auto/static/...` are protected. Auth E2E flow (`tests/e2e/test_auth_flow.py`) passes.
- `ui/app.py`: with auth enabled and no session, `/health` and `/health/ready` return status/config/immich/version only; automation detail requires a session. Auth disabled keeps today's payload. Extracted `_operational_detail()` to keep cognitive complexity under the gate.
- `processing/streaming_assembler.py`: `-nostats`, stderr drained on a daemon thread from `start()`, tail kept for the error message; `ffmpeg_command` injectable for tests. New shared `drain_stderr_tail()` in `processing/ffmpeg_runner.py` (also used by `titles/taichi_video.py`). Test pipes 240 KB of frames through a fake encoder that writes 200 KB to stderr before reading stdin — hangs on the old code, passes now.
- chore: generic example names in `filename_builder.py` docstring and test fixtures.
- `docker/Dockerfile`: image runs as **UID/GID 1000** (bind mounts writable without chown; matches the K8s/Terraform `runAsUser: 1000`), contract test.

## Verification

`make ci` gates green (pre-commit ran lint/format/mypy/complexity/dead-code/bandit/deptry/import-linter/jscpd/diff-cover), `make critique`, `make semgrep`, `make commitlint`, `make e2e` (24 passed, hermetic launch smoke renders a real video), `tests/e2e/test_auth_flow.py` (3 passed).

## Not in this PR (tracked in the review)

Remaining stderr-pipe sites (#279), `Secure` cookie option (#306), dead config knobs (PR from `refactor/config-knobs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
