### PR TITLE
fix(automation): count the cooldown from the last run's start so a daily timer fires daily

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -351,32 +351,12 @@
       {
         "name": "AutoRunner::suggest",
         "complexity": 21,
-        "line_start": 730,
-        "line_end": 815,
+        "line_start": 735,
+        "line_end": 820,
         "line_complexities": [
           {
-            "line": 734,
-            "complexity": 0
-          },
-          {
-            "line": 735,
-            "complexity": 0
-          },
-          {
-            "line": 736,
-            "complexity": 0
-          },
-          {
-            "line": 737,
-            "complexity": 0
-          },
-          {
-            "line": 738,
-            "complexity": 0
-          },
-          {
             "line": 739,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 740,
@@ -384,15 +364,19 @@
           },
           {
             "line": 741,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 742,
             "complexity": 0
           },
           {
-            "line": 744,
+            "line": 743,
             "complexity": 0
+          },
+          {
+            "line": 744,
+            "complexity": 1
           },
           {
             "line": 745,
@@ -400,22 +384,34 @@
           },
           {
             "line": 746,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 747,
             "complexity": 0
           },
           {
-            "line": 753,
+            "line": 749,
             "complexity": 0
           },
           {
-            "line": 756,
+            "line": 750,
             "complexity": 0
           },
           {
-            "line": 759,
+            "line": 751,
+            "complexity": 0
+          },
+          {
+            "line": 752,
+            "complexity": 0
+          },
+          {
+            "line": 758,
+            "complexity": 0
+          },
+          {
+            "line": 761,
             "complexity": 0
           },
           {
@@ -423,28 +419,20 @@
             "complexity": 0
           },
           {
-            "line": 765,
-            "complexity": 3
-          },
-          {
-            "line": 768,
-            "complexity": 0
-          },
-          {
             "line": 769,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 770,
+            "complexity": 3
+          },
+          {
+            "line": 773,
             "complexity": 0
           },
           {
-            "line": 771,
+            "line": 774,
             "complexity": 4
-          },
-          {
-            "line": 772,
-            "complexity": 0
           },
           {
             "line": 775,
@@ -452,18 +440,10 @@
           },
           {
             "line": 776,
-            "complexity": 3
-          },
-          {
-            "line": 777,
-            "complexity": 0
-          },
-          {
-            "line": 778,
             "complexity": 4
           },
           {
-            "line": 779,
+            "line": 777,
             "complexity": 0
           },
           {
@@ -471,23 +451,39 @@
             "complexity": 0
           },
           {
-            "line": 788,
-            "complexity": 1
+            "line": 781,
+            "complexity": 3
           },
           {
-            "line": 789,
+            "line": 782,
             "complexity": 0
           },
           {
-            "line": 791,
+            "line": 783,
+            "complexity": 4
+          },
+          {
+            "line": 784,
+            "complexity": 0
+          },
+          {
+            "line": 785,
             "complexity": 0
           },
           {
             "line": 793,
+            "complexity": 1
+          },
+          {
+            "line": 794,
             "complexity": 0
           },
           {
-            "line": 804,
+            "line": 796,
+            "complexity": 0
+          },
+          {
+            "line": 798,
             "complexity": 0
           },
           {
@@ -495,7 +491,11 @@
             "complexity": 0
           },
           {
-            "line": 815,
+            "line": 814,
+            "complexity": 0
+          },
+          {
+            "line": 820,
             "complexity": 0
           }
         ]
@@ -503,209 +503,209 @@
       {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 843,
-        "line_end": 984,
+        "line_start": 848,
+        "line_end": 989,
         "line_complexities": [
           {
-            "line": 853,
-            "complexity": 0
-          },
-          {
-            "line": 857,
-            "complexity": 0
-          },
-          {
             "line": 858,
-            "complexity": 2
-          },
-          {
-            "line": 859,
-            "complexity": 0
-          },
-          {
-            "line": 861,
             "complexity": 0
           },
           {
             "line": 862,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 863,
+            "complexity": 2
+          },
+          {
+            "line": 864,
             "complexity": 0
           },
           {
-            "line": 865,
+            "line": 866,
             "complexity": 0
           },
           {
-            "line": 869,
-            "complexity": 3
+            "line": 867,
+            "complexity": 2
+          },
+          {
+            "line": 868,
+            "complexity": 0
           },
           {
             "line": 870,
             "complexity": 0
           },
           {
-            "line": 872,
-            "complexity": 0
-          },
-          {
-            "line": 873,
-            "complexity": 2
-          },
-          {
             "line": 874,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 875,
             "complexity": 0
           },
           {
-            "line": 876,
-            "complexity": 1
-          },
-          {
             "line": 877,
             "complexity": 0
           },
           {
-            "line": 885,
+            "line": 878,
             "complexity": 2
           },
           {
-            "line": 887,
+            "line": 879,
             "complexity": 0
           },
           {
-            "line": 897,
+            "line": 880,
             "complexity": 0
           },
           {
-            "line": 898,
+            "line": 881,
             "complexity": 1
           },
           {
-            "line": 899,
+            "line": 882,
             "complexity": 0
           },
           {
-            "line": 900,
+            "line": 890,
+            "complexity": 2
+          },
+          {
+            "line": 892,
             "complexity": 0
+          },
+          {
+            "line": 902,
+            "complexity": 0
+          },
+          {
+            "line": 903,
+            "complexity": 1
           },
           {
             "line": 904,
             "complexity": 0
           },
           {
-            "line": 910,
+            "line": 905,
+            "complexity": 0
+          },
+          {
+            "line": 909,
+            "complexity": 0
+          },
+          {
+            "line": 915,
             "complexity": 1
           },
           {
-            "line": 911,
+            "line": 916,
             "complexity": 1
           },
           {
-            "line": 912,
+            "line": 917,
             "complexity": 0
           },
           {
-            "line": 914,
+            "line": 919,
             "complexity": 0
           },
           {
-            "line": 921,
+            "line": 926,
             "complexity": 2
           },
           {
-            "line": 922,
+            "line": 927,
             "complexity": 0
           },
           {
-            "line": 923,
+            "line": 928,
             "complexity": 0
           },
           {
-            "line": 925,
+            "line": 930,
             "complexity": 0
-          },
-          {
-            "line": 932,
-            "complexity": 0
-          },
-          {
-            "line": 936,
-            "complexity": 2
           },
           {
             "line": 937,
             "complexity": 0
           },
           {
-            "line": 938,
-            "complexity": 0
-          },
-          {
-            "line": 944,
+            "line": 941,
             "complexity": 2
           },
           {
-            "line": 945,
+            "line": 942,
             "complexity": 0
           },
           {
-            "line": 946,
+            "line": 943,
             "complexity": 0
           },
           {
-            "line": 953,
-            "complexity": 0
-          },
-          {
-            "line": 954,
+            "line": 949,
             "complexity": 2
           },
           {
-            "line": 955,
+            "line": 950,
             "complexity": 0
           },
           {
-            "line": 956,
+            "line": 951,
             "complexity": 0
           },
           {
-            "line": 964,
+            "line": 958,
             "complexity": 0
           },
           {
-            "line": 972,
+            "line": 959,
+            "complexity": 2
+          },
+          {
+            "line": 960,
+            "complexity": 0
+          },
+          {
+            "line": 961,
+            "complexity": 0
+          },
+          {
+            "line": 969,
+            "complexity": 0
+          },
+          {
+            "line": 977,
             "complexity": 1
           },
           {
-            "line": 973,
+            "line": 978,
             "complexity": 0
           },
           {
-            "line": 974,
+            "line": 979,
             "complexity": 1
           },
           {
-            "line": 976,
+            "line": 981,
             "complexity": 0
           },
           {
-            "line": 983,
+            "line": 988,
             "complexity": 0
           },
           {
-            "line": 984,
+            "line": 989,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 117
+    "complexity": 116
   },
   {
     "path": "src/immich_memories/cli/_analyze_export.py",

--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -131,7 +131,7 @@ invocation. Exactly one action per invocation, then it exits.
 |------|------|---------|-------------|
 | `--dry-run` | flag | `false` | Show what would be generated, don't do it |
 | `--force` | flag | `false` | Skip cooldown check |
-| `--cooldown` | int | config `automation.cooldown_hours` (24) | Min hours since last auto-run |
+| `--cooldown` | int | config `automation.cooldown_hours` (24) | Min hours since the last auto-run *started* (30 min tolerance, so a daily timer with `24` fires every day) |
 | `--upload` | flag | `false` | Upload result to Immich |
 | `--quiet` | flag | `false` | Emit exactly one JSON result object on stdout |
 
@@ -239,7 +239,7 @@ Under `advanced:` in `config.yaml`:
 ```yaml
 advanced:
   automation:
-    cooldown_hours: 24              # min hours between auto-generated memories
+    cooldown_hours: 24              # min hours between auto-run starts (daily timer + 24 = once a day)
     upload_to_immich: false         # auto-upload generated videos
     album_name: null                # album for uploads
     detect_monthly: true

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 _GENERATION_TIMEOUT_SECONDS = 7200
 _GENERATION_TIMEOUT_REASON = "generation timed out after 2 hours"
 _OUTPUT_TAIL_LENGTH = 2000
+# A fixed-time scheduler (cron, launchd, in-process timer) fires at the same wall-clock
+# time every day; the child process records its start a few seconds later. Without slack,
+# "24h since the last run" is never quite true at the next day's fire and every other day
+# gets skipped (#330). 30 min still rejects any realistic double fire.
+_COOLDOWN_SCHEDULE_TOLERANCE = timedelta(minutes=30)
 
 
 class ImmichDiscoveryError(RuntimeError):
@@ -272,16 +277,16 @@ def _cooldown_status(
     cooldown_hours: int,
     now: datetime | None = None,
 ) -> CooldownStatus:
-    """Derive cooldown from completion time, falling back for legacy rows."""
+    """Cooldown counts from the last run's *start* so a daily timer means once a day."""
     if last_run is None:
         return CooldownStatus(hours=cooldown_hours, active=False, until=None)
-    completed_at = last_run.completed_at or last_run.created_at
-    if completed_at.tzinfo is None:
-        completed_at = completed_at.replace(tzinfo=UTC)
+    started_at = last_run.created_at
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=UTC)
     current = now or datetime.now(tz=UTC)
     if current.tzinfo is None:
         current = current.replace(tzinfo=UTC)
-    until = completed_at + timedelta(hours=cooldown_hours)
+    until = started_at + timedelta(hours=cooldown_hours) - _COOLDOWN_SCHEDULE_TOLERANCE
     return CooldownStatus(hours=cooldown_hours, active=current < until, until=until)
 
 

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -619,6 +619,51 @@ class TestRunOneCooldown:
         finish.assert_called_once()
         assert runner.state.get_last_attempt().outcome is AutoOutcome.SKIPPED
 
+    def test_daily_schedule_is_not_blocked_by_previous_days_completion_time(
+        self, config: Config
+    ) -> None:
+        """A 24h cooldown must not skip a fixed daily timer because yesterday's run took a while.
+
+        Yesterday's run started 24h minus a little scheduler jitter ago and finished 40 min later.
+        Measured from completion it would still be "active" and every other day gets skipped.
+        """
+        runner = AutoRunner(config)
+        started = datetime.now(tz=UTC) - timedelta(hours=24) + timedelta(seconds=45)
+        runner.db.save_run(
+            RunMetadata(
+                run_id="yesterday",
+                created_at=started,
+                completed_at=started + timedelta(minutes=40),
+                status="completed",
+                source="auto",
+            )
+        )
+
+        with patch.object(runner, "suggest", return_value=[]) as suggest:
+            result = runner.run_one(cooldown_hours=24)
+
+        assert result.reason == "no eligible candidates"
+        suggest.assert_called_once_with(limit=1)
+
+    def test_second_fire_an_hour_after_start_is_still_cooled_down(self, config: Config) -> None:
+        """Jitter tolerance must not open the door to a second run shortly after the first."""
+        runner = AutoRunner(config)
+        started = datetime.now(tz=UTC) - timedelta(hours=1)
+        runner.db.save_run(
+            RunMetadata(
+                run_id="an-hour-ago",
+                created_at=started,
+                completed_at=started + timedelta(minutes=30),
+                status="completed",
+                source="auto",
+            )
+        )
+
+        result = runner.run_one(cooldown_hours=24)
+
+        assert result.outcome is AutoOutcome.SKIPPED
+        assert result.reason == "cooldown active"
+
     def test_recent_manual_run_does_not_activate_auto_cooldown(self, config: Config) -> None:
         """A manual export must not consume the smart automation cooldown."""
         runner = AutoRunner(config)

--- a/tests/test_auto_status.py
+++ b/tests/test_auto_status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -533,16 +533,16 @@ def test_status_does_not_hide_detector_programming_failures(tmp_path: Path) -> N
         runner.status(refresh_suggestion=True)
 
 
-def test_cooldown_uses_auto_completion_time_not_start_time(tmp_path: Path) -> None:
-    """A long run completed recently even if it started before the cooldown window."""
+def test_cooldown_counts_from_auto_run_start_not_completion(tmp_path: Path) -> None:
+    """A daily timer fires at the same wall-clock time; run duration must not push it out (#330)."""
     config = _config(tmp_path)
     runner = AutoRunner(config)
-    now = datetime.now()
+    now = datetime.now(tz=UTC)
     runner.db.save_run(
         RunMetadata(
-            run_id="long-auto-run",
-            created_at=now - timedelta(hours=30),
-            completed_at=now - timedelta(hours=1),
+            run_id="yesterdays-auto-run",
+            created_at=now - timedelta(hours=24),
+            completed_at=now - timedelta(hours=23),
             status="completed",
             source="auto",
         )
@@ -550,9 +550,9 @@ def test_cooldown_uses_auto_completion_time_not_start_time(tmp_path: Path) -> No
 
     status = runner.status(cooldown_hours=24)
 
-    assert status.cooldown.active is True
+    assert status.cooldown.active is False
     assert status.last_completed_auto_run is not None
-    assert status.last_completed_auto_run.run_id == "long-auto-run"
+    assert status.last_completed_auto_run.run_id == "yesterdays-auto-run"
 
 
 def test_status_preserves_explicit_zero_cooldown(tmp_path: Path) -> None:

--- a/tests/test_timestamp_migration.py
+++ b/tests/test_timestamp_migration.py
@@ -242,7 +242,7 @@ def test_v11_canonical_utc_keeps_completion_order_and_cooldown_chronological(
     assert _cooldown_status(
         runs[0],
         24,
-        now=datetime(2026, 8, 11, 7, 45, tzinfo=UTC),
+        now=datetime(2026, 8, 11, 7, 0, tzinfo=UTC),
     ).active
     last_attempt = AutomationStateStore(db_path).get_last_attempt()
     assert last_attempt is not None


### PR DESCRIPTION
## Summary

- The auto-run cooldown was measured from the previous run's **completion**. A fixed-time scheduler (cron / launchd / systemd installed by `auto install`, and the in-process timer coming in #305) fires at the same wall-clock time every day, so "24 h since completion" was never true at the next fire → every other day was skipped.
- Now measured from the previous run's **start**, with a 30 min tolerance for scheduler jitter (the child `generate` process records its start a few seconds after the timer fires). A second fire an hour after the first is still rejected.
- Deliberately flips `test_cooldown_uses_auto_completion_time_not_start_time` (from the #277 mega-commit, no rationale on record). Its scenario — a 29 h auto run — is unreachable anyway: `_GENERATION_TIMEOUT_SECONDS` kills the child at 2 h.
- Docs: `auto.md` `--cooldown` row and the config sample say what the number now means.

Closes #330

## Test plan

- [x] `make ci` green locally (4573 passed)
- [x] New: run started 24 h − 45 s ago and completed 23 h 20 min ago → not cooled down (was: SKIPPED "cooldown active")
- [x] New: run started 1 h ago → still SKIPPED
- [x] `test_timestamp_migration` cooldown probe moved inside the new window (07:00 vs start 07:45+24h−30min = 07:15) — still asserts UTC normalisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM