### PR TITLE
fix(log): stop the photo cap calling a mid-pipeline count final

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,21 +6,9 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 575,
-        "line_end": 618,
+        "line_start": 580,
+        "line_end": 623,
         "line_complexities": [
-          {
-            "line": 585,
-            "complexity": 0
-          },
-          {
-            "line": 586,
-            "complexity": 1
-          },
-          {
-            "line": 587,
-            "complexity": 0
-          },
           {
             "line": 590,
             "complexity": 0
@@ -39,31 +27,31 @@
           },
           {
             "line": 596,
-            "complexity": 0
+            "complexity": 1
           },
           {
-            "line": 598,
-            "complexity": 0
-          },
-          {
-            "line": 599,
+            "line": 597,
             "complexity": 0
           },
           {
             "line": 600,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 601,
             "complexity": 0
           },
           {
-            "line": 602,
-            "complexity": 2
+            "line": 603,
+            "complexity": 0
           },
           {
             "line": 604,
             "complexity": 0
+          },
+          {
+            "line": 605,
+            "complexity": 1
           },
           {
             "line": 606,
@@ -71,10 +59,6 @@
           },
           {
             "line": 607,
-            "complexity": 1
-          },
-          {
-            "line": 608,
             "complexity": 2
           },
           {
@@ -82,19 +66,35 @@
             "complexity": 0
           },
           {
-            "line": 610,
-            "complexity": 3
+            "line": 611,
+            "complexity": 0
           },
           {
             "line": 612,
-            "complexity": 4
+            "complexity": 1
           },
           {
             "line": 613,
-            "complexity": 5
+            "complexity": 2
+          },
+          {
+            "line": 614,
+            "complexity": 0
+          },
+          {
+            "line": 615,
+            "complexity": 3
+          },
+          {
+            "line": 617,
+            "complexity": 4
           },
           {
             "line": 618,
+            "complexity": 5
+          },
+          {
+            "line": 623,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -119,9 +119,14 @@ def enforce_photo_cap(
     photos.sort(key=lambda c: c.score, reverse=True)
     kept_photos = photos[:max_photos]
 
+    # WHY not "final": duration backfill runs after this and adds more clips, so
+    # the count here is the pool mid-refinement. A real run logged "2 photos
+    # (50% of 4 final clips)" and delivered a 13-clip video with 7 photos in it,
+    # which reads as the cap having been ignored rather than simply not final.
     logger.info(
         f"Photo cap: {len(photos)} → {len(kept_photos)} photos "
-        f"({max_ratio:.0%} of {len(videos) + len(kept_photos)} final clips)"
+        f"(at most {max_ratio:.0%} alongside {len(videos)} videos; "
+        f"backfill may add more)"
     )
 
     return videos + kept_photos


### PR DESCRIPTION
The photo cap logged:

```
Photo cap: 10 → 2 photos (50% of 4 final clips)
```

and the same run delivered a **13-clip video with 7 photos in it**.

Nothing was wrong with the cap. Duration backfill runs after this point and adds more clips, so the count is the pool mid-refinement — but the word *final* made it read as a limit that had been ignored. I spent real time chasing that before noticing the number simply wasn't final, so the message has cost at least one debugging session already.

Now:

```
Photo cap: 10 → 2 photos (at most 50% alongside 2 videos; backfill may add more)
```

Verified against a real dry run. Message only — the cap is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3