### PR TITLE
feat(automation): daily timer inside the UI process so Docker gets scheduled memories

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -329,6 +329,7 @@ src/immich_memories/
 │   ├── trip_input_cache.py     # Durable, identity-checked inputs for auto trip discovery
 │   ├── notifications.py        # Apprise notification integration
 │   ├── runner.py               # Auto-run orchestrator
+│   ├── in_process_scheduler.py # Daily timer inside the UI/Docker process
 │   └── system_scheduler.py     # OS scheduler integration (launchd/systemd/cron)
 │
 ├── operations/                 # Public lifecycle contract + read-only ops reports

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ one eligible memory. It never tries to catch up by doing several things in one i
 The terminal outcome is `skipped`, `dry_run`, `completed`, or `failed`. The first three exit 0;
 `failed` exits 1. Use `--quiet` when a scheduler needs the stable JSON result.
 
+Docker: no cron needed — set `IMMICH_MEMORIES_AUTOMATION__ENABLED=true` (and `…__DAILY_AT=09:00`)
+and the web UI process runs that same decision once a day itself.
+
 The selector keeps variety on purpose: latest completed month only, at most one monthly review per
 calendar month, no category twice in a row, and no category more than twice in the last six
 completed automatic runs. See the [auto CLI docs](https://sam-dumont.github.io/immich-video-memory-generator/docs/create/cli/auto).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@ services:
       # Optional: basic auth
       # IMMICH_MEMORIES_AUTH_USERNAME: "${IMMICH_MEMORIES_AUTH_USERNAME}"
       # IMMICH_MEMORIES_AUTH_PASSWORD: "${IMMICH_MEMORIES_AUTH_PASSWORD}"
+      # Optional: daily automation inside the container (no host cron needed)
+      # IMMICH_MEMORIES_AUTOMATION__ENABLED: "true"
+      # IMMICH_MEMORIES_AUTOMATION__DAILY_AT: "09:00"
+      # TZ: "Europe/Brussels"
     restart: unless-stopped
     deploy:
       resources:

--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -173,6 +173,10 @@ immich-memories auto install [OPTIONS]
 
 Sets up your OS scheduler. Detects the platform and generates the right config file.
 
+Running in Docker (or wanting the web UI process to do it)? Skip this command and set
+`automation.enabled: true` + `automation.daily_at` instead — the UI process then runs `auto run`
+once a day itself. See [automated generation](../recipes/automated-generation.md#docker-and-the-web-ui-built-in-daily-timer).
+
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--hour` | int | `9` | Hour to run (0-23) |

--- a/docs-site/docs/create/recipes/automated-generation.md
+++ b/docs-site/docs/create/recipes/automated-generation.md
@@ -32,6 +32,34 @@ completed automatic runs.
 
 See [auto CLI docs](../cli/auto.md) for the full reference including detector details and scoring.
 
+### Docker and the web UI: built-in daily timer
+
+`auto install` needs a host scheduler and the binary on the host. In Docker the container's only
+process is the web UI, so the timer lives there instead: one config toggle makes the UI process
+run the same `auto run` decision once a day — same lease, history, delivery retry, and
+notifications as the CLI.
+
+```yaml
+advanced:
+  automation:
+    enabled: true        # default false
+    daily_at: "09:00"    # local wall-clock time of the container (set TZ=)
+```
+
+or, for compose, `IMMICH_MEMORIES_AUTOMATION__ENABLED=true` and
+`IMMICH_MEMORIES_AUTOMATION__DAILY_AT=09:00`. Then `docker compose up` is the whole setup: a memory
+appears on schedule, uploads if `upload_to_immich` is on, and notifies if notifications are on.
+
+- One automation decision per calendar day: a container that was down at `daily_at` catches up
+  when it starts; if the day's run already happened (including a manual `docker exec … auto run`),
+  it waits for tomorrow.
+- A manual UI or CLI run in progress holds the same lock, so the timer's run is reported as
+  `skipped` rather than overlapping it.
+- `/health/ready` shows the timer under `in_process_scheduler` (`enabled`, `daily_at`, `next_run`,
+  `running`, `last_fired_at`, `last_outcome`, `last_reason`).
+- The timer never runs when `enabled` is `false` (the default) — `auto install` stays the route
+  for bare-metal installs.
+
 ## Scheduler daemon (advanced/legacy)
 
 :::tip Use smart automation instead

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -142,6 +142,8 @@ Inside Immich's own compose stack, `immich-server` listens on **2283** (every Im
 | `IMMICH_MEMORIES_CONTENT_ANALYSIS__ENABLED` | No | `true` to actually use the LLM for clip scoring. Off by default. |
 | `IMMICH_MEMORIES_AUTH_USERNAME` | No | Basic auth username. Set with `IMMICH_MEMORIES_AUTH_PASSWORD` to enable auth. |
 | `IMMICH_MEMORIES_AUTH_PASSWORD` | No | Basic auth password. Set with `IMMICH_MEMORIES_AUTH_USERNAME` to enable auth. |
+| `IMMICH_MEMORIES_AUTOMATION__ENABLED` | No | `true` to run the daily `auto run` decision inside the container. Off by default. See [Daily automation](#daily-automation). |
+| `IMMICH_MEMORIES_AUTOMATION__DAILY_AT` | No | Wall-clock time for that run, `HH:MM` in the container's `TZ` (default `09:00`). |
 
 All config options can also be set via env vars with the `IMMICH_MEMORIES_` prefix. Double underscores for nesting: `IMMICH_MEMORIES_ANALYSIS__SCENE_THRESHOLD=25`.
 
@@ -180,6 +182,27 @@ The root `docker-compose.yml` has these options as a commented section: uncommen
 :::caution tmpfs size for 4K
 The default tmpfs is 2 GB. If you're generating 4K videos, FFmpeg intermediates can exceed that. Either increase to 8 GB (`/tmp:size=8G`) or remove the tmpfs entry and let the container write to disk.
 :::
+
+## Daily automation
+
+The container's only process is the web UI, so there is no cron to install. Turn on the built-in
+timer instead:
+
+```yaml
+    environment:
+      - IMMICH_MEMORIES_AUTOMATION__ENABLED=true
+      - IMMICH_MEMORIES_AUTOMATION__DAILY_AT=09:00
+      - TZ=Europe/Brussels   # daily_at is read in this zone
+```
+
+Every day at that time the UI process runs the same `auto run` decision as the CLI (retry one
+pending upload, or generate one eligible memory, then notify) with the same lock and history. If
+the container was down at that time it catches up on start; if the day's run already happened it
+waits for tomorrow. Details and the config-file form: [automated generation](../../create/recipes/automated-generation.md#docker-and-the-web-ui-built-in-daily-timer).
+
+Check it from outside with `/health/ready` — the `in_process_scheduler` block shows `next_run`,
+`running`, and the last outcome. Automation history stays in the config volume, so keep it
+persistent (see below).
 
 ## Health check
 

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -477,6 +477,8 @@ Controls what `immich-memories auto suggest` and `auto run` detect and generate.
 
 ```yaml
 automation:
+  enabled: false                  # run the daily auto-run decision inside the web UI process (Docker)
+  daily_at: "09:00"               # HH:MM, local time of that process (container TZ)
   cooldown_hours: 24              # min hours between auto-generated memories (1-168)
   upload_to_immich: false         # auto-upload results
   album_name: null                # target album for uploads

--- a/src/immich_memories/automation/in_process_scheduler.py
+++ b/src/immich_memories/automation/in_process_scheduler.py
@@ -1,0 +1,174 @@
+"""Daily automation timer that runs inside the UI process.
+
+Docker users have no host cron and the container's only process is the UI, so
+`automation.enabled: true` makes that process fire the same `auto run` decision the
+CLI does — same lease, history, and delivery retry — once a day at `automation.daily_at`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from immich_memories.automation.models import AutoRunResult
+    from immich_memories.config_loader import Config
+
+logger = logging.getLogger(__name__)
+
+# How often the loop re-reads config; also the worst-case lateness of a fire.
+POLL_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class SchedulerSnapshot:
+    """What `/health` and the settings page can say about the in-process timer."""
+
+    enabled: bool
+    daily_at: str | None
+    next_run: datetime | None
+    running: bool
+    last_fired_at: datetime | None
+    last_outcome: str | None
+    last_reason: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "daily_at": self.daily_at,
+            "next_run": self.next_run.isoformat() if self.next_run else None,
+            "running": self.running,
+            "last_fired_at": self.last_fired_at.isoformat() if self.last_fired_at else None,
+            "last_outcome": self.last_outcome,
+            "last_reason": self.last_reason,
+        }
+
+
+def _local_now() -> datetime:
+    return datetime.now().astimezone()
+
+
+def _slot_today(now: datetime, daily_at: str) -> datetime:
+    at = time.fromisoformat(daily_at)
+    return now.replace(hour=at.hour, minute=at.minute, second=0, microsecond=0)
+
+
+class InProcessScheduler:
+    """One asyncio loop: read config, fire the daily decision once per calendar day.
+
+    Fires at (or as soon as possible after) `daily_at`; a container that was down at that
+    time catches up on start, like systemd's `Persistent=true`. Uses `run_once` in a worker
+    thread because `AutoRunner.run_one` blocks for the whole generation.
+    """
+
+    def __init__(
+        self,
+        config_provider: Callable[[], Config],
+        *,
+        run_once: Callable[[Config], AutoRunResult] | None = None,
+        clock: Callable[[], datetime] = _local_now,
+    ) -> None:
+        self._config_provider = config_provider
+        self._run_once = run_once or _run_auto_once
+        self._clock = clock
+        self._enabled = False
+        self._daily_at: str | None = None
+        self._next_run: datetime | None = None
+        self._running = False
+        self._last_fired_at: datetime | None = None
+        self._last_fired_date: date | None = None
+        self._last_outcome: str | None = None
+        self._last_reason: str | None = None
+
+    def snapshot(self) -> SchedulerSnapshot:
+        return SchedulerSnapshot(
+            enabled=self._enabled,
+            daily_at=self._daily_at,
+            next_run=self._next_run,
+            running=self._running,
+            last_fired_at=self._last_fired_at,
+            last_outcome=self._last_outcome,
+            last_reason=self._last_reason,
+        )
+
+    async def tick(self) -> bool:
+        """Re-read config and fire if today's slot is due and unfired. True when it fired."""
+        config = self._config_provider()
+        automation = config.automation
+        self._enabled = automation.enabled
+        self._daily_at = automation.daily_at if automation.enabled else None
+        if not automation.enabled:
+            self._next_run = None
+            return False
+
+        now = self._clock()
+        slot = _slot_today(now, automation.daily_at)
+        if now >= slot and self._last_fired_date != now.date():
+            # WHY: the durable attempt table is the source of truth across restarts and
+            # `docker exec … auto run` — one automation decision per calendar day.
+            self._last_fired_date = await asyncio.to_thread(_last_attempt_local_date, config, now)
+        if now < slot or self._last_fired_date == now.date():
+            self._next_run = slot if now < slot else slot + timedelta(days=1)
+            return False
+
+        self._last_fired_date = now.date()
+        self._last_fired_at = now
+        self._next_run = slot + timedelta(days=1)
+        await self._fire(config)
+        return True
+
+    async def _fire(self, config: Config) -> None:
+        self._running = True
+        try:
+            result = await asyncio.to_thread(self._run_once, config)
+        except Exception as exc:
+            # WHY: only the exception type is kept — messages can carry paths or secrets
+            # and this lands in /health.
+            self._last_outcome = "error"
+            self._last_reason = type(exc).__name__
+            logger.exception("In-process automation run failed")
+        else:
+            self._last_outcome = result.outcome.value
+            self._last_reason = result.reason
+            logger.info("In-process automation: %s (%s)", result.outcome.value, result.reason)
+        finally:
+            self._running = False
+
+    async def run_forever(self, sleep: Callable[[float], Awaitable[None]] = asyncio.sleep) -> None:
+        """Poll forever; a failing tick is logged and retried at the next poll."""
+        while True:
+            try:
+                await self.tick()
+            except Exception:
+                logger.exception("In-process automation tick failed")
+            await sleep(POLL_SECONDS)
+
+
+def _last_attempt_local_date(config: Config, now: datetime) -> date | None:
+    from immich_memories.automation.state_store import AutomationStateStore
+
+    last = AutomationStateStore(config.cache.database_path).get_last_attempt()
+    if last is None:
+        return None
+    return last.started_at.astimezone(now.tzinfo).date()
+
+
+def _run_auto_once(config: Config) -> AutoRunResult:
+    from immich_memories.automation.runner import AutoRunner
+
+    return AutoRunner(config).run_one()
+
+
+def _current_config() -> Config:
+    # WHY: resolved per tick so a config reloaded by the settings page changes the schedule.
+    from immich_memories.config import get_config
+
+    return get_config()
+
+
+# The UI process's single timer; `ui/app.py` starts it and `/health` reads its snapshot.
+automation_scheduler = InProcessScheduler(_current_config)

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -806,6 +806,14 @@ class PhotoConfig(BaseModel):
 class AutomationConfig(BaseModel):
     """Smart automation settings for candidate detection and auto-generation."""
 
+    enabled: bool = Field(
+        default=False,
+        description="Run the daily auto-run decision inside the UI/Docker process",
+    )
+    daily_at: str = Field(
+        default="09:00",
+        description="Local wall-clock time (HH:MM) for the in-process daily run",
+    )
     cooldown_hours: int = Field(default=24, ge=1, le=168)
     upload_to_immich: bool = Field(default=False)
     album_name: str | None = Field(default=None)
@@ -815,6 +823,14 @@ class AutomationConfig(BaseModel):
     detect_person_spotlight: bool = Field(default=True)
     detect_activity_burst: bool = Field(default=True)
     burst_threshold: float = Field(default=2.0, ge=1.0, le=10.0)
+
+    @field_validator("daily_at")
+    @classmethod
+    def _normalize_daily_at(cls, value: str) -> str:
+        match = re.fullmatch(r"(\d{1,2}):(\d{2})", value.strip())
+        if not match or int(match[1]) > 23 or int(match[2]) > 59:
+            raise ValueError("daily_at must be a 24h wall-clock time like '09:00'")
+        return f"{int(match[1]):02d}:{match[2]}"
 
 
 class NotificationConfig(BaseModel):

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -22,6 +22,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from immich_memories import __version__
+from immich_memories.automation.in_process_scheduler import automation_scheduler
 from immich_memories.config import get_config, init_config_dir
 from immich_memories.security import configured_secret_values, sanitize_error_message
 from immich_memories.ui.auth import (
@@ -483,6 +484,7 @@ async def _build_health_snapshot() -> dict[str, Any]:
             "oldest_pending_delivery": None,
             "notification_health": None,
             "last_successful_run": None,
+            "in_process_scheduler": None,
             "version": __version__,
         }
 
@@ -523,6 +525,9 @@ async def _build_health_snapshot() -> dict[str, Any]:
         ),
         "notification_health": _automation_field(automation, "notification_health"),
         "last_successful_run": last_successful_run,
+        "in_process_scheduler": (
+            automation_scheduler.snapshot().to_dict() if _health_detail_allowed(config) else None
+        ),
         "version": __version__,
     }
 
