### PR TITLE
fix(auth): Secure session cookie option and trusted forwarded IPs behind a reverse proxy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,6 +263,7 @@ src/immich_memories/
 │   ├── app.py                  # App setup & routing
 │   ├── auth.py                 # Auth middleware, credential verification, session helpers
 │   ├── auth_oidc.py            # OIDC client (authlib starlette integration, singleton)
+│   ├── reverse_proxy.py        # Secure cookie + trusted X-Forwarded-* kwargs for ui.run
 │   ├── state.py                # Shared UI state
 │   ├── theme.py                # UI theme
 │   ├── components.py           # Shared UI components

--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -239,19 +239,35 @@ In your config YAML, set `trusted_proxies` to Traefik's container IP (prefer a s
 - Logout via the sidebar button or by navigating to `/logout`.
 - OIDC logout redirects to the IdP's `end_session_endpoint` when available (the IdP terminates the SSO session too). Falls back to a local-only logout if the IdP doesn't advertise that endpoint.
 
-:::warning Behind a reverse proxy: bind locally and tell uvicorn who the proxy is
+:::warning Behind a reverse proxy: bind locally, name the proxy, mark the cookie Secure
 
-Two things to know when the UI sits behind Traefik, Caddy or nginx with TLS:
+Three things to set when the UI sits behind Traefik, Caddy or nginx with TLS:
 
-1. **The session cookie is not marked `Secure` today** (the app does not read
-   `X-Forwarded-Proto`). That is only a problem if the plain-HTTP port is *also* reachable, so
-   don't publish `8080` on the LAN once the proxy is up: bind it to localhost
+1. **Don't publish `8080` on the LAN once the proxy is up.** Bind it to localhost
    (`127.0.0.1:8080:8080` in compose) or keep the container on the proxy network only.
-2. **Set `FORWARDED_ALLOW_IPS` to your proxy's address** so uvicorn trusts its `X-Forwarded-For`
-   / `X-Forwarded-Proto` headers. Without it every visitor looks like the proxy's IP — five wrong
-   passwords from anyone lock the whole household out of login for 10 minutes — and the OIDC
-   `redirect_uri` is built as `http://…` instead of `https://…`, which most identity providers
-   reject.
+2. **List the proxy in `auth.trusted_proxies`.** The app passes it to uvicorn as
+   `forwarded_allow_ips`, so `X-Forwarded-For` / `X-Forwarded-Proto` from that address are
+   honored. Without it every visitor looks like the proxy's IP — five wrong passwords from anyone
+   lock the whole household out of login for 10 minutes — and the OIDC `redirect_uri` is built as
+   `http://…` instead of `https://…`, which most identity providers reject. `"*"` trusts any
+   peer; only use it when the app is unreachable except through the proxy.
+3. **Set `server.secure_cookies: true`** so the session cookie carries the `Secure` flag and
+   browsers never send it over plain HTTP. Only do this once every visitor arrives over HTTPS —
+   with it on, a plain `http://` origin (other than `localhost`) can't log in at all.
+
+```yaml
+# ~/.immich-memories/config.yaml
+advanced:
+  server:
+    secure_cookies: true
+  auth:
+    enabled: true
+    provider: basic            # or oidc
+    username: admin
+    password: ${MY_SECRET_PASSWORD}
+    trusted_proxies:
+      - 172.20.0.2             # your proxy container's IP or CIDR
+```
 
 ```yaml
 # docker-compose.yml
@@ -259,9 +275,13 @@ services:
   immich-memories:
     ports:
       - "127.0.0.1:8080:8080"     # or drop `ports:` entirely and expose via the proxy network
-    environment:
-      FORWARDED_ALLOW_IPS: "172.20.0.2"   # your proxy container's IP (or "*" on a trusted network)
 ```
+
+The `FORWARDED_ALLOW_IPS` environment variable still works and, when set, wins over
+`trusted_proxies`. With `provider: header` the forwarded headers are deliberately *not* applied:
+the app has to keep seeing the proxy's own address to trust `Remote-User`, and the login rate
+limiter and OIDC redirect don't apply to that provider anyway. Leave `FORWARDED_ALLOW_IPS` unset
+in that case.
 
 When running without a reverse proxy (direct access on localhost), none of this applies.
 :::
@@ -287,4 +307,4 @@ All fields under `advanced.auth` with their defaults:
 | `button_text` | `Sign in with SSO` | OIDC: login button label |
 | `user_header` | `Remote-User` | Header: header name for the username |
 | `email_header` | `Remote-Email` | Header: header name for the email |
-| `trusted_proxies` | `[]` | Header: IPs/CIDRs allowed to set auth headers |
+| `trusted_proxies` | `[]` | IPs/CIDRs of your reverse proxy. Header provider: allowed to set auth headers. Basic/OIDC: their `X-Forwarded-For` / `X-Forwarded-Proto` are honored (uvicorn `forwarded_allow_ips`) |

--- a/docs-site/docs/deploy/configuration/environment-variables.md
+++ b/docs-site/docs/deploy/configuration/environment-variables.md
@@ -139,7 +139,7 @@ Not config fields, but read by the app:
 | `ACESTEP_CHECKPOINTS_DIR` | ACE-Step `lib` mode: where model checkpoints are downloaded (default `~/.cache/ace-step/checkpoints`). |
 | `ACESTEP_MLX_VAE_CHUNK` | ACE-Step `lib` mode on Apple Silicon: VAE decode chunk size in latent frames (minimum 192). Lower it if MLX runs out of memory. |
 | `IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32` | ACE-Step `lib` mode on Apple Silicon: `1` keeps the MLX decoder in fp32 instead of casting to bf16 (roughly doubles decoder memory). |
-| `FORWARDED_ALLOW_IPS` | uvicorn: proxies whose `X-Forwarded-*` headers are trusted. Needed behind a reverse proxy — see [Authentication](authentication.mdx). |
+| `FORWARDED_ALLOW_IPS` | uvicorn: proxies whose `X-Forwarded-*` headers are trusted. Wins over `auth.trusted_proxies` when set — see [Authentication](authentication.mdx). |
 
 There is no environment variable for the log *level*.
 

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -440,6 +440,7 @@ server:
   host: "0.0.0.0"               # Listen address (use 127.0.0.1 to restrict to localhost)
   port: 8080                     # Listen port (1-65535)
   enable_demo_mode: false        # Show the demo/privacy (blur) toggle in the sidebar
+  secure_cookies: false          # Mark the session cookie Secure (turn on behind an HTTPS reverse proxy)
 ```
 
 These can also be set via CLI flags: `immich-memories ui --host 127.0.0.1 --port 9090`.
@@ -515,7 +516,8 @@ auth:
   # Trusted header (reverse proxy)
   user_header: "Remote-User"
   email_header: "Remote-Email"
-  trusted_proxies: []            # Required for header provider — IPs/CIDRs of your proxy
+  trusted_proxies: []            # IPs/CIDRs of your proxy. Required for header provider;
+                                 # for basic/oidc their X-Forwarded-* headers are trusted
 ```
 
 Place under `advanced:` in your config file (like all Tier 2 sections).

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -377,6 +377,10 @@ class ServerConfig(BaseModel):
     enable_demo_mode: bool = Field(
         default=False, description="Show demo/privacy toggle in sidebar (for screenshots/E2E)"
     )
+    secure_cookies: bool = Field(
+        default=False,
+        description="Mark the session cookie Secure (only when every visitor arrives over HTTPS)",
+    )
 
 
 class TripsConfig(BaseModel):

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -34,6 +34,7 @@ from immich_memories.ui.auth import (
     is_trusted_proxy,
     set_session,
 )
+from immich_memories.ui.reverse_proxy import reverse_proxy_run_kwargs
 from immich_memories.ui.state import ensure_config, get_app_state
 from immich_memories.ui.theme import apply_theme, render_theme_toggle
 
@@ -787,6 +788,7 @@ def main(port: int = 8080, host: str = "0.0.0.0", reload: bool = False) -> None:
         "reload": reload,
         "storage_secret": _get_storage_secret(),
     }
+    kwargs.update(reverse_proxy_run_kwargs(get_config(), os.environ))
     if reload:
         kwargs["uvicorn_reload_includes"] = "*.py"
         kwargs["uvicorn_reload_excludes"] = ".*, *.log, *.db, *.db-journal"

--- a/src/immich_memories/ui/reverse_proxy.py
+++ b/src/immich_memories/ui/reverse_proxy.py
@@ -1,0 +1,35 @@
+"""Settings the UI server needs when it sits behind a TLS-terminating reverse proxy.
+
+Turns config into the ``ui.run(**kwargs)`` entries NiceGUI forwards to Starlette's
+SessionMiddleware (``session_middleware_kwargs``) and to uvicorn (``forwarded_allow_ips``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from immich_memories.config_loader import Config
+
+
+def reverse_proxy_run_kwargs(config: Config, environ: Mapping[str, str]) -> dict[str, Any]:
+    """Return the ``ui.run`` kwargs derived from ``server`` and ``auth`` config.
+
+    ``auth.trusted_proxies`` becomes uvicorn's ``forwarded_allow_ips`` so ``X-Forwarded-For``
+    and ``X-Forwarded-Proto`` from those proxies rewrite ``request.client`` (login rate
+    limiter) and ``request.url`` (OIDC ``redirect_uri``). An explicit ``FORWARDED_ALLOW_IPS``
+    env var is left for uvicorn to read, so it keeps winning over config.
+    """
+    kwargs: dict[str, Any] = {}
+    if config.server.secure_cookies:
+        kwargs["session_middleware_kwargs"] = {"https_only": True}
+    if "FORWARDED_ALLOW_IPS" not in environ:
+        if config.auth.provider == "header":
+            # WHY: header auth trusts the proxy by the address it connects from. Once uvicorn
+            # rewrites request.client to X-Forwarded-For, that check would see the visitor.
+            kwargs["forwarded_allow_ips"] = []
+        elif config.auth.trusted_proxies:
+            kwargs["forwarded_allow_ips"] = config.auth.trusted_proxies.copy()
+    return kwargs

--- a/tests/test_reverse_proxy.py
+++ b/tests/test_reverse_proxy.py
@@ -1,0 +1,177 @@
+"""Reverse-proxy settings: Secure session cookie and trusted X-Forwarded-* headers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, RedirectResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+from immich_memories.config_loader import Config
+from immich_memories.ui.auth import record_failed_login, reset_rate_limiter
+from immich_memories.ui.reverse_proxy import reverse_proxy_run_kwargs
+
+_BASIC_AUTH = {"enabled": True, "provider": "basic", "username": "op", "password": "pw"}
+_PROXY, _VISITOR, _STRANGER = "10.0.0.2", "203.0.113.5", "192.0.2.9"
+
+
+def _session_cookie(run_kwargs: dict) -> str:
+    """Set-Cookie header Starlette emits with the SessionMiddleware kwargs we hand NiceGUI."""
+
+    async def touch_session(request: Request) -> PlainTextResponse:
+        request.session["seen"] = True
+        return PlainTextResponse("ok")
+
+    middleware_kwargs = run_kwargs.get("session_middleware_kwargs") or {}
+    app = Starlette(
+        routes=[Route("/", touch_session)],
+        middleware=[Middleware(SessionMiddleware, secret_key="test-secret", **middleware_kwargs)],  # noqa: S106
+    )
+    return TestClient(app).get("/").headers["set-cookie"].lower()
+
+
+class TestSecureCookies:
+    def test_secure_cookies_marks_the_session_cookie_secure(self):
+        config = Config(server={"secure_cookies": True})
+
+        cookie = _session_cookie(reverse_proxy_run_kwargs(config, environ={}))
+
+        assert "; secure" in cookie
+
+    def test_default_keeps_the_cookie_plain_for_http_localhost_setups(self):
+        cookie = _session_cookie(reverse_proxy_run_kwargs(Config(), environ={}))
+
+        assert "secure" not in cookie
+
+
+def _request_after_proxy(run_kwargs: dict, peer: str, headers: dict[str, str]) -> Request:
+    """The Request the app sees once uvicorn applied our ``forwarded_allow_ips``."""
+    seen: list[Request] = []
+
+    async def capture(scope, receive, send):
+        seen.append(Request(scope))
+        await PlainTextResponse("ok")(scope, receive, send)
+
+    proxied = ProxyHeadersMiddleware(capture, trusted_hosts=run_kwargs["forwarded_allow_ips"])
+    TestClient(proxied, client=(peer, 40000)).get("/login", headers=headers)
+    return seen[0]
+
+
+@pytest.fixture
+def _login_storage():
+    # WHY: the login helpers read/write NiceGUI's app.storage.user, which only
+    # exists inside a running NiceGUI request.
+    reset_rate_limiter()
+    with patch("immich_memories.ui.app.app") as mock_app:
+        mock_app.storage.user = {}
+        yield mock_app.storage.user
+    reset_rate_limiter()
+
+
+class TestForwardedClientIp:
+    def test_rate_limiter_keys_on_the_forwarded_visitor_behind_a_trusted_proxy(
+        self, _login_storage
+    ):
+        from immich_memories.ui.app import _check_login_rate_limit
+
+        config = Config(auth={**_BASIC_AUTH, "trusted_proxies": [_PROXY]})
+        run_kwargs = reverse_proxy_run_kwargs(config, environ={})
+        for _ in range(5):
+            record_failed_login(_VISITOR)
+
+        visitor = _request_after_proxy(run_kwargs, _PROXY, {"X-Forwarded-For": _VISITOR})
+        neighbour = _request_after_proxy(run_kwargs, _PROXY, {"X-Forwarded-For": "203.0.113.6"})
+
+        assert _check_login_rate_limit(visitor) is not None
+        assert _check_login_rate_limit(neighbour) is None
+
+    def test_forwarded_header_from_an_untrusted_peer_is_ignored(self, _login_storage):
+        from immich_memories.ui.app import _check_login_rate_limit
+
+        config = Config(auth={**_BASIC_AUTH, "trusted_proxies": [_PROXY]})
+        run_kwargs = reverse_proxy_run_kwargs(config, environ={})
+        for _ in range(5):
+            record_failed_login(_STRANGER)
+
+        spoofed = _request_after_proxy(run_kwargs, _STRANGER, {"X-Forwarded-For": _VISITOR})
+
+        assert _check_login_rate_limit(spoofed) is not None
+
+
+class TestForwardedAllowIpsPrecedence:
+    def test_an_explicit_env_var_wins_over_config(self):
+        config = Config(auth={**_BASIC_AUTH, "trusted_proxies": [_PROXY]})
+
+        run_kwargs = reverse_proxy_run_kwargs(config, environ={"FORWARDED_ALLOW_IPS": "*"})
+
+        # uvicorn reads FORWARDED_ALLOW_IPS itself; passing the kwarg would silently override it.
+        assert "forwarded_allow_ips" not in run_kwargs
+
+
+class TestHeaderProvider:
+    def test_header_auth_still_sees_the_proxy_when_it_forwards_the_visitor_ip(self, _login_storage):
+        from immich_memories.ui.app import _try_header_auth
+
+        config = Config(auth={"enabled": True, "provider": "header", "trusted_proxies": [_PROXY]})
+        run_kwargs = reverse_proxy_run_kwargs(config, environ={})
+
+        request = _request_after_proxy(
+            run_kwargs, _PROXY, {"X-Forwarded-For": _VISITOR, "Remote-User": "alice"}
+        )
+        _try_header_auth(request, config.auth)
+
+        assert _login_storage.get("authenticated") is True
+
+
+class _FakeOAuth:
+    """authlib stand-in that records the redirect_uri the app hands to the IdP."""
+
+    def __init__(self) -> None:
+        self.oidc = self
+        self.redirect_uri = ""
+
+    async def authorize_redirect(self, request: Request, redirect_uri: str) -> RedirectResponse:
+        self.redirect_uri = redirect_uri
+        return RedirectResponse("https://idp.example.com/authorize")
+
+
+class TestOidcRedirectUri:
+    def _redirect_uri_for(self, peer: str) -> str:
+        from immich_memories.ui.app import app
+
+        config = Config(
+            auth={
+                "enabled": True,
+                "provider": "oidc",
+                "issuer_url": "https://idp.example.com",
+                "client_id": "memories",
+                "trusted_proxies": [_PROXY],
+            }
+        )
+        run_kwargs = reverse_proxy_run_kwargs(config, environ={})
+        served = ProxyHeadersMiddleware(app, trusted_hosts=run_kwargs["forwarded_allow_ips"])
+        oauth = _FakeOAuth()
+        with (
+            # WHY: the app reads its config from disk; the test decides who the proxy is.
+            patch("immich_memories.ui.app.get_config", return_value=config),
+            # WHY: authlib would fetch the IdP's discovery document over the network.
+            patch("immich_memories.ui.auth_oidc.create_oidc_client", return_value=oauth),
+        ):
+            TestClient(served, client=(peer, 40000), follow_redirects=False).get(
+                "/auth/authorize",
+                headers={"Host": "memories.example.com", "X-Forwarded-Proto": "https"},
+            )
+        return oauth.redirect_uri
+
+    def test_redirect_uri_is_https_when_the_trusted_proxy_forwards_the_scheme(self):
+        assert self._redirect_uri_for(_PROXY) == "https://memories.example.com/auth/callback"
+
+    def test_redirect_uri_ignores_the_scheme_claimed_by_an_untrusted_peer(self):
+        assert self._redirect_uri_for(_STRANGER) == "http://memories.example.com/auth/callback"


### PR DESCRIPTION
## Summary

Closes #306.

Behind Docker + Traefik every visitor arrived as the proxy's IP (five wrong passwords locked the whole household out of login for 10 minutes), the OIDC `redirect_uri` was built as `http://`, and the session cookie could never be marked `Secure`.

- **`server.secure_cookies: bool`** (Tier 2, default `false`) → passed to NiceGUI as `session_middleware_kwargs={"https_only": True}` (NiceGUI 3.16 forwards it to Starlette's `SessionMiddleware`), so the session cookie carries the `Secure` flag.
- **`auth.trusted_proxies`** (already existed for the header provider) now also feeds uvicorn's `forwarded_allow_ips` (through `ui.run(**kwargs)`), so `X-Forwarded-For` / `X-Forwarded-Proto` from those proxies drive the login rate limiter (`request.client.host`) and the OIDC `redirect_uri` (`request.url_for`). Precedence: an explicit `FORWARDED_ALLOW_IPS` env var still wins (the kwarg is simply not passed, uvicorn reads the env itself).
- With `provider: header` the forwarded headers are deliberately **not** applied (`forwarded_allow_ips=[]`): header auth trusts the proxy by the address it connects from, and once uvicorn rewrites `request.client` to the visitor that check would fail. Rate limiter / OIDC redirect don't apply to that provider anyway. Documented.
- New `src/immich_memories/ui/reverse_proxy.py` holds the kwargs logic (app.py stays under the 800-line gate; the change there is 2 lines).
- Docs: `authentication.mdx` warning box rewritten (no longer says the cookie is never Secure), `config-reference.md` (`secure_cookies`, `trusted_proxies` comment), `environment-variables.md` (`FORWARDED_ALLOW_IPS` precedence), `ARCHITECTURE.md`.

## Test plan

- [x] `tests/test_reverse_proxy.py` (8 tests, TDD):
  - Secure flag present/absent on the actual `Set-Cookie` emitted by Starlette's `SessionMiddleware` built with the kwargs we hand NiceGUI
  - login rate limiter keys on the forwarded visitor IP behind a trusted proxy (real `_check_login_rate_limit` behind uvicorn's `ProxyHeadersMiddleware` configured with our kwargs)
  - a forged `X-Forwarded-For` from an untrusted peer is ignored
  - `FORWARDED_ALLOW_IPS` env wins over config
  - header provider: `Remote-User` from the proxy still authenticates when the proxy forwards the visitor IP
  - OIDC `redirect_uri` is `https://…` under a forwarded request through the real `app`, and stays `http://…` when an untrusted peer claims the scheme
- [x] `make ci` green (4596 passed), `make critique` nothing new for the touched files
- [x] `make docs-build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
