### PR TITLE
feat(cli): --from-album generates a memory from one Immich album (#270)

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1071,184 +1071,24 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 180,
-        "line_start": 132,
-        "line_end": 795,
+        "complexity": 179,
+        "line_start": 225,
+        "line_end": 933,
         "line_complexities": [
           {
-            "line": 413,
+            "line": 514,
             "complexity": 0
           },
           {
-            "line": 414,
+            "line": 515,
             "complexity": 0
           },
           {
-            "line": 421,
+            "line": 522,
             "complexity": 2
           },
           {
-            "line": 422,
-            "complexity": 0
-          },
-          {
-            "line": 423,
-            "complexity": 0
-          },
-          {
-            "line": 425,
-            "complexity": 2
-          },
-          {
-            "line": 427,
-            "complexity": 3
-          },
-          {
-            "line": 431,
-            "complexity": 3
-          },
-          {
-            "line": 432,
-            "complexity": 0
-          },
-          {
-            "line": 434,
-            "complexity": 0
-          },
-          {
-            "line": 435,
-            "complexity": 2
-          },
-          {
-            "line": 436,
-            "complexity": 1
-          },
-          {
-            "line": 441,
-            "complexity": 3
-          },
-          {
-            "line": 442,
-            "complexity": 0
-          },
-          {
-            "line": 446,
-            "complexity": 0
-          },
-          {
-            "line": 447,
-            "complexity": 1
-          },
-          {
-            "line": 448,
-            "complexity": 0
-          },
-          {
-            "line": 451,
-            "complexity": 3
-          },
-          {
-            "line": 455,
-            "complexity": 3
-          },
-          {
-            "line": 459,
-            "complexity": 4
-          },
-          {
-            "line": 463,
-            "complexity": 3
-          },
-          {
-            "line": 467,
-            "complexity": 3
-          },
-          {
-            "line": 473,
-            "complexity": 2
-          },
-          {
-            "line": 475,
-            "complexity": 0
-          },
-          {
-            "line": 488,
-            "complexity": 1
-          },
-          {
-            "line": 489,
-            "complexity": 0
-          },
-          {
-            "line": 492,
-            "complexity": 2
-          },
-          {
-            "line": 493,
-            "complexity": 0
-          },
-          {
-            "line": 495,
-            "complexity": 3
-          },
-          {
-            "line": 496,
-            "complexity": 0
-          },
-          {
-            "line": 500,
-            "complexity": 1
-          },
-          {
-            "line": 503,
-            "complexity": 1
-          },
-          {
-            "line": 504,
-            "complexity": 0
-          },
-          {
-            "line": 505,
-            "complexity": 0
-          },
-          {
-            "line": 508,
-            "complexity": 2
-          },
-          {
-            "line": 509,
-            "complexity": 0
-          },
-          {
-            "line": 510,
-            "complexity": 1
-          },
-          {
-            "line": 511,
-            "complexity": 0
-          },
-          {
-            "line": 512,
-            "complexity": 3
-          },
-          {
-            "line": 517,
-            "complexity": 1
-          },
-          {
-            "line": 518,
-            "complexity": 3
-          },
-          {
-            "line": 519,
-            "complexity": 0
-          },
-          {
-            "line": 520,
-            "complexity": 1
-          },
-          {
-            "line": 521,
+            "line": 523,
             "complexity": 0
           },
           {
@@ -1256,171 +1096,211 @@
             "complexity": 0
           },
           {
-            "line": 528,
+            "line": 526,
             "complexity": 2
+          },
+          {
+            "line": 528,
+            "complexity": 3
+          },
+          {
+            "line": 532,
+            "complexity": 3
           },
           {
             "line": 533,
             "complexity": 0
           },
           {
-            "line": 536,
+            "line": 535,
             "complexity": 0
+          },
+          {
+            "line": 536,
+            "complexity": 2
           },
           {
             "line": 537,
-            "complexity": 2
-          },
-          {
-            "line": 538,
-            "complexity": 0
-          },
-          {
-            "line": 541,
             "complexity": 1
           },
           {
-            "line": 544,
+            "line": 542,
             "complexity": 3
           },
           {
-            "line": 545,
-            "complexity": 3
+            "line": 543,
+            "complexity": 0
+          },
+          {
+            "line": 547,
+            "complexity": 0
           },
           {
             "line": 548,
-            "complexity": 2
+            "complexity": 1
           },
           {
             "line": 549,
             "complexity": 0
           },
           {
-            "line": 550,
-            "complexity": 3
-          },
-          {
             "line": 551,
-            "complexity": 0
-          },
-          {
-            "line": 553,
-            "complexity": 0
-          },
-          {
-            "line": 575,
-            "complexity": 1
-          },
-          {
-            "line": 576,
             "complexity": 2
           },
           {
-            "line": 580,
-            "complexity": 1
-          },
-          {
-            "line": 591,
+            "line": 565,
             "complexity": 3
           },
           {
-            "line": 592,
+            "line": 569,
+            "complexity": 3
+          },
+          {
+            "line": 573,
+            "complexity": 4
+          },
+          {
+            "line": 577,
+            "complexity": 3
+          },
+          {
+            "line": 581,
+            "complexity": 3
+          },
+          {
+            "line": 585,
             "complexity": 0
           },
           {
-            "line": 593,
+            "line": 601,
+            "complexity": 2
+          },
+          {
+            "line": 602,
             "complexity": 0
           },
           {
-            "line": 595,
-            "complexity": 0
+            "line": 603,
+            "complexity": 1
           },
           {
-            "line": 597,
-            "complexity": 0
-          },
-          {
-            "line": 599,
+            "line": 605,
             "complexity": 0
           },
           {
             "line": 606,
-            "complexity": 6
+            "complexity": 1
+          },
+          {
+            "line": 607,
+            "complexity": 0
+          },
+          {
+            "line": 608,
+            "complexity": 3
+          },
+          {
+            "line": 613,
+            "complexity": 1
+          },
+          {
+            "line": 614,
+            "complexity": 3
+          },
+          {
+            "line": 615,
+            "complexity": 0
+          },
+          {
+            "line": 616,
+            "complexity": 1
+          },
+          {
+            "line": 617,
+            "complexity": 0
+          },
+          {
+            "line": 620,
+            "complexity": 0
+          },
+          {
+            "line": 624,
+            "complexity": 2
+          },
+          {
+            "line": 629,
+            "complexity": 0
+          },
+          {
+            "line": 632,
+            "complexity": 0
+          },
+          {
+            "line": 633,
+            "complexity": 2
+          },
+          {
+            "line": 634,
+            "complexity": 0
+          },
+          {
+            "line": 637,
+            "complexity": 1
+          },
+          {
+            "line": 640,
+            "complexity": 3
+          },
+          {
+            "line": 641,
+            "complexity": 3
+          },
+          {
+            "line": 645,
+            "complexity": 3
+          },
+          {
+            "line": 646,
+            "complexity": 0
+          },
+          {
+            "line": 647,
+            "complexity": 3
           },
           {
             "line": 648,
             "complexity": 0
           },
           {
-            "line": 649,
-            "complexity": 5
-          },
-          {
             "line": 650,
-            "complexity": 6
-          },
-          {
-            "line": 651,
             "complexity": 0
           },
           {
-            "line": 652,
-            "complexity": 0
-          },
-          {
-            "line": 653,
-            "complexity": 7
-          },
-          {
-            "line": 661,
-            "complexity": 6
-          },
-          {
-            "line": 662,
-            "complexity": 0
-          },
-          {
-            "line": 663,
-            "complexity": 7
-          },
-          {
-            "line": 664,
-            "complexity": 0
-          },
-          {
-            "line": 666,
+            "line": 673,
             "complexity": 1
           },
           {
-            "line": 671,
-            "complexity": 7
+            "line": 674,
+            "complexity": 2
           },
           {
-            "line": 672,
-            "complexity": 0
+            "line": 678,
+            "complexity": 1
           },
           {
-            "line": 685,
-            "complexity": 7
-          },
-          {
-            "line": 686,
-            "complexity": 0
-          },
-          {
-            "line": 687,
-            "complexity": 0
+            "line": 689,
+            "complexity": 3
           },
           {
             "line": 690,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 691,
             "complexity": 0
           },
           {
-            "line": 692,
+            "line": 693,
             "complexity": 0
           },
           {
@@ -1428,81 +1308,173 @@
             "complexity": 0
           },
           {
-            "line": 705,
+            "line": 697,
             "complexity": 0
           },
           {
-            "line": 706,
+            "line": 704,
             "complexity": 5
           },
           {
-            "line": 707,
+            "line": 744,
             "complexity": 6
-          },
-          {
-            "line": 708,
-            "complexity": 7
-          },
-          {
-            "line": 712,
-            "complexity": 6
-          },
-          {
-            "line": 715,
-            "complexity": 6
-          },
-          {
-            "line": 720,
-            "complexity": 0
-          },
-          {
-            "line": 722,
-            "complexity": 5
-          },
-          {
-            "line": 724,
-            "complexity": 5
-          },
-          {
-            "line": 728,
-            "complexity": 5
-          },
-          {
-            "line": 731,
-            "complexity": 1
-          },
-          {
-            "line": 733,
-            "complexity": 0
-          },
-          {
-            "line": 735,
-            "complexity": 0
-          },
-          {
-            "line": 778,
-            "complexity": 1
-          },
-          {
-            "line": 781,
-            "complexity": 1
-          },
-          {
-            "line": 784,
-            "complexity": 1
-          },
-          {
-            "line": 785,
-            "complexity": 0
           },
           {
             "line": 786,
+            "complexity": 0
+          },
+          {
+            "line": 787,
+            "complexity": 5
+          },
+          {
+            "line": 788,
+            "complexity": 6
+          },
+          {
+            "line": 789,
+            "complexity": 0
+          },
+          {
+            "line": 790,
+            "complexity": 0
+          },
+          {
+            "line": 791,
+            "complexity": 7
+          },
+          {
+            "line": 799,
+            "complexity": 6
+          },
+          {
+            "line": 800,
+            "complexity": 0
+          },
+          {
+            "line": 801,
+            "complexity": 7
+          },
+          {
+            "line": 802,
+            "complexity": 0
+          },
+          {
+            "line": 804,
+            "complexity": 1
+          },
+          {
+            "line": 809,
+            "complexity": 7
+          },
+          {
+            "line": 810,
+            "complexity": 0
+          },
+          {
+            "line": 823,
+            "complexity": 7
+          },
+          {
+            "line": 824,
+            "complexity": 0
+          },
+          {
+            "line": 825,
+            "complexity": 0
+          },
+          {
+            "line": 828,
+            "complexity": 1
+          },
+          {
+            "line": 829,
+            "complexity": 0
+          },
+          {
+            "line": 830,
+            "complexity": 0
+          },
+          {
+            "line": 833,
+            "complexity": 0
+          },
+          {
+            "line": 843,
+            "complexity": 0
+          },
+          {
+            "line": 844,
+            "complexity": 5
+          },
+          {
+            "line": 845,
+            "complexity": 6
+          },
+          {
+            "line": 846,
+            "complexity": 7
+          },
+          {
+            "line": 850,
+            "complexity": 6
+          },
+          {
+            "line": 853,
+            "complexity": 6
+          },
+          {
+            "line": 858,
+            "complexity": 0
+          },
+          {
+            "line": 860,
+            "complexity": 5
+          },
+          {
+            "line": 862,
+            "complexity": 5
+          },
+          {
+            "line": 866,
+            "complexity": 5
+          },
+          {
+            "line": 869,
+            "complexity": 1
+          },
+          {
+            "line": 871,
+            "complexity": 0
+          },
+          {
+            "line": 873,
+            "complexity": 0
+          },
+          {
+            "line": 916,
+            "complexity": 1
+          },
+          {
+            "line": 919,
+            "complexity": 1
+          },
+          {
+            "line": 922,
+            "complexity": 1
+          },
+          {
+            "line": 923,
+            "complexity": 0
+          },
+          {
+            "line": 924,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 197
+    "complexity": 203
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -29,6 +29,7 @@ immich-memories generate [OPTIONS]
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--memory-type` | — | choice | — | `year_in_review`, `season`, `person_spotlight`, `multi_person`, `monthly_highlights`, `on_this_day`, `trip` |
+| `--from-album` | — | string | — | Generate from an Immich album (name or ID) instead of a date range. See [Album Memories](../memory-types/album-memories). Cannot be combined with any time-period or person flag |
 | `--person` | `-p` | string | — | Person name from Immich face recognition (repeatable: `--person "Alice" --person "Bob"`) |
 | `--birthday` | `-b` | flag/string | — | Use birthday-based year. Bare flag auto-detects from Immich; or pass `MM/DD` to override |
 | `--season` | — | choice | — | `spring`, `summer`, `fall`, `autumn`, `winter` (use with `--memory-type season`) |

--- a/docs-site/docs/create/memory-types/album-memories.mdx
+++ b/docs-site/docs/create/memory-types/album-memories.mdx
@@ -1,0 +1,85 @@
+---
+sidebar_label: "Album Memories"
+---
+
+# Album Memories
+
+Generate a memory from one Immich album instead of a date range. The album *is* the
+selection — nothing outside it is considered, and nothing inside it is filtered out by
+date.
+
+This is the right mode when you have already curated the moments: a birthday, a wedding,
+a single trip, a school year.
+
+## CLI
+
+```bash
+# By name
+immich-memories generate --from-album "Trip 2025"
+
+# By album ID
+immich-memories generate --from-album 59080965-22f0-46a4-be67-135692a9f584
+```
+
+The video is titled after the album, and named `album_<slug>.mp4` in your output
+directory. `--title` still overrides the title if you want something else.
+
+Because the album defines its own contents, `--from-album` cannot be combined with
+`--year`, `--start`/`--end`, `--period`, `--birthday`, `--season`, `--month`,
+`--memory-type` or `--person`. Everything else — `--duration`, `--orientation`,
+`--music`, `--no-music`, `--upload`, `--dry-run` — works as usual.
+
+## What gets used
+
+| Asset in the album | How it is used |
+|---|---|
+| Video | Analyzed and cut like any other clip |
+| Live Photo | Bursts merged into one moving clip (as everywhere else) |
+| Photo | Animated still, subject to the usual photo share of the runtime |
+| A Live Photo's video component | Ignored — it is already part of the merged clip |
+
+With Live Photo merging turned off, a Live Photo is used as a still rather than being
+dropped: you picked these assets by hand, so nothing silently disappears.
+
+## Duration
+
+Without `--duration`, the runtime is planned from the album's own media — the same
+media-aware planner trips use, bounded to 60–300 s and capped by what the album can
+honestly fill. A 10-asset album will not be stretched into a five-minute video.
+
+## Duplicate album names
+
+Immich libraries synced from iOS routinely carry several albums with the same name.
+When a name is ambiguous, the run stops and lists the candidates so you can pick one:
+
+```
+Error: 6 albums are named 'Récentes'. Pass the ID instead:
+  41e64fa3-3a6e-4024-820c-2e23bdc73186  (37318 assets)
+  a381c349-a0c7-43d9-913b-0013f4da8891  (15672 assets)
+  ...
+```
+
+## Very large albums
+
+Smart albums like *Recents* or *Favorites* can hold tens of thousands of assets. Reading
+one costs roughly 9 KB of memory per asset, so album mode reads at most
+`advanced.analysis.max_album_assets` assets **per media type** (default `10000`).
+
+Immich returns newest assets first, so a larger album is truncated to its most recent
+assets, and the run says so:
+
+```
+Album exceeds 10000 assets per type — using the most recent ones
+```
+
+If you hit that line, you probably want a date range rather than an album. Raise the
+limit only if you have the memory for it:
+
+```yaml
+advanced:
+  analysis:
+    max_album_assets: 25000
+```
+
+For reference, on a real library: a 1,052-asset trip album reads in 0.1 s and ~12 MB; a
+37,318-asset *Recents* album reads in 5.6 s and ~110 MB with the default limit.

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -219,6 +219,7 @@ immich-memories generate [OPTIONS]
 | `--end` | text | - | End date (use with --start) |
 | `--period` | text | - | Period from start date (e.g., 6m, 1y, 2w) |
 | `--birthday`, `-b` | text | - | Use birthday-based year (auto-detects from Immich, or specify MM/DD) |
+| `--from-album` | text | - | Generate from an Immich album (name or ID) instead of a date range |
 | `--person`, `-p` | text | - | Person name (repeatable) |
 | `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` | - | Memory type preset |
 | `--season` | choice: `spring` \| `summer` \| `fall` \| `autumn` \| `winter` | - | Season (use with --memory-type season) |

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
             'create/memory-types/year-in-review',
             'create/memory-types/monthly-person-season',
             'create/memory-types/trip-memories',
+            'create/memory-types/album-memories',
           ],
         },
         {

--- a/src/immich_memories/cli/_album_generation.py
+++ b/src/immich_memories/cli/_album_generation.py
@@ -1,0 +1,154 @@
+"""Album-mode generation: an Immich album is the candidate pool (#270)."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+from typing import TYPE_CHECKING
+
+from immich_memories.cli._helpers import console, print_error, print_info, print_success
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from immich_memories.api.sync_client import SyncImmichClient
+    from immich_memories.cli._live_display import ProgressDisplay
+    from immich_memories.config_loader import Config
+
+_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
+
+
+def album_output_path(default_path: Path, album_name: str, container: str) -> Path:
+    """Name the output file after the album, alongside the default output."""
+    folded = unicodedata.normalize("NFKD", album_name).encode("ascii", "ignore").decode()
+    slug = _SLUG_STRIP.sub("_", folded.lower()).strip("_")[:40]
+    stem = f"album_{slug}" if slug else "album"
+    return default_path.parent / f"{stem}.{container}"
+
+
+def handle_album_generation(
+    *,
+    client: SyncImmichClient,
+    config: Config,
+    progress: ProgressDisplay,
+    album_ref: str,
+    person_names: list[str],
+    output_path: Path,
+    use_live_photos: bool,
+    use_photos: bool,
+    effective_analysis_depth: str,
+    transition: str,
+    music: str | None,
+    music_volume: float,
+    no_music: bool,
+    resolution: str,
+    scale_mode: str | None,
+    output_format: str | None,
+    add_date: bool,
+    keep_intermediates: bool,
+    privacy_mode: bool,
+    title_override: str | None,
+    subtitle_override: str | None,
+    upload_to_immich: bool,
+    album: str | None,
+    duration: float | int | None = None,
+    orientation: str = "landscape",
+    source: str = "manual",
+    memory_key: str | None = None,
+    memory_category: str | None = None,
+    automation_attempt_id: str | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Generate one memory from the assets of a single Immich album."""
+    import click
+
+    from immich_memories.analysis.album_source import fetch_album_media
+    from immich_memories.api.album_service import AlbumNotFoundError, AmbiguousAlbumError
+    from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
+    from immich_memories.cli._trip_generation import resolve_music_arg
+    from immich_memories.processing.encoding_plan import resolve_output_selection
+
+    task = progress.add_task(f"Resolving album: {album_ref}...", total=None)
+    try:
+        resolved = client.resolve_album(album_ref)
+    except (AlbumNotFoundError, AmbiguousAlbumError) as exc:
+        progress.update(task, completed=True)
+        progress.stop()
+        raise click.ClickException(str(exc)) from exc
+    progress.update(task, completed=True)
+    print_success(f"Album: {resolved.name} ({resolved.asset_count} assets)")
+
+    media = fetch_album_media(
+        client,
+        resolved,
+        config=config,
+        use_live_photos=use_live_photos,
+        use_photos=use_photos,
+    )
+    if media.truncated:
+        print_info(
+            f"Album exceeds {config.analysis.max_album_assets} assets per type — "
+            "using the most recent ones"
+        )
+    if media.date_range is None or not (media.videos or media.live_photo_clips or media.photos):
+        print_error(f"No usable videos or photos in album: {resolved.name}")
+        sys.exit(1)
+
+    print_info(
+        f"Album pool: {len(media.videos)} videos, "
+        f"{len(media.live_photo_clips)} live photo clips, {len(media.photos)} photos"
+    )
+
+    output_selection = resolve_output_selection(
+        config_codec=config.output.codec,
+        config_container=config.output.format,
+        format_override=output_format,
+    )
+    album_output = album_output_path(output_path, resolved.name, output_selection.container)
+
+    result_path, should_upload, album_name = run_pipeline_and_generate(
+        assets=media.videos,
+        live_photo_clips=media.live_photo_clips,
+        photo_assets=media.photos or None,
+        include_photos=use_photos and bool(media.photos),
+        analysis_depth=effective_analysis_depth,
+        client=client,
+        config=config,
+        progress=progress,
+        duration=float(duration) if duration is not None else None,
+        transition=transition if transition != "smart" else config.defaults.transition,
+        music=resolve_music_arg(music),
+        music_volume=music_volume,
+        no_music=no_music,
+        output_path=album_output,
+        output_resolution=resolution,
+        output_orientation=orientation,
+        scale_mode=scale_mode or config.defaults.scale_mode,
+        output_format=output_format,
+        add_date_overlay=add_date,
+        debug_preserve_intermediates=keep_intermediates,
+        privacy_mode=privacy_mode,
+        # The album's own name is the best title we have; an explicit --title still wins.
+        title_override=title_override or resolved.name,
+        subtitle_override=subtitle_override,
+        memory_type="album",
+        person_names=person_names,
+        date_range=media.date_range,
+        upload_to_immich=upload_to_immich,
+        album=album,
+        memory_preset_params={"album_name": resolved.name, "album_id": resolved.id},
+        source=source,
+        memory_key=memory_key,
+        memory_category=memory_category,
+        automation_attempt_id=automation_attempt_id,
+        dry_run=dry_run,
+    )
+
+    console.print()
+    if dry_run:
+        print_success(f"Album plan complete: {resolved.name}")
+        return
+    print_success(f"Album video: {result_path}")
+    if should_upload:
+        print_success(f"Uploaded to Immich (album: {album_name or 'none'})")

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -92,8 +92,10 @@ def _resolve_requested_duration(
     """Resolve Auto only after the CLI has discovered usable media."""
     if requested_duration is not None:
         return float(requested_duration)
-    if memory_type != "trip":
-        raise ValueError("Automatic media-aware duration is currently available for trips only")
+    if memory_type not in ("trip", "album"):
+        raise ValueError(
+            "Automatic media-aware duration is currently available for trips and albums only"
+        )
 
     from immich_memories.planning.auto_duration import resolve_trip_auto_duration
 
@@ -109,7 +111,8 @@ def _resolve_requested_duration(
         ending_duration=ending_duration,
     )
     logger.info(
-        "Trip Auto duration: %.0fs from %d active days (editorial %.0fs, capacity %.0fs)",
+        "%s Auto duration: %.0fs from %d active days (editorial %.0fs, capacity %.0fs)",
+        memory_type.capitalize(),
         result.total_seconds,
         result.active_days,
         result.editorial_seconds,

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,13 +29,108 @@ if TYPE_CHECKING:
     from immich_memories.config_loader import Config
 
 
+def _resolve_generation_scope(
+    *,
+    from_album: str | None,
+    year: int | None,
+    start: str | None,
+    end: str | None,
+    period: str | None,
+    birthday: str | None,
+    memory_type: str | None,
+    season: str | None,
+    month: int | None,
+    hemisphere: str,
+    years_back: int | None,
+    on_this_day_target: date | None,
+) -> tuple[DateRange, list[DateRange]]:
+    """Resolve what a memory covers: date range(s), or an album that defines its own.
+
+    Returns the display range plus the ranges to search. Album mode returns no ranges
+    at all — its span comes from the album's assets, which need a connection to read —
+    so the returned range is a stand-in that album mode replaces and never displays.
+    """
+    if from_album:
+        now = datetime.now()
+        return DateRange(start=now, end=now), []
+
+    # WHY: birthday="auto" means detect from Immich later — don't pass to parser
+    initial_birthday = None if birthday == "auto" else birthday
+    date_result = resolve_date_range(
+        year,
+        start,
+        end,
+        period,
+        initial_birthday,
+        memory_type=memory_type,
+        season=season,
+        month=month,
+        hemisphere=hemisphere,
+        years_back=years_back,
+        on_this_day_target=on_this_day_target,
+    )
+
+    # Normalize to single DateRange for display (multi-range for on_this_day)
+    if not isinstance(date_result, list):
+        return date_result, [date_result]
+    if not date_result:
+        print_error("No date ranges generated for On This Day")
+        sys.exit(1)
+    return DateRange(start=date_result[-1].start, end=date_result[0].end), date_result
+
+
+def _reject_album_scope_conflicts(
+    *,
+    year: int | None,
+    start: str | None,
+    end: str | None,
+    period: str | None,
+    birthday: str | None,
+    season: str | None,
+    month: int | None,
+    memory_type: str | None,
+    person_names: list[str] | tuple[str, ...],
+) -> None:
+    """Album mode replaces date-range discovery, so date scoping is meaningless."""
+    conflicts = {
+        "--year": year,
+        "--start": start,
+        "--end": end,
+        "--period": period,
+        "--birthday": birthday,
+        "--season": season,
+        "--month": month,
+        "--memory-type": memory_type,
+        "--person": person_names,
+    }
+    used = sorted(flag for flag, value in conflicts.items() if value)
+    if used:
+        raise click.UsageError(f"--from-album selects its own assets; drop {', '.join(used)}")
+
+
+def _add_scope_rows(table: Table, *, album_ref: str | None, date_range: DateRange) -> None:
+    """Describe what the memory is drawn from: an album, or a span of time."""
+    if album_ref:
+        table.add_row("Album", album_ref)
+        return
+    table.add_row("Time Period", date_range.description)
+    table.add_row("Duration", f"{date_range.days} days")
+
+
+def _format_target_duration(duration: float | None) -> str:
+    if duration is None:
+        return "auto"
+    return f"{duration / 60:.1f} min" if duration >= 60 else f"{duration:.0f}s"
+
+
 def _build_params_table(
     *,
     config: Config,
     memory_type: str | None,
     date_range: DateRange,
     person_names: list[str],
-    duration: float,
+    duration: float | None,
+    album_ref: str | None = None,
     orientation: str,
     scale_mode: str | None,
     transition: str,
@@ -59,11 +154,9 @@ def _build_params_table(
 
     if memory_type:
         table.add_row("Memory Type", memory_type)
-    table.add_row("Time Period", date_range.description)
-    table.add_row("Duration", f"{date_range.days} days")
+    _add_scope_rows(table, album_ref=album_ref, date_range=date_range)
     table.add_row("Person", ", ".join(person_names) if person_names else "All people")
-    dur_display = f"{duration / 60:.1f} min" if duration >= 60 else f"{duration:.0f}s"
-    table.add_row("Target Duration", dur_display)
+    table.add_row("Target Duration", _format_target_duration(duration))
     table.add_row("Orientation", orientation)
     table.add_row("Scale Mode", scale_mode or config.defaults.scale_mode)
     table.add_row("Transition", transition)
@@ -146,6 +239,13 @@ def register_generate_commands(main: click.Group) -> None:
         flag_value="auto",
         default=None,
         help="Use birthday-based year (auto-detects from Immich, or specify MM/DD)",
+    )
+    @click.option(
+        "--from-album",
+        "from_album",
+        type=str,
+        default=None,
+        help="Generate from an Immich album (name or ID) instead of a date range",
     )
     @click.option("--person", "-p", type=str, multiple=True, help="Person name (repeatable)")
     @click.option(
@@ -371,6 +471,7 @@ def register_generate_commands(main: click.Group) -> None:
         dry_run: bool,
         upload_to_immich: bool,
         album: str | None,
+        from_album: str | None,
         add_date: bool,
         keep_intermediates: bool,
         privacy_mode: bool,
@@ -447,6 +548,19 @@ def register_generate_commands(main: click.Group) -> None:
             except ValueError as exc:
                 raise click.UsageError(str(exc)) from exc
 
+        if from_album:
+            _reject_album_scope_conflicts(
+                year=year,
+                start=start,
+                end=end,
+                period=period,
+                birthday=birthday,
+                season=season,
+                month=month,
+                memory_type=memory_type,
+                person_names=person_names,
+            )
+
         # Validate memory type constraints
         if memory_type in ("person_spotlight", "multi_person") and not person_names:
             print_error(f"--person is required with --memory-type {memory_type}")
@@ -468,45 +582,27 @@ def register_generate_commands(main: click.Group) -> None:
             print_error("--years-back requires --memory-type on_this_day")
             sys.exit(1)
 
-        # Resolve date range(s)
-        # WHY: birthday="auto" means detect from Immich later — don't pass to parser
-        initial_birthday = None if birthday == "auto" else birthday
-        try:
-            date_result = resolve_date_range(
-                year,
-                start,
-                end,
-                period,
-                initial_birthday,
-                memory_type=memory_type,
-                season=season,
-                month=month,
-                hemisphere=hemisphere,
-                years_back=years_back,
-                on_this_day_target=exact_on_this_day,
-            )
-        except click.UsageError:
-            raise
-
-        # Normalize to single DateRange for display (multi-range for on_this_day)
-        if isinstance(date_result, list):
-            date_ranges = date_result
-            # Use first and last range for display
-            if date_ranges:
-                date_range = DateRange(
-                    start=date_ranges[-1].start,
-                    end=date_ranges[0].end,
-                )
-            else:
-                print_error("No date ranges generated for On This Day")
-                sys.exit(1)
-        else:
-            date_range = date_result
-            date_ranges = [date_result]
+        date_range, date_ranges = _resolve_generation_scope(
+            from_album=from_album,
+            year=year,
+            start=start,
+            end=end,
+            period=period,
+            birthday=birthday,
+            memory_type=memory_type,
+            season=season,
+            month=month,
+            hemisphere=hemisphere,
+            years_back=years_back,
+            on_this_day_target=exact_on_this_day,
+        )
 
         # Determine output path
         if output:
             output_path = normalize_output_path(Path(output), output_selection.container)
+        elif from_album:
+            # A placeholder directory anchor; the album handler names the file.
+            output_path = config.output.output_path / f"album.{output_selection.container}"
         else:
             output_dir = config.output.output_path
             person_slug = (
@@ -545,14 +641,16 @@ def register_generate_commands(main: click.Group) -> None:
             memory_type = "person_spotlight" if len(person_names) == 1 else "multi_person"
 
         # Resolve duration: CLI --duration > memory type default > date-range scaling
-        if duration is None:
+        # Album mode defers to the pipeline, which sizes it from the album's media.
+        if duration is None and not from_album:
             duration = default_duration_for_type(memory_type, date_range)
             if duration is None:
                 duration = duration_from_date_range(date_range)
 
         table = _build_params_table(
             config=config,
-            memory_type=memory_type,
+            memory_type="album" if from_album else memory_type,
+            album_ref=from_album,
             date_range=date_range,
             person_names=person_names,
             duration=duration,
@@ -602,6 +700,46 @@ def register_generate_commands(main: click.Group) -> None:
                     api_version=config.immich.api_version,
                 ) as client:
                     progress.update(task, completed=True)
+                    # Album flow: the album is the pool, so branch before discovery
+                    if from_album:
+                        from immich_memories.cli._album_generation import (
+                            handle_album_generation,
+                        )
+
+                        handle_album_generation(
+                            client=client,
+                            config=config,
+                            progress=progress,
+                            album_ref=from_album,
+                            person_names=[],
+                            output_path=output_path,
+                            use_live_photos=use_live_photos,
+                            use_photos=use_photos,
+                            effective_analysis_depth=effective_analysis_depth,
+                            transition=transition,
+                            music=music,
+                            music_volume=music_volume,
+                            no_music=no_music,
+                            resolution=resolution,
+                            scale_mode=scale_mode,
+                            output_format=output_format,
+                            add_date=add_date,
+                            keep_intermediates=keep_intermediates,
+                            privacy_mode=privacy_mode,
+                            title_override=title_override,
+                            subtitle_override=subtitle_override,
+                            upload_to_immich=upload_to_immich,
+                            album=album,
+                            duration=duration,
+                            orientation=orientation,
+                            source=source,
+                            memory_key=memory_key,
+                            memory_category=memory_category,
+                            automation_attempt_id=automation_attempt_id,
+                            dry_run=dry_run,
+                        )
+                        return
+
                     # Trip detection flow: branch early
                     if memory_type == "trip" and year:
                         handle_trip_generation(

--- a/src/immich_memories/memory_types/registry.py
+++ b/src/immich_memories/memory_types/registry.py
@@ -13,6 +13,7 @@ class MemoryType(StrEnum):
     MULTI_PERSON = "multi_person"
     MONTHLY_HIGHLIGHTS = "monthly_highlights"
     ON_THIS_DAY = "on_this_day"
+    ALBUM = "album"
     # Phase 2 (placeholders)
     HOLIDAY = "holiday"
     TRIP = "trip"

--- a/tests/test_album_generation.py
+++ b/tests/test_album_generation.py
@@ -1,0 +1,144 @@
+"""CLI album-mode helpers (#270)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from immich_memories.api.album_service import AlbumRef
+from immich_memories.api.models import Asset, AssetType
+from immich_memories.cli._album_generation import album_output_path, handle_album_generation
+from immich_memories.config_loader import Config
+
+
+def test_output_filename_is_built_from_the_album_name():
+    path = album_output_path(Path("/out/all_memories_2025.mp4"), "Trip 2025", "mp4")
+
+    assert path == Path("/out/album_trip_2025.mp4")
+
+
+def test_accented_album_names_survive_as_a_usable_filename():
+    """Sam's albums are French — 'Récentes' must not become an empty slug."""
+    path = album_output_path(Path("/out/x.mp4"), "Val d'Aoste 2021", "mkv")
+
+    assert path == Path("/out/album_val_d_aoste_2021.mkv")
+
+
+def test_a_name_with_no_usable_characters_still_yields_a_filename():
+    path = album_output_path(Path("/out/x.mp4"), "***", "mp4")
+
+    assert path == Path("/out/album.mp4")
+
+
+class _Progress:
+    """WHY: replaces the terminal progress display."""
+
+    def add_task(self, *_args, **_kwargs):
+        return 1
+
+    def update(self, *_args, **_kwargs):
+        return None
+
+    def stop(self):
+        return None
+
+
+class _Client:
+    """WHY: replaces the Immich API."""
+
+    def __init__(self, album: AlbumRef, videos, images):
+        self._album = album
+        self._by_type = {AssetType.VIDEO: videos, AssetType.IMAGE: images}
+
+    def resolve_album(self, _name_or_id):
+        return self._album
+
+    def get_assets_for_album(self, _album_id, *, asset_type, limit=None, progress_callback=None):
+        return self._by_type[asset_type]
+
+
+def _asset(asset_id: str, asset_type: AssetType, created: datetime) -> Asset:
+    return Asset(
+        id=asset_id,
+        type=asset_type,
+        fileCreatedAt=created,
+        fileModifiedAt=created,
+        updatedAt=created,
+        width=1920,
+        height=1080,
+    )
+
+
+def _run_album(monkeypatch, videos, images, **overrides):
+    """Drive handle_album_generation, capturing what it hands the pipeline."""
+    captured: dict = {}
+
+    def _fake_pipeline(**kwargs):
+        captured.update(kwargs)
+        return Path("/out/album_trip_2025.mp4"), False, None
+
+    # WHY: replaces the whole analysis + assembly pipeline.
+    monkeypatch.setattr(
+        "immich_memories.cli._pipeline_runner.run_pipeline_and_generate", _fake_pipeline
+    )
+    album = AlbumRef(id="a-1", name="Trip 2025", asset_count=len(videos) + len(images))
+    kwargs = {
+        "client": _Client(album, videos, images),
+        "config": Config(),
+        "progress": _Progress(),
+        "album_ref": "Trip 2025",
+        "person_names": [],
+        "output_path": Path("/out/all_memories.mp4"),
+        "use_live_photos": False,
+        "use_photos": True,
+        "effective_analysis_depth": "auto",
+        "transition": "fade",
+        "music": None,
+        "music_volume": 0.5,
+        "no_music": True,
+        "resolution": "4k",
+        "scale_mode": None,
+        "output_format": None,
+        "add_date": False,
+        "keep_intermediates": False,
+        "privacy_mode": False,
+        "title_override": None,
+        "subtitle_override": None,
+        "upload_to_immich": False,
+        "album": None,
+    }
+    kwargs.update(overrides)
+    handle_album_generation(**kwargs)
+    return captured
+
+
+def test_the_album_supplies_the_pool_the_title_and_the_span(monkeypatch):
+    videos = [_asset("v1", AssetType.VIDEO, datetime(2025, 7, 1, tzinfo=UTC))]
+    images = [_asset("p1", AssetType.IMAGE, datetime(2025, 7, 9, tzinfo=UTC))]
+
+    captured = _run_album(monkeypatch, videos, images)
+
+    assert [a.id for a in captured["assets"]] == ["v1"]
+    assert [a.id for a in captured["photo_assets"]] == ["p1"]
+    assert captured["memory_type"] == "album"
+    assert captured["title_override"] == "Trip 2025"
+    assert captured["date_range"].start == datetime(2025, 7, 1, tzinfo=UTC)
+    assert captured["date_range"].end == datetime(2025, 7, 9, tzinfo=UTC)
+    assert captured["output_path"] == Path("/out/album_trip_2025.mp4")
+
+
+def test_an_explicit_title_still_wins_over_the_album_name(monkeypatch):
+    videos = [_asset("v1", AssetType.VIDEO, datetime(2025, 7, 1, tzinfo=UTC))]
+
+    captured = _run_album(monkeypatch, videos, [], title_override="Something Else")
+
+    assert captured["title_override"] == "Something Else"
+
+
+def test_an_album_with_no_usable_media_stops_the_run(monkeypatch):
+    with pytest.raises(SystemExit) as exc:
+        _run_album(monkeypatch, [], [])
+
+    assert exc.value.code == 1

--- a/tests/test_auto_duration.py
+++ b/tests/test_auto_duration.py
@@ -147,3 +147,18 @@ def test_trip_date_default_is_an_editorial_estimate_not_35_seconds_per_day() -> 
     date_range = DateRange(start=start, end=start + timedelta(days=11))
 
     assert default_duration_for_type("trip", date_range) == 150.0
+
+
+def test_cli_auto_album_resolves_from_the_albums_media() -> None:
+    """An album's span is unknown up front, so its runtime comes from its media."""
+    clips, photos = _dense_trip(12)
+
+    resolved = _resolve_requested_duration(
+        None,
+        memory_type="album",
+        clips=clips,
+        photos=photos,
+        config=Config(),
+    )
+
+    assert resolved == 150.0

--- a/tests/test_generation_scope.py
+++ b/tests/test_generation_scope.py
@@ -1,0 +1,123 @@
+"""Resolving what a memory covers: date range(s), or an album (#270)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import click
+import pytest
+from rich.table import Table
+
+from immich_memories.cli.generate import (
+    _add_scope_rows,
+    _format_target_duration,
+    _reject_album_scope_conflicts,
+    _resolve_generation_scope,
+)
+from immich_memories.timeperiod import DateRange
+
+
+def _scope(**overrides):
+    kwargs = {
+        "from_album": None,
+        "year": None,
+        "start": None,
+        "end": None,
+        "period": None,
+        "birthday": None,
+        "memory_type": None,
+        "season": None,
+        "month": None,
+        "hemisphere": "north",
+        "years_back": None,
+        "on_this_day_target": None,
+    }
+    kwargs.update(overrides)
+    return _resolve_generation_scope(**kwargs)
+
+
+def test_album_mode_searches_no_date_ranges_at_all():
+    """The album is the pool, so nothing is discovered by date."""
+    _display_range, ranges = _scope(from_album="Trip 2025")
+
+    assert ranges == []
+
+
+def test_a_year_resolves_to_one_searchable_range():
+    display, ranges = _scope(year=2025)
+
+    assert len(ranges) == 1
+    assert display.start.year == 2025
+
+
+def test_on_this_day_spans_its_ranges_for_display_but_searches_each():
+    display, ranges = _scope(memory_type="on_this_day", years_back=3)
+
+    assert len(ranges) > 1
+    assert display.start < display.end
+
+
+def test_album_mode_rejects_flags_that_would_scope_it_differently():
+    with pytest.raises(click.UsageError) as exc:
+        _reject_album_scope_conflicts(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday=None,
+            season=None,
+            month=None,
+            memory_type=None,
+            person_names=["Alice"],
+        )
+
+    assert "--year" in str(exc.value)
+    assert "--person" in str(exc.value)
+
+
+def test_album_mode_accepts_a_bare_album():
+    _reject_album_scope_conflicts(
+        year=None,
+        start=None,
+        end=None,
+        period=None,
+        birthday=None,
+        season=None,
+        month=None,
+        memory_type=None,
+        person_names=[],
+    )
+
+
+def test_the_parameters_table_names_the_album_instead_of_a_time_period():
+    table = Table()
+    table.add_column("Setting")
+    table.add_column("Value")
+
+    _add_scope_rows(
+        table,
+        album_ref="Trip 2025",
+        date_range=DateRange(start=datetime(2025, 1, 1), end=datetime(2025, 12, 31)),
+    )
+
+    assert [c._cells for c in table.columns] == [["Album"], ["Trip 2025"]]
+
+
+def test_the_parameters_table_falls_back_to_the_time_period():
+    table = Table()
+    table.add_column("Setting")
+    table.add_column("Value")
+
+    _add_scope_rows(
+        table,
+        album_ref=None,
+        date_range=DateRange(start=datetime(2025, 1, 1), end=datetime(2025, 12, 31)),
+    )
+
+    assert table.columns[0]._cells == ["Time Period", "Duration"]
+
+
+def test_an_unknown_target_duration_reads_as_auto():
+    assert _format_target_duration(None) == "auto"
+    assert _format_target_duration(45.0) == "45s"
+    assert _format_target_duration(120.0) == "2.0 min"

--- a/tests/test_memory_types/test_registry_presets.py
+++ b/tests/test_memory_types/test_registry_presets.py
@@ -42,8 +42,11 @@ class TestMemoryTypeEnum:
         }
         assert {str(m) for m in phase2} == expected
 
+    def test_album_value_exists(self) -> None:
+        assert str(MemoryType.ALBUM) == "album"
+
     def test_total_enum_count(self) -> None:
-        assert len(MemoryType) == 9
+        assert len(MemoryType) == 10
 
     def test_is_str_enum(self) -> None:
         assert isinstance(MemoryType.YEAR_IN_REVIEW, str)


### PR DESCRIPTION
> Stacked on #360 — review that first; this will retarget to `main` when it merges.

The most-requested external feature, and the one with a concrete use case behind it: an 18th-birthday video from an album the user already curated.

```bash
immich-memories generate --from-album "Trip 2025"     # name or ID
```

## Design notes

**Album mode branches before discovery**, the way trips already do, because the album replaces date-range search rather than narrowing it — an 18-year birthday album would otherwise make the date-range path fetch the whole library.

**`--album` was already taken** (the album a finished video is uploaded *into*), so the input flag is `--from-album`. No breaking change, no compat shim. Because an album defines its own contents, it is rejected alongside any time-period or person flag.

**Runtime** comes from the album's own media when `--duration` is omitted, reusing the media-aware planner trips use — already bounded to 60–300 s, so an album of unknown span cannot produce an absurd runtime.

Verified against a real instance: a 10-asset album resolves by name and plans 6 videos + 4 merged Live Photo clips into 32 s, spanning the real event date. A full generate produced a valid 3840×2160 HEVC HLG-HDR file.

Extracting `_resolve_generation_scope`, `_add_scope_rows` and `_reject_album_scope_conflicts` keeps `register_generate_commands` below its complexity watermark (180 → 179).

Part of #270.