@@ -732,6 +737,7 @@ def _start_cleanup_task() -> None:
 
 
 app.on_startup(_start_cleanup_task)
+app.on_startup(lambda: asyncio.ensure_future(automation_scheduler.run_forever()))
 
 
 def _shutdown_app() -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -99,6 +100,41 @@ class TestHealthEndpoint:
         assert ready.json()["status"] == "degraded"
         assert legacy.status_code == 200
         assert legacy.json()["status"] == "degraded"
+
+    def test_readiness_reports_the_in_process_automation_timer(self, tmp_path: Path):
+        """Docker users check /health to see when the in-app daily run will fire (#305)."""
+        from immich_memories.ui.app import _ImmichDependency, app
+
+        config = Config(
+            immich={"url": "http://immich.test", "api_key": "health-secret"},
+            cache={"database": str(tmp_path / "t.db"), "directory": str(tmp_path / "c")},
+            automation={"enabled": True, "daily_at": "07:30"},
+        )
+        from immich_memories.automation.in_process_scheduler import InProcessScheduler
+
+        # WHY: a fixed clock before the slot keeps the timer from catch-up firing a real run.
+        scheduler = InProcessScheduler(
+            lambda: config, clock=lambda: datetime(2026, 8, 18, 6, 0).astimezone()
+        )
+        asyncio.run(scheduler.tick())
+        client = TestClient(app, raise_server_exceptions=False)
+        with (
+            # WHY: /health must not reach out to a real Immich in a unit test.
+            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch(
+                "immich_memories.ui.app._check_immich_dependency",
+                new_callable=AsyncMock,
+                return_value=_ImmichDependency(status="ready", reachable=True),
+            ),
+            patch("immich_memories.ui.app.automation_scheduler", scheduler),
+        ):
+            response = client.get("/health/ready")
+
+        timer = response.json()["in_process_scheduler"]
+        assert timer["enabled"] is True
+        assert timer["daily_at"] == "07:30"
+        assert timer["next_run"] is not None
+        assert timer["running"] is False
 
     def test_registered_readiness_uses_one_configuration_snapshot(self):
         """A real detailed request cannot reload config while reading run history."""

