### PR TITLE
fix(analysis): fetch missing thumbnails before phase-1 de-dup on the CLI path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,6 +130,7 @@ src/immich_memories/
 │   ├── duplicates.py           # Duplicate/near-duplicate detection
 │   ├── duplicate_hashing.py    # Perceptual hashing for duplicates
 │   ├── thumbnail_clustering.py # Thumbnail-based clustering
+│   ├── thumbnail_prefetch.py   # ThumbnailPrefetcher: fills the thumbnail cache before phase 1 (CLI/auto path)
 │   ├── scoring.py              # Quality scoring (face, motion, duration, segments)
 │   ├── scenes.py               # Scene detection
 │   ├── silence_detection.py    # Audio silence detection

--- a/docs-site/docs/create/pipeline/duplicate-detection.md
+++ b/docs-site/docs/create/pipeline/duplicate-detection.md
@@ -13,6 +13,8 @@ Each video gets a perceptual hash: a fingerprint based on what the video *looks 
 
 The hamming distance between hashes determines similarity. A distance of 0 means identical. Higher values mean more different.
 
+Hashes are computed on Immich's preview thumbnails, not the full videos. The web UI caches those in Step 1. `generate` and `auto run` fetch whatever is missing at the start of the clustering phase, using `analysis.download_workers` parallel clients (3 by default), so the automated path de-duplicates the same way the UI does. Previews are cached on disk, so a second run over the same clips fetches nothing. If a preview can't be fetched, that clip skips duplicate detection, a warning is logged, and the run continues.
+
 ## Configuration
 
 ```yaml

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -71,7 +71,7 @@ analysis:
   duplicate_hash_threshold: 8    # Perceptual hash threshold (0-64)
 
   # Performance
-  download_workers: 3            # Parallel download clients for video prefetching (1-8)
+  download_workers: 3            # Parallel download clients for video and thumbnail prefetching (1-8)
   enable_downscaling: true       # Downscale for analysis (~3-5x faster)
   analysis_resolution: 480       # Target height for analysis (240-1080)
 

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -21,6 +21,7 @@ from immich_memories.analysis.clip_refiner import ClipRefiner
 from immich_memories.analysis.clip_scaler import ClipScaler
 from immich_memories.analysis.preview_builder import PreviewBuilder
 from immich_memories.analysis.progress import PipelinePhase, ProgressTracker
+from immich_memories.analysis.thumbnail_prefetch import ThumbnailPrefetcher
 
 if TYPE_CHECKING:
     from immich_memories.api.immich import SyncImmichClient
@@ -203,6 +204,12 @@ class SmartPipeline:
         )
         self.scaler = ClipScaler()
         self.refiner = ClipRefiner(self.config, self.scaler)
+        self.thumbnail_prefetcher = ThumbnailPrefetcher.from_client(
+            client,
+            thumbnail_cache,
+            api_policy=app_config.immich.api_version,
+            max_workers=analysis_config.download_workers,
+        )
 
     def run(
         self,
@@ -374,6 +381,7 @@ class SmartPipeline:
         from immich_memories.analysis.thumbnail_clustering import deduplicate_by_thumbnails
 
         self.tracker.start_phase(PipelinePhase.CLUSTERING, len(clips))
+        self.thumbnail_prefetcher.ensure_cached(clips)
 
         def progress(current: int, total: int) -> None:
             if current <= len(clips) and current > 0:

--- a/src/immich_memories/analysis/thumbnail_prefetch.py
+++ b/src/immich_memories/analysis/thumbnail_prefetch.py
@@ -1,0 +1,128 @@
+"""Fill the thumbnail cache before phase-1 clustering.
+
+The web UI pre-caches Immich previews in Step 1, so thumbnail de-dup always
+had hashes there. ``generate`` and ``auto run`` never populated the cache,
+so the same phase hashed nothing and silently kept burst duplicates (#316).
+This module fetches whatever previews are missing with the same bounded,
+isolated-client worker pattern the video prefetcher uses.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from immich_memories.processing.download_coordinator import (
+    DownloadClientFactory,
+    DownloadCoordinator,
+    DownloadTarget,
+    PrefetchAsset,
+    build_sync_client_factory,
+    has_sync_client_connection,
+)
+from immich_memories.security import sanitize_error_message
+
+if TYPE_CHECKING:
+    from immich_memories.api.compatibility import ApiVersionPolicy
+    from immich_memories.api.immich import SyncImmichClient
+    from immich_memories.api.models import VideoClipInfo
+    from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+logger = logging.getLogger(__name__)
+
+THUMBNAIL_SIZE = "preview"
+
+
+class ThumbnailPrefetcher:
+    """Best-effort preview fetcher; failures degrade de-dup, never abort the run."""
+
+    def __init__(
+        self,
+        thumbnail_cache: ThumbnailCache,
+        client_factory: DownloadClientFactory | None,
+        *,
+        max_workers: int,
+    ) -> None:
+        self._thumbnail_cache = thumbnail_cache
+        self._client_factory = client_factory
+        self._max_workers = max_workers
+
+    @classmethod
+    def from_client(
+        cls,
+        client: SyncImmichClient,
+        thumbnail_cache: ThumbnailCache,
+        *,
+        api_policy: ApiVersionPolicy,
+        max_workers: int,
+    ) -> ThumbnailPrefetcher:
+        """Seed isolated worker clients from the pipeline's client when possible."""
+        factory = None
+        if has_sync_client_connection(client):
+            factory = build_sync_client_factory(client, api_policy)
+        return cls(thumbnail_cache, factory, max_workers=max_workers)
+
+    def ensure_cached(self, clips: Sequence[VideoClipInfo]) -> None:
+        """Fetch previews that are not cached yet; log (never raise) on failure."""
+        missing = [
+            clip for clip in clips if not self._thumbnail_cache.has(clip.asset.id, THUMBNAIL_SIZE)
+        ]
+        if not missing:
+            return
+        if self._client_factory is None:
+            logger.warning(
+                "Phase 1: %d clips have no cached thumbnail and the client cannot seed "
+                "thumbnail workers; duplicate detection is skipped for them",
+                len(missing),
+            )
+            return
+
+        logger.info(
+            "Phase 1: fetching %d missing thumbnails with %d workers",
+            len(missing),
+            self._max_workers,
+        )
+        try:
+            fetched = self._fetch(missing, self._client_factory)
+        except Exception as exc:  # WHY: prefetch is best-effort; the run must continue
+            logger.warning(
+                "Phase 1: thumbnail prefetch failed (%s); duplicate detection runs on "
+                "cached thumbnails only",
+                sanitize_error_message(str(exc)),
+            )
+            return
+
+        failed = len(missing) - fetched
+        if failed:
+            logger.warning(
+                "Phase 1: %d of %d thumbnails could not be fetched; those clips are "
+                "excluded from duplicate detection",
+                failed,
+                len(missing),
+            )
+
+    def _fetch(self, clips: Sequence[VideoClipInfo], client_factory: DownloadClientFactory) -> int:
+        cache = self._thumbnail_cache
+
+        def fetch_thumbnail(client: SyncImmichClient, asset: PrefetchAsset) -> Path | None:
+            data = client.get_asset_thumbnail(asset.id, size=THUMBNAIL_SIZE)
+            if not data:
+                return None
+            return cache.put(asset.id, THUMBNAIL_SIZE, data)
+
+        coordinator = DownloadCoordinator(
+            client_factory,
+            None,
+            self._max_workers,
+            download_operation=fetch_thumbnail,
+        )
+        # Synthetic targets keep the fetch keyed on the clip's own asset ID:
+        # live photos need the photo asset's preview, not the video component's.
+        targets = [DownloadTarget(id=clip.asset.id) for clip in clips]
+        results = coordinator.prefetch(targets)
+        for result in results.values():
+            if result.error:
+                logger.debug("Thumbnail %s: %s", result.asset_id[:8], result.error)
+        return sum(1 for result in results.values() if result.path is not None)

--- a/src/immich_memories/cache/thumbnail_cache.py
+++ b/src/immich_memories/cache/thumbnail_cache.py
@@ -26,6 +26,9 @@ class ThumbnailCache:
             return path.read_bytes()
         return None
 
+    def has(self, asset_id: str, size: str) -> bool:
+        return self._path(asset_id, size).exists()
+
     def get_batch(self, asset_ids: set[str] | list[str], size: str) -> dict[str, bytes]:
         result: dict[str, bytes] = {}
         for asset_id in asset_ids:
@@ -34,10 +37,11 @@ class ThumbnailCache:
                 result[asset_id] = data
         return result
 
-    def put(self, asset_id: str, size: str, data: bytes) -> None:
+    def put(self, asset_id: str, size: str, data: bytes) -> Path:
         path = self._path(asset_id, size)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
+        return path
 
     def clear(self) -> int:
         """Remove all cached thumbnails. Returns count of removed files."""

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -89,7 +89,7 @@ class AnalysisConfig(BaseModel):
         default=3,
         ge=1,
         le=8,
-        description="Concurrent isolated clients used for video download prefetching",
+        description="Concurrent isolated clients used for video and thumbnail prefetching",
     )
     scene_threshold: float = Field(default=27.0, ge=1.0, le=100.0)
     min_scene_duration: float = Field(default=1.0, ge=0.5, le=10.0)

--- a/tests/test_thumbnail_prefetch.py
+++ b/tests/test_thumbnail_prefetch.py
@@ -1,0 +1,169 @@
+"""Phase-1 thumbnail prefetch: de-dup must work without the UI's pre-cached previews."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+try:
+    import cv2
+except ImportError:
+    pytest.skip("cv2 not available", allow_module_level=True)
+
+from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+from immich_memories.api.immich import SyncImmichClient
+from immich_memories.cache.thumbnail_cache import ThumbnailCache
+from immich_memories.config_loader import Config
+from immich_memories.config_models import AnalysisConfig
+from tests.conftest import make_clip
+
+
+def _jpeg(split: str) -> bytes:
+    """A 64x64 half-black/half-white JPEG; the split axis makes distinct hashes."""
+    img = np.zeros((64, 64, 3), dtype=np.uint8)
+    if split == "vertical":
+        img[:, 32:] = 255
+    else:
+        img[32:, :] = 255
+    ok, encoded = cv2.imencode(".jpg", img)
+    assert ok
+    return encoded.tobytes()
+
+
+class _ThumbnailServer:
+    """Localhost stand-in for the Immich thumbnail endpoint (the read boundary)."""
+
+    def __init__(
+        self,
+        thumbnails: dict[str, bytes],
+        failing: set[str] | None = None,
+        latency: float = 0.0,
+    ) -> None:
+        self.thumbnails = thumbnails
+        self.failing = failing or set()
+        self.latency = latency
+        self.requested: list[str] = []
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802
+                parts = self.path.split("?")[0].strip("/").split("/")
+                asset_id = parts[2] if len(parts) == 4 and parts[3] == "thumbnail" else None
+                with server._lock:
+                    server._in_flight += 1
+                    server.max_in_flight = max(server.max_in_flight, server._in_flight)
+                    if asset_id:
+                        server.requested.append(asset_id)
+                try:
+                    time.sleep(server.latency)
+                    if asset_id in server.failing or asset_id not in server.thumbnails:
+                        # 404 is non-retryable, so failures stay fast in tests.
+                        self.send_response(404)
+                        self.end_headers()
+                    else:
+                        body = server.thumbnails[asset_id]
+                        self.send_response(200)
+                        self.send_header("Content-Type", "image/jpeg")
+                        self.send_header("Content-Length", str(len(body)))
+                        self.end_headers()
+                        self.wfile.write(body)
+                finally:
+                    with server._lock:
+                        server._in_flight -= 1
+
+            def log_message(self, _format: str, *args: object) -> None:
+                pass
+
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        host, port = self._httpd.server_address[:2]
+        self.base_url = f"http://{host}:{port}"
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+@pytest.fixture()
+def thumbnail_server():
+    server = _ThumbnailServer(
+        {
+            "dup-a": _jpeg("vertical"),
+            "dup-b": _jpeg("vertical"),
+            "other": _jpeg("horizontal"),
+        }
+    )
+    yield server
+    server.close()
+
+
+def _cli_pipeline(
+    server: _ThumbnailServer, cache_dir: Path, analysis_config: AnalysisConfig | None = None
+) -> SmartPipeline:
+    """Build the pipeline the way the CLI does: fresh, empty thumbnail cache."""
+    # WHY: the analysis DB is a write boundary; returning no cached analysis
+    # keeps planning on the metadata fallback path.
+    analysis_cache = MagicMock()
+    analysis_cache.get_analysis.return_value = None
+    client = SyncImmichClient(base_url=server.base_url, api_key="test-key", timeout=5.0)
+    return SmartPipeline(
+        client=client,
+        analysis_cache=analysis_cache,
+        thumbnail_cache=ThumbnailCache(cache_dir=cache_dir),
+        config=PipelineConfig(target_clips=10, avg_clip_duration=5.0),
+        analysis_config=analysis_config or AnalysisConfig(),
+        app_config=Config(),
+    )
+
+
+def test_cli_path_deduplicates_near_duplicates_without_precached_thumbnails(
+    thumbnail_server, tmp_path
+):
+    clips = [make_clip("dup-a"), make_clip("dup-b"), make_clip("other")]
+    pipeline = _cli_pipeline(thumbnail_server, tmp_path / "thumbs")
+
+    planned = pipeline.run_planning_analysis(clips)
+
+    kept = {entry.clip.asset.id for entry in planned}
+    assert "other" in kept
+    assert len(kept & {"dup-a", "dup-b"}) == 1
+    assert sorted(thumbnail_server.requested) == ["dup-a", "dup-b", "other"]
+
+    pipeline.run_planning_analysis(clips)
+    assert len(thumbnail_server.requested) == 3, "second run must reuse the cache"
+
+
+def test_thumbnail_fetch_failure_degrades_gracefully(thumbnail_server, tmp_path, caplog):
+    thumbnail_server.failing.add("other")
+    clips = [make_clip("dup-a"), make_clip("dup-b"), make_clip("other")]
+    pipeline = _cli_pipeline(thumbnail_server, tmp_path / "thumbs")
+
+    with caplog.at_level(logging.WARNING, logger="immich_memories.analysis"):
+        planned = pipeline.run_planning_analysis(clips)
+
+    kept = {entry.clip.asset.id for entry in planned}
+    assert "other" in kept
+    assert len(kept & {"dup-a", "dup-b"}) == 1
+    assert any("1 of 3 thumbnails could not be fetched" in rec.message for rec in caplog.records)
+
+
+def test_thumbnails_are_fetched_with_bounded_workers(tmp_path):
+    server = _ThumbnailServer({f"clip-{i}": _jpeg("vertical") for i in range(6)}, latency=0.1)
+    try:
+        pipeline = _cli_pipeline(server, tmp_path / "thumbs", AnalysisConfig(download_workers=2))
+        pipeline.run_planning_analysis([make_clip(f"clip-{i}") for i in range(6)])
+    finally:
+        server.close()
+
+    assert 1 < server.max_in_flight <= 2


### PR DESCRIPTION
## Summary

Phase-1 thumbnail de-duplication only ever worked in the web UI, because the UI is the only thing that filled the thumbnail cache (Step 1 caching / clip review). On `immich-memories generate` and `auto run`, `_phase_cluster` hashed zero thumbnails and silently kept every burst duplicate — on exactly the path we point automated users to.

- New `analysis/thumbnail_prefetch.py`: `ThumbnailPrefetcher` fetches the previews that are missing from the cache before clustering, through the existing `DownloadCoordinator` (bounded, one isolated sync client per worker, `analysis.download_workers` — default 3). Failures are per-clip and best-effort: a warning says how many previews could not be fetched, those clips just skip de-dup, and the run continues. If the client cannot seed workers at all, it logs a warning instead of silently doing nothing.
- `SmartPipeline._phase_cluster` calls it before `deduplicate_by_thumbnails`, so CLI, scheduler and UI now share the same de-dup behaviour. Second runs fetch nothing (cache hit).
- `ThumbnailCache.has()` (existence check without reading bytes) and `put()` returns the written path.
- Docs: duplicate-detection page explains where the hashes come from; `download_workers` description mentions thumbnails.

No new config knob. No change to `_pipeline_runner.py`.

Closes #316

## Test plan

- [x] `tests/test_thumbnail_prefetch.py`: real `SyncImmichClient` + real `ThumbnailCache` against a localhost thumbnail server — CLI-style pipeline (empty cache) now de-dups two identical previews and keeps a distinct one; second run makes no requests; a 404 for one asset degrades to a warning and the clip is kept; 6 assets with `download_workers=2` never exceed 2 in-flight requests
- [x] `make ci` green locally
- [x] `make docs-build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
