### PR TITLE
fix(ui): Step 4 recovers a generation that outlived the browser page

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -285,6 +285,7 @@ src/immich_memories/
 │       ├── _step3_music_preview.py # Music preview controls
 │       ├── step4_export.py         # Export & download
 │       ├── _step4_generate.py      # Generation logic
+│       ├── step4_recovery.py       # Reload recovers a run that outlived the page
 │       ├── _step4_upload.py        # Upload-back to Immich
 │       ├── _step4_music.py         # Music generation/mixing helpers
 │       └── settings_config.py      # Settings page

--- a/docs-site/docs/create/web-ui/step4-preview-export.mdx
+++ b/docs-site/docs/create/web-ui/step4-preview-export.mdx
@@ -54,6 +54,20 @@ During assembly, a preview image updates as frames are rendered, so you can watc
 
 <ThemedScreenshot name="step4-complete" alt="Generation complete with video ready" />
 
+### If the page loses the run
+
+The render keeps going on the server even if the browser tab is reloaded, throttled, or
+its connection drops. Reload Step 4 and you get one of:
+
+- **"A generation started at HH:MM is still running (run …)"** — the page re-checks every few
+  seconds and switches to the result on its own.
+- the **Result** header with the finished video, if it completed while the page was away.
+- a warning that the last run failed (or was still marked running hours later — the process died),
+  with a pointer to the server log. Generating again is always allowed.
+
+The server log also says `Run … finished (…) but the browser had disconnected; reload Step 4`
+whenever a completion screen could not be delivered.
+
 ## Re-generating
 
 If the result isn't right, **Back to Generation Options** or go back to Step 2, adjust clip selection or settings, and generate again. The analysis cache means you don't re-analyze anything. **Start New Project** clears the session and returns to Step 1.

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -107,8 +107,9 @@ def _write_completion_ui(
     output_container,
     result_path: Path,
     state,
+    run_id: str | None = None,
 ) -> bool:
-    """Render completed-artifact facts unless the NiceGUI client disconnected."""
+    """Render completed-artifact facts; say where the result went if the client is gone."""
 
     def write() -> None:
         run_id_label.set_text(f"Output: {result_path.parent.name}")