--- a/tests/test_in_process_scheduler.py
+++ b/tests/test_in_process_scheduler.py
@@ -1,0 +1,213 @@
+"""In-process daily automation timer for the UI/Docker process (#305)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from immich_memories.config_models import AutomationConfig
+
+
+class TestDailyAtConfig:
+    def test_defaults_are_off_and_nine_am(self) -> None:
+        auto = AutomationConfig()
+
+        assert auto.enabled is False
+        assert auto.daily_at == "09:00"
+
+    @pytest.mark.parametrize("value", ["25:00", "09:60", "9am", "", "09:00:00"])
+    def test_rejects_times_that_are_not_hh_mm(self, value: str) -> None:
+        with pytest.raises(ValidationError):
+            AutomationConfig(daily_at=value)
+
+    def test_normalizes_single_digit_hour(self) -> None:
+        assert AutomationConfig(daily_at="9:05").daily_at == "09:05"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler behaviour
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402
+from datetime import datetime, timedelta  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from immich_memories.automation.in_process_scheduler import InProcessScheduler  # noqa: E402
+from immich_memories.automation.models import AutoOutcome, AutoRunResult  # noqa: E402
+from immich_memories.config_loader import Config  # noqa: E402
+
+LOCAL = datetime.now().astimezone().tzinfo
+
+
+def _config(tmp_path: Path, **automation: object) -> Config:
+    return Config(
+        immich={"url": "http://immich.test:2283", "api_key": "test-key"},
+        cache={"database": str(tmp_path / "test.db"), "directory": str(tmp_path / "cache")},
+        automation=automation,
+    )
+
+
+class _FakeClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, **kwargs: float) -> None:
+        self.now += timedelta(**kwargs)
+
+
+def _completed(config: Config) -> AutoRunResult:
+    return AutoRunResult(outcome=AutoOutcome.COMPLETED, reason="generated")
+
+
+class TestTick:
+    async def test_disabled_scheduler_never_fires(self, tmp_path: Path) -> None:
+        config = _config(tmp_path, enabled=False, daily_at="09:00")
+        fired: list[Config] = []
+        clock = _FakeClock(datetime(2026, 8, 18, 9, 0, 5, tzinfo=LOCAL))
+        scheduler = InProcessScheduler(
+            lambda: config, run_once=lambda c: fired.append(c) or _completed(c), clock=clock
+        )
+
+        assert await scheduler.tick() is False
+
+        assert fired == []
+        snap = scheduler.snapshot()
+        assert snap.enabled is False
+        assert snap.next_run is None
+
+    async def test_enabled_before_slot_reports_next_run_today(self, tmp_path: Path) -> None:
+        config = _config(tmp_path, enabled=True, daily_at="09:00")
+        fired: list[Config] = []
+        clock = _FakeClock(datetime(2026, 8, 18, 8, 59, tzinfo=LOCAL))
+        scheduler = InProcessScheduler(
+            lambda: config, run_once=lambda c: fired.append(c) or _completed(c), clock=clock
+        )
+
+        assert await scheduler.tick() is False
+
+        assert fired == []
+        snap = scheduler.snapshot()
+        assert snap.enabled is True
+        assert snap.daily_at == "09:00"
+        assert snap.next_run == datetime(2026, 8, 18, 9, 0, tzinfo=LOCAL)
+
+    async def test_fires_once_when_slot_arrives_then_waits_for_tomorrow(
+        self, tmp_path: Path
+    ) -> None:
+        config = _config(tmp_path, enabled=True, daily_at="09:00")
+        fired: list[Config] = []
+        clock = _FakeClock(datetime(2026, 8, 18, 8, 59, 50, tzinfo=LOCAL))
+        scheduler = InProcessScheduler(
+            lambda: config, run_once=lambda c: fired.append(c) or _completed(c), clock=clock
+        )
+        assert await scheduler.tick() is False
+
+        clock.advance(seconds=25)  # 09:00:15 — one poll interval late, still today's slot
+        assert await scheduler.tick() is True
+        clock.advance(minutes=30)
+        assert await scheduler.tick() is False
+        clock.advance(hours=12)
+        assert await scheduler.tick() is False
+
+        assert fired == [config]
+        snap = scheduler.snapshot()
+        assert snap.last_fired_at == datetime(2026, 8, 18, 9, 0, 15, tzinfo=LOCAL)
+        assert snap.last_outcome == "completed"
+        assert snap.last_reason == "generated"
+        assert snap.running is False
+        assert snap.next_run == datetime(2026, 8, 19, 9, 0, tzinfo=LOCAL)
+
+
+class TestRestartCatchUp:
+    """A container that was down at daily_at behaves like systemd Persistent=true."""
+
+    async def test_starts_after_slot_with_no_attempt_today_fires_immediately(
+        self, tmp_path: Path
+    ) -> None:
+        config = _config(tmp_path, enabled=True, daily_at="09:00")
+        fired: list[Config] = []
+        clock = _FakeClock(datetime(2026, 8, 18, 14, 30, tzinfo=LOCAL))
+        scheduler = InProcessScheduler(
+            lambda: config, run_once=lambda c: fired.append(c) or _completed(c), clock=clock
+        )
+
+        assert await scheduler.tick() is True
+        assert fired == [config]
+
+    async def test_starts_after_slot_with_an_attempt_already_today_waits_for_tomorrow(
+        self, tmp_path: Path
+    ) -> None:
+        from immich_memories.automation.state_store import AutomationStateStore
+
+        config = _config(tmp_path, enabled=True, daily_at="09:00")
+        # The durable attempt row is what a pre-restart fire (or `docker exec … auto run`)
+        # leaves behind; started_at is "now" in UTC, i.e. today.
+        AutomationStateStore(config.cache.database_path).start_attempt(reason="daily wake")
+        fired: list[Config] = []
+        now = datetime.now().astimezone().replace(hour=23, minute=0, second=0, microsecond=0)
+        clock = _FakeClock(now)
+        scheduler = InProcessScheduler(
+            lambda: config, run_once=lambda c: fired.append(c) or _completed(c), clock=clock
+        )
+
+        assert await scheduler.tick() is False
+
+        assert fired == []
+        assert scheduler.snapshot().next_run == now.replace(hour=9) + timedelta(days=1)
+
+
+class TestFailureIsolation:
+    async def test_crashing_run_is_recorded_by_type_only_and_not_retried_today(
+        self, tmp_path: Path
+    ) -> None:
+        config = _config(tmp_path, enabled=True, daily_at="09:00")
+        calls = 0
+
+        def boom(_config: Config) -> AutoRunResult:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("api key hunter2 leaked in message")
+
+        clock = _FakeClock(datetime(2026, 8, 18, 9, 0, 1, tzinfo=LOCAL))
+        scheduler = InProcessScheduler(lambda: config, run_once=boom, clock=clock)
+
+        assert await scheduler.tick() is True
+        clock.advance(hours=1)
+        assert await scheduler.tick() is False
+
+        assert calls == 1
+        snap = scheduler.snapshot()
+        assert snap.last_outcome == "error"
+        assert snap.last_reason == "RuntimeError"
+        assert "hunter2" not in str(snap.to_dict())
+        assert snap.running is False
+
+    async def test_run_forever_survives_a_failing_tick_and_keeps_polling(
+        self, tmp_path: Path
+    ) -> None:
+        good = _config(tmp_path, enabled=False)
+        providers = iter([RuntimeError("config unreadable"), good, good])
+
+        def provider() -> Config:
+            item = next(providers)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+            if len(sleeps) == 3:
+                raise asyncio.CancelledError
+
+        scheduler = InProcessScheduler(provider)
+
+        with pytest.raises(asyncio.CancelledError):
+            await scheduler.run_forever(sleep=fake_sleep)
+
+        assert len(sleeps) == 3
+        assert scheduler.snapshot().enabled is False


### PR DESCRIPTION
## Summary

Wave 1 item 1 of the launch roadmap — the #1 product gap from the launch review.

`automation.enabled: true` (+ `daily_at: "HH:MM"`; env `IMMICH_MEMORIES_AUTOMATION__ENABLED` / `__DAILY_AT`) makes the web UI process run the **same `auto run` decision the CLI does** — same flock lease, attempt history, delivery retry, notifications — once a day. No host cron, no second binary: `docker compose up` + one toggle.

- **`automation/in_process_scheduler.py`** (new): 30 s poll loop, re-reads config every tick (settings reload changes the schedule without a restart), fires at or after the slot.
  - One decision per calendar day; the durable `automation_attempts` table is the source of truth, so a container restart or a manual `docker exec … auto run` does not double-fire; a container that was down at `daily_at` catches up on start (like systemd `Persistent=true`).
  - `AutoRunner.run_one` blocks for the whole generation → runs in `asyncio.to_thread`. Failures are recorded by exception type only (nothing from the message reaches `/health`) and never kill the loop.
  - The existing flock means a concurrent manual run just makes the timer's run `skipped`.
- **`/health/ready`** gains `in_process_scheduler` (`enabled`, `daily_at`, `next_run`, `running`, `last_fired_at`, `last_outcome`, `last_reason`), gated by the same rule as the other automation detail.
- `AutomationConfig.enabled` / `daily_at` (validated `HH:MM`, default off / `09:00`).
- `ui/app.py`: +6 lines (import, one health key, one `on_startup`) — stays under 800.
- Docs: `docker.md` (env table + *Daily automation* section), `automated-generation.md`, `auto.md`, `config-reference.md`, README, compose example, ARCHITECTURE listing. `make docs-build` passes.

Note: to actually deliver *daily* rather than every other day this depends on the cooldown fix in #331 (independent code, no merge dependency).

Closes #305

## Test plan

- [x] `make ci` green (4586 passed, +15), `make critique` clean on the touched files, `make docs-build` OK
- [x] `tests/test_in_process_scheduler.py`: config validation; disabled never fires; before slot → `next_run` today; fires once at the slot then waits for tomorrow; restart after slot with no attempt today → fires (catch-up); restart with an attempt already today (real SQLite store) → waits; crashing run recorded by type only, not retried today; `run_forever` survives a failing tick
- [x] `tests/test_health.py`: `/health/ready` reports the timer block
- [x] Manual smoke: `IMMICH_MEMORIES_AUTOMATION__ENABLED=true …__DAILY_AT=23:58 immich-memories ui` → `/health/ready` reports `{"enabled": true, "daily_at": "23:58", "next_run": "2026-08-18T23:58:00+02:00", "running": false, …}`; startup log clean. (Did not let it fire against the live library.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM