### PR TITLE
feat(config): `preset: fast` — one switch for CPU-only / NAS boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ analysis results are cached, so the first run of a library is the slow one.
 | Encoding 1080p | 4GB | 4 cores | ~2 min per 5 min of output | ~15 min for a 30-clip video |
 | Encoding 4K | 6-8GB | 4+ cores | ~5 min per 5 min of output | not recommended |
 
+Measured once for calibration (2026-08-18): a 14-clip monthly at 1080p, cold cache, in the Docker
+image with `--cpus=4 --memory=4g` and no GPU took **10 min with `preset: fast`** and 15.7 min
+with the default profile (4 M5 Max cores; a Celeron-class NAS is 2–3× slower). Details in the
+[NAS guide](https://sam-dumont.github.io/immich-video-memory-generator/docs/deploy/common-setups/nas-only#performance-expectations).
+
 Default Docker limits: 4GB RAM, 4 CPUs. A monthly memory (~30 clips) is a coffee break on a
 Mac or GPU box and up to an hour on a NAS; a full year is an overnight job on a NAS. On a
 CPU-only box set `IMMICH_MEMORIES_PRESET=fast` (or `preset: fast` in config.yaml): 1080p H.264,

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ analysis results are cached, so the first run of a library is the slow one.
 | Encoding 4K | 6-8GB | 4+ cores | ~5 min per 5 min of output | not recommended |
 
 Default Docker limits: 4GB RAM, 4 CPUs. A monthly memory (~30 clips) is a coffee break on a
-Mac or GPU box and up to an hour on a NAS; a full year is an overnight job on a NAS. See the
+Mac or GPU box and up to an hour on a NAS; a full year is an overnight job on a NAS. On a
+CPU-only box set `IMMICH_MEMORIES_PRESET=fast` (or `preset: fast` in config.yaml): 1080p H.264,
+fast encoder, static titles, no speech pass, favorites-first analysis — one switch, explicit
+settings still win. See the
 [NAS-only guide](https://sam-dumont.github.io/immich-video-memory-generator/docs/deploy/common-setups/nas-only)
 for a Celeron-class table and the settings that keep it usable.
 

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -850,7 +850,7 @@
         "name": "register_config_commands",
         "complexity": 52,
         "line_start": 14,
-        "line_end": 226,
+        "line_end": 227,
         "line_complexities": [
           {
             "line": 31,
@@ -885,39 +885,35 @@
             "complexity": 0
           },
           {
-            "line": 60,
-            "complexity": 2
-          },
-          {
             "line": 61,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 62,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 63,
+            "complexity": 2
+          },
+          {
+            "line": 64,
             "complexity": 0
           },
           {
-            "line": 65,
+            "line": 66,
             "complexity": 3
           },
           {
-            "line": 68,
+            "line": 69,
             "complexity": 1
           },
           {
-            "line": 73,
+            "line": 74,
             "complexity": 0
           },
           {
-            "line": 77,
-            "complexity": 0
-          },
-          {
-            "line": 83,
+            "line": 78,
             "complexity": 0
           },
           {
@@ -925,104 +921,104 @@
             "complexity": 0
           },
           {
-            "line": 90,
+            "line": 85,
+            "complexity": 0
+          },
+          {
+            "line": 91,
             "complexity": 3
           },
           {
-            "line": 94,
+            "line": 95,
             "complexity": 0
           },
           {
-            "line": 99,
+            "line": 100,
             "complexity": 0
           },
           {
-            "line": 101,
+            "line": 102,
             "complexity": 1
           },
           {
-            "line": 108,
+            "line": 109,
             "complexity": 0
           },
           {
-            "line": 110,
+            "line": 111,
             "complexity": 3
           },
           {
-            "line": 116,
+            "line": 117,
             "complexity": 0
           },
           {
-            "line": 121,
+            "line": 122,
             "complexity": 0
           },
           {
-            "line": 123,
+            "line": 124,
             "complexity": 0
-          },
-          {
-            "line": 127,
-            "complexity": 3
           },
           {
             "line": 128,
+            "complexity": 3
+          },
+          {
+            "line": 129,
             "complexity": 4
           },
           {
-            "line": 138,
+            "line": 139,
             "complexity": 0
           },
           {
-            "line": 140,
+            "line": 141,
             "complexity": 3
           },
           {
-            "line": 146,
+            "line": 147,
             "complexity": 0
           },
           {
-            "line": 151,
+            "line": 152,
             "complexity": 0
           },
           {
-            "line": 154,
+            "line": 155,
             "complexity": 3
           },
           {
-            "line": 171,
+            "line": 172,
             "complexity": 0
           },
           {
-            "line": 176,
+            "line": 177,
             "complexity": 0
           },
           {
-            "line": 179,
+            "line": 180,
             "complexity": 0
           },
           {
-            "line": 183,
+            "line": 184,
             "complexity": 2
           },
           {
-            "line": 186,
+            "line": 187,
             "complexity": 0
-          },
-          {
-            "line": 193,
-            "complexity": 2
           },
           {
             "line": 194,
+            "complexity": 2
+          },
+          {
+            "line": 195,
             "complexity": 0
           },
           {
-            "line": 199,
+            "line": 200,
             "complexity": 3
-          },
-          {
-            "line": 207,
-            "complexity": 0
           },
           {
             "line": 208,
@@ -1037,7 +1033,7 @@
             "complexity": 0
           },
           {
-            "line": 212,
+            "line": 211,
             "complexity": 0
           },
           {
@@ -1045,19 +1041,23 @@
             "complexity": 0
           },
           {
-            "line": 215,
-            "complexity": 2
+            "line": 214,
+            "complexity": 0
           },
           {
             "line": 216,
+            "complexity": 2
+          },
+          {
+            "line": 217,
             "complexity": 3
           },
           {
-            "line": 220,
+            "line": 221,
             "complexity": 1
           },
           {
-            "line": 222,
+            "line": 223,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -58,11 +58,19 @@ tier. `--quality` changes the effective CRF preset; an explicit `output.crf` in 
 more precise control. The app passes it directly to software H.264/H.265 and translates it for
 Apple VideoToolbox; other hardware backends retain their existing quality policies.
 
+### Preset (root option)
+
+`--preset fast` is a root option — it goes before `generate`: `immich-memories --preset fast generate --month 6`.
+It applies the CPU-only/NAS profile for this run (1080p H.264, fast encoder, medium quality,
+static title backgrounds, no speech pass, photos ≤25 %, favorites-first analysis) to every knob you
+have not set explicitly; the flags below still win. Persistent form: `preset: fast` in
+`config.yaml` or `IMMICH_MEMORIES_PRESET=fast` — see the [config reference](../../reference/config-reference.md#preset).
+
 ### Analysis
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--analysis-depth` | — | choice | `auto` | `auto` (all manageable cache misses, shortlist large pools), `fast` (favorites first), or `thorough` (every eligible clip) |
+| `--analysis-depth` | — | choice | `auto` | `auto` (all manageable cache misses, shortlist large pools), `fast` (favorites first), or `thorough` (every eligible clip). Under `preset: fast`, `auto` runs as `fast` |
 | `--include-photos` | — | flag | — | Include photos alongside videos |
 | `--photo-duration` | — | float | `4.0` | Seconds per photo clip (use with `--include-photos`) |
 

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -110,7 +110,20 @@ the preset is active. `immich-memories --preset fast generate …` does the same
 
 ## Performance expectations
 
-On a typical NAS CPU (Intel Celeron J4125, 4 cores, 2.0 GHz):
+One measured number (2026-08-18), so you can calibrate: a monthly memory from a real library,
+14 clips (7 videos + 6 photos, HDR iPhone sources), 62 s of 1080p H.264 out, cold cache, the
+Docker image with `--cpus=4 --memory=4g` and no GPU (4 cores of an Apple M5 Max running the
+linux/arm64 image):
+
+| Profile | Wall time | Analysis | Render | Output |
+|---------|-----------|----------|--------|--------|
+| `preset: fast` | 10 min 08 s | 7.4 min | 2.7 min | 30 MB |
+| default | 15 min 42 s | 10.1 min | 5.6 min | 87 MB |
+
+Analysis (downloading, downscaling, scoring every candidate clip) is where the time goes, and it
+is cached: a second run of the same month skips most of it. A Celeron-class NAS core is a good
+deal slower than an M5 core, so budget 2–3× these numbers there. Estimates for that class of CPU
+(Intel Celeron J4125, 4 cores, 2.0 GHz):
 
 | Clips | Resolution | Time |
 |-------|-----------|------|

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -92,6 +92,22 @@ If Immich runs on the same Docker network, use the container name (`immich-serve
 - **GPU encoding**: NAS CPUs (Celeron, Atom, low-end Xeon) don't have usable GPU encoders. Encoding is CPU-only via libx264.
 - **Taichi GPU title renderer**: falls back to PIL. Title screens still look good, just without particle effects and animated globes.
 
+## One switch: `preset: fast`
+
+Add `IMMICH_MEMORIES_PRESET=fast` to the compose `environment:` (or `preset: fast` at the top of
+`config.yaml`) and the CPU-only profile is on: 1080p H.264 with the fast encoder preset and
+medium quality, static title backgrounds instead of animated ones, no per-clip speech analysis,
+photos capped at a quarter of the cut, and analysis depth `auto` running as `fast` (favorites
+first). Every value you set explicitly still wins, and the web UI's Step 3 shows a banner when
+the preset is active. `immich-memories --preset fast generate …` does the same for one CLI run.
+
+```yaml
+    environment:
+      IMMICH_URL: "${IMMICH_URL}"
+      IMMICH_API_KEY: "${IMMICH_API_KEY}"
+      IMMICH_MEMORIES_PRESET: "fast"
+```
+
 ## Performance expectations
 
 On a typical NAS CPU (Intel Celeron J4125, 4 cores, 2.0 GHz):

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -135,6 +135,7 @@ Inside Immich's own compose stack, `immich-server` listens on **2283** (every Im
 |----------|----------|-------------|
 | `IMMICH_URL` | Yes | Your Immich server URL |
 | `IMMICH_API_KEY` | Yes | Immich API key |
+| `IMMICH_MEMORIES_PRESET` | No | `fast` = CPU-only/NAS profile (1080p h264, fast encoder, static titles, no speech pass, favorites-first analysis). Explicit settings win. See the [NAS guide](../common-setups/nas-only.md#one-switch-preset-fast). |
 | `IMMICH_MEMORIES_OUTPUT__DIRECTORY` | Recommended | Set to `/app/output` so videos land in the mounted output directory (default is `~/Videos/Memories` inside the container). |
 | `IMMICH_MEMORIES_STORAGE_SECRET` | No | Session secret for the web UI. Auto-generated if not set. Set this explicitly to keep sessions across restarts. It does not make multiple replicas supported. |
 | `IMMICH_MEMORIES_LLM__BASE_URL` | No | LLM endpoint (any OpenAI-compatible API). On its own it does nothing for scoring — see the next row. |

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -27,6 +27,30 @@ Unknown keys *inside* a section are silently ignored; unknown top-level keys and
 fail validation at startup.
 :::
 
+## Preset
+
+One top-level switch that fills several knobs at once. `fast` is the CPU-only / NAS profile.
+Anything you set yourself — a key in the file, an `IMMICH_MEMORIES_…` env var, a CLI flag, a
+choice in the web UI — wins over the preset, exactly like `clip_style`.
+
+```yaml
+preset: null                       # null | fast
+```
+
+`fast` sets, unless you set them yourself: `output.resolution: 1080p`, `output.codec: h264`,
+`output.quality: medium`, `hardware.encoder_preset: fast`, `speech.enabled: false` (no per-clip
+voice-activity pass), `title_screens.animated_background: false` (static title backgrounds),
+`photos.max_ratio: 0.25`; and an analysis depth of `auto` runs as `fast` (favorites first).
+The heavy optional features (LLM scoring, music generation, audio-content tagging, transcription)
+are already off by default and stay wherever you put them.
+
+Env: `IMMICH_MEMORIES_PRESET=fast`. One-off on the CLI: `immich-memories --preset fast generate …`
+(root option, before the subcommand). The settings page names the active preset; Step 3 defaults
+its resolution to the preset's and says so.
+
+Caveat: the settings page's "save" writes every value to `config.yaml`, after which they all count
+as "set by you" — remove the keys you want the preset to own again.
+
 ## Immich connection
 
 Immich Memories supports **Immich v2 and v3**. Automatic runtime detection is the default:

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -22,6 +22,7 @@ from immich_memories.analysis.clip_scaler import ClipScaler
 from immich_memories.analysis.preview_builder import PreviewBuilder
 from immich_memories.analysis.progress import PipelinePhase, ProgressTracker
 from immich_memories.analysis.thumbnail_prefetch import ThumbnailPrefetcher
+from immich_memories.config_presets import resolve_analysis_depth
 
 if TYPE_CHECKING:
     from immich_memories.api.immich import SyncImmichClient
@@ -269,7 +270,11 @@ class SmartPipeline:
 
     def _analysis_candidates(self, eligible: list[VideoClipInfo]) -> list[VideoClipInfo]:
         """Resolve user-facing analysis depth into the concrete candidate set."""
-        requested_depth = self.config.analysis_depth
+        requested_depth = resolve_analysis_depth(
+            self.config.analysis_depth, self._app_config.preset
+        )
+        # The analyzer reads the same PipelineConfig, so the resolved depth has to land there.
+        self.config.analysis_depth = requested_depth
         if requested_depth == "thorough":
             logger.info("Thorough mode: analyzing all %d eligible clips", len(eligible))
             self._complete_passthrough_filter("Thorough", len(eligible))

--- a/src/immich_memories/cli/__init__.py
+++ b/src/immich_memories/cli/__init__.py
@@ -48,8 +48,15 @@ def _warn_about_unauthenticated_external_bind(config: Config, host: str) -> None
 @click.group()
 @click.version_option(version=__version__)
 @click.option("--config", "-c", type=click.Path(), help="Path to config file")
+@click.option(
+    "--preset",
+    type=click.Choice(["fast"]),
+    default=None,
+    help="Config preset for this run: fast = CPU-only/NAS profile (1080p h264, fast encoder, "
+    "no speech analysis, static titles, fewer photos, favorites-first analysis)",
+)
 @click.pass_context
-def main(ctx: click.Context, config: str | None) -> None:
+def main(ctx: click.Context, config: str | None, preset: str | None) -> None:
     """Immich Memories - Create video compilations from your Immich library."""
     ctx.ensure_object(dict)
 
@@ -77,6 +84,11 @@ def main(ctx: click.Context, config: str | None) -> None:
         else:
             ctx.obj["config"] = get_config()
             ctx.obj["config_path"] = None
+        if preset:
+            from immich_memories.config_presets import apply_preset
+
+            ctx.obj["config"].preset = preset
+            apply_preset(ctx.obj["config"])
     except ValidationError as e:
         print_error(format_validation_error(e))
         sys.exit(1)

--- a/src/immich_memories/cli/config_cmd.py
+++ b/src/immich_memories/cli/config_cmd.py
@@ -53,6 +53,7 @@ def register_config_commands(main: click.Group) -> None:
             table.add_row("API Key", "****" if cfg.immich.api_key else "(not set)")
             table.add_row("Output directory", str(cfg.output.output_path))
             table.add_row("Default scale mode", cfg.defaults.scale_mode)
+            table.add_row("Preset", cfg.preset or "(none)")
 
             console.print(table)
             return

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -14,7 +14,7 @@ import stat
 from pathlib import Path
 
 import yaml
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from immich_memories.config_models import (
@@ -41,6 +41,7 @@ from immich_memories.config_models import (
     UploadConfig,
 )
 from immich_memories.config_models_auth import AuthConfig
+from immich_memories.config_presets import PresetName, apply_preset
 from immich_memories.scheduling.models import SchedulerConfig
 
 # Tier 2 sections — grouped under `advanced:` in YAML, flat on Config at runtime.
@@ -129,6 +130,12 @@ class Config(BaseSettings):
         case_sensitive=False,
     )
 
+    preset: PresetName | None = Field(
+        default=None,
+        description="Named profile that fills several knobs at once (fast = CPU-only/NAS); "
+        "explicit values win",
+    )
+
     server: ServerConfig = Field(default_factory=ServerConfig)
     immich: ImmichConfig = Field(default_factory=ImmichConfig)
     defaults: DefaultsConfig = Field(default_factory=DefaultsConfig)
@@ -155,6 +162,11 @@ class Config(BaseSettings):
     auth: AuthConfig = Field(default_factory=AuthConfig)
     automation: AutomationConfig = Field(default_factory=AutomationConfig)
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
+
+    @model_validator(mode="after")
+    def _apply_preset(self) -> Config:
+        apply_preset(self)
+        return self
 
     @classmethod
     def from_yaml(cls, path: Path) -> Config:

--- a/src/immich_memories/config_presets.py
+++ b/src/immich_memories/config_presets.py
@@ -1,0 +1,54 @@
+"""Named config presets — one switch that fills several knobs at once.
+
+`preset: fast` is the CPU-only / NAS profile: no per-clip speech analysis, static title
+backgrounds, the fast software encoder preset, medium quality at 1080p, fewer photos, and
+`analysis_depth: auto` resolving to `fast` (favorites first). Anything the user has set
+explicitly (config file key, env var, CLI flag) wins over the preset, like `clip_style`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from immich_memories.config_loader import Config
+
+PresetName = Literal["fast"]
+
+PRESETS: dict[str, dict[str, dict[str, Any]]] = {
+    "fast": {
+        "output": {"resolution": "1080p", "codec": "h264", "quality": "medium"},
+        "hardware": {"encoder_preset": "fast"},
+        "speech": {"enabled": False},
+        "title_screens": {"animated_background": False},
+        "photos": {"max_ratio": 0.25},
+    },
+}
+
+
+def apply_preset(config: Config) -> list[str]:
+    """Fill every knob of `config.preset` that the user did not set; return what changed.
+
+    "Set by the user" means the field is in the section's `model_fields_set` — a key in
+    the YAML section, an `IMMICH_MEMORIES_<SECTION>__<FIELD>` env var, or an assignment
+    made before this call. Later assignments (env overrides, CLI flags) still win because
+    they happen after.
+    """
+    if config.preset is None:
+        return []
+    applied: list[str] = []
+    for section_name, values in PRESETS[config.preset].items():
+        section = getattr(config, section_name)
+        for field, value in values.items():
+            if field in section.model_fields_set:
+                continue
+            setattr(section, field, value)
+            applied.append(f"{section_name}.{field}")
+    return applied
+
+
+def resolve_analysis_depth(requested: str, preset: str | None) -> str:
+    """`auto` means `fast` (favorites first) under the fast preset; explicit depths stand."""
+    if requested == "auto" and preset == "fast":
+        return "fast"
+    return requested

--- a/src/immich_memories/ui/pages/settings_config.py
+++ b/src/immich_memories/ui/pages/settings_config.py
@@ -109,7 +109,12 @@ def render_config_viewer() -> None:
 
     im_info_card(
         "Active config from ~/.immich-memories/config.yaml with env overrides. "
-        "API keys are redacted.",
+        "API keys are redacted."
+        + (
+            f" Preset '{config.preset}' is active and fills the knobs you have not set."
+            if config.preset
+            else ""
+        ),
         variant="info",
     )
 

--- a/src/immich_memories/ui/pages/step3_options.py
+++ b/src/immich_memories/ui/pages/step3_options.py
@@ -37,6 +37,28 @@ def configured_output_format_label(config) -> str:
     return f"{container} ({codec_label})"
 
 
+_RESOLUTION_LABELS = {"4k": "4K", "1080p": "1080p", "720p": "720p"}
+
+
+def default_resolution_label(config) -> str:
+    """Match clips unless a preset pins the resolution (fast → 1080p on a NAS, not 4K)."""
+    if config is None or config.preset is None:
+        return "Auto (match clips)"
+    return _RESOLUTION_LABELS.get(config.output.resolution, "Auto (match clips)")
+
+
+def _render_preset_banner(config) -> None:
+    if config is None or config.preset != "fast":
+        return
+    im_info_card(
+        "Fast (NAS) preset is active: 1080p H.264 with the fast encoder preset, static "
+        "title backgrounds, no speech analysis, fewer photos, favorites-first analysis. "
+        "Set with `preset: fast` in config.yaml or IMMICH_MEMORIES_PRESET=fast; the choices "
+        "below still win for this run.",
+        variant="info",
+    )
+
+
 def _render_volume_slider(options: dict, width: str = "w-64") -> None:
     """Render a music volume slider."""
     with ui.row().classes("items-center gap-4 mt-2"):
@@ -127,7 +149,7 @@ def render_step3() -> None:
             "orientation": "Auto (detect from clips)",
             "scale_mode": "Smart Crop (keep faces)",
             "transition": "Smart (mix of fades & cuts)",
-            "resolution": "Auto (match clips)",
+            "resolution": default_resolution_label(config),
             "format": configured_format,
             "add_date": False,
             "music_source": "AI Generated" if musicgen_available else "None",
@@ -141,6 +163,7 @@ def render_step3() -> None:
     # Output Settings
     # ========================================================================
     im_section_header("Output Settings", icon="tune")
+    _render_preset_banner(config)
 
     with im_card() as card:
         card.classes("p-4")

--- a/tests/test_config_presets.py
+++ b/tests/test_config_presets.py
@@ -1,0 +1,122 @@
+"""`preset: fast` — one switch for CPU-only / NAS boxes (#311)."""
+
+from __future__ import annotations
+
+import pytest
+
+from immich_memories.config_loader import Config
+
+
+class TestFastPreset:
+    def test_fast_preset_fills_the_cpu_only_knobs(self) -> None:
+        config = Config(preset="fast")
+
+        assert config.output.resolution == "1080p"
+        assert config.output.codec == "h264"
+        assert config.output.quality == "medium"
+        assert config.hardware.encoder_preset == "fast"
+        assert config.speech.enabled is False
+        assert config.title_screens.animated_background is False
+        assert config.photos.max_ratio == 0.25
+
+    def test_explicit_values_win_over_the_preset(self) -> None:
+        config = Config(
+            preset="fast",
+            output={"resolution": "720p"},
+            speech={"enabled": True},
+        )
+
+        assert config.output.resolution == "720p"
+        assert config.speech.enabled is True
+        assert config.hardware.encoder_preset == "fast"  # untouched knobs still filled
+
+    def test_no_preset_changes_nothing(self) -> None:
+        config = Config()
+
+        assert config.preset is None
+        assert config.hardware.encoder_preset == "balanced"
+        assert config.speech.enabled is True
+
+    def test_unknown_preset_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="preset"):
+            Config(preset="turbo")
+
+    def test_env_var_selects_the_preset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("IMMICH_MEMORIES_PRESET", "fast")
+
+        assert Config().hardware.encoder_preset == "fast"
+
+
+class TestAnalysisDepthUnderPreset:
+    @pytest.mark.parametrize(
+        ("requested", "preset", "expected"),
+        [
+            ("auto", "fast", "fast"),
+            ("auto", None, "auto"),
+            ("thorough", "fast", "thorough"),
+            ("fast", None, "fast"),
+        ],
+    )
+    def test_auto_becomes_fast_only_under_the_fast_preset(
+        self, requested: str, preset: str | None, expected: str
+    ) -> None:
+        from immich_memories.config_presets import resolve_analysis_depth
+
+        assert resolve_analysis_depth(requested, preset) == expected
+
+    def test_pipeline_hands_the_analyzer_fast_depth_when_auto_and_preset_fast(self) -> None:
+        from unittest.mock import MagicMock
+
+        from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
+        from immich_memories.config_models import AnalysisConfig
+        from tests.conftest import make_clip
+
+        pipeline_config = PipelineConfig(target_clips=4, analysis_depth="auto")
+        pipeline = SmartPipeline(
+            client=MagicMock(),  # WHY: Immich is never contacted for the depth decision
+            analysis_cache=MagicMock(),  # WHY: cache-miss counting is the auto path we bypass
+            thumbnail_cache=MagicMock(),  # WHY: constructor dependency, unused here
+            config=pipeline_config,
+            analysis_config=AnalysisConfig(),
+            app_config=Config(preset="fast"),
+        )
+        clips = [make_clip(f"c{i}", duration=10.0) for i in range(6)]
+
+        pipeline._analysis_candidates(clips)
+
+        # The analyzer reads the same PipelineConfig object; "fast" is what it must see.
+        assert pipeline_config.analysis_depth == "fast"
+
+
+class TestCliPresetFlag:
+    def test_root_preset_flag_applies_to_the_loaded_config(self) -> None:
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from immich_memories.cli import main
+
+        config = Config()
+        with (
+            # WHY: the CLI would otherwise create ~/.immich-memories and read the real file
+            patch("immich_memories.cli.init_config_dir"),
+            patch("immich_memories.cli.get_config", return_value=config),
+        ):
+            result = CliRunner().invoke(
+                main, ["--preset", "fast", "config", "--show"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "fast" in result.output
+        assert config.preset == "fast"
+        assert config.hardware.encoder_preset == "fast"
+        assert config.output.resolution == "1080p"
+
+
+class TestUiDefaultsUnderPreset:
+    def test_step3_resolution_defaults_to_the_preset_resolution(self) -> None:
+        from immich_memories.ui.pages.step3_options import default_resolution_label
+
+        assert default_resolution_label(Config(preset="fast")) == "1080p"
+        assert default_resolution_label(Config()) == "Auto (match clips)"
+        assert default_resolution_label(None) == "Auto (match clips)"


### PR DESCRIPTION
## Summary

Wave 1 item 6 (#311). Decisions from you: `--preset fast` + config key, **1080p** (not 720p); studied `immich-memories-lite` (MIT) for what it does — reference only, nothing copied.

`preset: fast` (top-level YAML), `IMMICH_MEMORIES_PRESET=fast` (Docker), or a root `immich-memories --preset fast generate …` for one run, fills the knobs a 4-core GPU-less box needs — **only the ones you have not set yourself** (same rule as `clip_style`, via each section's `model_fields_set`):

| knob | fast |
|---|---|
| `output.resolution` / `codec` / `quality` | 1080p / h264 / medium |
| `hardware.encoder_preset` | fast |
| `speech.enabled` | false (no per-clip VAD pass) |
| `title_screens.animated_background` | false (static backgrounds) |
| `photos.max_ratio` | 0.25 |
| `analysis_depth: auto` | runs as `fast` (favorites first) |

LLM scoring / music generation / audio-content / transcription are already off by default and stay wherever you put them.

- new `config_presets.py` (PRESETS, `apply_preset`, `resolve_analysis_depth`); `Config.preset` + after-validator; root CLI `--preset`; `config --show` prints it
- `SmartPipeline` resolves the depth once so the analyzer reads the same value
- UI: Step 3 defaults its resolution to the preset's and shows a banner; settings viewer names the active preset
- Docs: config reference (new **Preset** section incl. the "settings-page save makes everything explicit" caveat), NAS guide (one-switch section + measured table), docker env table, `generate` CLI page, README

**Measured, cold cache, Docker `--cpus=4 --memory=4g`, no GPU, real library, 14-clip monthly at 1080p:** `preset: fast` **10 min 08 s** (analysis 7.4 / render 2.7 min, 30 MB) vs default **15 min 42 s** (10.1 / 5.6 min, 87 MB). Hardware stated honestly in the docs (4 M5 Max cores under the linux/arm64 image; Celeron-class ≈ 2–3× slower). Measuring this is also how #339 and #343 were found — the image needed both fixes before any number could be produced.

Not in this PR (by design): a `max_clips` cap (target duration already bounds it), and a UI toggle to switch presets at runtime (the settings page is read-only today).

Closes #311

## Test plan

- [x] `make ci` green on top of current main (4680 passed), `make docs-build`, `make critique` clean for the touched files
- [x] `tests/test_config_presets.py`: fills unset knobs; explicit wins; no preset changes nothing; unknown preset rejected; env var; `resolve_analysis_depth` matrix; pipeline hands the analyzer `fast`; root CLI flag mutates the loaded config; Step 3 default label
- [x] Benchmark above run twice end-to-end in the container (first attempt exposed #339/#343)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM