### PR TITLE
fix(cache): atomic video downloads, probe-based eviction, mid-batch cap

### DIFF
--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -88,14 +88,14 @@ Downloaded Immich clips are cached locally to avoid re-downloading on repeat run
 
 ### How it works
 
-The cache uses a two-level directory structure: `{id[:2]}/{id}{ext}`. When you request a clip, it checks the cache first. On a hit, it returns the local path instantly. On a miss, it downloads from Immich and stores the file.
+The cache uses a two-level directory structure: `{id[:2]}/{id}{ext}`. When you request a clip, it checks the cache first. On a hit, it runs a quick `ffprobe` on the file and returns the local path; if ffprobe cannot read it (a truncated or corrupt file), the entry is deleted and downloaded again. On a miss, it streams the download into `{id}{ext}.part` and renames it into place only once complete, so a run killed mid-download never leaves a half file that the next run would trust. Leftover `.part` files nobody has written to for an hour are removed at the start of the next run.
 
 ### Eviction
 
 Two eviction strategies run automatically:
 
-1. **Age-based eviction** (`evict_old`): removes files older than `video_cache_max_age_days` (default: 7 days). Runs at the start of every generation.
-2. **Size-based eviction** (`evict_if_over_limit`): removes oldest files (by modification time, LRU) until the cache is under `video_cache_max_size_gb` (default: 10 GB). Runs after each new download.
+1. **Age-based eviction**: removes files older than `video_cache_max_age_days` (default: 7 days). Runs at the start of every generation.
+2. **Size-based eviction**: removes oldest files (by modification time, LRU) until the cache is under `video_cache_max_size_gb` (default: 10 GB). Runs after each download during a run — files the current run already handed out are spared until it finishes, so a large prefetch can temporarily exceed the cap — and once more at the end of the run.
 
 ### Configuration
 

--- a/src/immich_memories/cache/video_cache.py
+++ b/src/immich_memories/cache/video_cache.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Container
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,6 +15,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from immich_memories.api.immich import ImmichAPIError
+from immich_memories.processing.probe_cache import ProbeCache, ProbeError
 from immich_memories.security import sanitize_error_message
 
 if TYPE_CHECKING:
@@ -21,6 +23,9 @@ if TYPE_CHECKING:
     from immich_memories.api.models import Asset
 
 logger = logging.getLogger(__name__)
+
+_PARTIAL_SUFFIX = ".part"
+_PARTIAL_GRACE_SECONDS = 3600
 
 
 def _safe_download_error(exc: Exception, client: SyncImmichClient) -> str:
@@ -53,7 +58,8 @@ class CacheBatch:
     """One explicit cache-maintenance lifecycle.
 
     A batch snapshots the cache once at creation, records successful downloads
-    in memory, and performs size eviction from that manifest when it finishes.
+    in memory, and evicts from that manifest after each download (sparing files
+    it already handed out) and once more, unconditionally, when it finishes.
     Call :meth:`invalidate_manifest` only when another actor changed the cache;
     that deliberately permits one replacement scan at finish.
     """
@@ -62,6 +68,7 @@ class CacheBatch:
         self._cache = cache
         self._condition = threading.Condition(cache._batch_lock)
         self._manifest: dict[Path, _ManifestEntry] = {}
+        self._handed_out: set[Path] = set()
         self._invalidated = False
         self._closing = False
         self._finished = False
@@ -172,9 +179,15 @@ class CacheBatch:
                     self._condition.notify_all()
 
     def _record_manifest_entry(self, path: Path) -> None:
-        """Update one manifest entry under the narrow batch lock."""
+        """Update one manifest entry and keep the cap enforced under the batch lock.
+
+        Files this batch already handed to callers are spared until finish: a
+        prefetched clip evicted before extraction reads it would fail the run.
+        """
         with self._condition:
             self._cache._record_manifest_entry(self._manifest, path)
+            self._handed_out.add(path)
+            self._cache._evict_manifest(self._manifest, protected=self._handed_out)
 
     def _require_open_locked(self) -> None:
         if self._finished or self._closing:
@@ -199,6 +212,7 @@ class VideoDownloadCache:
         self.max_age_days = max_age_days
         self._batch_lock = threading.RLock()
         self._active_batch: CacheBatch | None = None
+        self._probe_cache = ProbeCache()
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def begin_batch(self) -> CacheBatch:
@@ -232,7 +246,10 @@ class VideoDownloadCache:
         if not sub_path.exists():
             return None
         # Match {asset_id}.* but not {asset_id}_480p.* (analysis downscale)
+        # nor an in-flight/abandoned {asset_id}.ext.part download.
         for match in sub_path.glob(f"{asset_id}.*"):
+            if match.suffix == _PARTIAL_SUFFIX:
+                continue
             if match.is_file() and match.stat().st_size > 0:
                 return match
         return None
@@ -276,26 +293,45 @@ class VideoDownloadCache:
         """Download one resolved video ID and update the active manifest."""
         cached = self._find_cached(download_id)
         if cached is not None:
-            batch._record_manifest_entry(cached)
-            return cached
+            if self._is_readable_media(cached):
+                batch._record_manifest_entry(cached)
+                return cached
+            logger.warning("Evicting cached video ffprobe cannot read: %s", cached)
+            cached.unlink(missing_ok=True)
+            batch._record_manifest_entry(cached)  # a missing path drops the manifest entry
 
         dest = self._video_path(download_id, extension)
         dest.parent.mkdir(parents=True, exist_ok=True)
+        # WHY: stream into a .part sibling and rename only once complete, so a run
+        # killed mid-download can never leave a truncated file at the cached path.
+        part = dest.with_name(f"{dest.name}{_PARTIAL_SUFFIX}")
 
         try:
-            client.download_asset(download_id, dest)
-            if dest.exists() and dest.stat().st_size > 0:
+            client.download_asset(download_id, part)
+            if part.exists() and part.stat().st_size > 0:
+                os.replace(part, dest)
                 batch._record_manifest_entry(dest)
                 return dest
             logger.warning("Downloaded file empty or missing: %s", dest)
-            dest.unlink(missing_ok=True)
         except (ImmichAPIError, httpx.HTTPError, OSError, RuntimeError) as e:
             logger.warning(
                 "Failed to download video %s: %s", download_id, _safe_download_error(e, client)
             )
-            dest.unlink(missing_ok=True)
+        finally:
+            part.unlink(missing_ok=True)
 
         return None
+
+    def _is_readable_media(self, path: Path) -> bool:
+        """Treat a cache hit ffprobe rejects as corrupt (truncated by a killed run, bad disk)."""
+        try:
+            self._probe_cache.get(path)
+        except ProbeError:
+            return False
+        except ValueError:
+            # Extension outside the probe whitelist: nothing to verify against.
+            pass
+        return True
 
     def get_analysis_video(
         self,
@@ -393,11 +429,12 @@ class VideoDownloadCache:
         return original, original
 
     def _scan_manifest(self) -> dict[Path, _ManifestEntry]:
-        """Scan once, removing expired files and returning valid metadata."""
+        """Scan once, dropping expired files and abandoned partial downloads."""
         if not self.cache_dir.exists():
             return {}
 
-        cutoff = time.time() - (self.max_age_days * 86400)
+        now = time.time()
+        cutoff = now - (self.max_age_days * 86400)
         manifest: dict[Path, _ManifestEntry] = {}
         for path in self.cache_dir.rglob("*"):
             if not path.is_file():
@@ -405,6 +442,12 @@ class VideoDownloadCache:
             try:
                 stat = path.stat()
             except OSError:
+                continue
+            if path.suffix == _PARTIAL_SUFFIX:
+                # WHY: a .part nobody wrote to for an hour is a download killed
+                # mid-stream; a fresh one may belong to another live cache instance.
+                if stat.st_mtime < now - _PARTIAL_GRACE_SECONDS:
+                    path.unlink(missing_ok=True)
                 continue
             if stat.st_mtime < cutoff:
                 path.unlink(missing_ok=True)
@@ -421,9 +464,14 @@ class VideoDownloadCache:
             return
         manifest[path] = _ManifestEntry(path, stat.st_size, stat.st_mtime)
 
-    def _evict_manifest(self, manifest: dict[Path, _ManifestEntry]) -> int:
-        """Evict oldest manifest entries without scanning the filesystem again."""
+    def _evict_manifest(
+        self, manifest: dict[Path, _ManifestEntry], protected: Container[Path] = ()
+    ) -> int:
+        """Evict oldest unprotected manifest entries without scanning the filesystem again."""
         max_bytes = self.max_size_gb * 1_073_741_824
+        # WHY: called after every batch download; skip the per-entry stat while under cap.
+        if sum(entry.size for entry in manifest.values()) <= max_bytes:
+            return 0
         entries = [entry for entry in manifest.values() if entry.path.exists()]
         total_size = sum(entry.size for entry in entries)
         if total_size <= max_bytes:
@@ -433,6 +481,8 @@ class VideoDownloadCache:
         for entry in sorted(entries, key=lambda item: item.mtime):
             if total_size <= max_bytes:
                 break
+            if entry.path in protected:
+                continue
             try:
                 entry.path.unlink()
             except OSError:

--- a/tests/test_video_cache.py
+++ b/tests/test_video_cache.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -38,13 +40,29 @@ def mock_asset():
     return asset
 
 
+@pytest.fixture(scope="session")
+def tiny_video_bytes(tmp_path_factory) -> bytes:
+    """A real, probe-able MP4 so cache hits survive the ffprobe validity check."""
+    if not shutil.which("ffmpeg"):
+        pytest.skip("FFmpeg not available")
+    path = tmp_path_factory.mktemp("video") / "tiny.mp4"
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=red:size=32x32:duration=0.2:rate=10"]
+        + ["-c:v", "libx264", "-pix_fmt", "yuv420p", str(path)],
+        capture_output=True,
+        timeout=60,
+        check=True,
+    )
+    return path.read_bytes()
+
+
 @pytest.fixture
-def mock_client(tmp_path):
-    """Create a mock Immich client that writes a fake video file on download."""
+def mock_client(tiny_video_bytes):
+    """Create a mock Immich client that writes a real tiny video file on download."""
 
     def fake_download(asset_id: str, output_path: Path) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"fake-video-data-" * 100)
+        output_path.write_bytes(tiny_video_bytes)
         return output_path
 
     client = MagicMock()
@@ -141,6 +159,71 @@ class TestDownloadOrGet:
         assert path is not None
         assert path.read_bytes() == b"complete"
         assert client.download_asset.call_count == 2
+
+    def test_download_is_only_visible_at_final_path_once_complete(self, cache, mock_asset):
+        """A killed or failed download never leaves a truncated file the cache would trust."""
+        final_path = cache._video_path(mock_asset.id, ".MOV")
+        seen_final_during_write: list[bool] = []
+        attempts = 0
+
+        def write_halfway_then_succeed(_asset_id: str, output_path: Path) -> None:
+            nonlocal attempts
+            attempts += 1
+            output_path.write_bytes(b"half")
+            seen_final_during_write.append(final_path.exists())
+            if attempts == 1:
+                raise OSError("connection reset")
+            output_path.write_bytes(b"complete")
+
+        # WHY: the Immich download is the only network boundary; the writer runs for real
+        client = MagicMock()
+        client.download_asset.side_effect = write_halfway_then_succeed
+
+        assert cache.download_or_get(client, mock_asset) is None
+        assert not final_path.exists()
+        assert list(final_path.parent.glob("*")) == []
+
+        assert cache.download_or_get(client, mock_asset) == final_path
+        assert final_path.read_bytes() == b"complete"
+        assert seen_final_during_write == [False, False]
+
+    def test_stale_partial_from_killed_run_is_never_served_and_gets_cleaned(
+        self, cache, mock_client, mock_asset
+    ):
+        import os
+
+        final_path = cache._video_path(mock_asset.id, ".MOV")
+        final_path.parent.mkdir(parents=True)
+        stale_part = final_path.with_name(f"{final_path.name}.part")
+        stale_part.write_bytes(b"truncated-by-sigkill" * 100)
+        # WHY: a .part nobody has written to for hours belongs to a dead process
+        two_hours_ago = time.time() - 7200
+        os.utime(stale_part, (two_hours_ago, two_hours_ago))
+        other_id = "ff000000-6789-0abc-def0-123456789abc"
+        in_flight_part = cache._video_path(other_id, ".MOV").with_name(f"{other_id}.MOV.part")
+        in_flight_part.parent.mkdir(parents=True)
+        in_flight_part.write_bytes(b"still-streaming")
+
+        assert cache._find_cached(mock_asset.id) is None
+        assert cache._find_cached(other_id) is None
+        assert cache.download_or_get(mock_client, mock_asset) == final_path
+        mock_client.download_asset.assert_called_once()
+        assert not stale_part.exists()
+        assert in_flight_part.exists(), "a freshly written .part may be another instance's download"
+
+    def test_entry_ffprobe_cannot_read_is_evicted_and_fetched_again(
+        self, cache, mock_client, mock_asset, tiny_video_bytes
+    ):
+        """A corrupt cached file must not poison every later run that requests it."""
+        corrupt = cache._video_path(mock_asset.id, ".MOV")
+        corrupt.parent.mkdir(parents=True)
+        corrupt.write_bytes(b"not-a-video" * 100)
+
+        path = cache.download_or_get(mock_client, mock_asset)
+
+        mock_client.download_asset.assert_called_once()
+        assert path == corrupt
+        assert path.read_bytes() == tiny_video_bytes
 
 
 class TestCacheBatch:
@@ -347,6 +430,36 @@ class TestCacheBatch:
         assert finish_returned.is_set()
         with pytest.raises(RuntimeError, match="finished"):
             batch.download_or_get(client, asset)
+
+    def test_cap_is_enforced_inside_the_batch_but_spares_files_it_handed_out(
+        self, cache_dir, mock_client, tiny_video_bytes
+    ):
+        """Prefetch of a large batch must not blow past the cap before extraction starts."""
+        import os
+
+        # WHY: one clip fits under the cap, two do not
+        cache = VideoDownloadCache(
+            cache_dir=cache_dir, max_size_gb=len(tiny_video_bytes) * 1.5 / 1024**3
+        )
+        previous_run = cache_dir / "zz" / "zz_previous_run.mp4"
+        previous_run.parent.mkdir(parents=True)
+        previous_run.write_bytes(tiny_video_bytes)
+        # WHY: older than anything this batch writes, but younger than the age cutoff
+        an_hour_ago = time.time() - 3600
+        os.utime(previous_run, (an_hour_ago, an_hour_ago))
+
+        def make_asset(asset_id: str):
+            asset = MagicMock()
+            asset.id = asset_id
+            asset.original_file_name = "clip.mp4"
+            asset.live_photo_video_id = None
+            return asset
+
+        with cache.begin_batch() as batch:
+            first = batch.download_or_get(mock_client, make_asset("aa-first"))
+            assert not previous_run.exists(), "stale entry must go before the batch ends"
+            second = batch.download_or_get(mock_client, make_asset("bb-second"))
+            assert first.exists() and second.exists(), "files this batch returned stay usable"
 
 
 class TestGetStats:


### PR DESCRIPTION
## Summary

Closes #314 (launch review, perf prism findings 3 & 5).

- **Atomic downloads**: `VideoDownloadCache` streams into `{id}{ext}.part` and `os.replace`s onto the final name only once the download completed. A run killed mid-download can no longer leave a truncated file at the cached path. Any failure path removes the `.part`.
- **Stale partials**: `.part` files are never served as hits. The batch scan deletes `.part` files nobody has written to for an hour (a fresh one may belong to another live cache instance; a killed run's stops getting written and is cleaned at the next scan).
- **Evict on probe failure**: a cache hit is checked with ffprobe (via the existing `ProbeCache`). Unreadable entries are deleted, dropped from the batch manifest, and re-downloaded. Extensions outside the probe whitelist are trusted as before.
- **Mid-batch cap**: the size cap is enforced after every download/hit inside a `CacheBatch`, evicting oldest entries the batch has *not* handed out. Files already returned to callers are spared until `finish()` (a prefetched clip evicted before extraction would fail the run), so a batch larger than the cap can still temporarily exceed it — but only by its own working set, not by stale entries from earlier runs. `_evict_manifest` short-circuits on the in-memory total so the common under-cap case does no per-entry stat.
- Docs: `deploy/maintenance/health-logs-cache.md` describes the new behaviour.

Cost note: one ffprobe (~20-40 ms) per cache hit; results are memoised per `VideoDownloadCache` instance keyed on path+size+mtime.

## Test plan

- [x] `tests/test_video_cache.py`: final path is absent while the writer runs and after a writer that raises halfway; no `.part` left behind
- [x] stale `.part` (aged 2 h) never served and cleaned by the next batch; a fresh `.part` is left alone
- [x] garbage bytes at the cached path -> real ffprobe rejects it -> evicted and re-fetched
- [x] cap enforced inside a batch: previous-run file evicted after the first download, the batch's own files kept
- [x] fixture now writes a real tiny lavfi MP4 (session-scoped) so hits survive the probe check with real ffprobe, no probe mocks
- [x] `make ci` green (4592 passed), `make docs-build` green, `make critique` nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
