### PR TITLE
fix(photos): bound photo scoring and stop stills duplicating videos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,9 @@ test-watch:
 	uv run pytest-watch -- -v
 
 # Run specific test file
+test-one:  ## Run one test file or node id: make test-one T=tests/test_foo.py
+	uv run pytest $(T) -v
+
 test-cache:
 	uv run pytest tests/test_cache.py -v
 

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1071,45 +1071,21 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 182,
-        "line_start": 120,
-        "line_end": 784,
+        "complexity": 180,
+        "line_start": 132,
+        "line_end": 795,
         "line_complexities": [
           {
-            "line": 401,
-            "complexity": 0
-          },
-          {
-            "line": 402,
-            "complexity": 0
-          },
-          {
-            "line": 409,
-            "complexity": 2
-          },
-          {
-            "line": 410,
-            "complexity": 0
-          },
-          {
-            "line": 411,
-            "complexity": 0
-          },
-          {
             "line": 413,
-            "complexity": 2
-          },
-          {
-            "line": 415,
-            "complexity": 3
-          },
-          {
-            "line": 419,
-            "complexity": 3
-          },
-          {
-            "line": 420,
             "complexity": 0
+          },
+          {
+            "line": 414,
+            "complexity": 0
+          },
+          {
+            "line": 421,
+            "complexity": 2
           },
           {
             "line": 422,
@@ -1117,18 +1093,22 @@
           },
           {
             "line": 423,
+            "complexity": 0
+          },
+          {
+            "line": 425,
             "complexity": 2
           },
           {
-            "line": 424,
-            "complexity": 1
-          },
-          {
-            "line": 429,
+            "line": 427,
             "complexity": 3
           },
           {
-            "line": 430,
+            "line": 431,
+            "complexity": 3
+          },
+          {
+            "line": 432,
             "complexity": 0
           },
           {
@@ -1137,23 +1117,31 @@
           },
           {
             "line": 435,
-            "complexity": 1
+            "complexity": 2
           },
           {
             "line": 436,
+            "complexity": 1
+          },
+          {
+            "line": 441,
+            "complexity": 3
+          },
+          {
+            "line": 442,
             "complexity": 0
           },
           {
-            "line": 439,
-            "complexity": 3
-          },
-          {
-            "line": 443,
-            "complexity": 3
+            "line": 446,
+            "complexity": 0
           },
           {
             "line": 447,
-            "complexity": 4
+            "complexity": 1
+          },
+          {
+            "line": 448,
+            "complexity": 0
           },
           {
             "line": 451,
@@ -1164,35 +1152,23 @@
             "complexity": 3
           },
           {
-            "line": 461,
-            "complexity": 2
+            "line": 459,
+            "complexity": 4
           },
           {
             "line": 463,
-            "complexity": 0
-          },
-          {
-            "line": 476,
-            "complexity": 1
-          },
-          {
-            "line": 477,
-            "complexity": 0
-          },
-          {
-            "line": 480,
-            "complexity": 2
-          },
-          {
-            "line": 481,
-            "complexity": 0
-          },
-          {
-            "line": 483,
             "complexity": 3
           },
           {
-            "line": 484,
+            "line": 467,
+            "complexity": 3
+          },
+          {
+            "line": 473,
+            "complexity": 2
+          },
+          {
+            "line": 475,
             "complexity": 0
           },
           {
@@ -1200,92 +1176,96 @@
             "complexity": 1
           },
           {
-            "line": 491,
-            "complexity": 1
+            "line": 489,
+            "complexity": 0
           },
           {
             "line": 492,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 493,
             "complexity": 0
           },
           {
+            "line": 495,
+            "complexity": 3
+          },
+          {
             "line": 496,
-            "complexity": 2
-          },
-          {
-            "line": 497,
-            "complexity": 0
-          },
-          {
-            "line": 498,
-            "complexity": 1
-          },
-          {
-            "line": 499,
             "complexity": 0
           },
           {
             "line": 500,
-            "complexity": 3
-          },
-          {
-            "line": 505,
             "complexity": 1
           },
           {
-            "line": 506,
-            "complexity": 3
+            "line": 503,
+            "complexity": 1
           },
           {
-            "line": 507,
+            "line": 504,
+            "complexity": 0
+          },
+          {
+            "line": 505,
             "complexity": 0
           },
           {
             "line": 508,
-            "complexity": 1
+            "complexity": 2
           },
           {
             "line": 509,
             "complexity": 0
           },
           {
+            "line": 510,
+            "complexity": 1
+          },
+          {
+            "line": 511,
+            "complexity": 0
+          },
+          {
             "line": 512,
+            "complexity": 3
+          },
+          {
+            "line": 517,
+            "complexity": 1
+          },
+          {
+            "line": 518,
+            "complexity": 3
+          },
+          {
+            "line": 519,
             "complexity": 0
           },
           {
-            "line": 516,
-            "complexity": 2
-          },
-          {
-            "line": 522,
+            "line": 520,
             "complexity": 1
           },
           {
-            "line": 525,
-            "complexity": 1
-          },
-          {
-            "line": 526,
-            "complexity": 2
-          },
-          {
-            "line": 527,
+            "line": 521,
             "complexity": 0
           },
           {
-            "line": 530,
-            "complexity": 1
+            "line": 524,
+            "complexity": 0
+          },
+          {
+            "line": 528,
+            "complexity": 2
           },
           {
             "line": 533,
-            "complexity": 3
+            "complexity": 0
           },
           {
-            "line": 534,
-            "complexity": 3
+            "line": 536,
+            "complexity": 0
           },
           {
             "line": 537,
@@ -1296,80 +1276,84 @@
             "complexity": 0
           },
           {
-            "line": 539,
-            "complexity": 3
-          },
-          {
-            "line": 540,
-            "complexity": 0
-          },
-          {
-            "line": 542,
-            "complexity": 0
-          },
-          {
-            "line": 564,
+            "line": 541,
             "complexity": 1
           },
           {
-            "line": 565,
+            "line": 544,
+            "complexity": 3
+          },
+          {
+            "line": 545,
+            "complexity": 3
+          },
+          {
+            "line": 548,
             "complexity": 2
           },
           {
-            "line": 569,
-            "complexity": 1
+            "line": 549,
+            "complexity": 0
           },
           {
-            "line": 580,
+            "line": 550,
             "complexity": 3
           },
           {
-            "line": 581,
+            "line": 551,
             "complexity": 0
           },
           {
-            "line": 582,
+            "line": 553,
             "complexity": 0
           },
           {
-            "line": 584,
+            "line": 575,
+            "complexity": 1
+          },
+          {
+            "line": 576,
+            "complexity": 2
+          },
+          {
+            "line": 580,
+            "complexity": 1
+          },
+          {
+            "line": 591,
+            "complexity": 3
+          },
+          {
+            "line": 592,
             "complexity": 0
           },
           {
-            "line": 586,
-            "complexity": 0
-          },
-          {
-            "line": 588,
+            "line": 593,
             "complexity": 0
           },
           {
             "line": 595,
-            "complexity": 6
-          },
-          {
-            "line": 637,
             "complexity": 0
           },
           {
-            "line": 638,
+            "line": 597,
+            "complexity": 0
+          },
+          {
+            "line": 599,
+            "complexity": 0
+          },
+          {
+            "line": 606,
+            "complexity": 6
+          },
+          {
+            "line": 648,
+            "complexity": 0
+          },
+          {
+            "line": 649,
             "complexity": 5
-          },
-          {
-            "line": 639,
-            "complexity": 6
-          },
-          {
-            "line": 640,
-            "complexity": 0
-          },
-          {
-            "line": 641,
-            "complexity": 0
-          },
-          {
-            "line": 642,
-            "complexity": 7
           },
           {
             "line": 650,
@@ -1381,128 +1365,144 @@
           },
           {
             "line": 652,
-            "complexity": 7
-          },
-          {
-            "line": 653,
             "complexity": 0
           },
           {
-            "line": 655,
-            "complexity": 1
-          },
-          {
-            "line": 660,
+            "line": 653,
             "complexity": 7
           },
           {
             "line": 661,
+            "complexity": 6
+          },
+          {
+            "line": 662,
             "complexity": 0
           },
           {
-            "line": 674,
+            "line": 663,
             "complexity": 7
           },
           {
-            "line": 675,
+            "line": 664,
             "complexity": 0
           },
           {
-            "line": 676,
-            "complexity": 0
-          },
-          {
-            "line": 679,
+            "line": 666,
             "complexity": 1
           },
           {
-            "line": 680,
+            "line": 671,
+            "complexity": 7
+          },
+          {
+            "line": 672,
             "complexity": 0
           },
           {
-            "line": 681,
+            "line": 685,
+            "complexity": 7
+          },
+          {
+            "line": 686,
             "complexity": 0
           },
           {
-            "line": 684,
+            "line": 687,
             "complexity": 0
           },
           {
-            "line": 694,
+            "line": 690,
+            "complexity": 1
+          },
+          {
+            "line": 691,
+            "complexity": 0
+          },
+          {
+            "line": 692,
             "complexity": 0
           },
           {
             "line": 695,
+            "complexity": 0
+          },
+          {
+            "line": 705,
+            "complexity": 0
+          },
+          {
+            "line": 706,
             "complexity": 5
           },
           {
-            "line": 696,
+            "line": 707,
             "complexity": 6
           },
           {
-            "line": 697,
+            "line": 708,
             "complexity": 7
           },
           {
-            "line": 701,
+            "line": 712,
             "complexity": 6
           },
           {
-            "line": 704,
+            "line": 715,
             "complexity": 6
-          },
-          {
-            "line": 709,
-            "complexity": 0
-          },
-          {
-            "line": 711,
-            "complexity": 5
-          },
-          {
-            "line": 713,
-            "complexity": 5
-          },
-          {
-            "line": 717,
-            "complexity": 5
           },
           {
             "line": 720,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 722,
-            "complexity": 0
+            "complexity": 5
           },
           {
             "line": 724,
+            "complexity": 5
+          },
+          {
+            "line": 728,
+            "complexity": 5
+          },
+          {
+            "line": 731,
+            "complexity": 1
+          },
+          {
+            "line": 733,
             "complexity": 0
           },
           {
-            "line": 767,
-            "complexity": 1
-          },
-          {
-            "line": 770,
-            "complexity": 1
-          },
-          {
-            "line": 773,
-            "complexity": 1
-          },
-          {
-            "line": 774,
+            "line": 735,
             "complexity": 0
           },
           {
-            "line": 775,
+            "line": 778,
+            "complexity": 1
+          },
+          {
+            "line": 781,
+            "complexity": 1
+          },
+          {
+            "line": 784,
+            "complexity": 1
+          },
+          {
+            "line": 785,
+            "complexity": 0
+          },
+          {
+            "line": 786,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 198
+    "complexity": 197
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",
@@ -2659,111 +2659,111 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 489,
-        "line_end": 594,
+        "line_start": 526,
+        "line_end": 631,
         "line_complexities": [
           {
-            "line": 510,
+            "line": 547,
             "complexity": 0
           },
           {
-            "line": 511,
+            "line": 548,
             "complexity": 1
           },
           {
-            "line": 513,
+            "line": 550,
             "complexity": 1
           },
           {
-            "line": 514,
+            "line": 551,
             "complexity": 0
           },
           {
-            "line": 515,
+            "line": 552,
             "complexity": 2
           },
           {
-            "line": 516,
+            "line": 553,
             "complexity": 0
           },
           {
-            "line": 523,
+            "line": 560,
             "complexity": 1
           },
           {
-            "line": 527,
+            "line": 564,
             "complexity": 0
           },
           {
-            "line": 528,
+            "line": 565,
             "complexity": 0
           },
           {
-            "line": 529,
+            "line": 566,
             "complexity": 1
           },
           {
-            "line": 530,
+            "line": 567,
             "complexity": 0
           },
           {
-            "line": 531,
+            "line": 568,
             "complexity": 2
           },
           {
-            "line": 532,
+            "line": 569,
             "complexity": 0
           },
           {
-            "line": 539,
+            "line": 576,
             "complexity": 1
-          },
-          {
-            "line": 543,
-            "complexity": 0
-          },
-          {
-            "line": 545,
-            "complexity": 0
           },
           {
             "line": 580,
             "complexity": 0
           },
           {
-            "line": 581,
-            "complexity": 0
-          },
-          {
             "line": 582,
-            "complexity": 1
-          },
-          {
-            "line": 583,
-            "complexity": 2
-          },
-          {
-            "line": 584,
             "complexity": 0
           },
           {
-            "line": 585,
-            "complexity": 1
-          },
-          {
-            "line": 586,
+            "line": 617,
             "complexity": 0
           },
           {
-            "line": 592,
+            "line": 618,
+            "complexity": 0
+          },
+          {
+            "line": 619,
             "complexity": 1
           },
           {
-            "line": 593,
+            "line": 620,
             "complexity": 2
           },
           {
-            "line": 594,
+            "line": 621,
+            "complexity": 0
+          },
+          {
+            "line": 622,
+            "complexity": 1
+          },
+          {
+            "line": 623,
+            "complexity": 0
+          },
+          {
+            "line": 629,
+            "complexity": 1
+          },
+          {
+            "line": 630,
+            "complexity": 2
+          },
+          {
+            "line": 631,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/pipeline/photo-support.md
+++ b/docs-site/docs/create/pipeline/photo-support.md
@@ -64,16 +64,43 @@ photos:
   enabled: true           # Include photos in memories
   max_ratio: 0.50         # Max 50% of clips can be photos
   duration: 4.0           # Seconds per photo clip
+  moment_gap_seconds: 120 # Window for "same moment as a video" (seconds)
+  moment_hash_threshold: 10  # Bits a photo may differ from that video and still match
   score_penalty: 0.2      # Photos score 80% of equivalent videos
 ```
 
 Older configs may still contain `collage_duration`, `animation_mode`, `enable_collage`, `series_gap_seconds` or `zoom_factor`; those keys were removed in 0.41 and are ignored (the zoom amount is randomized per photo, and collages are not wired in).
+
+## Photos a video already shows
+
+A still shot seconds before a video of the same thing puts that instant on screen
+twice — once as motion, once as a Ken Burns pan. Before scoring, photos are grouped
+with the video clips by capture time and dropped when a clip already covers them:
+
+- **Same scene.** A photo within `moment_gap_seconds` of a clip whose thumbnail is
+  within `moment_hash_threshold` bits of it is dropped as redundant. On a 5,128-photo
+  year, 802 photos fell inside a clip's window and 101 of them were dropped.
+- **Same asset.** A Live Photo's still and its motion clip are one asset, so a still
+  that reaches the photo pool by ID — including every still merged into a burst — is
+  removed outright. Immich normally keeps Live Photo stills out of the photo pool on
+  its own; this is a guard for when it doesn't.
+
+A photo with no cached thumbnail is always kept — redundancy is measured, never
+assumed. Thumbnails are only fetched for photos that fall inside a clip's window, so
+photos nowhere near a video cost nothing. Set `moment_gap_seconds: 0` to leave
+everything but the exact-asset case alone.
 
 ## CLI Flags
 
 ```bash
 # Include photos in generation
 immich-memories generate --include-photos --year 2024
+
+# Leave photos out even when photos.enabled is true in config
+immich-memories generate --no-photos --year 2024
+
+# Same for Live Photos
+immich-memories generate --no-live-photos --year 2024
 
 # Override photo duration
 immich-memories generate --include-photos --photo-duration 5.0

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -243,8 +243,8 @@ immich-memories generate [OPTIONS]
 | `--privacy-mode` | boolean | false | Blur faces and mute speech |
 | `--title` | text | - | Override video title text |
 | `--subtitle` | text | - | Override video subtitle text |
-| `--include-live-photos` | boolean | false | Include Live Photo video clips (3s iPhone clips, merged when burst-captured) |
-| `--include-photos` | boolean | false | Include photos as animated Ken Burns clips (blur background, face-aware pan) |
+| `--include-live-photos` | boolean | - | Include Live Photo video clips (3s iPhone clips, merged when burst-captured) |
+| `--include-photos` | boolean | - | Include photos as animated Ken Burns clips (blur background, face-aware pan) |
 | `--photo-duration` | float | - | Duration per photo clip in seconds (default: 4.0) |
 | `--analysis-depth` | choice: `auto` \| `fast` \| `thorough` | - | Analysis depth: auto (full analysis for manageable pools), fast (favorites first), or thorough (every eligible clip) |
 | `--trip-index` | integer | - | Select a specific trip by index (use with --memory-type trip) |

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -148,6 +148,8 @@ photos:
   enabled: true                  # Include photos in memories
   max_ratio: 0.50               # Max 50% of clips can be photos (0-1)
   duration: 4.0                  # Seconds per photo clip (1-10)
+  moment_gap_seconds: 120        # Window for "same moment as a video" (0-3600)
+  moment_hash_threshold: 10      # Hash bits allowed between photo and that video (0-64)
   score_penalty: 0.2             # Photos score 80% of equivalent videos (0-1)
 ```
 

--- a/src/immich_memories/analysis/live_photo_pipeline.py
+++ b/src/immich_memories/analysis/live_photo_pipeline.py
@@ -206,6 +206,7 @@ def fetch_live_photo_clips(
             live_burst_video_ids=burst_ids,
             live_burst_trim_points=burst_trims,
             live_burst_shutter_timestamps=burst_shutters,
+            live_burst_still_ids=[a.id for a in cluster.assets],
         )
         if cluster.is_favorite:
             clip.asset.is_favorite = True

--- a/src/immich_memories/api/models.py
+++ b/src/immich_memories/api/models.py
@@ -389,6 +389,7 @@ class VideoClipInfo(BaseModel):
     live_burst_video_ids: list[str] | None = None
     live_burst_trim_points: list[tuple[float, float]] | None = None
     live_burst_shutter_timestamps: list[float] | None = None  # epoch seconds per clip
+    live_burst_still_ids: list[str] | None = None  # still assets merged into this clip
 
     # Audio categories detected (populated during pipeline analysis)
     audio_categories: list[str] | None = None  # e.g. ["laughter", "speech", "engine"]

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -385,6 +385,7 @@ def run_pipeline_and_generate(
     # Merge photos into the unified selection pool (if enabled)
     all_candidates = _merge_photos_into_pool(
         analyzed_videos,
+        live_photo_clips=live_photo_clips,
         photo_assets=photo_assets,
         include_photos=include_photos,
         config=config,
@@ -572,6 +573,7 @@ def _send_notification(
 def _merge_photos_into_pool(
     analyzed_videos: list,
     *,
+    live_photo_clips: list | None = None,
     photo_assets: list | None,
     include_photos: bool,
     config: Config,
@@ -592,7 +594,10 @@ def _merge_photos_into_pool(
 
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
     from immich_memories.api.models import VideoClipInfo
-    from immich_memories.photos.photo_pipeline import score_photos
+    from immich_memories.photos.photo_pipeline import (
+        score_photos,
+        video_count_for_photo_budget,
+    )
     from immich_memories.photos.scoring import score_photo
 
     _logger = logging.getLogger(__name__)
@@ -606,7 +611,9 @@ def _merge_photos_into_pool(
         scored = score_photos(
             assets=photo_assets,
             config=config.photos,
-            video_clip_count=len(analyzed_videos),
+            video_clip_count=video_count_for_photo_budget(
+                len(analyzed_videos), len(live_photo_clips or [])
+            ),
             work_dir=photo_dir,
             download_fn=client.download_asset,
             db_path=config.cache.database_path,

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -393,6 +393,7 @@ def run_pipeline_and_generate(
         work_dir=output_path.parent,
         provider_circuit=pipeline.provider_circuit,
         dry_run=dry_run,
+        thumbnail_cache=thumbnail_cache,
     )
 
     # Phase 4: Unified selection (videos + photos compete together)
@@ -581,6 +582,7 @@ def _merge_photos_into_pool(
     work_dir: Path,
     provider_circuit=None,
     dry_run: bool = False,
+    thumbnail_cache=None,
 ) -> list:
     """Score photos and merge them as ClipWithSegment into the video pool.
 
@@ -601,6 +603,16 @@ def _merge_photos_into_pool(
     from immich_memories.photos.scoring import score_photo
 
     _logger = logging.getLogger(__name__)
+
+    photo_assets = _drop_photos_already_shown_as_motion(
+        photo_assets,
+        analyzed_videos,
+        config=config,
+        client=client,
+        thumbnail_cache=thumbnail_cache,
+    )
+    if not photo_assets:
+        return analyzed_videos
 
     photo_duration = config.photos.duration
     if dry_run:
@@ -644,6 +656,33 @@ def _merge_photos_into_pool(
     )
 
     return analyzed_videos + photo_candidates
+
+
+def _drop_photos_already_shown_as_motion(
+    photo_assets: list,
+    analyzed_videos: list,
+    *,
+    config: Config,
+    client: SyncImmichClient,
+    thumbnail_cache=None,
+) -> list:
+    """Remove photos a selected clip from the same moment already shows.
+
+    Runs before scoring so the removed photos never reach the LLM.
+    """
+    from immich_memories.photos.moment_suppression import filter_photos_covered_by_motion
+
+    motion_clips = [c.clip for c in analyzed_videos if getattr(c, "clip", None) is not None]
+    if not motion_clips:
+        return photo_assets
+
+    return filter_photos_covered_by_motion(
+        photo_assets,
+        motion_clips,
+        config=config.photos,
+        thumbnail_cache=thumbnail_cache,
+        thumbnail_fn=client.get_asset_thumbnail,
+    )
 
 
 def fetch_videos_and_live_photos(

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -101,6 +101,18 @@ def _has_music_backends(config: Config) -> bool:
     return music_config_available(config)
 
 
+def resolve_inclusion(flag: bool | None, *, config_enabled: bool) -> bool:
+    """Resolve a content-inclusion choice from an optional CLI flag and config.
+
+    `flag or config_enabled` made the flag one-way: with the feature enabled in
+    config there was no way to ask for a run without it. None means "not
+    specified", so the config decides; an explicit True or False wins.
+    """
+    if flag is None:
+        return config_enabled
+    return flag
+
+
 def _print_generation_result(
     *,
     dry_run: bool,
@@ -271,15 +283,15 @@ def register_generate_commands(main: click.Group) -> None:
         help="Override video subtitle text",
     )
     @click.option(
-        "--include-live-photos",
-        is_flag=True,
-        default=False,
+        "--include-live-photos/--no-live-photos",
+        "include_live_photos",
+        default=None,
         help="Include Live Photo video clips (3s iPhone clips, merged when burst-captured)",
     )
     @click.option(
-        "--include-photos",
-        is_flag=True,
-        default=False,
+        "--include-photos/--no-photos",
+        "include_photos",
+        default=None,
         help="Include photos as animated Ken Burns clips (blur background, face-aware pan)",
     )
     @click.option(
@@ -364,8 +376,8 @@ def register_generate_commands(main: click.Group) -> None:
         privacy_mode: bool,
         title_override: str | None,
         subtitle_override: str | None,
-        include_live_photos: bool,
-        include_photos: bool,
+        include_live_photos: bool | None,
+        include_photos: bool | None,
         photo_duration: float | None,
         analysis_depth: str | None,
         trip_index: int | None,
@@ -518,11 +530,10 @@ def register_generate_commands(main: click.Group) -> None:
             console.print("[bold]Immich Memories Generator[/bold]")
             console.print()
 
-        # Resolve live photos: CLI flag OR config
-        use_live_photos = include_live_photos or config.analysis.include_live_photos
-
-        # Resolve photo inclusion: CLI flag OR config
-        use_photos = include_photos or config.photos.enabled
+        use_live_photos = resolve_inclusion(
+            include_live_photos, config_enabled=config.analysis.include_live_photos
+        )
+        use_photos = resolve_inclusion(include_photos, config_enabled=config.photos.enabled)
         if photo_duration is not None:
             config.photos.duration = photo_duration
 

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -799,6 +799,24 @@ class PhotoConfig(BaseModel):
         le=10.0,
         description="Duration per single photo clip in seconds",
     )
+    moment_gap_seconds: float = Field(
+        default=120.0,
+        ge=0.0,
+        le=3600.0,
+        description=(
+            "Time window for treating a photo and a video as the same moment. "
+            "A photo this close to a visually matching video is dropped."
+        ),
+    )
+    moment_hash_threshold: int = Field(
+        default=10,
+        ge=0,
+        le=64,
+        description=(
+            "Perceptual-hash bits a photo may differ from a nearby video and "
+            "still count as the same scene (0 = only identical framing)"
+        ),
+    )
     score_penalty: float = Field(
         default=0.2,
         ge=0.0,

--- a/src/immich_memories/photos/moment_suppression.py
+++ b/src/immich_memories/photos/moment_suppression.py
@@ -1,0 +1,211 @@
+"""Drops photos that a video from the same moment already shows.
+
+Stills shot around a video of the same scene put that instant on screen twice —
+once as motion, once as a Ken Burns pan. This groups candidates by capture time
+and removes the stills a motion clip already covers.
+"""
+
+from __future__ import annotations
+
+import bisect
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from immich_memories.analysis.duplicate_hashing import compute_thumbnail_hash, hamming_distance
+from immich_memories.api.models import Asset, VideoClipInfo
+from immich_memories.config_models import PhotoConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MomentAsset:
+    """A selection candidate reduced to what moment grouping needs."""
+
+    asset_id: str
+    taken_at: datetime
+    thumbnail_hash: str | None = None
+    covered_asset_ids: tuple[str, ...] = field(default=())
+
+
+@dataclass(frozen=True)
+class SuppressionResult:
+    """Surviving photo IDs plus why the rest were dropped."""
+
+    kept_ids: list[str]
+    identity_drops: int = 0
+    similarity_drops: int = 0
+    compared: int = 0
+
+
+def suppress_photos_covered_by_motion(
+    photos: list[MomentAsset],
+    motion: list[MomentAsset],
+    *,
+    gap_seconds: float,
+    hash_threshold: int,
+    resolve_hash: Callable[[str], str | None] | None = None,
+) -> SuppressionResult:
+    """Remove photos a motion clip from the same moment already shows.
+
+    A photo is dropped when a clip carries its asset ID outright, or when a clip
+    within ``gap_seconds`` is within ``hash_threshold`` bits of it. A photo whose
+    hash cannot be resolved can only be dropped by the first rule — visual
+    redundancy is measured, never assumed.
+
+    ``resolve_hash`` is consulted only for assets inside a clip's time window, so
+    the window bounds thumbnail I/O as well as the comparison itself.
+    """
+    represented = {m.asset_id for m in motion}
+    represented.update(covered for m in motion for covered in m.covered_asset_ids)
+
+    by_time = sorted(motion, key=lambda m: m.taken_at)
+    times = [m.taken_at.timestamp() for m in by_time]
+    hashes = _HashResolver(resolve_hash)
+
+    kept: list[str] = []
+    identity_drops = 0
+    similarity_drops = 0
+    compared = 0
+    for candidate in photos:
+        if candidate.asset_id in represented:
+            identity_drops += 1
+            continue
+
+        neighbours = _clips_within_window(by_time, times, candidate, gap_seconds)
+        if not neighbours:
+            kept.append(candidate.asset_id)
+            continue
+
+        compared += 1
+        if _matches_any(candidate, neighbours, hashes, hash_threshold):
+            similarity_drops += 1
+        else:
+            kept.append(candidate.asset_id)
+
+    return SuppressionResult(
+        kept_ids=kept,
+        identity_drops=identity_drops,
+        similarity_drops=similarity_drops,
+        compared=compared,
+    )
+
+
+class _HashResolver:
+    """Memoizing view over pre-known hashes and an optional lookup callback."""
+
+    def __init__(self, lookup: Callable[[str], str | None] | None) -> None:
+        self._lookup = lookup
+        self._seen: dict[str, str | None] = {}
+
+    def of(self, asset: MomentAsset) -> str | None:
+        if asset.thumbnail_hash:
+            return asset.thumbnail_hash
+        if self._lookup is None:
+            return None
+        if asset.asset_id not in self._seen:
+            self._seen[asset.asset_id] = self._lookup(asset.asset_id)
+        return self._seen[asset.asset_id]
+
+
+def _clips_within_window(
+    by_time: list[MomentAsset],
+    times: list[float],
+    candidate: MomentAsset,
+    gap_seconds: float,
+) -> list[MomentAsset]:
+    at = candidate.taken_at.timestamp()
+    lo = bisect.bisect_left(times, at - gap_seconds)
+    hi = bisect.bisect_right(times, at + gap_seconds)
+    return by_time[lo:hi]
+
+
+def _matches_any(
+    candidate: MomentAsset,
+    neighbours: list[MomentAsset],
+    hashes: _HashResolver,
+    hash_threshold: int,
+) -> bool:
+    candidate_hash = hashes.of(candidate)
+    if not candidate_hash:
+        return False
+    return any(
+        (clip_hash := hashes.of(clip))
+        and hamming_distance(candidate_hash, clip_hash) <= hash_threshold
+        for clip in neighbours
+    )
+
+
+def filter_photos_covered_by_motion(
+    photo_assets: list[Asset],
+    motion_clips: list[VideoClipInfo],
+    *,
+    config: PhotoConfig,
+    thumbnail_cache: Any = None,
+    thumbnail_fn: Any = None,
+) -> list[Asset]:
+    """Drop photos that a video or live-photo clip from the same moment covers.
+
+    Runs before scoring, so every photo removed here is also an LLM call saved.
+    """
+    if not photo_assets or not motion_clips:
+        return photo_assets
+
+    photos = [MomentAsset(asset_id=a.id, taken_at=a.file_created_at) for a in photo_assets]
+    motion = [
+        MomentAsset(
+            asset_id=c.asset.id,
+            taken_at=c.asset.file_created_at,
+            covered_asset_ids=tuple(c.live_burst_still_ids or ()),
+        )
+        for c in motion_clips
+    ]
+
+    result = suppress_photos_covered_by_motion(
+        photos,
+        motion,
+        gap_seconds=config.moment_gap_seconds,
+        hash_threshold=config.moment_hash_threshold,
+        resolve_hash=_thumbnail_hash_resolver(thumbnail_cache, thumbnail_fn),
+    )
+
+    dropped = result.identity_drops + result.similarity_drops
+    if dropped:
+        logger.info(
+            "Moment grouping: %d photos dropped (%d already shown as motion, "
+            "%d visually matched a nearby clip out of %d compared)",
+            dropped,
+            result.identity_drops,
+            result.similarity_drops,
+            result.compared,
+        )
+
+    kept = set(result.kept_ids)
+    return [a for a in photo_assets if a.id in kept]
+
+
+def _thumbnail_hash_resolver(
+    thumbnail_cache: Any, thumbnail_fn: Any
+) -> Callable[[str], str | None]:
+    def resolve(asset_id: str) -> str | None:
+        data = thumbnail_cache.get(asset_id, "preview") if thumbnail_cache is not None else None
+        if data is None and thumbnail_fn is not None:
+            try:
+                data = thumbnail_fn(asset_id, size="preview")
+            except (OSError, RuntimeError, ValueError):
+                return None
+            if data and thumbnail_cache is not None:
+                thumbnail_cache.put(asset_id, "preview", data)
+        if not data:
+            return None
+        # WHY: thumbnails come off the wire and off disk — a truncated or
+        # non-JPEG body must cost this photo its comparison, not the run.
+        try:
+            return compute_thumbnail_hash(data) or None
+        except (OSError, TypeError, ValueError):
+            return None
+
+    return resolve

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -71,11 +71,16 @@ def score_photos(
     metadata_scored = [(a, score_photo(a, config)) for a in assets]
 
     # Cap only the expensive semantic-scoring shortlist.
-    max_photos = _compute_max_photos(video_clip_count, config.max_ratio)
-    shortlist_size = min(len(metadata_scored), max_photos * 3)
+    shortlist_size = llm_shortlist_size(video_clip_count, len(metadata_scored), config.max_ratio)
     shortlist = metadata_scored
     if len(shortlist) > shortlist_size:
         shortlist = _select_distributed(shortlist, shortlist_size)
+    logger.info(
+        "Photo scoring: %d available -> %d shortlisted for LLM (max %d selectable)",
+        len(metadata_scored),
+        len(shortlist),
+        _compute_max_photos(video_clip_count, config.max_ratio),
+    )
 
     # Phase 2: LLM scoring on shortlist (uses thumbnails, not full downloads)
     enhanced = _enhance_with_llm(
@@ -221,15 +226,47 @@ def render_photo_clips(
     return clips
 
 
+# Scoring one photo costs an LLM round trip, so the shortlist is what actually
+# determines how long a run takes. A real library produced a 1194-photo
+# shortlist to place a few dozen photos, which ran for hours.
+LLM_SHORTLIST_CEILING = 200
+_LLM_SHORTLIST_HEADROOM = 3
+
+
 def _compute_max_photos(video_count: int, max_ratio: float) -> int:
     """How many photos to render given video count and max photo ratio."""
     if max_ratio >= 1.0:
         return 999
     if video_count == 0:
         return 10  # Sensible limit when there are no videos
-    # max_ratio of total: photos / (videos + photos) <= max_ratio
-    # photos <= max_ratio * videos / (1 - max_ratio)
-    return max(1, int(max_ratio * video_count / (1 - max_ratio)))
+    # max_ratio is the photos' share of the finished timeline:
+    #   photos / (videos + photos) <= max_ratio
+    # so photos <= max_ratio * videos / (1 - max_ratio). At max_ratio 0.5 that
+    # is exactly video_count, which reads as a cap but is really a 1:1 licence
+    # to score a photo for every video. Never exceed the video count.
+    ratio_bound = int(max_ratio * video_count / (1 - max_ratio))
+    return max(1, min(ratio_bound, video_count))
+
+
+def video_count_for_photo_budget(total_clips: int, live_photo_clips: int) -> int:
+    """Real video clips, excluding live-photo clips.
+
+    The photo budget is a ratio against video content. Live-photo clips are
+    themselves built from photos, so counting them as videos lets the photo
+    budget grow from the content it is supposed to be balanced against -- on a
+    real library 778 live photos became 349 clips and tripled the shortlist.
+    """
+    return max(0, total_clips - live_photo_clips)
+
+
+def llm_shortlist_size(video_count: int, available: int, max_ratio: float) -> int:
+    """How many photos are worth an LLM call.
+
+    Headroom over what can actually be selected, then an absolute ceiling: on a
+    large library the relative bound alone still authorises thousands of calls.
+    """
+    selectable = _compute_max_photos(video_count, max_ratio)
+    return min(available, selectable * _LLM_SHORTLIST_HEADROOM, LLM_SHORTLIST_CEILING)
 
 
 def _select_distributed(

--- a/tests/test_cli_inclusion_flags.py
+++ b/tests/test_cli_inclusion_flags.py
@@ -1,0 +1,23 @@
+"""The CLI flags must be able to turn a feature OFF, not only ON.
+
+`use_photos = include_photos or config.photos.enabled` means a config with
+photos enabled makes the feature unconditional: there is no way to run a
+video-only memory from the command line.
+"""
+
+from __future__ import annotations
+
+from immich_memories.cli.generate import resolve_inclusion
+
+
+class TestResolveInclusion:
+    def test_flag_absent_falls_back_to_config(self):
+        assert resolve_inclusion(None, config_enabled=True) is True
+        assert resolve_inclusion(None, config_enabled=False) is False
+
+    def test_flag_can_enable_against_config(self):
+        assert resolve_inclusion(True, config_enabled=False) is True
+
+    def test_flag_can_disable_against_config(self):
+        """The case that was impossible before."""
+        assert resolve_inclusion(False, config_enabled=True) is False

--- a/tests/test_moment_suppression.py
+++ b/tests/test_moment_suppression.py
@@ -1,0 +1,188 @@
+"""Photos that a video already covers should not also appear as stills."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from immich_memories.photos.moment_suppression import (
+    MomentAsset,
+    suppress_photos_covered_by_motion,
+)
+from tests.conftest import make_asset
+
+BASE = datetime(2026, 7, 4, 15, 0, 0)
+
+
+def photo(asset_id: str, offset: float = 0.0, thumbnail_hash: str | None = None) -> MomentAsset:
+    return MomentAsset(
+        asset_id=asset_id,
+        taken_at=BASE + timedelta(seconds=offset),
+        thumbnail_hash=thumbnail_hash,
+    )
+
+
+def test_photo_already_represented_by_a_motion_clip_is_dropped() -> None:
+    """A live photo still shares its asset ID with the clip built from it."""
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("live-still"), photo("unrelated", offset=9000)],
+        motion=[photo("live-still")],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["unrelated"]
+    assert result.identity_drops == 1
+
+
+def test_burst_stills_behind_a_merged_clip_are_dropped() -> None:
+    """A merged burst plays every shutter press, but only the first asset IDs it."""
+    burst_clip = MomentAsset(
+        asset_id="shot-1",
+        taken_at=BASE,
+        covered_asset_ids=("shot-2", "shot-3"),
+    )
+
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("shot-1"), photo("shot-2", 1.4), photo("shot-3", 2.9)],
+        motion=[burst_clip],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == []
+    assert result.identity_drops == 3
+
+
+SCENE = "ff00ff00ff00ff00"
+SCENE_SHIFTED = "ff00ff00ff00ff03"  # 2 bits from SCENE — same framing, later frame
+OTHER_SCENE = "00ff00ff00ff00ff"  # 64 bits from SCENE
+
+
+def test_photo_of_the_same_scene_as_a_nearby_video_is_dropped() -> None:
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("still", offset=20, thumbnail_hash=SCENE_SHIFTED)],
+        motion=[photo("clip", offset=0, thumbnail_hash=SCENE)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == []
+    assert result.similarity_drops == 1
+
+
+def test_same_scene_on_a_different_day_survives() -> None:
+    """The same room filmed twice is two memories, not one duplicate."""
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("still", offset=86400, thumbnail_hash=SCENE)],
+        motion=[photo("clip", offset=0, thumbnail_hash=SCENE)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["still"]
+
+
+def test_different_scene_in_the_same_minute_survives() -> None:
+    """Filming the kids then shooting the sunset is two subjects, not one."""
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("sunset", offset=15, thumbnail_hash=OTHER_SCENE)],
+        motion=[photo("clip", offset=0, thumbnail_hash=SCENE)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["sunset"]
+
+
+def test_photo_without_a_thumbnail_hash_survives() -> None:
+    """No hash means no evidence of redundancy — keeping it is the safe default."""
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("unhashed", offset=5)],
+        motion=[photo("clip", offset=0, thumbnail_hash=SCENE)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["unhashed"]
+
+
+def test_photos_similar_to_each_other_but_not_to_a_clip_all_survive() -> None:
+    """Photo-vs-photo redundancy is deduplication's job, not this filter's."""
+    result = suppress_photos_covered_by_motion(
+        photos=[
+            photo("a", offset=0, thumbnail_hash=SCENE),
+            photo("b", offset=3, thumbnail_hash=SCENE_SHIFTED),
+        ],
+        motion=[photo("clip", offset=1, thumbnail_hash=OTHER_SCENE)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["a", "b"]
+
+
+def test_no_motion_clips_keeps_every_photo_in_order() -> None:
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("a", 0, SCENE), photo("b", 5, SCENE), photo("c", 10, SCENE)],
+        motion=[],
+        gap_seconds=120.0,
+        hash_threshold=10,
+    )
+
+    assert result.kept_ids == ["a", "b", "c"]
+
+
+def test_thumbnails_are_only_resolved_for_photos_near_a_clip() -> None:
+    """Fetching a thumbnail costs an HTTP round trip; a photo hours from any
+    video can never be suppressed, so it must never be fetched."""
+    asked: list[str] = []
+
+    def resolve(asset_id: str) -> str | None:
+        asked.append(asset_id)
+        return SCENE
+
+    result = suppress_photos_covered_by_motion(
+        photos=[photo("near", offset=30), photo("far", offset=9000)],
+        motion=[photo("clip", offset=0)],
+        gap_seconds=120.0,
+        hash_threshold=10,
+        resolve_hash=resolve,
+    )
+
+    assert "far" not in asked
+    assert result.kept_ids == ["far"]
+
+
+def _asset(asset_id: str, offset: float = 0.0):
+    return make_asset(
+        asset_id,
+        file_created_at=BASE + timedelta(seconds=offset),
+        original_file_name=f"{asset_id}.heic",
+    )
+
+
+def test_live_photo_stills_are_filtered_out_of_the_photo_pool() -> None:
+    """A Live Photo's still and the clip built from it are one asset. Immich
+    normally keeps such stills out of the photo pool, but if one gets through it
+    must not be animated on top of the motion clip already showing it."""
+    from immich_memories.api.models import VideoClipInfo
+    from immich_memories.config_models import PhotoConfig
+    from immich_memories.photos.moment_suppression import filter_photos_covered_by_motion
+
+    still = _asset("live-still")
+    burst_sibling = _asset("burst-2", offset=1.5)
+    unrelated = _asset("holiday", offset=50000)
+
+    clip = VideoClipInfo(
+        asset=still,
+        duration_seconds=3.0,
+        live_burst_still_ids=["live-still", "burst-2"],
+    )
+
+    kept = filter_photos_covered_by_motion(
+        [still, burst_sibling, unrelated],
+        [clip],
+        config=PhotoConfig(),
+    )
+
+    assert [a.id for a in kept] == ["holiday"]

--- a/tests/test_photo_budget.py
+++ b/tests/test_photo_budget.py
@@ -1,0 +1,55 @@
+"""Tests for how many photos get LLM-scored.
+
+A real run scored ~1155 photos to place at most a few dozen, taking hours:
+max_ratio 0.5 makes max_photos equal the video count rather than capping it,
+the shortlist is 3x that again, and live-photo clips inflate the video count
+they are derived from.
+"""
+
+from __future__ import annotations
+
+from immich_memories.photos.photo_pipeline import _compute_max_photos, llm_shortlist_size
+
+
+class TestComputeMaxPhotos:
+    def test_half_ratio_allows_one_photo_per_video(self):
+        """0.5 is a share of the finished timeline: 100 photos + 100 videos is half."""
+        assert _compute_max_photos(100, 0.50) == 100
+
+    def test_high_ratio_never_exceeds_the_video_count(self):
+        """Above 0.5 the raw formula authorises more photos than videos (300 for
+        100 at 0.75), which is a licence to LLM-score most of a library."""
+        assert _compute_max_photos(100, 0.75) <= 100
+
+    def test_no_videos_still_bounded(self):
+        assert _compute_max_photos(0, 0.5) <= 10
+
+
+class TestLlmShortlistSize:
+    def test_shortlist_is_bounded_absolutely(self):
+        """A huge library must not translate into a huge number of LLM calls."""
+        assert llm_shortlist_size(video_count=400, available=5128, max_ratio=0.5) <= 200
+
+    def test_shortlist_gives_headroom_over_what_is_selectable(self):
+        size = llm_shortlist_size(video_count=20, available=5128, max_ratio=0.5)
+        assert size > _compute_max_photos(20, 0.5)
+
+    def test_never_exceeds_what_is_available(self):
+        assert llm_shortlist_size(video_count=400, available=12, max_ratio=0.5) == 12
+
+
+class TestLivePhotosDoNotInflateThePhotoBudget:
+    """Live-photo clips are made from photos. Counting them as videos lets the
+    photo budget grow from the very content it is meant to be balanced against:
+    778 live photos became 349 clips, tripling the photo shortlist.
+    """
+
+    def test_live_photo_clips_are_excluded_from_the_video_count(self):
+        from immich_memories.photos.photo_pipeline import video_count_for_photo_budget
+
+        assert video_count_for_photo_budget(total_clips=398, live_photo_clips=349) == 49
+
+    def test_never_negative_when_all_clips_are_live_photos(self):
+        from immich_memories.photos.photo_pipeline import video_count_for_photo_budget
+
+        assert video_count_for_photo_budget(total_clips=349, live_photo_clips=349) == 0

--- a/tests/test_unified_selection.py
+++ b/tests/test_unified_selection.py
@@ -21,6 +21,7 @@ from immich_memories.analysis.smart_pipeline import (
 from immich_memories.api.models import Asset, AssetType, VideoClipInfo
 from immich_memories.config_loader import Config
 from immich_memories.config_models import AnalysisConfig
+from tests.conftest import make_asset
 
 
 def _make_clip(
@@ -335,7 +336,17 @@ class TestMergePhotosIntoPool:
         mock_client.download_asset = MagicMock()
         mock_client.get_asset_thumbnail = MagicMock()
 
-        video_candidates = [MagicMock(), MagicMock()]
+        # WHY: the merge now groups photos against clip capture times, so the
+        # video candidates have to be real ClipWithSegment objects, not mocks.
+        video_candidates = [
+            ClipWithSegment(
+                clip=VideoClipInfo(asset=make_asset(f"video-{i}"), duration_seconds=8.0),
+                start_time=0.0,
+                end_time=8.0,
+                score=0.7,
+            )
+            for i in range(2)
+        ]
 
         photo_asset = Asset(
             id="photo-merge-001",


### PR DESCRIPTION
Closes #328.

Four defects in photo selection, all found while validating an end-to-end run against a real library.

## What was wrong

**The LLM shortlist was unbounded.** `_compute_max_photos` returns the video count exactly at `max_ratio: 0.50` — a 1:1 licence, not a cap — and more than the video count above it. The shortlist then triples it. One person-year produced a **1194-photo shortlist to place a few dozen photos**; each entry is an LLM round trip, so a generation sat two hours in a phase that logged nothing.

**Live-photo clips inflated the budget they feed.** They are merged into the video pool before the ratio is computed, so 349 live-photo clips + 49 real videos counted as 398 "videos" and tripled the photo budget derived from them.

**`--include-photos` could not say no.** `include_photos or config.photos.enabled` made the flag one-way — with photos enabled in config there was no way to ask for a video-only memory.

**Stills duplicated the video next to them.** A photo shot seconds either side of a video of the same thing put that instant on screen twice, once as motion and once as a Ken Burns pan. Nothing grouped the two pools.

## What changed

| | before | after |
|---|--:|--:|
| LLM shortlist | 1194 | **200** |
| clips counted for the photo ratio | 398 | **49** |
| `--no-photos` / `--no-live-photos` | absent | **work, and beat config** |

Plus `photos/moment_suppression.py`: photos are grouped with the clip pool by capture time before scoring, and dropped when a clip within `moment_gap_seconds` is within `moment_hash_threshold` bits of their thumbnail. Every photo removed is also an LLM call saved.

## Measurement

On a 5128-photo person-year (871 videos, 349 live-photo clips): 802 photos fall inside a clip's window, **101 are dropped** at the 120s/10 default. Threshold 6 drops 33, threshold 14 drops 202.

Six sampled pairs at distance 10 — the loosest band, where false positives surface first — were all genuinely the same scene: a father and baby in a hot tub 96s apart, the same selfie 22s apart, a highland cow 10s apart, a swing 105s apart (which a 30s window would have missed).

Cost is bounded by the same window that does the filtering: thumbnails are fetched only for photos inside a clip's window, so the 4326 photos nowhere near a video cost nothing. Warm cache runs in 5.5s.

**Correction to my first read of this:** I expected the Live Photo path to be the main source of duplicates, on the theory that Immich's documented person-filter quirk (`livePhotoVideoId` omitted from IMAGE+person search) leaks stills into the photo pool. Measured on the same year: **0 leaks, 0 identity drops.** That filter holds. The ID-based rule stays as a cheap guard — a still and its clip really are one asset — but it is a guard, not a fix for anything observed.

## Notes

- A photo whose thumbnail will not decode is always **kept**. Redundancy is measured, never assumed.
- `moment_gap_seconds: 0` leaves everything but the exact-asset case alone.
- `Makefile` gains `test-one T=<path>` so single-file TDD loops don't run the full suite.
- `tests/test_unified_selection.py` had `MagicMock()` video candidates; the merge now reads clip capture times, so that test uses real `ClipWithSegment` objects.

`make ci` green: 4597 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3