### PR TITLE
fix(analysis): make the subject policy actually fire on a real library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,14 +505,10 @@ build-check:
 	uvx twine check dist/*
 
 # Ensure dev dependencies are installed
-# Deliberately an exact sync. --inexact would preserve a manually installed
-# ACE-Step, but tests/test_ace_step_backend.py aborts the pytest process with
-# SIGABRT when a real acestep is importable: its fakes only override five
-# acestep.* keys, the real install leaves its others in sys.modules, and the
-# code under test then initialises Metal for real. Until that test is made
-# hermetic, the gates run against a clean tree and `make install-acestep`
-# restores music generation afterwards.
-ENSURE_DEV_COMMAND ?= uv sync --all-extras --quiet
+# --inexact: an exact sync deletes anything this project does not declare, which
+# silently uninstalls the ACE-Step inference stack (make install-acestep) every
+# time a quality gate runs, so music generation breaks after every `make ci`.
+ENSURE_DEV_COMMAND ?= uv sync --all-extras --inexact --quiet
 ensure-dev:
 	@$(ENSURE_DEV_COMMAND)
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,17 @@ install:
 dev:
 	uv sync --all-extras
 
+install-acestep:  ## Install the tested ACE-Step 1.5 inference stack (music generation)
+	uv pip install --python .venv/bin/python --no-deps \
+	  'ace-step @ git+https://github.com/ace-step/ACE-Step-1.5.git@v0.1.8'
+	uv pip install --python .venv/bin/python \
+	  'accelerate>=1.12.0' 'diffusers>=0.37.0' diskcache 'loguru>=0.7.3' \
+	  'mlx>=0.25.2' 'mlx-lm>=0.20.0' 'pytorch-wavelets>=1.3.0' \
+	  'pywavelets>=1.9.0' toml 'torchvision==0.25.0' \
+	  'transformers>=4.51.0,<4.58.0' 'typer-slim>=0.21.1' \
+	  'vector-quantize-pytorch>=1.27.15'
+	@uv run python -c "from immich_memories.audio.generators.ace_step_backend import ACEStepBackend; import torch, torchvision.ops as o; o.nms(torch.zeros((0,4)), torch.zeros((0,)), 0.5); print('ACE-Step stack OK')"
+
 # Install dev tools only (no GPU/CUDA/audio-ml/face deps — for CI quality gates)
 dev-ci:
 	uv sync --extra dev
@@ -494,6 +505,13 @@ build-check:
 	uvx twine check dist/*
 
 # Ensure dev dependencies are installed
+# Deliberately an exact sync. --inexact would preserve a manually installed
+# ACE-Step, but tests/test_ace_step_backend.py aborts the pytest process with
+# SIGABRT when a real acestep is importable: its fakes only override five
+# acestep.* keys, the real install leaves its others in sys.modules, and the
+# code under test then initialises Metal for real. Until that test is made
+# hermetic, the gates run against a clean tree and `make install-acestep`
+# restores music generation afterwards.
 ENSURE_DEV_COMMAND ?= uv sync --all-extras --quiet
 ensure-dev:
 	@$(ENSURE_DEV_COMMAND)

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -155,6 +155,17 @@ inference dependencies:
 
 ```bash
 uv sync --extra demucs
+make install-acestep
+```
+
+`make install-acestep` runs the pinned commands below and then imports the backend to
+prove the install actually works — a mismatched `torchvision` fails only at model load,
+several minutes into a generation, with `operator torchvision::nms does not exist`.
+
+<details>
+<summary>What the target runs</summary>
+
+```bash
 uv pip install --python .venv/bin/python --no-deps \
   'ace-step @ git+https://github.com/ace-step/ACE-Step-1.5.git@v0.1.8'
 uv pip install --python .venv/bin/python \
@@ -165,10 +176,15 @@ uv pip install --python .venv/bin/python \
   'vector-quantize-pytorch>=1.27.15'
 ```
 
+</details>
+
 The command above is the tested Apple Silicon inference installation; it deliberately does not
 install ACE-Step's Gradio UI. CUDA hosts should use the pinned v0.1.8 release with the appropriate
-PyTorch wheels. `uv sync --inexact` preserves this manual installation. An exact `uv sync` removes
-packages not declared by this project, so rerun the ACE-Step commands afterward.
+PyTorch wheels. :::note Quality gates remove this install
+`make ci`, `make check` and friends run an exact `uv sync`, which deletes packages this
+project does not declare — ACE-Step among them. Rerun `make install-acestep` afterwards
+to get music generation back; it is fast once the wheels are cached.
+:::
 
 ### Memory on Apple Silicon
 

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -180,11 +180,9 @@ uv pip install --python .venv/bin/python \
 
 The command above is the tested Apple Silicon inference installation; it deliberately does not
 install ACE-Step's Gradio UI. CUDA hosts should use the pinned v0.1.8 release with the appropriate
-PyTorch wheels. :::note Quality gates remove this install
-`make ci`, `make check` and friends run an exact `uv sync`, which deletes packages this
-project does not declare — ACE-Step among them. Rerun `make install-acestep` afterwards
-to get music generation back; it is fast once the wheels are cached.
-:::
+PyTorch wheels. The `make` quality gates sync with `--inexact`, so they leave this installation alone.
+A bare `uv sync` is exact and removes packages this project does not declare, so rerun
+`make install-acestep` afterwards if you run one.
 
 ### Memory on Apple Silicon
 

--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -114,9 +114,12 @@ Objects are rationed rather than banned. Buying a new car is a memory and a
 lawnmower is not, and the thing separating them is whether the clip is any good — so
 objects must clear the same bar as scenery *and* fit the quota.
 
-That bar is the median people-clip score rather than a fixed number, because photo
-scores and video scores sit on different scales and one threshold would silently
-exclude a whole pool.
+That bar is the median people-clip score rather than a fixed number — and it is
+computed **separately for photos and for motion clips**, because the two are scored
+by different pipelines and land in different ranges. On a real June pool, people
+motion clips sat at a 0.70 median while photos sat at 0.43. Pooling both put the bar
+at 0.43, low enough for a clip of a string trimmer scoring 0.61 to clear it; judged
+against its own scale, it does not.
 
 A clip nobody has described yet is **kept**. On a real library 35–46% of the pool
 has no cached description, and treating that silence as "probably an object" would

--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -76,23 +76,37 @@ Live photos go through the same pipeline as videos after burst merging and are s
 
 **Favorite inheritance**: If ANY photo in a burst cluster is favorited, the entire merged live photo clip inherits the favorite flag.
 
+## Source Quality
+
+Messaging apps re-encode video to a few hundred pixels and strip the camera EXIF on
+the way through. A clip whose short side is under `min_source_short_side` (default
+1080) is dropped **unless it carries a camera make or model**, which is what
+separates a WhatsApp forward from genuinely old footage that was always small.
+
+Measured on a 111-clip June pool: all 17 sub-1080p candidates had no camera EXIF
+whatsoever, and all 89 with camera EXIF were 1080p or better.
+
 ## What a Clip Is Of
 
 A memory is about the people in it. Scoring ranks clips on faces, motion, stability
 and cut quality, so a steady handheld pan across a lawn can outrank a shaky clip of
 a child — a real generation put a string trimmer in a family video that way.
 
-Every candidate is therefore categorised as **people**, **animal**, **landscape** or
-**object** before selection, using the most trustworthy signal available:
+Every candidate is therefore categorised as **people**, **animal**, **landscape**,
+**object** or **screen** before selection, from two signals only:
 
 1. **Immich face tags.** Face recognition has already run over your library. A clip
-   with a tagged person is people, no model call needed. This covers roughly half a
-   typical pool and works on already-cached clips.
-2. **The category the model picks.** Content analysis asks the VLM to choose one of
-   the four. This fills in as clips are analysed — existing cache entries keep
-   working through step 3 until they are re-analysed.
-3. **Keywords in the description**, for clips analysed before the model was ever
-   asked for a category.
+   with a tagged person is people, no model call needed — this covers roughly half a
+   typical pool.
+2. **The category the model picks**, from that closed set, as part of content
+   analysis.
+
+Nothing else decides. An earlier version matched keywords in the model's written
+description and it was wrong in every interesting case: a treadmill and a
+driver's-eye road view became "landscape" because both descriptions said *close-up
+view*; a tray of animal figurines became "animal"; a smartwatch demo became "people"
+because a person was wearing the watch. Prose is not a label. A clip the model has
+not labelled is **unknown**, and unknown is kept.
 
 The quotas:
 
@@ -101,6 +115,7 @@ The quotas:
 | people | always eligible |
 | animal | up to `max_animal_ratio` of the video (default 10%) |
 | object | up to `max_object_ratio` (default 5%) **and** must beat the median people clip |
+| screen | never — a screenshot, a phone or watch display, or a document is not a memory |
 | landscape | must beat the median people-clip score |
 | unknown | always kept |
 

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -93,6 +93,7 @@ analysis:
 
   # Duplicate detection
   duplicate_hash_threshold: 8    # Perceptual hash threshold (0-64)
+  min_source_short_side: 1080    # Drop smaller clips unless they carry camera EXIF
   subject_policy_enabled: true   # Prefer clips of people over things
   max_animal_ratio: 0.10         # Share of the video that may be animal clips
   max_object_ratio: 0.05         # Share that may be object clips (must also score well)

--- a/src/immich_memories/analysis/cache_projection.py
+++ b/src/immich_memories/analysis/cache_projection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from immich_memories.cache.versions import ANALYSIS_VERSION
+
 if TYPE_CHECKING:
     from immich_memories.api.models import VideoClipInfo
     from immich_memories.cache.database_models import CachedSegment, CachedVideoAnalysis
@@ -11,8 +13,16 @@ if TYPE_CHECKING:
 
 
 def is_compatible_analysis_cache(cached: CachedVideoAnalysis | None, config: Config) -> bool:
-    """Return whether a cache row is safe to reuse under the active configuration."""
+    """Return whether a cache row is safe to reuse under the active configuration.
+
+    The analysis generation is part of that question. needs_reanalysis() has always
+    compared it, but this check -- the one the analyzer actually consults -- did not,
+    so bumping ANALYSIS_VERSION invalidated nothing here and fields added by a new
+    generation stayed empty on every already-analysed clip.
+    """
     if not (cached and cached.segments):
+        return False
+    if cached.analysis_version != ANALYSIS_VERSION:
         return False
     if config.content_analysis.enabled:
         return cached.model_version == config.llm.model

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -76,6 +76,8 @@ def build_content_analysis_prompt(transcript: str | None = None) -> str:
     return "\n\n".join(sections)
 
 
+MAX_LIST = 10
+
 CONTENT_ANALYSIS_PROMPT = build_content_analysis_prompt()
 
 
@@ -378,7 +380,6 @@ class ContentAnalyzer:
             ContentAnalysis instance.
         """
         MAX_STR = 500
-        MAX_LIST = 10
         description = str(data.get("description", ""))[:MAX_STR]
         activities = [str(a)[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]]
         subjects = [str(s)[:MAX_STR] for s in data.get("subjects", [])[:MAX_LIST]]
@@ -491,6 +492,23 @@ class ContentAnalyzer:
         setting_match = re.search(r'"setting"\s*:\s*"([^"]+)"', text)
         if setting_match:
             result.setting = setting_match.group(1)
+
+        # WHY: the subject policy decides on the category alone, so a response that
+        # reaches this path without one silently drops out of the filter. Sampled
+        # against the live model every response was well-formed and carried a
+        # category, so this is insurance rather than a fix for something observed --
+        # but the two fields it adds are the two the policy cannot work without.
+        category_match = re.search(r'"category"\s*:\s*"([^"]+)"', text)
+        if category_match:
+            result.category = category_match.group(1)
+
+        subjects_match = re.search(r'"subjects"\s*:\s*\[([^\]]*)\]', text)
+        if subjects_match:
+            result.subjects = [
+                item.strip().strip('"').strip("'")
+                for item in subjects_match.group(1).split(",")
+                if item.strip().strip('"').strip("'")
+            ][:MAX_LIST]
 
         if result.description or result.emotion:
             desc_preview = result.description[:50] if result.description else "(none)"

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -23,9 +23,12 @@ _PROMPT_HEAD = """Describe what you see in this image."""
 
 _PROMPT_TAIL = """Return JSON with these fields:
 - description: What is happening in this scene?
-- category: What is this mainly of? Exactly one of: people, animal, landscape, object.
-  Use "people" if any person is visible, even partly. Use "landscape" only for a wide
-  outdoor view, never for a close-up of a thing. Use "object" for anything else.
+- category: What is this mainly of? Exactly one of: people, animal, landscape, object, screen.
+  Use "screen" if the subject is a phone, watch, computer or TV display, a screenshot,
+  or a document or form -- even when a person is holding or wearing the device.
+  Use "people" if a person is the subject. Use "animal" only for a live animal, not a
+  toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
+  never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)

--- a/src/immich_memories/analysis/source_quality.py
+++ b/src/immich_memories/analysis/source_quality.py
@@ -1,0 +1,35 @@
+"""Reject messaging re-encodes without rejecting genuinely old footage.
+
+WhatsApp and similar apps re-encode to a few hundred pixels and strip the
+camera EXIF while doing it. Filtering on resolution alone would also throw away
+legitimately small originals from an older camera, so the two signals are used
+together: a small clip is only rejected when nothing says a camera made it.
+
+Measured on a real June pool of 111 motion candidates: all 17 below 1080p had
+no camera make or model at all, and all 89 with camera EXIF were 1080p or
+better. One clip had no EXIF and full resolution, and it survives the rule.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def is_usable_source(
+    *,
+    width: int,
+    height: int,
+    has_camera_exif: bool,
+    min_short_side: int,
+) -> bool:
+    """Whether a clip is worth putting in a memory at full output resolution."""
+    short_side = min(width, height) if width and height else 0
+    if short_side == 0:
+        # Live-photo rows frequently have no cached dimensions. Absence of
+        # evidence is not evidence of a re-encode.
+        return True
+    if short_side >= min_short_side:
+        return True
+    return has_camera_exif

--- a/src/immich_memories/analysis/subject_policy.py
+++ b/src/immich_memories/analysis/subject_policy.py
@@ -5,17 +5,20 @@ animals are a garnish, and a clip of a lawnmower is not a memory. Selection
 scored clips on faces, motion and stability alone, so a steady handheld pan
 across a lawn outranked a shaky clip of a child.
 
-The policy acts only on evidence. A clip nobody has described yet is kept, not
-rationed -- on a real library 35-46% of the pool has no cached description, and
+The policy acts only on evidence, and the evidence is a label, never prose.
+Keyword matching over the model's description was tried and measured: it called
+a treadmill and a driver's-eye road view "landscape" because both descriptions
+said "close-up view", a tray of animal figurines "animal", and a smartwatch
+demo "people" because a person was holding the watch. The model is now asked
+for the category outright. A clip it has not labelled is unknown, and unknown
+is kept -- on a real library a third of the pool has no analysis yet, and
 treating that silence as "probably an object" would delete half the memory.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 import statistics
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -29,142 +32,28 @@ class SubjectCategory(Enum):
     ANIMAL = "animal"
     LANDSCAPE = "landscape"
     OBJECT = "object"
+    SCREEN = "screen"
     UNKNOWN = "unknown"
-
-
-_PEOPLE_TERMS = frozenset(
-    {
-        "person",
-        "people",
-        "man",
-        "men",
-        "woman",
-        "women",
-        "child",
-        "children",
-        "kid",
-        "kids",
-        "baby",
-        "babies",
-        "toddler",
-        "boy",
-        "boys",
-        "girl",
-        "girls",
-        "family",
-        "adult",
-        "adults",
-        "couple",
-        "crowd",
-        "group",
-        "someone",
-        "father",
-        "mother",
-        "dad",
-        "mom",
-        "parent",
-        "parents",
-        "friends",
-    }
-)
-
-_ANIMAL_TERMS = frozenset(
-    {
-        "dog",
-        "dogs",
-        "puppy",
-        "cat",
-        "cats",
-        "kitten",
-        "kittens",
-        "animal",
-        "animals",
-        "pet",
-        "pets",
-        "bird",
-        "birds",
-        "horse",
-        "horses",
-        "cow",
-        "cows",
-        "sheep",
-        "duck",
-        "ducks",
-        "chicken",
-        "rabbit",
-        "fish",
-        "goat",
-    }
-)
-
-# Deliberately narrow, and narrowed further by measurement. "view" and "field"
-# were dropped after they classified a treadmill, a bike hub and an office
-# renovation as scenery -- each of those descriptions said "close-up view".
-# A term earns its place only if it cannot also describe an object in a room.
-_LANDSCAPE_TERMS = frozenset(
-    {
-        "landscape",
-        "scenery",
-        "vista",
-        "panorama",
-        "horizon",
-        "skyline",
-        "sunset",
-        "sunrise",
-        "mountain",
-        "mountains",
-        "valley",
-        "countryside",
-        "sea",
-        "ocean",
-        "lake",
-        "river",
-        "waterfall",
-        "forest",
-        "beach",
-        "cliff",
-        "cliffs",
-        "meadow",
-        "shoreline",
-    }
-)
 
 
 def classify_subject(
     *,
     tagged_people: int,
     category: str | None = None,
-    subjects: Sequence[str] | None = None,
     description: str | None = None,
 ) -> SubjectCategory:
-    """Categorise a clip, most trustworthy signal first.
+    """Categorise a clip from Immich face tags and the model's own label.
 
-    1. Immich face tags. Face recognition has already run across the library, so
-       a tagged clip needs no model call and no guessing.
-    2. The category the VLM was asked to pick from a closed set.
-    3. Keywords in the VLM's prose, for the segments cached before the model was
-       ever asked for a category.
-
-    People win over anything else in frame -- a child chasing a dog is a memory
-    about the child.
+    Face tags settle it outright -- face recognition has already run across the
+    library, so a tagged clip needs no model call. Otherwise the answer is
+    whichever category the model was asked to choose, and nothing else. The
+    description is accepted so callers can pass what they have, and is
+    deliberately ignored; the module docstring records what happened when it
+    was trusted.
     """
     if tagged_people > 0:
         return SubjectCategory.PEOPLE
-
-    stated = _stated_category(category)
-    if stated is not None:
-        return stated
-
-    words = _words(subjects, description)
-    if not words:
-        return SubjectCategory.UNKNOWN
-    if words & _PEOPLE_TERMS:
-        return SubjectCategory.PEOPLE
-    if words & _ANIMAL_TERMS:
-        return SubjectCategory.ANIMAL
-    if words & _LANDSCAPE_TERMS:
-        return SubjectCategory.LANDSCAPE
-    return SubjectCategory.OBJECT
+    return _stated_category(category) or SubjectCategory.UNKNOWN
 
 
 def _stated_category(category: str | None) -> SubjectCategory | None:
@@ -176,12 +65,6 @@ def _stated_category(category: str | None) -> SubjectCategory | None:
     except ValueError:
         return None
     return None if stated is SubjectCategory.UNKNOWN else stated
-
-
-def _words(subjects: Sequence[str] | None, description: str | None) -> set[str]:
-    """Lowercased word set over the VLM's structured subjects and its prose."""
-    blob = " ".join([*(subjects or []), description or ""])
-    return set(re.findall(r"[a-z]+", blob.lower()))
 
 
 @dataclass(frozen=True)
@@ -270,6 +153,8 @@ def _survivors(
     def clears(candidate: SubjectCandidate) -> bool:
         return candidate.score >= bars.get(candidate.scale, 0.0)
 
+    if category is SubjectCategory.SCREEN:
+        return []
     if category is SubjectCategory.OBJECT:
         return _top([c for c in members if clears(c)], max_object)
     if category is SubjectCategory.LANDSCAPE:
@@ -346,8 +231,6 @@ def filter_candidates_by_subject(
             category=classify_subject(
                 tagged_people=len(candidate.clip.asset.people or []),
                 category=candidate.clip.llm_category,
-                subjects=candidate.clip.llm_subjects,
-                description=candidate.clip.llm_description,
             ),
             score=candidate.score,
             scale="photo" if candidate.clip.asset.id in photos else "motion",

--- a/src/immich_memories/analysis/subject_policy.py
+++ b/src/immich_memories/analysis/subject_policy.py
@@ -191,6 +191,7 @@ class SubjectCandidate:
     key: str
     category: SubjectCategory
     score: float
+    scale: str = "motion"
 
 
 @dataclass(frozen=True)
@@ -199,7 +200,7 @@ class QuotaOutcome:
 
     kept_keys: list[str]
     dropped: dict[SubjectCategory, int] = field(default_factory=dict)
-    quality_bar: float = 0.0
+    bars: dict[str, float] = field(default_factory=dict)
     bypassed: bool = False
 
 
@@ -224,16 +225,17 @@ def apply_subject_quotas(
     """
     max_animal = quota_for(animal_ratio, expected_clips)
     max_object = quota_for(object_ratio, expected_clips)
+
     by_category: dict[SubjectCategory, list[SubjectCandidate]] = {}
     for candidate in candidates:
         by_category.setdefault(candidate.category, []).append(candidate)
 
-    bar = _quality_bar(by_category, candidates)
+    bars = _quality_bars(candidates)
 
     keep: set[str] = set()
     dropped: dict[SubjectCategory, int] = {}
     for category, members in by_category.items():
-        survivors = _survivors(category, members, bar, max_animal, max_object)
+        survivors = _survivors(category, members, bars, max_animal, max_object)
         keep.update(c.key for c in survivors)
         if len(survivors) < len(members):
             dropped[category] = len(members) - len(survivors)
@@ -244,30 +246,34 @@ def apply_subject_quotas(
         # stands down rather than deleting the memory.
         return QuotaOutcome(
             kept_keys=[c.key for c in candidates],
-            quality_bar=bar,
+            bars=bars,
             bypassed=True,
         )
 
     return QuotaOutcome(
         kept_keys=[c.key for c in candidates if c.key in keep],
         dropped=dropped,
-        quality_bar=bar,
+        bars=bars,
     )
 
 
 def _survivors(
     category: SubjectCategory,
     members: list[SubjectCandidate],
-    bar: float,
+    bars: dict[str, float],
     max_animal: int,
     max_object: int,
 ) -> list[SubjectCandidate]:
     if category is SubjectCategory.ANIMAL:
         return _top(members, max_animal)
+
+    def clears(candidate: SubjectCandidate) -> bool:
+        return candidate.score >= bars.get(candidate.scale, 0.0)
+
     if category is SubjectCategory.OBJECT:
-        return _top([c for c in members if c.score >= bar], max_object)
+        return _top([c for c in members if clears(c)], max_object)
     if category is SubjectCategory.LANDSCAPE:
-        return [c for c in members if c.score >= bar]
+        return [c for c in members if clears(c)]
     return members
 
 
@@ -291,15 +297,27 @@ def _top(members: list[SubjectCandidate], limit: int) -> list[SubjectCandidate]:
     return sorted(members, key=lambda c: -c.score)[:limit]
 
 
-def _quality_bar(
-    by_category: dict[SubjectCategory, list[SubjectCandidate]],
-    candidates: list[SubjectCandidate],
-) -> float:
-    people = by_category.get(SubjectCategory.PEOPLE)
-    reference = people or candidates
-    if not reference:
-        return 0.0
-    return statistics.median(c.score for c in reference)
+def _quality_bars(candidates: list[SubjectCandidate]) -> dict[str, float]:
+    """The median people-clip score, computed separately for each score scale.
+
+    Photos and motion clips are scored by different pipelines and land in
+    different ranges -- on a real June pool, people motion clips sat at a 0.70
+    median while photos sat far below. One pooled median put the bar at 0.43,
+    low enough for a clip of a string trimmer to clear it. Each scale is
+    therefore judged against its own people.
+    """
+    by_scale: dict[str, list[float]] = {}
+    for candidate in candidates:
+        by_scale.setdefault(candidate.scale, []).append(candidate.score)
+
+    people: dict[str, list[float]] = {}
+    for candidate in candidates:
+        if candidate.category is SubjectCategory.PEOPLE:
+            people.setdefault(candidate.scale, []).append(candidate.score)
+
+    return {
+        scale: statistics.median(people.get(scale) or scores) for scale, scores in by_scale.items()
+    }
 
 
 def filter_candidates_by_subject(
@@ -308,6 +326,7 @@ def filter_candidates_by_subject(
     animal_ratio: float,
     object_ratio: float,
     content_budget_seconds: float,
+    photo_asset_ids: set[str] | None = None,
 ) -> list:
     """Apply the subject policy to a pool of ClipWithSegment candidates.
 
@@ -319,6 +338,7 @@ def filter_candidates_by_subject(
         return candidates
 
     expected_clips = _expected_clip_count(candidates, content_budget_seconds)
+    photos = photo_asset_ids or set()
 
     described = [
         SubjectCandidate(
@@ -330,6 +350,7 @@ def filter_candidates_by_subject(
                 description=candidate.clip.llm_description,
             ),
             score=candidate.score,
+            scale="photo" if candidate.clip.asset.id in photos else "motion",
         )
         for candidate in candidates
     ]
@@ -352,9 +373,9 @@ def filter_candidates_by_subject(
             f"{n} {category.value}" for category, n in sorted(outcome.dropped.items(), key=str)
         )
         logger.info(
-            "Subject policy: dropped %s (scenery had to beat %.2f, the median people clip)",
+            "Subject policy: dropped %s (had to beat %s)",
             counts,
-            outcome.quality_bar,
+            ", ".join(f"{scale} {bar:.2f}" for scale, bar in sorted(outcome.bars.items())),
         )
 
     kept = set(outcome.kept_keys)

--- a/src/immich_memories/cache/database_models.py
+++ b/src/immich_memories/cache/database_models.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from immich_memories.cache.versions import ANALYSIS_VERSION
+
 if TYPE_CHECKING:
     from immich_memories.analysis.scenes import Scene
     from immich_memories.analysis.scoring import MomentScore
@@ -87,6 +89,10 @@ class CachedVideoAnalysis:
     analysis_timestamp: datetime
 
     # Versioning
+    # Defaults to the current generation: an instance built in memory describes
+    # analysis being produced now. row_to_analysis() passes 0 for a stored row
+    # that predates the column, which correctly reads as stale.
+    analysis_version: int = ANALYSIS_VERSION
     scoring_version: int = 1
     model_version: str | None = None
 

--- a/src/immich_memories/cache/database_rows.py
+++ b/src/immich_memories/cache/database_rows.py
@@ -27,6 +27,7 @@ def row_to_analysis(row: sqlite3.Row) -> CachedVideoAnalysis:
             datetime.fromisoformat(row["file_modified_at"]) if row["file_modified_at"] else None
         ),
         analysis_timestamp=datetime.fromisoformat(row["analysis_timestamp"]),
+        analysis_version=_row_value(row, "analysis_version", 0),
         scoring_version=_row_value(row, "scoring_version", 1),
         model_version=_row_value(row, "model_version", None),
         perceptual_hash=row["perceptual_hash"],

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
 SCHEMA_VERSION = 18
-ANALYSIS_VERSION = 13
+ANALYSIS_VERSION = 14
 SCORING_VERSION = 3

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
 SCHEMA_VERSION = 18
-ANALYSIS_VERSION = 12
+ANALYSIS_VERSION = 13
 SCORING_VERSION = 3

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -396,6 +396,7 @@ def run_pipeline_and_generate(
         thumbnail_cache=thumbnail_cache,
     )
 
+    all_candidates = _drop_reencoded_sources(all_candidates, config=config)
     all_candidates = _apply_subject_policy(
         all_candidates,
         config=config,
@@ -663,6 +664,38 @@ def _merge_photos_into_pool(
     )
 
     return analyzed_videos + photo_candidates
+
+
+def _drop_reencoded_sources(candidates: list, *, config: Config) -> list:
+    """Drop messaging re-encodes: small, and with no camera EXIF to vouch for them."""
+    from immich_memories.analysis.source_quality import is_usable_source
+
+    floor = config.analysis.min_source_short_side
+    if floor <= 0:
+        return candidates
+
+    kept = [
+        c
+        for c in candidates
+        if is_usable_source(
+            width=c.clip.width or c.clip.asset.width or 0,
+            height=c.clip.height or c.clip.asset.height or 0,
+            has_camera_exif=_has_camera_exif(c.clip.asset),
+            min_short_side=floor,
+        )
+    ]
+    if len(kept) < len(candidates):
+        logger.info(
+            "Source quality: dropped %d clips under %dp with no camera EXIF",
+            len(candidates) - len(kept),
+            floor,
+        )
+    return kept
+
+
+def _has_camera_exif(asset) -> bool:
+    exif = getattr(asset, "exif_info", None)
+    return bool(exif and (exif.make or exif.model))
 
 
 def _apply_subject_policy(

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -400,6 +400,7 @@ def run_pipeline_and_generate(
         all_candidates,
         config=config,
         content_budget_seconds=timeline_plan.content_budget,
+        photo_assets=photo_assets,
     )
 
     # Phase 4: Unified selection (videos + photos compete together)
@@ -665,7 +666,11 @@ def _merge_photos_into_pool(
 
 
 def _apply_subject_policy(
-    candidates: list, *, config: Config, content_budget_seconds: float
+    candidates: list,
+    *,
+    config: Config,
+    content_budget_seconds: float,
+    photo_assets: list | None = None,
 ) -> list:
     """Prefer clips of people, and ration animals and objects by share of runtime."""
     if not config.analysis.subject_policy_enabled:
@@ -678,6 +683,7 @@ def _apply_subject_policy(
         animal_ratio=config.analysis.max_animal_ratio,
         object_ratio=config.analysis.max_object_ratio,
         content_budget_seconds=content_budget_seconds,
+        photo_asset_ids={a.id for a in photo_assets or []},
     )
 
 

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -233,6 +233,14 @@ class AnalysisConfig(BaseModel):
         le=1.0,
         description="Minimum duration (seconds) of quiet audio to count as a silence gap",
     )
+    min_source_short_side: int = Field(
+        default=1080,
+        ge=0,
+        description=(
+            "Clips below this short side are dropped unless they carry camera EXIF, "
+            "which is how messaging re-encodes are told from genuinely old footage"
+        ),
+    )
     subject_policy_enabled: bool = Field(
         default=True,
         description="Prefer clips of people; ration animals and exclude object-only clips",

--- a/tests/test_ace_step_backend.py
+++ b/tests/test_ace_step_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from contextlib import suppress
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -23,6 +24,16 @@ from immich_memories.audio.generators.base import GenerationRequest
 # ---------------------------------------------------------------------------
 # _detect_season
 # ---------------------------------------------------------------------------
+
+
+# WHY: several tests below swap a fake "mlx"/"mlx.core" into sys.modules. Metal
+# initialises once per process, so if the real extension is first imported *after*
+# one of those fakes has been installed and removed, the re-import aborts the whole
+# pytest run (SIGABRT) instead of failing a test. Loading it up front, before any
+# patching, keeps the real module object in sys.modules for the fakes to shadow and
+# restore. No-op when MLX is not installed, which is the case in CI.
+with suppress(ImportError):
+    import mlx.core  # noqa: F401
 
 
 class TestDetectSeason:
@@ -541,6 +552,11 @@ class TestACEStepBackendV15Library:
     ):
         captured = {}
         modules, _ = self._fake_v15_modules(tmp_path, captured)
+        # WHY: _init_pipeline calls _bound_mlx_memory, which imports mlx.core. With
+        # ACE-Step actually installed that pulls in the real Metal runtime and aborts
+        # the pytest process; the sibling tests in this class fake it for the same
+        # reason. This test asserts generation wiring, not GPU behaviour.
+        modules.update(self._fake_mlx_modules(captured))
         checkpoint_root = tmp_path / "checkpoints"
         backend = ACEStepBackend(ACEStepConfig(mode="lib", model_variant=variant, use_lm=False))
         backend._effective_mode = "lib"

--- a/tests/test_analysis_cache_versioning.py
+++ b/tests/test_analysis_cache_versioning.py
@@ -1,0 +1,34 @@
+"""Bumping ANALYSIS_VERSION must actually invalidate the analyzer's cache."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from immich_memories.analysis.cache_projection import is_compatible_analysis_cache
+from immich_memories.cache.database_models import CachedSegment, CachedVideoAnalysis
+from immich_memories.cache.versions import ANALYSIS_VERSION
+from immich_memories.config_loader import Config
+
+
+def _cached(analysis_version: int) -> CachedVideoAnalysis:
+    return CachedVideoAnalysis(
+        asset_id="asset-1",
+        checksum=None,
+        file_modified_at=None,
+        analysis_timestamp=datetime(2026, 6, 1),
+        analysis_version=analysis_version,
+        model_version="a-model",
+        segments=[CachedSegment(segment_index=0, start_time=0.0, end_time=3.0)],
+    )
+
+
+def test_analysis_from_an_older_generation_is_not_reused() -> None:
+    """needs_reanalysis() has always compared analysis_version, but the analyzer's
+    own cache check did not, so bumping the constant invalidated nothing on the
+    path that actually runs — new analysis fields silently stayed empty."""
+    config = Config()
+    config.content_analysis.enabled = True
+    config.llm.model = "a-model"
+
+    assert not is_compatible_analysis_cache(_cached(ANALYSIS_VERSION - 1), config)
+    assert is_compatible_analysis_cache(_cached(ANALYSIS_VERSION), config)

--- a/tests/test_audio_context_prompt.py
+++ b/tests/test_audio_context_prompt.py
@@ -25,9 +25,12 @@ TODAYS_PROMPT = """Describe what you see in this image.
 
 Return JSON with these fields:
 - description: What is happening in this scene?
-- category: What is this mainly of? Exactly one of: people, animal, landscape, object.
-  Use "people" if any person is visible, even partly. Use "landscape" only for a wide
-  outdoor view, never for a close-up of a thing. Use "object" for anything else.
+- category: What is this mainly of? Exactly one of: people, animal, landscape, object, screen.
+  Use "screen" if the subject is a phone, watch, computer or TV display, a screenshot,
+  or a document or form -- even when a person is holding or wearing the device.
+  Use "people" if a person is the subject. Use "animal" only for a live animal, not a
+  toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
+  never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from immich_memories.analysis.clip_analyzer import ClipAnalyzer
 from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+from immich_memories.cache.versions import ANALYSIS_VERSION
 from immich_memories.config_loader import Config
 from tests.conftest import make_clip
 
@@ -88,6 +89,7 @@ def _make_cached_analysis(segment: MagicMock | None = None) -> MagicMock:
     """Build a mock CachedVideoAnalysis wrapping a segment."""
     analysis = MagicMock()
     analysis.segments = [segment] if segment else []
+    analysis.analysis_version = ANALYSIS_VERSION
     return analysis
 
 
@@ -295,6 +297,7 @@ class TestCheckAnalysisCache:
         high = _make_cached_segment(start=5.0, end=8.0, score=0.95)
         analysis = MagicMock()
         analysis.segments = [low, high]
+        analysis.analysis_version = ANALYSIS_VERSION
         mock_cache.get_analysis.return_value = analysis
 
         clip = make_clip("asset-6", duration=10.0)

--- a/tests/test_delivery_retry.py
+++ b/tests/test_delivery_retry.py
@@ -330,8 +330,9 @@ def test_v13_delivery_migration_keeps_v12_analysis_cache_current(
             (asset.id,),
         ).fetchone()[0]
     assert schema_version == 13
-    assert cache_database.ANALYSIS_VERSION == 12
-    assert analysis_version == 12
+    # The claim is that a delivery-only schema migration leaves the analysis
+    # generation alone -- not that it happens to be any particular number.
+    assert analysis_version == cache_database.ANALYSIS_VERSION
     assert migrated_cache.needs_reanalysis(asset, max_age_days=365) is False
 
 

--- a/tests/test_llm_category_parsing.py
+++ b/tests/test_llm_category_parsing.py
@@ -1,0 +1,32 @@
+"""The subject category has to survive a malformed response, not just clean JSON."""
+
+from __future__ import annotations
+
+from immich_memories.analysis.content_analyzer import get_content_analyzer  # noqa: F401
+from immich_memories.analysis.llm_response_parser import ContentAnalyzer
+
+
+def _partial(text: str):
+    return ContentAnalyzer._extract_partial_data(ContentAnalyzer.__new__(ContentAnalyzer), text)
+
+
+def test_category_survives_the_regex_fallback() -> None:
+    """The fallback used to extract description, emotion, interestingness, quality
+    and setting, and drop the rest — so a response that failed strict JSON parsing
+    lost the one field the subject policy reads."""
+    text = (
+        'Here you go!\n{"description": "A smartwatch showing running data", '
+        '"category": "screen", "subjects": ["watch", "wrist"], "emotion": "calm", '
+        '"interestingness": 0.4, "quality": 0.8'
+    )
+
+    result = _partial(text)
+
+    assert result.category == "screen"
+    assert result.subjects == ["watch", "wrist"]
+    assert result.description.startswith("A smartwatch")
+
+
+def test_a_missing_category_stays_empty() -> None:
+    result = _partial('{"description": "Kids on a beach", "emotion": "happy"')
+    assert result.category == ""

--- a/tests/test_operational_phases.py
+++ b/tests/test_operational_phases.py
@@ -222,6 +222,8 @@ def test_analysis_continues_when_attempt_phase_write_fails(tmp_path: Path) -> No
         analysed.score = 0.5
         analysed.start_time = 0.0
         analysed.end_time = 4.0
+        analysed.clip.width = 3840
+        analysed.clip.height = 2160
         pipeline_type.return_value.run_analysis.return_value = [analysed]
         pipeline_type.return_value.run_selection.return_value = result
         actual, _, _ = run_pipeline_and_generate(

--- a/tests/test_pipeline_efficiency.py
+++ b/tests/test_pipeline_efficiency.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from immich_memories.cache.versions import ANALYSIS_VERSION
 from immich_memories.config_loader import Config
 
 
@@ -217,7 +218,11 @@ class TestAnalysisEligibility:
 
         def cached_or_missing(asset_id: str):
             if int(asset_id.removeprefix("clip-")) < 50:
-                return MagicMock(model_version="qwen-3.6", segments=[MagicMock()])
+                return MagicMock(
+                    model_version="qwen-3.6",
+                    analysis_version=ANALYSIS_VERSION,
+                    segments=[MagicMock()],
+                )
             return None
 
         pipeline.analysis_cache.get_analysis.side_effect = cached_or_missing

--- a/tests/test_source_quality.py
+++ b/tests/test_source_quality.py
@@ -1,0 +1,27 @@
+"""Messaging re-encodes should not reach a 4K memory."""
+
+from __future__ import annotations
+
+from immich_memories.analysis.source_quality import is_usable_source
+
+
+def test_a_whatsapp_reencode_is_rejected() -> None:
+    """Measured on a real June pool: all 17 sub-1080p candidates had no camera
+    EXIF at all, and every candidate with camera EXIF was 1080p or better."""
+    assert not is_usable_source(width=356, height=634, has_camera_exif=False, min_short_side=1080)
+
+
+def test_a_legitimately_small_original_is_kept() -> None:
+    """An old camera's 480p footage carries real EXIF and is a real memory."""
+    assert is_usable_source(width=640, height=480, has_camera_exif=True, min_short_side=1080)
+
+
+def test_a_full_resolution_clip_without_exif_is_kept() -> None:
+    """Resolution alone is enough; missing EXIF only condemns a small clip."""
+    assert is_usable_source(width=3840, height=2160, has_camera_exif=False, min_short_side=1080)
+
+
+def test_unknown_dimensions_are_kept() -> None:
+    """Live-photo rows often have no cached dimensions. Absence of evidence
+    must not delete the clip."""
+    assert is_usable_source(width=0, height=0, has_camera_exif=False, min_short_side=1080)

--- a/tests/test_step2_loading.py
+++ b/tests/test_step2_loading.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import immich_memories.ui.pages.step2_loading as step2_loading
 from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+from immich_memories.cache.versions import ANALYSIS_VERSION
 from immich_memories.config_loader import Config
 from immich_memories.ui.pages.step2_loading import _set_initial_selection
 from immich_memories.ui.state import AppState
@@ -66,7 +67,9 @@ def test_load_surfaces_only_current_model_cached_analysis() -> None:
         llm_quality=0.86,
         audio_categories=["waves"],
     )
-    current_analysis = MagicMock(model_version="qwen-3.6", segments=[current_segment])
+    current_analysis = MagicMock(
+        model_version="qwen-3.6", segments=[current_segment], analysis_version=ANALYSIS_VERSION
+    )
     current_analysis.get_best_segment.return_value = current_segment
     stale_analysis = MagicMock(model_version="qwen-3.5", segments=[MagicMock()])
     cache = MagicMock()

--- a/tests/test_subject_policy.py
+++ b/tests/test_subject_policy.py
@@ -53,10 +53,10 @@ def test_people_outrank_whatever_else_is_in_frame() -> None:
     )
 
 
-def _cand(key, category, score):
+def _cand(key, category, score, scale="motion"):
     from immich_memories.analysis.subject_policy import SubjectCandidate
 
-    return SubjectCandidate(key=key, category=category, score=score)
+    return SubjectCandidate(key=key, category=category, score=score, scale=scale)
 
 
 def test_a_high_scoring_object_still_loses_to_a_lower_scoring_person() -> None:
@@ -242,3 +242,26 @@ def test_a_genuinely_good_object_gets_in_but_a_dull_one_does_not() -> None:
 
     assert "new-car" in outcome.kept_keys
     assert "lawnmower" not in outcome.kept_keys
+
+
+def test_the_bar_is_computed_within_a_scale_not_across_two() -> None:
+    """Measured on a real June pool: people video clips score a 0.70 median,
+    photos a much lower one. Pooling both gave a 0.43 bar, and a string trimmer
+    scoring 0.61 cleared it. Judged against its own scale it does not."""
+    from immich_memories.analysis.subject_policy import apply_subject_quotas
+
+    outcome = apply_subject_quotas(
+        [
+            _cand("clip-person-a", SubjectCategory.PEOPLE, 0.70, scale="motion"),
+            _cand("clip-person-b", SubjectCategory.PEOPLE, 0.85, scale="motion"),
+            _cand("trimmer", SubjectCategory.OBJECT, 0.61, scale="motion"),
+            _cand("photo-person-a", SubjectCategory.PEOPLE, 0.28, scale="photo"),
+            _cand("photo-person-b", SubjectCategory.PEOPLE, 0.43, scale="photo"),
+        ],
+        animal_ratio=0.10,
+        object_ratio=0.05,
+        expected_clips=15,
+    )
+
+    assert "trimmer" not in outcome.kept_keys
+    assert "photo-person-a" in outcome.kept_keys

--- a/tests/test_subject_policy.py
+++ b/tests/test_subject_policy.py
@@ -8,47 +8,7 @@ from immich_memories.analysis.subject_policy import SubjectCategory, classify_su
 def test_an_immich_face_tag_settles_it() -> None:
     """Immich's own face tagging is authoritative and needs no LLM round trip."""
     assert (
-        classify_subject(tagged_people=1, subjects=None, description="a red lawnmower on grass")
-        is SubjectCategory.PEOPLE
-    )
-
-
-def test_an_untagged_clip_is_people_when_the_description_says_so() -> None:
-    """Immich only tags faces it recognises; a stranger or a back of a head is
-    still a person. These are verbatim descriptions from a real cache."""
-    for text in (
-        "Three children are playing with sand at the beach.",
-        "A man and a baby are interacting playfully in a cozy indoor setting.",
-        "A woman and a child are seated in the back of a bicycle-like vehicle.",
-    ):
-        assert (
-            classify_subject(tagged_people=0, subjects=None, description=text)
-            is SubjectCategory.PEOPLE
-        ), text
-
-
-def test_animals_landscapes_and_objects_are_told_apart() -> None:
-    cases = {
-        "A dog is running across the garden": SubjectCategory.ANIMAL,
-        "Two cats sit on a windowsill": SubjectCategory.ANIMAL,
-        "Sunset over the sea with mountains in the distance": SubjectCategory.LANDSCAPE,
-        "A view of the valley from the top of the hill": SubjectCategory.LANDSCAPE,
-        "A red lawnmower parked on the lawn": SubjectCategory.OBJECT,
-        "A bicycle mounted on an indoor trainer": SubjectCategory.OBJECT,
-        "A shelf holding plastic storage boxes": SubjectCategory.OBJECT,
-    }
-    for text, expected in cases.items():
-        assert classify_subject(tagged_people=0, subjects=None, description=text) is expected, text
-
-
-def test_people_outrank_whatever_else_is_in_frame() -> None:
-    """A child playing with the dog is a memory about the child."""
-    assert (
-        classify_subject(
-            tagged_people=0,
-            subjects=None,
-            description="A dog runs along the beach while two children chase it",
-        )
+        classify_subject(tagged_people=1, description="a red lawnmower on grass")
         is SubjectCategory.PEOPLE
     )
 
@@ -153,27 +113,12 @@ def test_a_clip_we_know_nothing_about_is_kept() -> None:
     assert "unanalysed" in outcome.kept_keys
 
 
-def test_a_close_up_of_an_object_is_not_scenery() -> None:
-    """'view' appears in 'a close-up view of a treadmill'. Real misclassifications
-    from a live library: a bike hub, a treadmill, an office renovation."""
-    for text in (
-        "A close-up view of a modern treadmill against a wall",
-        "This is a close-up photograph of the rear wheel hub and disc brake assembly",
-        "A series of images showing an office renovation",
-    ):
-        assert (
-            classify_subject(tagged_people=0, subjects=None, description=text)
-            is not SubjectCategory.LANDSCAPE
-        ), text
-
-
 def test_an_explicit_category_from_the_model_is_used_directly() -> None:
     """Asking the VLM to pick from a closed set beats keyword-matching its prose."""
     assert (
         classify_subject(
             tagged_people=0,
             category="object",
-            subjects=None,
             description="A close-up of a string trimmer lying on concrete blocks",
         )
         is SubjectCategory.OBJECT
@@ -183,20 +128,7 @@ def test_an_explicit_category_from_the_model_is_used_directly() -> None:
 def test_face_tags_still_beat_an_explicit_category() -> None:
     """Immich recognised a face; the VLM saying 'object' does not overrule that."""
     assert (
-        classify_subject(tagged_people=2, category="object", subjects=None, description=None)
-        is SubjectCategory.PEOPLE
-    )
-
-
-def test_an_unrecognised_category_falls_back_to_the_description() -> None:
-    """Models return junk. A bad label must not silently become OBJECT."""
-    assert (
-        classify_subject(
-            tagged_people=0,
-            category="Category.PEOPLE!!",
-            subjects=None,
-            description="Two children are digging in the sand",
-        )
+        classify_subject(tagged_people=2, category="object", description=None)
         is SubjectCategory.PEOPLE
     )
 
@@ -265,3 +197,35 @@ def test_the_bar_is_computed_within_a_scale_not_across_two() -> None:
 
     assert "trimmer" not in outcome.kept_keys
     assert "photo-person-a" in outcome.kept_keys
+
+
+def test_a_screen_demo_is_its_own_category() -> None:
+    """A clip of a smartwatch showing running data has a person in it and is
+    still not a memory. The model is asked to say so directly."""
+    assert (
+        classify_subject(tagged_people=0, category="screen", description=None)
+        is SubjectCategory.SCREEN
+    )
+
+
+def test_the_description_never_decides_the_category() -> None:
+    """Keyword matching on prose classified figurines as animals, a smartwatch
+    demo as people, and a treadmill as scenery. Only the model's own label and
+    Immich's face tags decide; anything else is unknown, and unknown is kept."""
+    for text in (
+        "A collection of small animal figurines arranged in a winding line",
+        "A person sitting still while wearing a smartwatch displaying running data",
+        "Sunset over the sea with mountains in the distance",
+    ):
+        assert (
+            classify_subject(tagged_people=0, category=None, description=text)
+            is SubjectCategory.UNKNOWN
+        ), text
+
+
+def test_a_junk_label_is_unknown_not_a_guess() -> None:
+    """Models return junk. An unrecognised label must not become a category."""
+    assert (
+        classify_subject(tagged_people=0, category="Category.PEOPLE!!", description=None)
+        is SubjectCategory.UNKNOWN
+    )


### PR DESCRIPTION
Follow-ups to #335, all found by running real generations rather than by tests. Every one of these was a silent no-op or a hard crash that unit tests could not see.

## Why this exists

After #335 merged I ran a full generation to validate it. The subject policy did **nothing** — no log line, no drops. Chasing that turned up four separate defects, three of them pre-existing.

## 1. `ANALYSIS_VERSION` invalidated nothing

Two gates disagreed. `needs_reanalysis()` compares the stored `analysis_version`; `is_compatible_analysis_cache()` — the one `ClipAnalyzer` actually consults — only compared `model_version`, and `CachedVideoAnalysis` never loaded `analysis_version` off the row at all.

So bumping the constant did nothing on the path that runs. Observed: all 62 June clips logged `Using cached analysis`, and the new `llm_category` stayed empty across all 9,609 cached segments.

## 2. The category could not survive a malformed response

`_extract_partial_data` — the fallback for responses that aren't valid JSON — pulled out description/emotion/interestingness/quality/setting and dropped the rest, so `category` and `subjects` could only ever survive the strict JSON path. The policy reads nothing but the category, so a response landing there drops silently out of the filter.

**Correction to my first reading of this.** I opened this thinking most responses were malformed, on the evidence that only 5 of 1,619 analysed segments carried a category. That denominator was wrong — it counted the whole cache, almost all of it written before the category existed. Measured properly:

| analysis_version | segments w/ description | of those, w/ category |
|---:|---:|---:|
| **14** (current) | 49 | **49 — 100%** |
| 12 | 669 | 0 |
| 9 | 901 | 0 |

And sampled against the live model, 8 of 8 responses were well-formed — markdown-fenced, which `_parse_json_object` already handles via `find("{")`/`rfind("}")` — and every one carried a category. So this change is **insurance, not a fix for something observed**. It stays because the two fields it adds are the two the policy cannot work without.

## 3. A real MLX install aborted the whole test run

`make test` died with **SIGABRT**, not a test failure, whenever ACE-Step was installed — which is the supported setup for music. Two causes, both in the test file:

- `test_v15_library_generates_stable_wav_result` exercises `_init_pipeline` → `_bound_mlx_memory` → `import mlx.core`. Every sibling test in that class fakes MLX for exactly that reason; this one didn't.
- Metal initialises once per process. Once a fake `mlx`/`mlx.core` has been swapped into `sys.modules` and removed, the first *real* import afterwards re-runs the extension's init and aborts the interpreter. Importing `mlx.core` once at module import time, before anything patches, leaves the real module for the fakes to shadow and restore.

That unblocks `ENSURE_DEV_COMMAND` syncing with `--inexact`, so the gates stop deleting the ACE-Step install on every run.

## 4. Two more selection defects

**The quality bar mixed two score scales.** It's derived (median people-clip score) precisely to avoid a fixed threshold breaking across pools — then it was computed over photos and motion clips together. Measured: people motion clips sit at a 0.70 median, photos at 0.43. The pooled median landed on the photo scale, and a clip of a string trimmer scoring 0.61 cleared it comfortably. Each scale now gets its own bar.

**Prose decided the category.** Keyword matching called a tray of animal figurines "animal", a smartwatch demo "people" (a person was wearing the watch), and a treadmill and a driver's-eye road view "landscape" (both descriptions said *close-up view*). The model is asked for the label outright, the closed set gains **`screen`** for displays/screenshots/documents, and the description decides nothing. Unlabelled is unknown, and unknown is kept.

**Source quality.** Messaging apps re-encode small *and* strip camera EXIF; an old camera's small footage keeps its EXIF. Across 111 June motion candidates that separates them perfectly: all 17 below 1080p had no camera make or model, and all 89 carrying camera EXIF were ≥1080p.

## Validated on a real run

```
Source quality:  dropped 75 clips under 1080p with no camera EXIF
Subject policy:  dropped 1 object, 2 screen (had to beat motion 0.31, photo 0.45)
```

The 2 screens are the smartwatch data-field clips that prompted this. Output verified: HEVC Main 10, `yuv420p10le`, HLG / BT.2020, 59s, with an ACE-Step track at −15.7 dB mean.

`make ci` green: 4692 passed — including with ACE-Step and MLX installed, which previously aborted.

## Note

`ANALYSIS_VERSION` 12 → 14. The first run after this merges re-analyses the library. That is intended — the category is now the only subject signal, and existing rows don't have one — but it isn't free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3