@@ -117,7 +118,14 @@ def _write_completion_ui(
         cancel_btn.set_visibility(False)
         _show_output(output_container, result_path, state)
 
-    return run_ui_observer(write, description="generation completion UI")
+    shown = run_ui_observer(write, description="generation completion UI")
+    if not shown:
+        logger.info(
+            "Run %s finished (%s) but the browser had disconnected; reload Step 4 to see the result",
+            run_id,
+            result_path,
+        )
+    return shown
 
 
 def _write_failure_ui(
@@ -353,10 +361,9 @@ async def run_generation(
 
         from immich_memories.tracking import RunTracker, generate_run_id
 
-        run_tracker = RunTracker(
-            generate_run_id(),
-            db_path=params.config.cache.database_path,
-        )
+        run_id = generate_run_id()
+        run_tracker = RunTracker(run_id, db_path=params.config.cache.database_path)
+        state.active_run_id = run_id
         prepared = await execute_ui_generation(
             state,
             params,
@@ -376,6 +383,7 @@ async def run_generation(
             output_container,
             result_path,
             state,
+            run_id=run_id,
         )
 
     except Exception as e:  # WHY: UI graceful degradation

--- a/src/immich_memories/ui/pages/step4_export.py
+++ b/src/immich_memories/ui/pages/step4_export.py
@@ -50,6 +50,36 @@ def _render_existing_result(state) -> None:
     )
 
 
+def _render_recovered_run(state) -> None:
+    """Tell a reloaded page about a run that outlived the previous page (#322)."""
+    from immich_memories.ui.pages.step4_recovery import recover_active_run
+
+    recovered = recover_active_run(state)
+    if recovered is None or recovered.status == "completed":
+        return  # a completed run is restored into state and shown by _render_existing_result
+    run_id = recovered.run.run_id if recovered.run else state.active_run_id
+    if recovered.status == "running":
+        started = recovered.run.created_at.astimezone().strftime("%H:%M") if recovered.run else "…"
+        im_info_card(
+            f"A generation started at {started} is still running (run {run_id}). "
+            "This page checks every few seconds and shows the video when it finishes.",
+            variant="info",
+        )
+
+        def poll() -> None:
+            current = recover_active_run(state)
+            if current is None or current.status != "running":
+                ui.navigate.reload()
+
+        ui.timer(5.0, poll)
+        return
+    if recovered.status == "stale":
+        message = f"Run {run_id} was still marked running hours later — it did not finish. "
+    else:
+        message = f"The last generation (run {run_id}) {recovered.status}. "
+    im_info_card(message + "Check the server log, then generate again.", variant="warning")
+
+
 def _render_photo_preview(state, photos_count: int) -> None:
     """Render the optional photo pool without inflating the page orchestrator."""
     if not photos_count:
@@ -189,7 +219,8 @@ def render_step4() -> None:
         "w-full"
     )
 
-    # Video result (if already generated) — below generate button, capped height
+    # A run that finished (or is still running) while this page was gone — below the button
+    _render_recovered_run(state)
     _render_existing_result(state)
 
     im_separator()

--- a/src/immich_memories/ui/pages/step4_recovery.py
+++ b/src/immich_memories/ui/pages/step4_recovery.py
@@ -1,0 +1,62 @@
+"""Recover Step 4 after a reload while a generation was, or still is, running.
+
+The generation coroutine outlives the browser page: NiceGUI deletes the client on
+disconnect, UI writes to it are dropped, and a fresh Step 4 knows nothing about the
+run. The session state keeps the run id; the run table keeps the truth (#322).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Literal
+
+from immich_memories.tracking import RunDatabase
+from immich_memories.ui.pages._step4_generate import _restore_completed_ui_state
+
+if TYPE_CHECKING:
+    from immich_memories.tracking.models import RunMetadata
+
+RecoveredStatus = Literal["running", "completed", "failed", "cancelled", "stale"]
+
+# WHY: a "running" row this old means the process died mid-run (there is no UI timeout);
+# without a cutoff every Step 4 visit would poll it forever.
+STALE_AFTER = timedelta(hours=3)
+
+
+@dataclass(frozen=True)
+class RecoveredRun:
+    status: RecoveredStatus
+    run: RunMetadata | None
+
+
+def recover_active_run(state, db: RunDatabase | None = None) -> RecoveredRun | None:
+    """Reconcile the session's active run with the run table; restore a finished artifact.
+
+    Returns None when the session has no run to recover. A run id without a row yet is
+    still "running" (the tracker writes its row a moment after the click). Terminal
+    failures are reported once and then forgotten so they do not haunt every visit.
+    """
+    run_id = state.active_run_id
+    if not run_id:
+        return None
+    database = db or RunDatabase(state.config.cache.database_path)
+    run = database.get_run(run_id)
+    if run is None:
+        return RecoveredRun("running", None)
+    if run.status == "running":
+        if _age(run.created_at) > STALE_AFTER:
+            state.active_run_id = None
+            return RecoveredRun("stale", run)
+        return RecoveredRun("running", run)
+    if run.status == "completed":
+        _restore_completed_ui_state(state, run)
+        state.active_run_id = None
+        return RecoveredRun("completed", run)
+    state.active_run_id = None
+    return RecoveredRun(run.status, run)
+
+
+def _age(created_at: datetime) -> timedelta:
+    started = created_at if created_at.tzinfo else created_at.replace(tzinfo=UTC)
+    return datetime.now(tz=UTC) - started

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -65,6 +65,9 @@ class AppState:
     generation_options: dict[str, Any] = field(default_factory=dict)
     processing: bool = False
     output_path: Path | None = None
+    # WHY: survives a page reload (state is cookie-keyed) so Step 4 can find a run
+    # that finished, or is still running, while the browser page was gone.
+    active_run_id: str | None = None
     generation_warning: str | None = None
     delivery_status: DeliveryStatus = DeliveryStatus.NOT_REQUESTED
 

--- a/tests/e2e/test_launch_smoke.py
+++ b/tests/e2e/test_launch_smoke.py
@@ -177,30 +177,12 @@ def _choose(page: Page, label: str, option: str) -> None:
     expect(select).to_have_value(option)
 
 
-def test_launch_flow_renders_real_video(
-    page: Page,
-    launch_app_url: str,
-    launch_workspace,
-) -> None:
-    """The default v3 monthly flow must publish and record one real H.264 video."""
+def _drive_to_step4(page: Page, launch_app_url: str) -> None:
+    """Walk the default v3 monthly flow up to the Step 4 'Generate Video' button."""
     page.goto(launch_app_url, wait_until="domcontentloaded", timeout=30_000)
-
     expect(page.get_by_text("Immich Connection — Fake Immich User", exact=True)).to_be_visible(
         timeout=30_000
     )
-    readiness = page.request.get(f"{launch_app_url}/health/ready")
-    assert readiness.status == 200
-    assert readiness.json()["immich"] == {
-        "status": "ready",
-        "reachable": True,
-        "api_version_policy": "auto",
-        "resolved_api_version": "v3",
-    }
-    launch_config = yaml.safe_load(launch_workspace.config_path.read_text())
-    assert launch_config["advanced"]["hardware"]["enabled"] is False
-    assert launch_config["advanced"]["musicgen"]["enabled"] is False
-    assert launch_config["advanced"]["ace_step"]["enabled"] is False
-
     page.get_by_text("Monthly Highlights", exact=True).click()
     _choose(page, "Month", "June")
     include_photos = page.locator(".q-toggle").filter(has_text="Include Photos")
@@ -227,6 +209,29 @@ def test_launch_flow_renders_real_video(
     _choose(page, "Output Format", "MP4 (H.264)")
     _choose(page, "Background music", "None")
     page.get_by_role("button", name="Next: Preview & Export").click()
+
+
+def test_launch_flow_renders_real_video(
+    page: Page,
+    launch_app_url: str,
+    launch_workspace,
+) -> None:
+    """The default v3 monthly flow must publish and record one real H.264 video."""
+    page.goto(launch_app_url, wait_until="domcontentloaded", timeout=30_000)
+    readiness = page.request.get(f"{launch_app_url}/health/ready")
+    assert readiness.status == 200
+    assert readiness.json()["immich"] == {
+        "status": "ready",
+        "reachable": True,
+        "api_version_policy": "auto",
+        "resolved_api_version": "v3",
+    }
+    launch_config = yaml.safe_load(launch_workspace.config_path.read_text())
+    assert launch_config["advanced"]["hardware"]["enabled"] is False
+    assert launch_config["advanced"]["musicgen"]["enabled"] is False
+    assert launch_config["advanced"]["ace_step"]["enabled"] is False
+
+    _drive_to_step4(page, launch_app_url)
     page.get_by_role("button", name="Generate Video").click()
 
     expect(page.get_by_text("Your memory video is ready!", exact=True)).to_be_visible(
@@ -260,3 +265,29 @@ def test_launch_flow_renders_real_video(
     assert len(completed) == 1
     assert Path(completed[0].output_path or "") == output_path
     assert database.list_runs(status="running") == []
+
+
+def test_reload_during_generation_recovers_the_finished_video(
+    page: Page,
+    launch_app_url: str,
+    launch_workspace,
+) -> None:
+    """A page reload mid-render must show the run is still going, then the result (#322)."""
+    before = set(launch_workspace.output_dir.rglob("*.mp4"))
+    _drive_to_step4(page, launch_app_url)
+    page.get_by_role("button", name="Generate Video").click()
+    expect(page.locator(".q-linear-progress").first).to_be_visible(timeout=30_000)
+
+    # WHY: a reload is what a user does when the progress bar seems stuck; it also deletes
+    # the NiceGUI client, so every later UI write from the running coroutine is dropped.
+    page.reload(wait_until="domcontentloaded", timeout=30_000)
+
+    expect(page.get_by_text(re.compile(r"is still running \(run "))).to_be_visible(timeout=30_000)
+    expect(page.get_by_text(re.compile(r"^Saved to: "))).to_be_visible(timeout=600_000)
+
+    outputs = set(launch_workspace.output_dir.rglob("*.mp4")) - before
+    assert len(outputs) == 1
+    completed = RunDatabase(launch_workspace.database_path).list_runs(
+        status="completed", source="manual", order_by_completion=True
+    )
+    assert completed and Path(completed[0].output_path or "") == outputs.pop()

--- a/tests/test_step4_recovery.py
+++ b/tests/test_step4_recovery.py
@@ -1,0 +1,122 @@
+"""Step 4 must recover a generation that outlived the browser page (#322)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.config_loader import Config
+from immich_memories.processing.output_contract import OutputProbe
+from immich_memories.tracking import RunDatabase, RunTracker
+from immich_memories.ui.pages.step4_recovery import recover_active_run
+from immich_memories.ui.state import AppState
+
+
+def _state(tmp_path: Path) -> AppState:
+    config = Config(cache={"database": str(tmp_path / "runs.db")})
+    return AppState(config=config)
+
+
+def _tracker(state: AppState, run_id: str) -> RunTracker:
+    return RunTracker(run_id, db_path=state.config.cache.database_path)
+
+
+def _complete(tracker: RunTracker, output_path: Path) -> None:
+    output_path.write_bytes(b"video")
+    probe = OutputProbe(
+        codec="h264",
+        duration_seconds=1.0,
+        size_bytes=5,
+        pixel_format="yuv420p",
+        color_transfer="bt709",
+        color_primaries="bt709",
+        width=1280,
+        height=720,
+        decoded_frames=30,
+        container="mp4",
+    )
+    tracker.complete_artifact(
+        output_path, probe, warnings=["one warning"], clips_analyzed=1, clips_selected=1
+    )
+
+
+def test_no_active_run_means_nothing_to_recover(tmp_path: Path) -> None:
+    assert recover_active_run(_state(tmp_path)) is None
+
+
+def test_completed_run_restores_output_into_the_session(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.active_run_id = "run-done"
+    tracker = _tracker(state, "run-done")
+    tracker.start_run(source="manual")
+    _complete(tracker, tmp_path / "memory.mp4")
+
+    recovered = recover_active_run(state)
+
+    assert recovered is not None
+    assert recovered.status == "completed"
+    assert state.output_path == tmp_path / "memory.mp4"
+    assert state.generation_warning == "one warning"
+
+
+def test_running_run_is_reported_as_in_progress(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.active_run_id = "run-live"
+    _tracker(state, "run-live").start_run(source="manual")
+
+    recovered = recover_active_run(state)
+
+    assert recovered is not None
+    assert recovered.status == "running"
+    assert recovered.run is not None and recovered.run.run_id == "run-live"
+    assert state.output_path is None
+
+
+def test_run_that_has_not_written_its_row_yet_still_counts_as_running(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.active_run_id = "run-starting"
+    RunDatabase(state.config.cache.database_path)  # schema only, no row
+
+    recovered = recover_active_run(state)
+
+    assert recovered is not None
+    assert recovered.status == "running"
+    assert recovered.run is None
+
+
+def test_failed_run_is_reported_and_forgotten(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    state.active_run_id = "run-failed"
+    tracker = _tracker(state, "run-failed")
+    tracker.start_run(source="manual")
+    tracker.fail_run("encoder exploded")
+
+    recovered = recover_active_run(state)
+
+    assert recovered is not None
+    assert recovered.status == "failed"
+    assert state.active_run_id is None
+
+
+def test_running_row_older_than_the_stale_window_is_reported_stale_and_forgotten(
+    tmp_path: Path,
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from immich_memories.tracking.models import RunMetadata
+
+    state = _state(tmp_path)
+    state.active_run_id = "run-orphan"
+    RunDatabase(state.config.cache.database_path).save_run(
+        RunMetadata(
+            run_id="run-orphan",
+            created_at=datetime.now(tz=UTC) - timedelta(hours=5),
+            status="running",
+            source="manual",
+        )
+    )
+
+    recovered = recover_active_run(state)
+
+    assert recovered is not None
+    assert recovered.status == "stale"
+    assert state.active_run_id is None

--- a/tests/test_ui_disconnect_observers.py
+++ b/tests/test_ui_disconnect_observers.py
@@ -285,6 +285,69 @@ async def test_completion_disconnect_preserves_pending_delivery_truth(
 
 
 @pytest.mark.asyncio
+async def test_completion_disconnect_logs_where_the_finished_run_went(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A skipped completion screen must leave an INFO trail, not silence (#322)."""
+    import logging
+
+    from immich_memories.ui.pages import _step4_generate as step4_generate
+
+    db_path = tmp_path / "runs.db"
+    output_path = tmp_path / "memory.mp4"
+    output_path.write_bytes(b"validated-video")
+    config = Config(cache={"database": str(db_path)})
+    state = AppState(config=config, generation_options={"music_source": "None"})
+    params = GenerationParams(clips=[make_clip("clip-1")], output_path=output_path, config=config)
+    prepared = PreparedGeneration(output_path, _h264_plan(), (), 1, 1)
+
+    async def execute(_state, _params, tracker, _progress, _status):
+        tracker.start_run(source="manual")
+        tracker.complete_artifact(
+            output_path, _probe(), warnings=[], clips_analyzed=1, clips_selected=1
+        )
+        return prepared
+
+    _patch_generation_shell(
+        monkeypatch,
+        step4_generate,
+        params=params,
+        output_path=output_path,
+        execute=execute,
+        run_id="ui-disconnect-logged",
+    )
+    monkeypatch.setattr(
+        step4_generate,
+        "_show_output",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError(_CLIENT_DELETED)),
+    )
+
+    with caplog.at_level(logging.INFO, logger="immich_memories.ui.pages._step4_generate"):
+        await step4_generate.run_generation(
+            state,
+            [make_clip("clip-1")],
+            total_duration=5.0,
+            output_dir=tmp_path,
+            output_path=output_path,
+            filename_input=_Element("memory.mp4"),
+            progress_container=_Container(),
+            output_container=_Container(),
+        )
+
+    skipped = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == step4_generate.logger.name and r.levelno == logging.INFO
+    ]
+    assert len(skipped) == 1, [r.getMessage() for r in caplog.records]
+    assert "ui-disconnect-logged" in skipped[0]
+    assert "reload" in skipped[0].lower()
+    assert str(output_path) in skipped[0]
+
+
+@pytest.mark.asyncio
 async def test_failure_notification_disconnect_preserves_failed_run(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Wave 1 item 2 (#322). Seen 3× during screenshot capture: server logs `Completed artifact for run …`, the browser keeps showing the progress bar, and a reload shows nothing.

**Why:** a reload / throttled tab / dropped websocket makes NiceGUI delete the client. The generation coroutine keeps running (nothing cancels it), but every later UI write is dropped by `run_ui_observer`, and a fresh Step 4 knew nothing about the in-flight run. The video lands on disk; the page looks stuck.

**Fix**
- `AppState.active_run_id` is set when a run starts (state is cookie-keyed, so it survives a reload).
- New `ui/pages/step4_recovery.py` — `recover_active_run(state)` reconciles that id against the run table on every Step 4 render:
  - `completed` → artifact facts restored into the session, shown by the existing **Result** block
  - `running` (or no row yet) → info card "A generation started at HH:MM is still running (run …)" + a 5 s `ui.timer` that reloads the page when it's no longer running
  - `failed` / `cancelled` → warning card once, then forgotten
  - a `running` row older than 3 h → "stale" (process died mid-run) instead of polling forever
- A skipped completion screen now logs at INFO: `Run … finished (…) but the browser had disconnected; reload Step 4 to see the result` (was a DEBUG "skipped").
- `_step4_generate.run_generation` stayed under the cognitive-complexity ceiling by folding the log into `_write_completion_ui`.
- E2E (`tests/e2e/test_launch_smoke.py`): click Generate, `page.reload()` as soon as the progress bar shows, assert the "is still running" card, then assert **Saved to:** appears by itself. Runs in the required `make e2e` (whole suite still ~35 s); the flow steps are shared via `_drive_to_step4`.
- Docs: Step 4 page, new "If the page loses the run".

Closes #322

## Test plan

- [x] `make ci` green (4595 passed)
- [x] `make e2e` green (25 passed), reload test run 3× standalone, strict on the in-progress card
- [x] `make docs-build` OK
- [x] Unit: log trail on skipped completion; recovery for completed / running / no-row-yet / failed / stale (real SQLite run table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM