### PR TITLE
feat(output): name a render after its recipe so a rerun replaces it

### DIFF
--- a/src/immich_memories/api/album_service.py
+++ b/src/immich_memories/api/album_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -17,6 +18,9 @@ _UPLOAD_MEDIA_TYPES = {
     ".mov": "video/quicktime",
     ".mp4": "video/mp4",
 }
+
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidUploadResponse(ValueError):
@@ -113,6 +117,17 @@ class AlbumService:
                 return album["id"]
         return None
 
+    async def list_album_assets(self, album_id: str) -> list[dict]:
+        """Assets in an album, via search: /albums/{id} omits them on Immich 3.x."""
+        data = await self._request(
+            "POST", "/search/metadata", json={"albumIds": [album_id], "size": 1000}
+        )
+        return list(data.get("assets", {}).get("items", []))
+
+    async def trash_assets(self, asset_ids: list[str]) -> None:
+        """Move assets to Immich's trash. Recoverable; never a hard delete."""
+        await self._request("DELETE", "/assets", json={"ids": asset_ids, "force": False})
+
     async def upload_memory(
         self, video_path: Path, album_name: str | None = None
     ) -> dict[str, str | None]:
@@ -129,4 +144,54 @@ class AlbumService:
                 album_id = await self.create_album(album_name)
             await self.add_assets_to_album(album_id, [asset_id])
 
+        # WHY: the upload has already succeeded. Failing the delivery because the
+        # tidy-up of a previous copy did not work would turn a working memory into
+        # a reported failure, so this never propagates.
+        try:
+            superseded = await supersede_previous_renders(
+                self, album_id=album_id, filename=video_path.name, keep_asset_id=asset_id
+            )
+        except (OSError, RuntimeError, ValueError, KeyError) as exc:
+            logger.warning("Could not supersede earlier renders: %s", exc)
+        else:
+            if superseded:
+                logger.info(
+                    "Superseded %d earlier upload(s) of the same recipe (moved to Immich trash)",
+                    len(superseded),
+                )
+
         return {"asset_id": asset_id, "album_id": album_id}
+
+
+async def supersede_previous_renders(
+    client,
+    *,
+    album_id: str | None,
+    filename: str,
+    keep_asset_id: str,
+) -> list[str]:
+    """Trash earlier uploads of the same recipe, keeping the one just uploaded.
+
+    The filename carries a hash of the recipe -- the memory type, range, duration
+    and the exact clips in order -- so an identical name means an identical edit
+    and the older copy is superseded rather than kept beside it. Without this, a
+    library accumulates one indistinguishable file per run; eight of them is what
+    prompted this.
+
+    Deliberately narrow. Only assets inside the album we just uploaded to, with
+    exactly this filename, and never the asset we just created. An identically
+    named file the user filed elsewhere is not ours to touch. Immich's trash is
+    recoverable, so this is reversible by the user.
+    """
+    if not album_id:
+        return []
+
+    assets = await client.list_album_assets(album_id)
+    superseded = [
+        asset["id"]
+        for asset in assets
+        if asset.get("originalFileName") == filename and asset.get("id") != keep_asset_id
+    ]
+    if superseded:
+        await client.trash_assets(superseded)
+    return superseded

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -446,6 +446,15 @@ def run_pipeline_and_generate(
             timeline_plan.max_dividers,
         )
 
+    output_path = _name_after_recipe(
+        output_path,
+        selected_clips=selected_clips,
+        clip_segments=clip_segments,
+        memory_type=memory_type,
+        date_range=date_range,
+        target_duration=timeline_plan.target_duration,
+    )
+
     print_success(f"Selected {len(selected_clips)} clips for final video")
 
     should_upload = upload_to_immich or config.upload.enabled
@@ -696,6 +705,38 @@ def _drop_reencoded_sources(candidates: list, *, config: Config) -> list:
 def _has_camera_exif(asset) -> bool:
     exif = getattr(asset, "exif_info", None)
     return bool(exif and (exif.make or exif.model))
+
+
+def _name_after_recipe(
+    output_path: Path,
+    *,
+    selected_clips: list,
+    clip_segments: dict,
+    memory_type: str | None,
+    date_range,
+    target_duration: float,
+) -> Path:
+    """Name the output after its recipe so an identical rerun replaces it.
+
+    The name can only be finalised here: the CLI builds it before analysis, and
+    the clips that define the edit are not known until selection has run.
+    """
+    from immich_memories.filename_builder import apply_recipe_hash, recipe_hash
+
+    clips = []
+    for clip in selected_clips:
+        asset_id = clip.asset.id
+        start, end = clip_segments.get(asset_id, (0.0, 0.0))
+        clips.append((asset_id, start, end))
+
+    digest = recipe_hash(
+        memory_type=memory_type,
+        date_start=date_range.start.date() if date_range else None,
+        date_end=date_range.end.date() if date_range else None,
+        target_duration=target_duration,
+        clips=clips,
+    )
+    return apply_recipe_hash(output_path, digest)
 
 
 def _apply_subject_policy(

--- a/src/immich_memories/filename_builder.py
+++ b/src/immich_memories/filename_builder.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 import calendar
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
 from datetime import date
 from pathlib import Path
 from typing import Literal
+
+# 8 hex characters: short enough to read in a filename, and with a few hundred
+# renders per library the odds of two recipes colliding are negligible.
+_RECIPE_HASH_CHARS = 8
+_RECIPE_HASH_SUFFIX = re.compile(rf"_[0-9a-f]{{{_RECIPE_HASH_CHARS}}}$")
+
+# Segment boundaries are floats derived from analysis. A rerun landing a few
+# milliseconds apart is the same edit, so boundaries are compared at 10 ms.
+_BOUNDARY_PRECISION = 2
 
 
 def build_music_output_path(video_path: Path) -> Path:
@@ -293,3 +306,48 @@ def _date_range_slug(start: date, end: date) -> str:
 
     # Different years
     return f"{start.strftime('%Y%m%d')}-{end.strftime('%Y%m%d')}"
+
+
+def recipe_hash(
+    *,
+    memory_type: str | None,
+    date_start: date | None,
+    date_end: date | None,
+    target_duration: float,
+    clips: Sequence[tuple[str, float, float]],
+    extras: Mapping[str, object] | None = None,
+) -> str:
+    """Fingerprint the inputs that decide what a render contains.
+
+    Two runs that would cut the same clips, in the same order, over the same
+    range hash the same and so write the same file -- the newer render replaces
+    the older instead of piling up beside it. Change the selection, the order,
+    the duration or the memory type and the hash changes with it.
+
+    This is a fingerprint of the *recipe*, not of the output. Music generation is
+    unseeded, so two renders sharing a hash are the same edit but not the same
+    bytes; the newer one wins deliberately.
+    """
+    payload = {
+        "memory_type": memory_type or "",
+        "date_start": date_start.isoformat() if date_start else "",
+        "date_end": date_end.isoformat() if date_end else "",
+        "target_duration": round(target_duration, _BOUNDARY_PRECISION),
+        "clips": [
+            [
+                asset_id,
+                round(start, _BOUNDARY_PRECISION),
+                round(end, _BOUNDARY_PRECISION),
+            ]
+            for asset_id, start, end in clips
+        ],
+        "extras": {k: str(v) for k, v in sorted((extras or {}).items())},
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:_RECIPE_HASH_CHARS]
+
+
+def apply_recipe_hash(path: Path, digest: str) -> Path:
+    """Return the path carrying this recipe hash, replacing any it already has."""
+    stem = _RECIPE_HASH_SUFFIX.sub("", path.stem)
+    return path.with_name(f"{stem}_{digest}{path.suffix}")

--- a/tests/test_api_upload.py
+++ b/tests/test_api_upload.py
@@ -443,6 +443,7 @@ class TestUploadMemory:
         client.albums.find_album_by_name = AsyncMock(return_value=None)
         client.albums.create_album = AsyncMock(return_value="album-new")
         client.albums.add_assets_to_album = AsyncMock()
+        client.albums.list_album_assets = AsyncMock(return_value=[])
 
         result = await client.upload_memory(video, album_name="2024 Memories")
 
@@ -464,6 +465,7 @@ class TestUploadMemory:
         client.albums.find_album_by_name = AsyncMock(return_value="album-existing")
         client.albums.create_album = AsyncMock()
         client.albums.add_assets_to_album = AsyncMock()
+        client.albums.list_album_assets = AsyncMock(return_value=[])
 
         result = await client.upload_memory(video, album_name="2024 Memories")
 
@@ -497,6 +499,7 @@ class TestSyncUploadWrappers:
         client._async_client.albums.find_album_by_name = AsyncMock(return_value=None)
         client._async_client.albums.create_album = AsyncMock(return_value="album-1")
         client._async_client.albums.add_assets_to_album = AsyncMock()
+        client._async_client.albums.list_album_assets = AsyncMock(return_value=[])
 
         result = client.upload_memory(video, album_name="Test Album")
 

--- a/tests/test_recipe_hash.py
+++ b/tests/test_recipe_hash.py
@@ -1,0 +1,51 @@
+"""A render is named after its recipe, so re-running the same one replaces it."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from immich_memories.filename_builder import apply_recipe_hash, recipe_hash
+
+RECIPE = {
+    "memory_type": "monthly_highlights",
+    "date_start": date(2026, 6, 1),
+    "date_end": date(2026, 6, 30),
+    "target_duration": 60.0,
+    "clips": [("asset-a", 0.0, 4.0), ("asset-b", 2.5, 7.25)],
+    "extras": {"music": "auto", "container": "mp4"},
+}
+
+
+def test_the_same_recipe_hashes_the_same_way() -> None:
+    assert recipe_hash(**RECIPE) == recipe_hash(**RECIPE)
+
+
+def test_a_different_clip_changes_the_hash() -> None:
+    other = {**RECIPE, "clips": [("asset-a", 0.0, 4.0), ("asset-c", 2.5, 7.25)]}
+    assert recipe_hash(**other) != recipe_hash(**RECIPE)
+
+
+def test_clip_order_changes_the_hash() -> None:
+    """Order is the edit. Two videos with the same clips in a different sequence
+    are different videos."""
+    other = {**RECIPE, "clips": list(reversed(RECIPE["clips"]))}
+    assert recipe_hash(**other) != recipe_hash(**RECIPE)
+
+
+def test_sub_frame_float_noise_does_not_change_the_hash() -> None:
+    """Segment boundaries are floats. A rerun that lands 3 ms apart is the same
+    edit and must not produce a second file."""
+    other = {**RECIPE, "clips": [("asset-a", 0.0, 4.001), ("asset-b", 2.4999, 7.25)]}
+    assert recipe_hash(**other) == recipe_hash(**RECIPE)
+
+
+def test_applying_the_hash_is_idempotent() -> None:
+    """Re-running must overwrite one file, not accumulate _a1b2_c3d4_e5f6."""
+    first = apply_recipe_hash(Path("/out/all_monthly_20260601-20260630.mp4"), "a1b2c3d4")
+    again = apply_recipe_hash(first, "a1b2c3d4")
+    swapped = apply_recipe_hash(first, "9f8e7d6c")
+
+    assert first.name == "all_monthly_20260601-20260630_a1b2c3d4.mp4"
+    assert again == first
+    assert swapped.name == "all_monthly_20260601-20260630_9f8e7d6c.mp4"

--- a/tests/test_supersede_render.py
+++ b/tests/test_supersede_render.py
@@ -1,0 +1,63 @@
+"""Re-rendering the same recipe replaces the old upload instead of stacking."""
+
+from __future__ import annotations
+
+import pytest
+
+from immich_memories.api.album_service import supersede_previous_renders
+
+
+class _Recorder:
+    """Stands in for the Immich album/asset endpoints."""
+
+    def __init__(self, existing: list[dict]) -> None:
+        self.existing = existing
+        self.trashed: list[list[str]] = []
+
+    async def list_album_assets(self, album_id: str) -> list[dict]:
+        return self.existing
+
+    async def trash_assets(self, asset_ids: list[str]) -> None:
+        self.trashed.append(asset_ids)
+
+
+@pytest.mark.asyncio
+async def test_an_older_render_of_the_same_recipe_is_trashed() -> None:
+    client = _Recorder(
+        [
+            {"id": "old", "originalFileName": "june_a1b2c3d4.mp4"},
+            {"id": "new", "originalFileName": "june_a1b2c3d4.mp4"},
+            {"id": "other-recipe", "originalFileName": "june_9f8e7d6c.mp4"},
+            {"id": "unrelated", "originalFileName": "holiday.mp4"},
+        ]
+    )
+
+    await supersede_previous_renders(
+        client, album_id="alb", filename="june_a1b2c3d4.mp4", keep_asset_id="new"
+    )
+
+    assert client.trashed == [["old"]]
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_trashed_when_the_recipe_is_new() -> None:
+    client = _Recorder([{"id": "new", "originalFileName": "june_a1b2c3d4.mp4"}])
+
+    await supersede_previous_renders(
+        client, album_id="alb", filename="june_a1b2c3d4.mp4", keep_asset_id="new"
+    )
+
+    assert client.trashed == []
+
+
+@pytest.mark.asyncio
+async def test_a_render_outside_the_album_is_left_alone() -> None:
+    """Scope is the album we uploaded into. An identically named asset the user
+    filed somewhere else is not ours to delete."""
+    client = _Recorder([{"id": "new", "originalFileName": "june_a1b2c3d4.mp4"}])
+
+    await supersede_previous_renders(
+        client, album_id=None, filename="june_a1b2c3d4.mp4", keep_asset_id="new"
+    )
+
+    assert client.trashed == []


### PR DESCRIPTION
Follow-up to #350. Sam couldn't find the video I'd just generated in Immich — because eight runs of the same memory had produced eight assets called `all_monthly_highlights_20260601-20260630.mp4`, distinguishable only by upload time. I had to query the API to confirm my own upload existed.

## The idea

Name the file after a deterministic hash of its **recipe** — memory type, date range, target duration, and the selected clips with their in/out points, in order. Same edit, same name. Different edit, different name.

```
two identical runs   ..._ca41c1f7.mp4   ← stable across runs
--duration 90        ..._2743efd2.mp4
--no-photos          ..._81bf17df.mp4
```

Verified against the real library, not just unit tests.

So a rerun of the same memory **overwrites** locally and **supersedes** in Immich; a genuinely different edit is kept alongside. One file per distinct recipe instead of one per run.

## Two deliberate choices

**It fingerprints the recipe, not the output.** Music generation is unseeded, so two renders sharing a hash are the same *edit* but not the same *bytes* — the newer one wins on purpose. If a re-render should never silently change the soundtrack of an otherwise-identical video, the fix is seeding ACE-Step, not this hash.

**Boundaries compare at 10 ms.** Segment start/end are floats from analysis; a rerun landing 3 ms apart is the same edit and must not spawn a second file.

The name can only be finalised after selection — the CLI builds it before analysis runs, and the clips that define the edit aren't known until then.

## Superseding in Immich

Narrow on purpose. Only assets **inside the album just uploaded to**, with **exactly** this filename, and **never** the asset just created. An identically named file the user filed elsewhere isn't ours to touch. Immich's trash is recoverable, so it's reversible.

It also never propagates. The upload has already succeeded by that point, so a failed tidy-up logs a warning rather than turning a delivered memory into a reported failure. That came out of a real test failure: the existing upload tests didn't mock the new lookup and attempted a live request, which showed the cleanup was sitting in the delivery's critical path.

`/albums/{id}` omits assets on Immich 3.x, so the lookup goes through `/search/metadata` — the same shape mismatch that made me briefly report the upload as missing from the album when it wasn't.

## Not covered

The **8 existing duplicates already in the album** predate the hash, so nothing supersedes them. They need a manual tidy — deliberately not automated here, since it means trashing assets that were created before this rule existed.

`make ci` green: 4701 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3