### PR TITLE
feat(api): read an Immich album as a bounded media pool (#270)

### DIFF
--- a/src/immich_memories/analysis/album_source.py
+++ b/src/immich_memories/analysis/album_source.py
@@ -1,0 +1,124 @@
+"""Turn an Immich album into the pipeline's media pools.
+
+Album mode replaces date-range discovery: the album *is* the candidate pool, so
+nothing is searched for. A birthday album spanning 18 years would otherwise make
+the date-range path fetch the whole library.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from immich_memories.api.models import AssetType
+from immich_memories.timeperiod import DateRange
+
+if TYPE_CHECKING:
+    from immich_memories.api.album_service import AlbumRef
+    from immich_memories.api.models import Asset, VideoClipInfo
+    from immich_memories.api.sync_client import SyncImmichClient
+    from immich_memories.config_loader import Config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AlbumMedia:
+    """The album's assets, split into the pools the pipeline consumes."""
+
+    videos: list[Asset] = field(default_factory=list)
+    live_photo_clips: list[VideoClipInfo] = field(default_factory=list)
+    photos: list[Asset] = field(default_factory=list)
+    date_range: DateRange | None = None
+    truncated: bool = False
+
+
+def split_album_assets(
+    assets: list[Asset],
+    *,
+    config: Config,
+    use_live_photos: bool,
+    use_photos: bool,
+) -> AlbumMedia:
+    """Split an album's assets into videos, merged Live Photo clips and stills.
+
+    With Live Photo merging off, a Live Photo counts as a still rather than being
+    dropped — the user picked these assets by hand, so nothing silently disappears.
+    """
+    if not assets:
+        return AlbumMedia()
+
+    videos = [a for a in assets if a.type == AssetType.VIDEO]
+    images = [a for a in assets if a.type == AssetType.IMAGE]
+    live_stills = [a for a in images if a.is_live_photo]
+    plain_stills = [a for a in images if not a.is_live_photo]
+
+    live_clips: list[VideoClipInfo] = []
+    if use_live_photos and live_stills:
+        from immich_memories.analysis.live_photo_pipeline import build_live_photo_clips
+
+        live_clips, live_video_ids = build_live_photo_clips(live_stills, config=config)
+        # The album may also list the Live Photo's video component as its own asset.
+        videos = [v for v in videos if v.id not in live_video_ids]
+    elif live_stills:
+        plain_stills = sorted(plain_stills + live_stills, key=lambda a: a.file_created_at)
+
+    photos = plain_stills if use_photos else []
+
+    logger.info(
+        "Album pool: %d videos, %d live photo clips, %d photos (from %d assets)",
+        len(videos),
+        len(live_clips),
+        len(photos),
+        len(assets),
+    )
+    return AlbumMedia(
+        videos=videos,
+        live_photo_clips=live_clips,
+        photos=photos,
+        date_range=DateRange(
+            start=min(a.file_created_at for a in assets),
+            end=max(a.file_created_at for a in assets),
+        ),
+    )
+
+
+def fetch_album_media(
+    client: SyncImmichClient,
+    album: AlbumRef,
+    *,
+    config: Config,
+    use_live_photos: bool,
+    use_photos: bool,
+) -> AlbumMedia:
+    """Read an album's media, one bounded request stream per asset type.
+
+    Images are skipped entirely when neither photos nor Live Photos are wanted —
+    on a 34k-image smart album that request stream alone costs ~58 MB and ~20 s.
+    """
+    cap = config.analysis.max_album_assets
+
+    videos = client.get_assets_for_album(album.id, asset_type=AssetType.VIDEO, limit=cap)
+    images: list[Asset] = []
+    if use_photos or use_live_photos:
+        images = client.get_assets_for_album(album.id, asset_type=AssetType.IMAGE, limit=cap)
+
+    truncated = len(videos) >= cap or len(images) >= cap
+    if truncated:
+        logger.warning(
+            "Album %r holds more than %d assets per type — using the most recent %d. "
+            "Narrow the album, raise advanced.analysis.max_album_assets, or use a date range.",
+            album.name,
+            cap,
+            cap,
+        )
+
+    media = split_album_assets(
+        videos + images,
+        config=config,
+        use_live_photos=use_live_photos,
+        use_photos=use_photos,
+    )
+    media.truncated = truncated
+    return media

--- a/src/immich_memories/analysis/live_photo_pipeline.py
+++ b/src/immich_memories/analysis/live_photo_pipeline.py
@@ -12,6 +12,7 @@ from immich_memories.api.models import VideoClipInfo
 
 if TYPE_CHECKING:
     from immich_memories.api.immich import SyncImmichClient
+    from immich_memories.api.models import Asset
     from immich_memories.config_loader import Config
     from immich_memories.timeperiod import DateRange
 
@@ -60,7 +61,6 @@ def _search_live_photos_multi_person(
     merge_window_seconds: float = 10.0,
 ) -> list:
     """Intersect live photos across multiple persons."""
-    from immich_memories.api.models import Asset
 
     per_person: list[set[str]] = []
     assets_by_id: dict[str, Asset] = {}
@@ -86,7 +86,6 @@ def _search_live_photos_for_person(
     merge_window_seconds: float = 10.0,
 ) -> list:
     """Fetch live photos tagged with a specific person, then expand to neighbors."""
-    from immich_memories.api.models import Asset
 
     tagged: list[Asset] = []
     page = 1
@@ -160,8 +159,6 @@ def fetch_live_photo_clips(
     Returns:
         Tuple of (live_photo_clips, live_video_ids).
     """
-    from immich_memories.processing.live_photo_merger import cluster_live_photos
-
     merge_window = config.analysis.live_photo_merge_window_seconds
 
     try:
@@ -180,6 +177,20 @@ def fetch_live_photo_clips(
         logger.info("No live photos found in date range")
         return [], set()
 
+    return build_live_photo_clips(live_assets, config=config)
+
+
+def build_live_photo_clips(
+    live_assets: list[Asset], *, config: Config
+) -> tuple[list[VideoClipInfo], set[str]]:
+    """Cluster Live Photo stills into merged clips.
+
+    Returns:
+        Tuple of (live_photo_clips, live_video_ids).
+    """
+    from immich_memories.processing.live_photo_merger import cluster_live_photos
+
+    merge_window = config.analysis.live_photo_merge_window_seconds
     live_video_ids = {a.live_photo_video_id for a in live_assets if a.live_photo_video_id}
 
     clusters = cluster_live_photos(

--- a/src/immich_memories/api/album_service.py
+++ b/src/immich_memories/api/album_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,27 @@ _UPLOAD_MEDIA_TYPES = {
 
 class InvalidUploadResponse(ValueError):
     """Raised when Immich returns a malformed successful upload response."""
+
+
+class AlbumNotFoundError(LookupError):
+    """Raised when an album reference matches no album name or ID."""
+
+
+class AmbiguousAlbumError(LookupError):
+    """Raised when an album name matches more than one album.
+
+    Immich libraries synced from iOS routinely carry several albums with the
+    same name ('Récentes', 'Favorites'), so a name alone is not an identifier.
+    """
+
+
+@dataclass(frozen=True)
+class AlbumRef:
+    """An album resolved to its ID, display name and asset count."""
+
+    id: str
+    name: str
+    asset_count: int
 
 
 def build_upload_fields(
@@ -61,6 +83,14 @@ def _upload_media_type(file_path: Path) -> str:
         return _UPLOAD_MEDIA_TYPES[suffix]
     except KeyError as exc:
         raise ValueError(f"Unsupported upload file suffix: {suffix or '<none>'}") from exc
+
+
+def _album_ref(album: dict) -> AlbumRef:
+    return AlbumRef(
+        id=album["id"],
+        name=album.get("albumName") or album["id"],
+        asset_count=album.get("assetCount") or 0,
+    )
 
 
 class AlbumService:
@@ -104,6 +134,42 @@ class AlbumService:
 
     async def get_albums(self) -> list[dict]:
         return await self._request("GET", "/albums")
+
+    async def resolve_album(self, name_or_id: str) -> AlbumRef:
+        """Resolve an album reference to its ID, name and asset count.
+
+        Matches an album ID first, then an exact name, then a case-insensitive
+        name, so users can pass what they see in Immich.
+
+        Raises:
+            AmbiguousAlbumError: the name matches several albums.
+            AlbumNotFoundError: nothing matches.
+        """
+        albums = await self.get_albums()
+
+        by_id = {a.get("id"): a for a in albums}
+        if name_or_id in by_id:
+            return _album_ref(by_id[name_or_id])
+
+        exact = [a for a in albums if a.get("albumName") == name_or_id]
+        folded = name_or_id.casefold()
+        matches = exact or [a for a in albums if (a.get("albumName") or "").casefold() == folded]
+
+        if len(matches) == 1:
+            return _album_ref(matches[0])
+        if matches:
+            raise AmbiguousAlbumError(
+                f"{len(matches)} albums are named {name_or_id!r}. Pass the ID instead:\n"
+                + "\n".join(
+                    f"  {a['id']}  ({a.get('assetCount') or 0} assets)"
+                    for a in sorted(matches, key=lambda a: -(a.get("assetCount") or 0))
+                )
+            )
+
+        known = ", ".join(sorted({n for a in albums if (n := a.get("albumName"))})) or "none"
+        raise AlbumNotFoundError(
+            f"No Immich album named or with ID {name_or_id!r}. Albums: {known}"
+        )
 
     async def find_album_by_name(self, name: str) -> str | None:
         """Returns album ID if found, None otherwise."""

--- a/src/immich_memories/api/immich.py
+++ b/src/immich_memories/api/immich.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from pydantic import ValidationError
 
-from immich_memories.api.album_service import AlbumService
+from immich_memories.api.album_service import AlbumRef, AlbumService
 from immich_memories.api.all_assets_service import AllAssetsService
 from immich_memories.api.asset_service import AssetService
 from immich_memories.api.compatibility import (
@@ -424,6 +424,21 @@ class ImmichClient:
         return await self.search.get_photos_for_date_range(
             date_range, progress_callback, person_id=person_id
         )
+
+    async def get_assets_for_album(
+        self,
+        album_id: str,
+        *,
+        asset_type: AssetType,
+        limit: int | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[Asset]:
+        return await self.search.get_assets_for_album(
+            album_id, asset_type=asset_type, limit=limit, progress_callback=progress_callback
+        )
+
+    async def resolve_album(self, name_or_id: str) -> AlbumRef:
+        return await self.albums.resolve_album(name_or_id)
 
     async def iter_videos_for_date_range(
         self,

--- a/src/immich_memories/api/search_service.py
+++ b/src/immich_memories/api/search_service.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
 RequestFn = Callable[..., Any]
 
+# Immich caps search page size at 1000; album fetches are bounded by asset count, not pages.
+_ALBUM_PAGE_SIZE = 1000
+
 
 def _api_datetime(value: date | datetime, *, inclusive_end: bool = False) -> str:
     """Serialize a date boundary or datetime with an explicit UTC offset."""
@@ -37,6 +40,7 @@ class SearchService:
     async def search_metadata(
         self,
         person_ids: list[str] | None = None,
+        album_ids: list[str] | None = None,
         asset_type: AssetType | None = None,
         taken_after: date | datetime | None = None,
         taken_before: date | datetime | None = None,
@@ -54,6 +58,8 @@ class SearchService:
 
         if person_ids:
             payload["personIds"] = person_ids
+        if album_ids:
+            payload["albumIds"] = album_ids
         if asset_type:
             payload["type"] = asset_type.value
         if taken_after:
@@ -137,6 +143,45 @@ class SearchService:
             page += 1
 
         all_assets.sort(key=lambda a: a.file_created_at)
+        return all_assets
+
+    async def get_assets_for_album(
+        self,
+        album_id: str,
+        *,
+        asset_type: AssetType,
+        limit: int | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[Asset]:
+        """Fetch an album's assets of one type, newest first, bounded by ``limit``.
+
+        Smart albums ('Récentes', 'Favorites') reach tens of thousands of assets —
+        ~9 KB of resident metadata each — so paging stops at ``limit`` rather than
+        materialising the whole album. Immich orders newest-first, so a truncated
+        album keeps its most recent assets.
+        """
+        all_assets: list[Asset] = []
+        page = 1
+
+        while True:
+            result = await self.search_metadata(
+                album_ids=[album_id],
+                asset_type=asset_type,
+                page=page,
+                size=_ALBUM_PAGE_SIZE,
+            )
+            all_assets.extend(result.all_assets)
+
+            if progress_callback:
+                progress_callback(len(all_assets), None)
+
+            if limit is not None and len(all_assets) >= limit:
+                del all_assets[limit:]
+                break
+            if not result.next_page:
+                break
+            page += 1
+
         return all_assets
 
     async def get_videos_for_date_range(

--- a/src/immich_memories/api/sync_client.py
+++ b/src/immich_memories/api/sync_client.py
@@ -7,9 +7,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.api.album_service import AlbumRef
 from immich_memories.api.compatibility import ResolvedApiVersion
 from immich_memories.api.models import (
     Asset,
+    AssetType,
     MetadataSearchResult,
     Person,
     ServerInfo,
@@ -260,6 +262,23 @@ class SyncImmichClient:
 
     def upload_asset(self, file_path: Path) -> str:
         return self._run(self._async_client.upload_asset(file_path))
+
+    def get_assets_for_album(
+        self,
+        album_id: str,
+        *,
+        asset_type: AssetType,
+        limit: int | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> list[Asset]:
+        return self._run(
+            self._async_client.get_assets_for_album(
+                album_id, asset_type=asset_type, limit=limit, progress_callback=progress_callback
+            )
+        )
+
+    def resolve_album(self, name_or_id: str) -> AlbumRef:
+        return self._run(self._async_client.resolve_album(name_or_id))
 
     def create_album(self, name: str, description: str | None = None) -> str:
         return self._run(self._async_client.create_album(name, description))

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -91,6 +91,13 @@ class AnalysisConfig(BaseModel):
         le=8,
         description="Concurrent isolated clients used for video and thumbnail prefetching",
     )
+    max_album_assets: int = Field(
+        default=10000,
+        ge=1,
+        description="Per media type, the most assets read from an album (#270). "
+        "Smart albums reach tens of thousands; Immich returns newest first, so a "
+        "larger album is truncated to its most recent assets.",
+    )
     scene_threshold: float = Field(default=27.0, ge=1.0, le=100.0)
     min_scene_duration: float = Field(default=1.0, ge=0.5, le=10.0)
     duplicate_hash_threshold: int = Field(default=8, ge=0, le=64)

--- a/tests/test_album_input.py
+++ b/tests/test_album_input.py
@@ -1,0 +1,138 @@
+"""Fetching an Immich album as a memory's source pool (#270).
+
+Albums are not always curated: 'Récentes'-style smart albums reach tens of
+thousands of assets, so the fetch is paginated and bounded.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from immich_memories.api.album_service import (
+    AlbumNotFoundError,
+    AlbumService,
+    AmbiguousAlbumError,
+)
+from immich_memories.api.models import AssetType, MetadataSearchResult
+from immich_memories.api.search_service import SearchService
+
+BASE = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+
+
+def _asset_dto(asset_id: str, index: int = 0) -> dict:
+    created = BASE + timedelta(minutes=index)
+    return {
+        "id": asset_id,
+        "type": AssetType.VIDEO.value,
+        "fileCreatedAt": created.isoformat(),
+        "fileModifiedAt": created.isoformat(),
+        "updatedAt": created.isoformat(),
+    }
+
+
+def _page(ids: list[str], *, next_page: str | None) -> MetadataSearchResult:
+    return MetadataSearchResult(
+        assets={"items": [_asset_dto(i) for i in ids], "nextPage": next_page}
+    )
+
+
+class TestGetAssetsForAlbum:
+    @pytest.mark.asyncio
+    async def test_pages_until_the_album_is_exhausted(self):
+        service = SearchService(AsyncMock())
+        # WHY: replaces the Immich /search/metadata endpoint; paging is the behaviour under test.
+        service.search_metadata = AsyncMock(
+            side_effect=[
+                _page(["a", "b"], next_page="2"),
+                _page(["c"], next_page=None),
+            ]
+        )
+
+        assets = await service.get_assets_for_album("album-1", asset_type=AssetType.VIDEO)
+
+        assert [a.id for a in assets] == ["a", "b", "c"]
+        first_call = service.search_metadata.await_args_list[0].kwargs
+        assert first_call["album_ids"] == ["album-1"]
+        assert first_call["size"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_stops_paging_once_the_limit_is_reached(self):
+        """A 37k-asset smart album must not be pulled into memory in full."""
+        service = SearchService(AsyncMock())
+        service.search_metadata = AsyncMock(
+            side_effect=[
+                _page(["a", "b", "c"], next_page="2"),
+                _page(["d", "e", "f"], next_page="3"),
+            ]
+        )
+
+        assets = await service.get_assets_for_album("album-1", asset_type=AssetType.VIDEO, limit=4)
+
+        assert [a.id for a in assets] == ["a", "b", "c", "d"]
+        assert service.search_metadata.await_count == 2
+
+
+def _albums_fn(*albums: dict) -> AsyncMock:
+    """WHY: replaces the Immich GET /albums endpoint."""
+    return AsyncMock(return_value=list(albums))
+
+
+def _album(album_id: str, name: str, count: int = 0) -> dict:
+    return {"id": album_id, "albumName": name, "assetCount": count}
+
+
+class TestResolveAlbum:
+    @pytest.mark.asyncio
+    async def test_matches_a_name_and_reports_the_asset_count(self):
+        service = AlbumService(
+            _albums_fn(_album("a-1", "Holidays", 12), _album("a-2", "Trip 2025", 340)), AsyncMock()
+        )
+
+        ref = await service.resolve_album("Trip 2025")
+
+        assert (ref.id, ref.name, ref.asset_count) == ("a-2", "Trip 2025", 340)
+
+    @pytest.mark.asyncio
+    async def test_matches_a_name_ignoring_case(self):
+        service = AlbumService(_albums_fn(_album("a-2", "Trip 2025", 3)), AsyncMock())
+
+        assert (await service.resolve_album("trip 2025")).id == "a-2"
+
+    @pytest.mark.asyncio
+    async def test_matches_an_album_id(self):
+        service = AlbumService(_albums_fn(_album("a-2", "Trip 2025", 3)), AsyncMock())
+
+        assert (await service.resolve_album("a-2")).name == "Trip 2025"
+
+    @pytest.mark.asyncio
+    async def test_a_duplicated_album_name_asks_for_an_id(self):
+        """Real libraries carry six albums named 'Récentes' — a name is not an identifier."""
+        service = AlbumService(
+            _albums_fn(
+                _album("a-1", "Récentes", 37318),
+                _album("a-2", "Récentes", 15672),
+                _album("a-3", "Autre", 4),
+            ),
+            AsyncMock(),
+        )
+
+        with pytest.raises(AmbiguousAlbumError) as exc:
+            await service.resolve_album("Récentes")
+
+        message = str(exc.value)
+        assert "a-1" in message and "a-2" in message and "37318" in message
+        assert "a-3" not in message
+
+    @pytest.mark.asyncio
+    async def test_unknown_album_lists_the_available_names(self):
+        service = AlbumService(
+            _albums_fn(_album("a-1", "Holidays"), _album("a-2", "Trip 2025")), AsyncMock()
+        )
+
+        with pytest.raises(AlbumNotFoundError) as exc:
+            await service.resolve_album("Nope")
+
+        assert "Holidays" in str(exc.value) and "Trip 2025" in str(exc.value)

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -1,0 +1,147 @@
+"""Splitting an Immich album into the pipeline's media pools (#270)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.album_source import fetch_album_media, split_album_assets
+from immich_memories.api.album_service import AlbumRef
+from immich_memories.api.models import Asset, AssetType
+from immich_memories.config import Config
+
+
+def _asset(
+    asset_id: str,
+    asset_type: AssetType,
+    created: datetime,
+    *,
+    live_video_id: str | None = None,
+) -> Asset:
+    return Asset(
+        id=asset_id,
+        type=asset_type,
+        fileCreatedAt=created,
+        fileModifiedAt=created,
+        updatedAt=created,
+        livePhotoVideoId=live_video_id,
+        width=1920,
+        height=1080,
+    )
+
+
+def test_splits_videos_stills_and_live_photos_into_their_own_pools():
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    assets = [
+        _asset("vid-1", AssetType.VIDEO, base),
+        _asset("still-1", AssetType.IMAGE, base + timedelta(minutes=5)),
+        _asset("live-1", AssetType.IMAGE, base + timedelta(minutes=10), live_video_id="lv-1"),
+    ]
+
+    media = split_album_assets(assets, config=Config(), use_live_photos=True, use_photos=True)
+
+    assert [a.id for a in media.videos] == ["vid-1"]
+    assert [a.id for a in media.photos] == ["still-1"]
+    assert [c.asset.id for c in media.live_photo_clips] == ["live-1"]
+
+
+def test_date_range_spans_the_albums_oldest_and_newest_asset():
+    oldest = datetime(2007, 5, 4, 9, 0, tzinfo=UTC)
+    newest = datetime(2025, 5, 4, 21, 0, tzinfo=UTC)
+    assets = [
+        _asset("vid-2", AssetType.VIDEO, newest),
+        _asset("vid-1", AssetType.VIDEO, oldest),
+    ]
+
+    media = split_album_assets(assets, config=Config(), use_live_photos=False, use_photos=False)
+
+    assert media.date_range.start == oldest
+    assert media.date_range.end == newest
+
+
+def test_live_photos_become_stills_when_merging_is_disabled():
+    """The user hand-picked these assets — none should silently vanish."""
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    assets = [
+        _asset("still-1", AssetType.IMAGE, base),
+        _asset("live-1", AssetType.IMAGE, base + timedelta(minutes=1), live_video_id="lv-1"),
+    ]
+
+    media = split_album_assets(assets, config=Config(), use_live_photos=False, use_photos=True)
+
+    assert media.live_photo_clips == []
+    assert [a.id for a in media.photos] == ["still-1", "live-1"]
+
+
+def test_a_live_photos_video_component_is_not_also_offered_as_a_video():
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    assets = [
+        _asset("live-1", AssetType.IMAGE, base, live_video_id="lv-1"),
+        _asset("lv-1", AssetType.VIDEO, base),
+        _asset("vid-real", AssetType.VIDEO, base + timedelta(hours=1)),
+    ]
+
+    media = split_album_assets(assets, config=Config(), use_live_photos=True, use_photos=True)
+
+    assert [a.id for a in media.videos] == ["vid-real"]
+
+
+def test_an_empty_album_yields_no_media_and_no_date_range():
+    media = split_album_assets([], config=Config(), use_live_photos=True, use_photos=True)
+
+    assert media.videos == []
+    assert media.photos == []
+    assert media.date_range is None
+
+
+class _FakeClient:
+    """WHY: replaces the Immich API; per-type album fetches are the boundary."""
+
+    def __init__(self, videos: list[Asset], images: list[Asset]) -> None:
+        self._by_type = {AssetType.VIDEO: videos, AssetType.IMAGE: images}
+        self.limits: dict[AssetType, int | None] = {}
+
+    def get_assets_for_album(self, album_id, *, asset_type, limit=None, progress_callback=None):
+        self.limits[asset_type] = limit
+        assets = self._by_type[asset_type]
+        return assets[:limit] if limit is not None else assets
+
+
+def test_fetch_reads_each_media_type_under_the_configured_cap():
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    videos = [_asset(f"v{i}", AssetType.VIDEO, base + timedelta(minutes=i)) for i in range(5)]
+    images = [_asset(f"p{i}", AssetType.IMAGE, base + timedelta(hours=i)) for i in range(5)]
+    client = _FakeClient(videos, images)
+    config = Config()
+    config.analysis.max_album_assets = 3
+
+    media = fetch_album_media(
+        client,
+        AlbumRef(id="a-1", name="Trip 2025", asset_count=10),
+        config=config,
+        use_live_photos=True,
+        use_photos=True,
+    )
+
+    assert client.limits == {AssetType.VIDEO: 3, AssetType.IMAGE: 3}
+    assert len(media.videos) == 3
+    assert len(media.photos) == 3
+    assert media.truncated is True
+
+
+def test_fetch_skips_images_entirely_when_photos_and_live_photos_are_off():
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    client = _FakeClient(
+        [_asset("v0", AssetType.VIDEO, base)], [_asset("p0", AssetType.IMAGE, base)]
+    )
+
+    media = fetch_album_media(
+        client,
+        AlbumRef(id="a-1", name="Trip 2025", asset_count=2),
+        config=Config(),
+        use_live_photos=False,
+        use_photos=False,
+    )
+
+    assert AssetType.IMAGE not in client.limits
+    assert media.photos == []
+    assert media.truncated is False


### PR DESCRIPTION
Source layer for generating a memory from an album: resolve an album reference, then read its assets as videos, merged Live Photo clips and stills.

## Why not `GET /albums/{id}`

Albums are not always curated. On a real library the *Recents* smart album holds **37,318 assets**, and that endpoint has no pagination — it returns every one in a single ~63 MB payload, at roughly **9 KB of resident metadata each**. On the test instance it returned `assets: []` entirely.

Assets are read through `POST /search/metadata` with `albumIds` instead: paginated, filtered by asset type server-side, and stopped at `advanced.analysis.max_album_assets` (default 10000) per type. Immich returns newest first, so a larger album keeps its most recent assets and the run says it truncated.

Measured against a real instance:

| album | time | memory |
|---|---|---|
| 1,052-asset trip album | 0.1 s | ~12 MB |
| 37,318-asset smart album | 5.6 s | ~110 MB (vs ~306 MB read whole) |

## Album names are not identifiers

The same library carries **six** albums named `Récentes`, so an ambiguous name raises with the candidate IDs and their asset counts rather than silently picking one.

## Notes

Live Photo clustering is reused by extracting `build_live_photo_clips` from `fetch_live_photo_clips`. With merging disabled a Live Photo is kept as a still rather than dropped, since album assets are hand-picked.

Part of #270.