### PR TITLE
fix(selection): the four loose ends from the subject-policy work

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,63 +6,43 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 568,
-        "line_end": 611,
+        "line_start": 575,
+        "line_end": 618,
         "line_complexities": [
-          {
-            "line": 578,
-            "complexity": 0
-          },
-          {
-            "line": 579,
-            "complexity": 1
-          },
-          {
-            "line": 580,
-            "complexity": 0
-          },
-          {
-            "line": 583,
-            "complexity": 0
-          },
-          {
-            "line": 584,
-            "complexity": 1
-          },
           {
             "line": 585,
             "complexity": 0
           },
           {
-            "line": 588,
+            "line": 586,
+            "complexity": 1
+          },
+          {
+            "line": 587,
             "complexity": 0
           },
           {
-            "line": 589,
+            "line": 590,
             "complexity": 0
           },
           {
             "line": 591,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 592,
             "complexity": 0
           },
           {
-            "line": 593,
-            "complexity": 1
-          },
-          {
-            "line": 594,
+            "line": 595,
             "complexity": 0
           },
           {
-            "line": 595,
-            "complexity": 2
+            "line": 596,
+            "complexity": 0
           },
           {
-            "line": 597,
+            "line": 598,
             "complexity": 0
           },
           {
@@ -75,26 +55,46 @@
           },
           {
             "line": 601,
-            "complexity": 2
-          },
-          {
-            "line": 602,
             "complexity": 0
           },
           {
-            "line": 603,
-            "complexity": 3
+            "line": 602,
+            "complexity": 2
           },
           {
-            "line": 605,
-            "complexity": 4
+            "line": 604,
+            "complexity": 0
           },
           {
             "line": 606,
+            "complexity": 0
+          },
+          {
+            "line": 607,
+            "complexity": 1
+          },
+          {
+            "line": 608,
+            "complexity": 2
+          },
+          {
+            "line": 609,
+            "complexity": 0
+          },
+          {
+            "line": 610,
+            "complexity": 3
+          },
+          {
+            "line": 612,
+            "complexity": 4
+          },
+          {
+            "line": 613,
             "complexity": 5
           },
           {
-            "line": 611,
+            "line": 618,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/analyzer_models.py
+++ b/src/immich_memories/analysis/analyzer_models.py
@@ -70,7 +70,6 @@ class ScoredSegment:
     llm_category: str | None = None
     llm_emotion: str | None = None
     llm_setting: str | None = None
-    llm_activities: list[str] | None = None
     llm_subjects: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None

--- a/src/immich_memories/analysis/cache_projection.py
+++ b/src/immich_memories/analysis/cache_projection.py
@@ -36,7 +36,6 @@ def semantic_payload_from_segment(segment: CachedSegment) -> dict[str, object] |
         "category": segment.llm_category,
         "emotion": segment.llm_emotion,
         "setting": segment.llm_setting,
-        "activities": segment.llm_activities,
         "subjects": segment.llm_subjects,
         "interestingness": segment.llm_interestingness,
         "quality": segment.llm_quality,
@@ -55,7 +54,6 @@ def apply_semantic_payload(
     clip.llm_category = cast(str | None, payload.get("category"))
     clip.llm_emotion = cast(str | None, payload.get("emotion"))
     clip.llm_setting = cast(str | None, payload.get("setting"))
-    clip.llm_activities = cast(list[str] | None, payload.get("activities"))
     clip.llm_subjects = cast(list[str] | None, payload.get("subjects"))
     clip.llm_interestingness = cast(float | None, payload.get("interestingness"))
     clip.llm_quality = cast(float | None, payload.get("quality"))

--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -436,7 +436,6 @@ class ClipAnalyzer:
                     "category": best_segment.llm_category,
                     "emotion": best_segment.llm_emotion,
                     "setting": best_segment.llm_setting,
-                    "activities": best_segment.llm_activities,
                     "subjects": best_segment.llm_subjects,
                     "interestingness": best_segment.llm_interestingness,
                     "quality": best_segment.llm_quality,

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -237,6 +237,32 @@ def _resolve_backfill_candidates(
     if exact:
         return _BackfillCandidates(exact, active_photo_limit)
 
+    # The photo ratio is spent last. It used to be the first constraint relaxed,
+    # so any shortage of runtime was answered with more stills: a real June video
+    # finished with 7 photos out of 13 clips against a cap that had just been
+    # computed as 4. Loosening who appears (non-favorites) or when (a nearby
+    # moment) changes the edit far less than turning a video into a slideshow.
+    relaxed_favorites = _admissible_backfill_candidates(
+        available,
+        context=context,
+        photo_limit=active_photo_limit,
+        remaining_budget=remaining_budget,
+        enforce_favorite_ratio=False,
+    )
+    if relaxed_favorites:
+        return _BackfillCandidates(relaxed_favorites, active_photo_limit, "favorite_ratio")
+
+    relaxed_temporal = _admissible_backfill_candidates(
+        available,
+        context=context,
+        photo_limit=active_photo_limit,
+        remaining_budget=remaining_budget,
+        enforce_favorite_ratio=False,
+        enforce_temporal_spacing=False,
+    )
+    if relaxed_temporal:
+        return _BackfillCandidates(relaxed_temporal, active_photo_limit, "temporal_spacing")
+
     relaxed_photo_limit = active_photo_limit
     if active_photo_limit is not None and active_photo_limit < 0.70:
         relaxed_photo_limit = 0.70
@@ -245,30 +271,11 @@ def _resolve_backfill_candidates(
             context=context,
             photo_limit=relaxed_photo_limit,
             remaining_budget=remaining_budget,
+            enforce_favorite_ratio=False,
+            enforce_temporal_spacing=False,
         )
         if relaxed_photos:
             return _BackfillCandidates(relaxed_photos, relaxed_photo_limit, "photo_ratio_70")
-
-    relaxed_favorites = _admissible_backfill_candidates(
-        available,
-        context=context,
-        photo_limit=relaxed_photo_limit,
-        remaining_budget=remaining_budget,
-        enforce_favorite_ratio=False,
-    )
-    if relaxed_favorites:
-        return _BackfillCandidates(relaxed_favorites, relaxed_photo_limit, "favorite_ratio")
-
-    relaxed_temporal = _admissible_backfill_candidates(
-        available,
-        context=context,
-        photo_limit=relaxed_photo_limit,
-        remaining_budget=remaining_budget,
-        enforce_favorite_ratio=False,
-        enforce_temporal_spacing=False,
-    )
-    if relaxed_temporal:
-        return _BackfillCandidates(relaxed_temporal, relaxed_photo_limit, "temporal_spacing")
 
     if relaxed_photo_limit is not None:
         unlimited_photos = _admissible_backfill_candidates(

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -30,11 +30,12 @@ _PROMPT_TAIL = """Return JSON with these fields:
   toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
   never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
+- setting: Where is it? (one or two words: beach, kitchen, park, car)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "beach", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 
@@ -87,7 +88,6 @@ class ContentAnalysis:
 
     description: str = ""
     category: str = ""
-    activities: list[str] = field(default_factory=list)
     subjects: list[str] = field(default_factory=list)
     setting: str = ""
     emotion: str = ""
@@ -381,7 +381,6 @@ class ContentAnalyzer:
         """
         MAX_STR = 500
         description = str(data.get("description", ""))[:MAX_STR]
-        activities = [str(a)[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]]
         subjects = [str(s)[:MAX_STR] for s in data.get("subjects", [])[:MAX_LIST]]
         category = str(data.get("category", ""))[:MAX_STR]
         setting = str(data.get("setting", ""))[:MAX_STR]
@@ -394,7 +393,6 @@ class ContentAnalyzer:
 
         return ContentAnalysis(
             description=description,
-            activities=activities,
             subjects=subjects,
             category=category,
             setting=setting,

--- a/src/immich_memories/analysis/subject_policy.py
+++ b/src/immich_memories/analysis/subject_policy.py
@@ -75,6 +75,7 @@ class SubjectCandidate:
     category: SubjectCategory
     score: float
     scale: str = "motion"
+    labelled: bool = True
 
 
 @dataclass(frozen=True)
@@ -183,25 +184,31 @@ def _top(members: list[SubjectCandidate], limit: int) -> list[SubjectCandidate]:
 
 
 def _quality_bars(candidates: list[SubjectCandidate]) -> dict[str, float]:
-    """The median people-clip score, computed separately for each score scale.
+    """The median people-clip score, per score scale, over comparable scores only.
 
-    Photos and motion clips are scored by different pipelines and land in
-    different ranges -- on a real June pool, people motion clips sat at a 0.70
-    median while photos sat far below. One pooled median put the bar at 0.43,
-    low enough for a clip of a string trimmer to clear it. Each scale is
-    therefore judged against its own people.
+    Two things make scores incomparable. Photos and motion clips come from
+    different pipelines and land in different ranges, so each scale gets its own
+    bar -- pooling them once put the bar at 0.43, low enough for a clip of a
+    string trimmer scoring 0.61 to clear it.
+
+    Within a scale, a score is only a semantic judgement if the clip was actually
+    analysed. One that was merely pre-filtered carries Asset.quality_score --
+    resolution and bitrate, not how good the moment is -- and one whose analysis
+    failed carries 0.0. Only clips the model labelled went through the same
+    scoring as the objects and scenery being judged against them, so only those
+    set the bar. A real run mixing all three produced a 0.31 motion bar against a
+    labelled-people median of about 0.83.
     """
     by_scale: dict[str, list[float]] = {}
+    comparable: dict[str, list[float]] = {}
     for candidate in candidates:
         by_scale.setdefault(candidate.scale, []).append(candidate.score)
-
-    people: dict[str, list[float]] = {}
-    for candidate in candidates:
-        if candidate.category is SubjectCategory.PEOPLE:
-            people.setdefault(candidate.scale, []).append(candidate.score)
+        if candidate.category is SubjectCategory.PEOPLE and candidate.labelled:
+            comparable.setdefault(candidate.scale, []).append(candidate.score)
 
     return {
-        scale: statistics.median(people.get(scale) or scores) for scale, scores in by_scale.items()
+        scale: statistics.median(comparable.get(scale) or scores)
+        for scale, scores in by_scale.items()
     }
 
 
@@ -234,6 +241,7 @@ def filter_candidates_by_subject(
             ),
             score=candidate.score,
             scale="photo" if candidate.clip.asset.id in photos else "motion",
+            labelled=bool(candidate.clip.llm_category),
         )
         for candidate in candidates
     ]
@@ -256,9 +264,10 @@ def filter_candidates_by_subject(
             f"{n} {category.value}" for category, n in sorted(outcome.dropped.items(), key=str)
         )
         logger.info(
-            "Subject policy: dropped %s (had to beat %s)",
+            "Subject policy: dropped %s (had to beat %s, from %d labelled people clips)",
             counts,
             ", ".join(f"{scale} {bar:.2f}" for scale, bar in sorted(outcome.bars.items())),
+            sum(1 for c in described if c.labelled and c.category is SubjectCategory.PEOPLE),
         )
 
     kept = set(outcome.kept_keys)

--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -582,7 +582,6 @@ class UnifiedSegmentAnalyzer:
                 segment.llm_category = analysis.category
                 segment.llm_emotion = analysis.emotion
                 segment.llm_setting = analysis.setting
-                segment.llm_activities = analysis.activities
                 segment.llm_subjects = analysis.subjects
                 segment.llm_interestingness = analysis.interestingness
                 segment.llm_quality = analysis.quality
@@ -636,9 +635,19 @@ class UnifiedSegmentAnalyzer:
             + segment.duration_score * duration_w
         )
 
-        # LLM bonus: only scores above neutral (0.5) add signal
+        # LLM bonus: only scores above neutral (0.5) add signal.
         # content_score=0.5 → +0.0, content_score=1.0 → +content_weight
-        # content_score<0.5 → +0.0 (never penalizes)
+        #
+        # The one-way clamp looks like it suppresses negative evidence, and it does
+        # not: measured over 1879 scored segments, exactly 3 sit below 0.5. The
+        # model effectively never says a clip is bad. Making this two-sided would
+        # move three clips and nothing else.
+        #
+        # The signal itself is what is weak. Across the same segments the range is
+        # 0.38-0.92 with a 0.76 median, and by the model's own category, objects
+        # score *higher* than people (0.72 vs 0.70). Ranking on it cannot separate
+        # a memory from a lawnmower, which is why subject_policy classifies rather
+        # than scores. Do not "fix" the clamp expecting selection to improve.
         llm_bonus = 0.0
         if enable_content_analysis and self.content_weight > 0:
             llm_bonus = max(0.0, (segment.content_score - 0.5)) * self.content_weight * 2

--- a/src/immich_memories/api/models.py
+++ b/src/immich_memories/api/models.py
@@ -399,7 +399,6 @@ class VideoClipInfo(BaseModel):
     llm_category: str | None = None  # people | animal | landscape | object
     llm_emotion: str | None = None  # Detected emotional tone (happy, calm, excited, etc.)
     llm_setting: str | None = None  # Where it takes place (indoor, outdoor, beach, etc.)
-    llm_activities: list[str] | None = None  # Activities detected
     llm_subjects: list[str] | None = None  # Who/what is in the video
     llm_interestingness: float | None = None  # Score 0-1 for how interesting
     llm_quality: float | None = None  # Score 0-1 for visual quality

--- a/src/immich_memories/cache/database.py
+++ b/src/immich_memories/cache/database.py
@@ -320,7 +320,7 @@ class VideoAnalysisCache:
             ("llm_description", "TEXT"),
             ("llm_emotion", "TEXT"),
             ("llm_setting", "TEXT"),
-            ("llm_activities", "TEXT"),  # JSON array
+            ("llm_activities", "TEXT"),  # JSON array; no longer written, never read
             ("llm_subjects", "TEXT"),  # JSON array
             ("llm_interestingness", "REAL"),
             ("llm_quality", "REAL"),
@@ -630,7 +630,6 @@ class VideoAnalysisCache:
     ) -> None:
         for i, segment in enumerate(segments):
             # Serialize list fields to JSON
-            activities = getattr(segment, "llm_activities", None)
             subjects = getattr(segment, "llm_subjects", None)
             audio_cats = getattr(segment, "audio_categories", None)
 
@@ -641,11 +640,11 @@ class VideoAnalysisCache:
                     face_score, motion_score, stability_score,
                     audio_score, total_score, face_positions,
                     llm_description, llm_category, llm_emotion, llm_setting,
-                    llm_activities, llm_subjects,
+                    llm_subjects,
                     llm_interestingness, llm_quality,
                     audio_categories,
                     transcript, transcript_language, transcript_confidence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     asset_id,
@@ -662,7 +661,6 @@ class VideoAnalysisCache:
                     getattr(segment, "llm_category", None),
                     getattr(segment, "llm_emotion", None),
                     getattr(segment, "llm_setting", None),
-                    json.dumps(list(activities)) if activities else None,
                     json.dumps(list(subjects)) if subjects else None,
                     getattr(segment, "llm_interestingness", None),
                     getattr(segment, "llm_quality", None),

--- a/src/immich_memories/cache/database_models.py
+++ b/src/immich_memories/cache/database_models.py
@@ -36,7 +36,6 @@ class CachedSegment:
     llm_category: str | None = None
     llm_emotion: str | None = None
     llm_setting: str | None = None
-    llm_activities: list[str] | None = None
     llm_subjects: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None

--- a/src/immich_memories/cache/database_rows.py
+++ b/src/immich_memories/cache/database_rows.py
@@ -71,7 +71,6 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         value = row[name] if name in keys else None
         return float(value) if value is not None else None
 
-    activities_raw = optional_str("llm_activities")
     subjects_raw = optional_str("llm_subjects")
     audio_categories_raw = optional_str("audio_categories")
 
@@ -93,7 +92,6 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         llm_category=optional_str("llm_category"),
         llm_emotion=optional_str("llm_emotion"),
         llm_setting=optional_str("llm_setting"),
-        llm_activities=(json.loads(activities_raw) if activities_raw else None),
         llm_subjects=(json.loads(subjects_raw) if subjects_raw else None),
         llm_interestingness=optional_float("llm_interestingness"),
         llm_quality=optional_float("llm_quality"),

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -2479,7 +2479,6 @@ class TestClipAnalyzerRunUnifiedAnalysis:
         mock_segment.llm_description = "People laughing at a party"
         mock_segment.llm_emotion = "joy"
         mock_segment.llm_setting = "indoor"
-        mock_segment.llm_activities = ["socializing"]
         mock_segment.llm_subjects = ["group"]
         mock_segment.llm_interestingness = 0.9
         mock_segment.llm_quality = 0.8

--- a/tests/test_audio_context_prompt.py
+++ b/tests/test_audio_context_prompt.py
@@ -32,11 +32,12 @@ Return JSON with these fields:
   toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
   never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
+- setting: Where is it? (one or two words: beach, kitchen, park, car)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "beach", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 
@@ -135,7 +136,6 @@ def test_score_content_passes_the_segments_transcript():
         description="d",
         emotion="happy",
         setting="",
-        activities=[],
         subjects=[],
         interestingness=0.7,
         quality=0.8,

--- a/tests/test_backfill_priority.py
+++ b/tests/test_backfill_priority.py
@@ -1,0 +1,65 @@
+"""Runtime shortfalls should not be filled with photos before anything else."""
+
+from __future__ import annotations
+
+from immich_memories.analysis.clip_refiner import (
+    _BackfillContext,
+    _resolve_backfill_candidates,
+)
+from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+from immich_memories.api.models import AssetType, VideoClipInfo
+from tests.conftest import make_asset
+
+
+def _clip(asset_id: str, *, is_photo: bool, favorite: bool) -> ClipWithSegment:
+    asset = make_asset(asset_id, is_favorite=favorite)
+    if is_photo:
+        asset.type = AssetType.IMAGE
+    return ClipWithSegment(
+        clip=VideoClipInfo(asset=asset, duration_seconds=4.0),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.5,
+    )
+
+
+def _context(**overrides) -> _BackfillContext:
+    defaults = {
+        "config": PipelineConfig(),
+        "selected_count": 8,
+        "photo_count": 4,
+        "non_favorite_count": 6,
+        "temporal_window": 0.0,
+        "occupied_temporal_buckets": set(),
+    }
+    defaults.update(overrides)
+    return _BackfillContext(**defaults)
+
+
+def test_a_non_favorite_video_is_preferred_over_relaxing_the_photo_ratio() -> None:
+    """The ladder used to spend the photo ratio first, so a shortage of runtime
+    was answered with more stills — a real June video ended at 7 photos of 13
+    while the cap had just been computed as 4. Photos are the last thing to give."""
+    available = [
+        _clip("photo-1", is_photo=True, favorite=True),
+        _clip("video-1", is_photo=False, favorite=False),
+    ]
+
+    # Strict fails for both: the photo would exceed a 50% cap (it is a favorite,
+    # so nothing else blocks it), and the video would exceed the non-favorite
+    # ratio. Relaxing either constraint unblocks exactly one, so the order the
+    # ladder tries them in decides what ends up on screen.
+    config = PipelineConfig()
+    config.prioritize_favorites = True
+    config.max_non_favorite_ratio = 0.7
+    config.target_clips = 8
+
+    resolved = _resolve_backfill_candidates(
+        available,
+        context=_context(config=config, selected_count=8, photo_count=4, non_favorite_count=6),
+        active_photo_limit=0.50,
+        remaining_budget=8.0,
+    )
+
+    assert resolved.tier != "photo_ratio_70"
+    assert [c.clip.asset.id for c in resolved.items] == ["video-1"]

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -62,7 +62,6 @@ def _make_cached_segment(
     llm_category: str | None = None,
     llm_emotion: str | None = None,
     llm_setting: str | None = None,
-    llm_activities: list[str] | None = None,
     llm_subjects: list[str] | None = None,
     llm_interestingness: float | None = None,
     llm_quality: float | None = None,
@@ -77,7 +76,6 @@ def _make_cached_segment(
     seg.llm_category = llm_category
     seg.llm_emotion = llm_emotion
     seg.llm_setting = llm_setting
-    seg.llm_activities = llm_activities
     seg.llm_subjects = llm_subjects
     seg.llm_interestingness = llm_interestingness
     seg.llm_quality = llm_quality
@@ -207,7 +205,6 @@ class TestCheckAnalysisCache:
                 llm_description="Noah building a sandcastle",
                 llm_emotion="delighted",
                 llm_setting="beach",
-                llm_activities=["playing"],
                 llm_subjects=["Noah"],
                 llm_interestingness=0.91,
                 llm_quality=0.88,
@@ -225,7 +222,6 @@ class TestCheckAnalysisCache:
         assert clip.llm_description == "Noah building a sandcastle"
         assert clip.llm_emotion == "delighted"
         assert clip.llm_setting == "beach"
-        assert clip.llm_activities == ["playing"]
         assert clip.llm_subjects == ["Noah"]
         assert clip.llm_interestingness == 0.91
         assert clip.llm_quality == 0.88
@@ -257,7 +253,6 @@ class TestCheckAnalysisCache:
             llm_description="Kids playing",
             llm_emotion="joyful",
             llm_setting="park",
-            llm_activities=["running", "laughing"],
             llm_subjects=["children"],
             llm_interestingness=0.85,
             llm_quality=0.7,
@@ -274,7 +269,6 @@ class TestCheckAnalysisCache:
         assert llm_analysis["description"] == "Kids playing"
         assert llm_analysis["emotion"] == "joyful"
         assert llm_analysis["setting"] == "park"
-        assert llm_analysis["activities"] == ["running", "laughing"]
         assert llm_analysis["subjects"] == ["children"]
         assert llm_analysis["interestingness"] == 0.85
         assert llm_analysis["quality"] == 0.7
@@ -457,7 +451,6 @@ class TestPhaseAnalyzeLLMMapping:
             "description": "Sunset over the ocean",
             "emotion": "calm",
             "setting": "beach",
-            "activities": ["watching"],
             "subjects": ["sky", "water"],
             "interestingness": 0.9,
             "quality": 0.8,
@@ -472,7 +465,6 @@ class TestPhaseAnalyzeLLMMapping:
         assert result_clip.llm_description == "Sunset over the ocean"
         assert result_clip.llm_emotion == "calm"
         assert result_clip.llm_setting == "beach"
-        assert result_clip.llm_activities == ["watching"]
         assert result_clip.llm_subjects == ["sky", "water"]
         assert result_clip.llm_interestingness == 0.9
         assert result_clip.llm_quality == 0.8

--- a/tests/test_llm_response_parser.py
+++ b/tests/test_llm_response_parser.py
@@ -18,7 +18,6 @@ class TestContentAnalysis:
     def test_default_values(self):
         ca = ContentAnalysis()
         assert ca.description == ""
-        assert ca.activities == []
         assert ca.subjects == []
         assert ca.setting == ""
         assert ca.emotion == ""
@@ -59,7 +58,6 @@ class TestContentAnalysis:
     def test_custom_fields(self):
         ca = ContentAnalysis(
             description="A park scene",
-            activities=["walking", "talking"],
             subjects=["person"],
             setting="outdoor park",
             emotion="happy",
@@ -68,7 +66,6 @@ class TestContentAnalysis:
             confidence=0.95,
         )
         assert ca.description == "A park scene"
-        assert ca.activities == ["walking", "talking"]
         assert ca.subjects == ["person"]
         assert ca.setting == "outdoor park"
         assert ca.emotion == "happy"
@@ -241,20 +238,15 @@ class TestBuildContentAnalysis:
         result = ContentAnalyzer._build_content_analysis(data, long_emotion)
         assert len(result.emotion) == 500
 
-    def test_limits_activities_list(self):
-        data = {"activities": [f"act_{i}" for i in range(15)]}
-        result = ContentAnalyzer._build_content_analysis(data, "")
-        assert len(result.activities) == 10
-
     def test_limits_subjects_list(self):
         data = {"subjects": [f"sub_{i}" for i in range(15)]}
         result = ContentAnalyzer._build_content_analysis(data, "")
         assert len(result.subjects) == 10
 
     def test_truncates_items_in_lists(self):
-        data = {"activities": ["a" * 600]}
+        data = {"subjects": ["a" * 600]}
         result = ContentAnalyzer._build_content_analysis(data, "")
-        assert len(result.activities[0]) == 500
+        assert len(result.subjects[0]) == 500
 
     def test_clamps_interestingness_above_1(self):
         data = {"interestingness": 1.5}
@@ -280,7 +272,6 @@ class TestBuildContentAnalysis:
         data: dict = {}
         result = ContentAnalyzer._build_content_analysis(data, "")
         assert result.description == ""
-        assert result.activities == []
         assert result.subjects == []
         assert result.setting == ""
         assert result.interestingness == pytest.approx(0.5)

--- a/tests/test_step2_loading.py
+++ b/tests/test_step2_loading.py
@@ -61,7 +61,6 @@ def test_load_surfaces_only_current_model_cached_analysis() -> None:
         llm_description="A child running into the sea",
         llm_emotion="excited",
         llm_setting="beach",
-        llm_activities=["running"],
         llm_subjects=["child"],
         llm_interestingness=0.9,
         llm_quality=0.86,
@@ -93,7 +92,6 @@ def test_load_surfaces_only_current_model_cached_analysis() -> None:
     assert current.llm_description == "A child running into the sea"
     assert current.llm_emotion == "excited"
     assert current.llm_setting == "beach"
-    assert current.llm_activities == ["running"]
     assert current.llm_subjects == ["child"]
     assert current.llm_interestingness == 0.9
     assert current.llm_quality == 0.86

--- a/tests/test_storage_cli_coverage.py
+++ b/tests/test_storage_cli_coverage.py
@@ -352,7 +352,7 @@ class TestSaveAnalysisWithLLMSegments:
         return VideoAnalysisCache(tmp_path / "test.db")
 
     def test_llm_fields_persisted(self, cache):
-        """LLM description, emotion, activities survive save/load cycle."""
+        """LLM description, emotion and setting survive a save/load cycle."""
         from immich_memories.analysis.scoring import MomentScore
 
         asset = _make_asset()
@@ -368,7 +368,6 @@ class TestSaveAnalysisWithLLMSegments:
         segment.llm_description = "Kids playing in park"
         segment.llm_emotion = "joyful"
         segment.llm_setting = "outdoor"
-        segment.llm_activities = ["running", "laughing"]
         segment.llm_subjects = ["child", "dog"]
         segment.llm_interestingness = 0.85
         segment.llm_quality = 0.9
@@ -380,7 +379,6 @@ class TestSaveAnalysisWithLLMSegments:
         assert seg.llm_description == "Kids playing in park"
         assert seg.llm_emotion == "joyful"
         assert seg.llm_setting == "outdoor"
-        assert seg.llm_activities == ["running", "laughing"]
         assert seg.llm_subjects == ["child", "dog"]
         assert seg.llm_interestingness == pytest.approx(0.85)
         assert seg.llm_quality == pytest.approx(0.9)

--- a/tests/test_subject_policy.py
+++ b/tests/test_subject_policy.py
@@ -13,10 +13,10 @@ def test_an_immich_face_tag_settles_it() -> None:
     )
 
 
-def _cand(key, category, score, scale="motion"):
+def _cand(key, category, score, scale="motion", labelled=True):
     from immich_memories.analysis.subject_policy import SubjectCandidate
 
-    return SubjectCandidate(key=key, category=category, score=score, scale=scale)
+    return SubjectCandidate(key=key, category=category, score=score, scale=scale, labelled=labelled)
 
 
 def test_a_high_scoring_object_still_loses_to_a_lower_scoring_person() -> None:
@@ -229,3 +229,32 @@ def test_a_junk_label_is_unknown_not_a_guess() -> None:
         classify_subject(tagged_people=0, category="Category.PEOPLE!!", description=None)
         is SubjectCategory.UNKNOWN
     )
+
+
+def test_the_bar_ignores_candidates_that_were_never_semantically_scored() -> None:
+    """ClipWithSegment.score is not one scale. An analysed clip carries its
+    segment's semantic score; a clip that was only pre-filtered carries
+    Asset.quality_score, which is resolution and bitrate, not how good the
+    moment is; a clip whose analysis failed carries 0.0. Mixing them dragged a
+    real June run's motion bar from ~0.83 down to 0.31, which let objects and
+    scenery through. Only clips the model actually labelled are comparable."""
+    from immich_memories.analysis.subject_policy import apply_subject_quotas
+
+    outcome = apply_subject_quotas(
+        [
+            _cand("labelled-a", SubjectCategory.PEOPLE, 0.80, scale="motion", labelled=True),
+            _cand("labelled-b", SubjectCategory.PEOPLE, 0.86, scale="motion", labelled=True),
+            _cand("failed", SubjectCategory.PEOPLE, 0.00, scale="motion", labelled=False),
+            _cand("prefiltered", SubjectCategory.PEOPLE, 0.20, scale="motion", labelled=False),
+            _cand("mediocre-object", SubjectCategory.OBJECT, 0.60, scale="motion", labelled=True),
+        ],
+        animal_ratio=0.10,
+        object_ratio=0.05,
+        expected_clips=15,
+    )
+
+    # bar is the median of the two labelled people clips (0.83), not of all four
+    assert "mediocre-object" not in outcome.kept_keys
+    assert outcome.bars["motion"] > 0.8
+    # unlabelled people are still kept -- they are just not evidence for the bar
+    assert "prefiltered" in outcome.kept_keys

--- a/tests/test_unified_analyzer.py
+++ b/tests/test_unified_analyzer.py
@@ -107,7 +107,6 @@ class TestPerInvocationAnalysisModes:
             description="family at the beach",
             emotion="joy",
             setting="beach",
-            activities=["swimming"],
             subjects=["family"],
             interestingness=0.9,
             quality=0.9,


### PR DESCRIPTION
The four items I flagged as known-open after #349. One of them turned out not to be a bug, and the measurement that showed that is the most useful thing here.

## 1. The quality bar compared scores that mean different things

`ClipWithSegment.score` is not one measurement:

```python
score = best_segment.total_score   # semantic, ~0.3–1.03
score = clip.quality_score         # resolution + bitrate + duration
score = 0.0                        # analysis failed
```

`quality_score` describes the *file*, not the moment. The subject policy's bar — the median people-clip score — was computed over all three, which dragged a real June run's motion bar to **0.31** against a labelled-people median of about **0.83**. A low bar is exactly what lets an object through, which is how I shipped #349 with a gate that barely gated.

Only clips the model labelled went through the same scoring as the objects being judged against them, so only those set the bar. Unlabelled clips are still kept — they're simply not evidence. The log now reports how many clips the bar was drawn from, because a bar from two people clips deserves less trust than one from thirty.

## 2. Backfill spent the photo ratio first

I called this "the cap is bypassed". It isn't — it's *relaxed to 70%* as the **first** escalation, before non-favorites or temporal spacing, and 7 photos of 13 fits under that. So a shortage of material was answered with more stills.

Loosening who appears or when changes the edit far less than turning a video into a slideshow. Photos are now the last constraint spent.

## 3. The one-way LLM bonus — measured, and left alone

`max(0.0, content_score - 0.5)` reads like it suppresses negative evidence. Over **1,879** scored segments:

```
below the 0.5 neutral point: 3  (0%)
content_score: min=0.38  median=0.76  max=0.92

people 0.70   object 0.72   screen 0.68
```

Three clips. Making it two-sided would move three clips and nothing else. And the signal can't do the job anyway — **objects score higher than people**. That's precisely why the subject policy classifies rather than scores.

**No code change.** A comment now records the measurement so the next person doesn't "fix" the clamp expecting selection to improve. Removing a real constraint on the strength of a plausible-sounding story is how you get a regression nobody can explain later.

## 4. `llm_setting` and `llm_activities`

Both plumbed end to end, both 0% populated, both for want of a line in the prompt. They deserve opposite treatment:

- **`llm_setting` is read** — `clip_grid.py:219` renders it as a semantic tag beside the emotion, so that chip has always been blank. The prompt asks for it now.
- **`llm_activities` is read by nothing.** Removed from the parser, models, projection and insert. The column stays — dropping one in SQLite means rebuilding the table, an unwritten column costs nothing, and the comment says so rather than leaving it looking like an oversight.

## Validated on a real dry run

| | before | after |
|---|---|---|
| motion quality bar | 0.31 | **0.70** (from 7 labelled people clips) |
| subject drops | 1 object, 2 screen | **2 landscape, 2 object, 2 screen** |
| photos in final cut | 7/13 = 54% | **5/12 = 42%** |

Photos are back under the configured 50% without the cap being touched — the ordering change alone did it.

`make ci` green: 4693 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3


---

## 5. Renders are named after their recipe (added after review)

Eight runs of the same memory produced eight files called `all_monthly_highlights_20260601-20260630.mp4` in one album, distinguishable only by upload time. I couldn't find the render I'd just made without querying the API.

The filename now carries an 8-char hash of the **recipe** — memory type, date range, target duration, and the selected clips with their in/out points in order:

```
two identical runs   ..._ca41c1f7.mp4   (same both times)
--duration 90        ..._2743efd2.mp4
--no-photos          ..._81bf17df.mp4
```

Same edit → same name → the newer render overwrites locally and supersedes in Immich. Different edit → different name → kept alongside.

Two deliberate details: the hash fingerprints the *recipe*, not the output — music generation is unseeded, so two renders sharing a hash are the same edit but not the same bytes, and the newer one wins on purpose. And boundaries are compared at 10 ms, because a rerun landing 3 ms apart is the same edit and must not spawn a second file.

**Superseding in Immich is narrow on purpose**: only assets inside the album just uploaded to, with exactly this filename, never the asset just created. Immich's trash is recoverable. And it never propagates — the upload has already succeeded, so a failed tidy-up logs a warning rather than turning a delivered memory into a reported failure.