### PR TITLE
fix(ffmpeg): drain stderr on the last two frame writers

### DIFF
--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -12,6 +12,7 @@ import logging
 import operator
 import random
 import subprocess
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ from immich_memories.photos.renderer import (
 )
 from immich_memories.photos.scoring import score_photo
 from immich_memories.processing.assembly_config import AssemblyClip
+from immich_memories.processing.ffmpeg_runner import write_frames_to_ffmpeg
 
 logger = logging.getLogger(__name__)
 
@@ -583,7 +585,15 @@ def _stream_render_to_mp4(
             logger.warning("zscale not available — rendering photo as SDR")
             vf = "format=yuv420p"
 
-    proc = subprocess.Popen(
+    def _frames() -> Iterator[bytes]:
+        use_16bit = pix_fmt == "rgb48le"
+        for frame in render_ken_burns_streaming(img, target_w, target_h, params):
+            if use_16bit:
+                yield (np.clip(frame * 65535, 0, 65535).astype(np.uint16)).tobytes()
+            else:
+                yield (np.clip(frame * 255, 0, 255).astype(np.uint8)).tobytes()
+
+    returncode, stderr_text = write_frames_to_ffmpeg(
         [
             "ffmpeg",
             "-y",
@@ -613,26 +623,12 @@ def _stream_render_to_mp4(
             "-shortest",
             str(output_path),
         ],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
+        _frames(),
+        wait_timeout=300,
     )
 
-    assert proc.stdin is not None
-    use_16bit = pix_fmt == "rgb48le"
-    for frame in render_ken_burns_streaming(img, target_w, target_h, params):
-        if use_16bit:
-            frame_bytes = (np.clip(frame * 65535, 0, 65535).astype(np.uint16)).tobytes()
-        else:
-            frame_bytes = (np.clip(frame * 255, 0, 255).astype(np.uint8)).tobytes()
-        proc.stdin.write(frame_bytes)
-
-    proc.stdin.close()
-    proc.wait(timeout=300)
-
-    if proc.returncode != 0:
-        stderr_text = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
-        raise RuntimeError(f"Photo FFmpeg encoding failed (exit {proc.returncode}): {stderr_text}")
+    if returncode != 0:
+        raise RuntimeError(f"Photo FFmpeg encoding failed (exit {returncode}): {stderr_text}")
 
 
 def _get_photo_encoder_args() -> list[str]:

--- a/src/immich_memories/processing/ffmpeg_runner.py
+++ b/src/immich_memories/processing/ffmpeg_runner.py
@@ -7,7 +7,7 @@ import logging
 import re
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from threading import Thread
 from typing import IO
@@ -21,6 +21,7 @@ __all__ = [
     "_parse_ffmpeg_progress",
     "_run_ffmpeg_with_progress",
     "drain_stderr_tail",
+    "write_frames_to_ffmpeg",
 ]
 
 FFMPEG_STDERR_TAIL_BYTES = 64 * 1024
@@ -44,6 +45,50 @@ def drain_stderr_tail(
         tail.extend(chunk)
         if len(tail) > limit:
             del tail[:-limit]
+
+
+def write_frames_to_ffmpeg(
+    cmd: list[str],
+    frames: Iterable[bytes],
+    *,
+    wait_timeout: float,
+    stderr_limit: int = FFMPEG_STDERR_TAIL_BYTES,
+) -> tuple[int, str]:
+    """Feed frames to FFmpeg's stdin while draining its stderr, and report both.
+
+    Every caller that pipes frames in has to do this the same way, and getting
+    it wrong hangs the render rather than failing it: FFmpeg writes progress to
+    stderr from its transcode loop, stops reading stdin once that 64 KB pipe is
+    full, and the writer blocks forever at 0% CPU. Reading stderr after wait()
+    is too late by definition.
+
+    Returns the exit code and the tail of stderr. stdin is closed and the reader
+    joined even when the frame iterator raises, so a failure part-way through
+    cannot leak the process.
+    """
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert process.stdin is not None
+    assert process.stderr is not None
+
+    tail = bytearray()
+    reader = Thread(
+        target=drain_stderr_tail,
+        args=(process.stderr, tail),
+        kwargs={"limit": stderr_limit},
+        daemon=True,
+    )
+    reader.start()
+
+    try:
+        for frame in frames:
+            process.stdin.write(frame)
+    finally:
+        with contextlib.suppress(OSError):
+            process.stdin.close()
+        process.wait(timeout=wait_timeout)
+        reader.join(timeout=10)
+
+    return process.returncode, bytes(tail).decode(errors="replace").strip()
 
 
 @dataclass

--- a/src/immich_memories/processing/title_inserter.py
+++ b/src/immich_memories/processing/title_inserter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
@@ -16,6 +16,7 @@ from immich_memories.processing.assembly_config import (
 )
 from immich_memories.processing.encoding_plan import HdrTransfer
 from immich_memories.processing.ffmpeg_prober import FFmpegProber
+from immich_memories.processing.ffmpeg_runner import write_frames_to_ffmpeg
 from immich_memories.processing.hdr_utilities import _get_colorspace_filter
 from immich_memories.processing.scaling_utilities import aggregate_mood_from_clips
 
@@ -118,25 +119,26 @@ class TitleInserter:
             str(output_path),
         ]  # fmt: skip
 
-        try:
-            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-            frame_count = 0
+        frame_count = 0
+
+        def _frames() -> Iterator[bytes]:
+            nonlocal frame_count
             max_frames = fps * 1  # 1 second
             for frame in decoder:
                 if frame_count >= max_frames:
                     break
-                proc.stdin.write(frame.data)  # type: ignore[union-attr]
+                yield frame.data
                 frame_count += 1
-            proc.stdin.close()  # type: ignore[union-attr]
-            proc.wait(timeout=30)
-            if proc.returncode == 0 and output_path.exists():
+
+        try:
+            returncode, stderr = write_frames_to_ffmpeg(cmd, _frames(), wait_timeout=30)
+            if returncode == 0 and output_path.exists():
                 logger.info(
                     f"Pre-rendered first clip ({frame_count} frames, "
                     f"{target_w}x{target_h}): {output_path}"
                 )
                 return output_path
-            stderr = proc.stderr.read().decode()[-200:] if proc.stderr else ""
-            logger.warning(f"Pre-render encode failed: {stderr}")
+            logger.warning(f"Pre-render encode failed: {stderr[-200:]}")
         except (OSError, subprocess.SubprocessError, ValueError) as e:
             logger.warning("Failed to pre-render first clip: %s", e, exc_info=True)
         return None

--- a/tests/test_ffmpeg_frame_writer.py
+++ b/tests/test_ffmpeg_frame_writer.py
@@ -1,0 +1,83 @@
+"""Feeding FFmpeg's stdin while its stderr is piped must not be able to deadlock.
+
+A real child process is used rather than a mock: the failure lives in OS pipe
+buffering, and a mock would happily "pass" a version that hangs in production.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+
+from immich_memories.processing.ffmpeg_runner import write_frames_to_ffmpeg
+
+# Floods stderr *before* reading any stdin, so an undrained parent blocks as
+# soon as the stderr buffer fills.
+_NOISY = (
+    "import sys;"
+    "sys.stderr.buffer.write(b'x' * 400000);"
+    "sys.stderr.buffer.flush();"
+    "data = sys.stdin.buffer.read();"
+    "sys.stderr.buffer.write(b'read %d bytes' % len(data));"
+    "sys.stderr.buffer.flush()"
+)
+_EXIT_2 = "import sys; sys.stderr.buffer.write(b'boom'); sys.stdin.buffer.read(); sys.exit(2)"
+
+
+def test_a_noisy_child_cannot_stall_the_writer() -> None:
+    code, tail = write_frames_to_ffmpeg(
+        [sys.executable, "-c", _NOISY],
+        (b"f" * 100000 for _ in range(3)),
+        wait_timeout=30,
+    )
+
+    assert code == 0
+    assert "read 300000 bytes" in tail
+
+
+def test_the_exit_code_and_stderr_tail_are_reported() -> None:
+    code, tail = write_frames_to_ffmpeg([sys.executable, "-c", _EXIT_2], [b"data"], wait_timeout=30)
+
+    assert code == 2
+    assert "boom" in tail
+
+
+def test_a_failing_frame_iterator_still_closes_the_process() -> None:
+    """A render that dies mid-loop must not leave FFmpeg holding the pipe."""
+
+    def _explode():
+        yield b"first"
+        raise ValueError("frame source failed")
+
+    try:
+        write_frames_to_ffmpeg([sys.executable, "-c", _NOISY], _explode(), wait_timeout=30)
+    except ValueError:
+        pass
+    else:  # pragma: no cover - the iterator raises by construction
+        raise AssertionError("the iterator's error must propagate")
+
+
+def test_the_bare_pattern_really_does_deadlock() -> None:
+    """Proves the child reproduces the bug, so the tests above mean something."""
+    process = subprocess.Popen(
+        [sys.executable, "-c", _NOISY], stdin=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    finished = threading.Event()
+
+    def _write_undrained() -> None:
+        try:
+            assert process.stdin is not None
+            process.stdin.write(b"f" * 300000)
+            process.stdin.flush()
+        except OSError:
+            pass
+        finally:
+            finished.set()
+
+    threading.Thread(target=_write_undrained, daemon=True).start()
+    try:
+        assert not finished.wait(timeout=5.0), "child did not reproduce the deadlock"
+    finally:
+        process.kill()
+        process.wait(timeout=10)


### PR DESCRIPTION
Closes #279.

The original fix covered the title renderer. Two sites feed FFmpeg stdin the same way and still piped stderr while reading it only after `wait()`:

- `photos/photo_pipeline._stream_render_to_mp4` — every animated photo clip
- `processing/title_inserter` — the first-clip pre-render

FFmpeg writes stats and warnings to stderr from its transcode loop and stops reading stdin once the 64 KB OS pipe fills. Reading stderr after `wait()` cannot help — by then the writer is already blocked forever and the render sits at 0% CPU.

## One helper instead of a third copy

Rather than paste the drain-and-join dance a third time, both call `write_frames_to_ffmpeg`, which owns it: start the reader, feed frames, and close stdin and join through a `finally` so a frame source that raises can't leak the process. It returns the exit code and the stderr tail so callers still report what FFmpeg said.

## The first version of this PR was wrong, and a gate caught it

I originally asserted the fix by grepping each function's source for `drain_stderr_tail`. That passes **without ever executing the code** — and diff-cover called it out: the pre-render path was **13.3% covered**. The assertion proved a string was present, not that the deadlock was gone.

Extracting the helper made the behaviour testable for real, against a child process that floods stderr before reading stdin:

- the writer completes and the full payload is read
- exit code and stderr tail are reported
- the process is cleaned up when the frame iterator raises

Plus a fourth test that drives the *bare* pattern and asserts it genuinely deadlocks:

```python
assert not finished.wait(timeout=5.0), "child did not reproduce the deadlock"
```

The other three are only meaningful while that still holds. None of this can be mocked — the failure lives in OS pipe buffering, and a mock would happily pass a version that hangs in production.

## Correction to an earlier note

This description originally carried an "unrelated observation" listing slow tests — a 46s `test_thumbnail_prefetch` and six `test_unified_selection` tests at ~26s each — suggesting they were the same class as #347.

**That was measured wrong.** Those numbers came from this branch while it still carried the 81s live-Immich test, which skewed everything timed after it. Re-measured on current `main` with #352 merged:

```
11.53s  test_benchmark_contract::test_profile_harness_requires_an_isolated_explicit_output_directory
 9.90s  test_bench_title_render::TestTitleRenderPerf::test_manual_timing_report
 5.02s  test_ffmpeg_pipe::TestDrainStderrTail::test_without_drain_the_writer_actually_deadlocks
4701 passed in 174s
```

Nothing pathological remains, and the two slowest are a benchmark harness and a deliberate perf report. There is no follow-up to do here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3
