### PR TITLE
feat(api): generate from albums shared with you (#48)

### DIFF
--- a/docs-site/docs/create/memory-types/album-memories.mdx
+++ b/docs-site/docs/create/memory-types/album-memories.mdx
@@ -41,6 +41,15 @@ Because the album defines its own contents, `--from-album` cannot be combined wi
 With Live Photo merging turned off, a Live Photo is used as a still rather than being
 dropped: you picked these assets by hand, so nothing silently disappears.
 
+## Shared albums
+
+An album someone shared with you works exactly like one of your own — Immich lists
+shared albums alongside yours, so pass the name or ID as usual:
+
+```bash
+immich-memories generate --from-album "Paris-Roubaix Challenge 2026"
+```
+
 ## Duration
 
 Without `--duration`, the runtime is planned from the album's own media — the same

--- a/src/immich_memories/cli/_album_generation.py
+++ b/src/immich_memories/cli/_album_generation.py
@@ -67,6 +67,7 @@ def handle_album_generation(
     from immich_memories.api.album_service import AlbumNotFoundError, AmbiguousAlbumError
     from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
     from immich_memories.cli._trip_generation import resolve_music_arg
+    from immich_memories.memory_types.registry import MemoryType
     from immich_memories.processing.encoding_plan import resolve_output_selection
 
     task = progress.add_task(f"Resolving album: {album_ref}...", total=None)
@@ -132,7 +133,7 @@ def handle_album_generation(
         # The album's own name is the best title we have; an explicit --title still wins.
         title_override=title_override or resolved.name,
         subtitle_override=subtitle_override,
-        memory_type="album",
+        memory_type=MemoryType.ALBUM,
         person_names=person_names,
         date_range=media.date_range,
         upload_to_immich=upload_to_immich,

--- a/tests/test_album_input.py
+++ b/tests/test_album_input.py
@@ -136,3 +136,18 @@ class TestResolveAlbum:
             await service.resolve_album("Nope")
 
         assert "Holidays" in str(exc.value) and "Trip 2025" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_an_album_shared_with_you_resolves_like_any_other(self):
+        """Immich lists shared albums in GET /albums — album mode must not filter them out (#48)."""
+        service = AlbumService(
+            _albums_fn(
+                _album("a-1", "Holidays", 12) | {"shared": False},
+                _album("a-2", "Paris-Roubaix 2026", 174) | {"shared": True},
+            ),
+            AsyncMock(),
+        )
+
+        ref = await service.resolve_album("Paris-Roubaix 2026")
+
+        assert (ref.id, ref.asset_count) == ("a-2", 174)

--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -1189,7 +1189,9 @@ class TestAudioFilterChain:
                 str(out),
             ],
             capture_output=True,
-            timeout=60,
+            # 30 inputs, 30 loudnorm passes and 29 crossfades: minutes on a loaded
+            # shared runner. This test is about duration accuracy, not speed.
+            timeout=300,
         )
         assert result.returncode == 0, f"FFmpeg failed: {result.stderr[-300:]}"
 


### PR DESCRIPTION
> Stacked on #361.

No new code path: Immich v3 returns shared albums from `GET /albums` alongside your own, so `--from-album` already resolves them. The legacy `?shared=true` query param is ignored by the server (v3 uses `isShared`/`isOwned`), which is why this needed checking rather than assuming.

Verified against a real instance: 11 shared albums are visible, and two of them fetch correctly through the album source (174 assets → 1 Live Photo clip + 173 photos; 67 assets → 11 videos + 56 photos).

Adds the regression test that pins it, so a later change to album listing cannot quietly drop shared albums, plus the docs section.

Closes #48