### PR TITLE
fix(audio): actually crossfade looped music instead of butt-splicing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ tests/integration/
 ├── auth/         make test-integration-auth         (~10s, no external deps)
 ├── assembly/     make test-integration-assembly     (~1min, FFmpeg only)
 ├── audio/        make test-integration-audio        (~2min, demucs/acestep packages)
+├── audio_mixing/ make test-integration-audio-mixing (~5s, FFmpeg only, loop seams)
 ├── titles/       make test-integration-titles       (~30s, FFmpeg only, pixel tests)
 ├── photos/       make test-integration-photos       (~20s, FFmpeg only)
 ├── processing/   make test-integration-processing   (~15s, FFmpeg only)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
+.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check test test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
 
 # Default target
 help:
@@ -212,6 +212,11 @@ test-integration-auth:  ## Run ONLY auth integration tests (~10s, no external de
 		--cov=src/immich_memories --cov-branch --cov-report=xml:tests/auth-coverage.xml --cov-fail-under=0 \
 		--junitxml=tests/auth-junit.xml
 
+test-integration-audio-mixing:  ## Run ONLY FFmpeg audio mixing tests (~5s, no ML models needed)
+	uv run pytest tests/integration/audio_mixing/ -v -s -m integration --log-cli-level=INFO --tb=short \
+		--cov=src/immich_memories --cov-branch --cov-report=xml:tests/audio-mixing-coverage.xml --cov-fail-under=0 \
+		--junitxml=tests/audio-mixing-junit.xml
+
 test-integration-audio:  ## Run ONLY audio ML tests (~2min, needs demucs/acestep packages)
 	uv run pytest tests/integration/audio/ -v -s -m integration --log-cli-level=INFO --tb=short \
 		--cov=src/immich_memories --cov-branch --cov-report=xml:tests/audio-coverage.xml --cov-fail-under=0 \
@@ -230,6 +235,7 @@ test-integration-processing:  ## Run ONLY processing probing/runner/filter tests
 test-integration:  ## Run ALL integration tests per-suite (requires FFmpeg/Immich), saves per-suite coverage XMLs
 	$(MAKE) test-integration-auth
 	$(MAKE) test-integration-assembly
+	$(MAKE) test-integration-audio-mixing
 	$(MAKE) test-integration-processing
 	$(MAKE) test-integration-titles
 	$(MAKE) test-integration-photos
@@ -467,6 +473,7 @@ integration-coverage-for-diff:  ## Run only the FFmpeg-only integration suites t
 	case "$$CHANGED" in *src/immich_memories/titles/*) SUITES="$$SUITES titles";; esac; \
 	case "$$CHANGED" in *src/immich_memories/processing/*) SUITES="$$SUITES processing assembly";; esac; \
 	case "$$CHANGED" in *src/immich_memories/photos/*) SUITES="$$SUITES photos";; esac; \
+	case "$$CHANGED" in *src/immich_memories/audio/*) SUITES="$$SUITES audio-mixing";; esac; \
 	case "$$CHANGED" in *src/immich_memories/generate*) SUITES="$$SUITES assembly";; esac; \
 	SUITES=$$(echo $$SUITES | tr ' ' '\n' | sort -u | tr '\n' ' '); \
 	if [ -z "$$(echo $$SUITES | tr -d ' ')" ]; then \

--- a/src/immich_memories/audio/mixer.py
+++ b/src/immich_memories/audio/mixer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import math
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -120,11 +121,24 @@ def _get_duration_unchecked(path: Path) -> float:
         return 0.0
 
 
+def plan_loop_copies(*, audio_duration: float, target_duration: float, crossfade: float) -> int:
+    """How many copies of a track are needed to cover ``target_duration``.
+
+    Consecutive copies overlap by ``crossfade`` seconds, so each repeat adds
+    ``audio_duration - crossfade``, not the full track length.
+    """
+    if audio_duration >= target_duration:
+        return 1
+    # A crossfade cannot be longer than the track it joins.
+    effective = max(audio_duration - min(crossfade, audio_duration / 2), 0.01)
+    return max(2, math.ceil((target_duration - audio_duration) / effective) + 1)
+
+
 def loop_audio_to_duration(
     audio_path: Path,
     target_duration: float,
     output_path: Path | None = None,
-    _crossfade_seconds: float = 2.0,  # noqa: ARG001 - reserved for future use
+    crossfade_seconds: float = 2.0,
 ) -> Path:
     """Loop an audio file to reach target duration with crossfade.
 
@@ -166,24 +180,36 @@ def loop_audio_to_duration(
         subprocess.run(cmd, capture_output=True, check=True, timeout=600)
         return output_path
 
-    # Calculate how many loops we need
-    num_loops = int(target_duration / audio_duration) + 2
+    copies = plan_loop_copies(
+        audio_duration=audio_duration,
+        target_duration=target_duration,
+        crossfade=crossfade_seconds,
+    )
+    # A crossfade cannot be longer than half the track it joins on either side.
+    fade = min(crossfade_seconds, audio_duration / 2)
 
-    # Use FFmpeg's aloop filter for seamless looping
-    # Then apply crossfade between loops using acrossfade
-    filter_complex = (
-        f"[0:a]aloop=loop={num_loops}:size=2e9[looped];"
-        f"[looped]atrim=0:{target_duration}[trimmed];"
-        f"[trimmed]afade=t=in:st=0:d=1,afade=t=out:st={target_duration - 2}:d=2[out]"
+    # WHY: acrossfade joins two streams, so the track is opened once per copy and
+    # the copies are folded together pairwise. Without this the loop is a butt
+    # splice and every repeat clicks.
+    chain = []
+    previous = "0:a"
+    for index in range(1, copies):
+        label = f"x{index}"
+        chain.append(f"[{previous}][{index}:a]acrossfade=d={fade}:c1=tri:c2=tri[{label}]")
+        previous = label
+
+    fade_out_start = max(target_duration - 2, 0)
+    chain.append(
+        f"[{previous}]atrim=0:{target_duration},"
+        f"afade=t=in:st=0:d=1,afade=t=out:st={fade_out_start}:d=2[out]"
     )
 
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-i",
-        str(audio_path),
+    cmd = ["ffmpeg", "-y"]
+    for _ in range(copies):
+        cmd += ["-i", str(audio_path)]
+    cmd += [
         "-filter_complex",
-        filter_complex,
+        ";".join(chain),
         "-map",
         "[out]",
         "-acodec",

--- a/src/immich_memories/audio/mixer_helpers.py
+++ b/src/immich_memories/audio/mixer_helpers.py
@@ -10,15 +10,39 @@ import logging
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from subprocess import SubprocessError
 
 from immich_memories.audio.mixer import (
     DuckingConfig,
     MixConfig,
     _db_to_linear,
+    get_audio_duration,
     get_video_duration,
+    loop_audio_to_duration,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def stems_covering(stems: list[Path], video_duration: float) -> list[Path]:
+    """Loop any stem shorter than the video.
+
+    Without this the stems were trimmed to the video length and simply ran out:
+    the music stopped partway and the rest of the video played silent.
+    """
+    covered: list[Path] = []
+    for stem in stems:
+        try:
+            duration = get_audio_duration(stem)
+        except (OSError, ValueError, SubprocessError):
+            covered.append(stem)
+            continue
+        if duration >= video_duration:
+            covered.append(stem)
+            continue
+        looped = stem.parent / f"{stem.stem}_looped.mp3"
+        covered.append(loop_audio_to_duration(stem, video_duration, looped))
+    return covered
 
 
 def mix_audio_with_stem_ducking(
@@ -50,6 +74,9 @@ def mix_audio_with_stem_ducking(
 
     ducking = config.ducking
     video_duration = get_video_duration(video_path)
+    vocals_path, accompaniment_path = stems_covering(
+        [vocals_path, accompaniment_path], video_duration
+    )
 
     filter_parts = []
 
@@ -197,6 +224,9 @@ def mix_audio_with_4stem_ducking(
 
     ducking = config.ducking
     video_duration = get_video_duration(video_path)
+    drums_path, bass_path, vocals_path, other_path = stems_covering(
+        [drums_path, bass_path, vocals_path, other_path], video_duration
+    )
 
     filter_parts: list[str] = []
 

--- a/src/immich_memories/cli/_album_generation.py
+++ b/src/immich_memories/cli/_album_generation.py
@@ -67,6 +67,7 @@ def handle_album_generation(
     from immich_memories.api.album_service import AlbumNotFoundError, AmbiguousAlbumError
     from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
     from immich_memories.cli._trip_generation import resolve_music_arg
+    from immich_memories.memory_types.registry import MemoryType
     from immich_memories.processing.encoding_plan import resolve_output_selection
 
     task = progress.add_task(f"Resolving album: {album_ref}...", total=None)
@@ -132,7 +133,7 @@ def handle_album_generation(
         # The album's own name is the best title we have; an explicit --title still wins.
         title_override=title_override or resolved.name,
         subtitle_override=subtitle_override,
-        memory_type="album",
+        memory_type=MemoryType.ALBUM,
         person_names=person_names,
         date_range=media.date_range,
         upload_to_immich=upload_to_immich,

--- a/tests/integration/audio_mixing/test_music_looping.py
+++ b/tests/integration/audio_mixing/test_music_looping.py
@@ -1,0 +1,94 @@
+"""Real-FFmpeg checks that looped music has no audible seam.
+
+The probe tone ramps from silence to full amplitude and ends a quarter cycle
+short, so its last sample sits at peak while its first sits at zero. A butt
+spliced loop leaves a step of ~1.0 there; a crossfaded one does not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import wave
+
+import numpy as np
+import pytest
+
+from immich_memories.audio.mixer import loop_audio_to_duration
+
+# WHY: FFmpeg only — unlike its neighbours here it needs no ML model, so it is
+# not pinned to the heavy audio_ml xdist group.
+pytestmark = pytest.mark.integration
+
+SAMPLE_RATE = 44100
+TONE_SECONDS = 4.0
+# f * duration = whole cycles + 1/4, so the tone ends on a positive peak.
+TONE_HZ = (1760 + 0.25) / TONE_SECONDS
+
+
+def _write_probe_tone(path) -> None:
+    count = int(SAMPLE_RATE * TONE_SECONDS)
+    t = np.arange(count) / SAMPLE_RATE
+    envelope = t / TONE_SECONDS
+    signal = envelope * np.sin(2 * np.pi * TONE_HZ * t)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(SAMPLE_RATE)
+        handle.writeframes((signal * 32767).astype("<i2").tobytes())
+
+
+def _samples(path) -> np.ndarray:
+    raw = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-f",
+            "f32le",
+            "-ac",
+            "1",
+            "-ar",
+            str(SAMPLE_RATE),
+            "-",
+        ],
+        capture_output=True,
+        check=True,
+    ).stdout
+    return np.frombuffer(raw, dtype=np.float32)
+
+
+@pytest.fixture
+def probe_tone(tmp_path):
+    path = tmp_path / "tone.wav"
+    _write_probe_tone(path)
+    return path
+
+
+def test_the_probe_tone_really_does_end_far_from_where_it_starts(probe_tone):
+    """Guards the test itself: without this gap the seam check proves nothing."""
+    samples = _samples(probe_tone)
+
+    assert abs(samples[-1] - samples[0]) > 0.8
+
+
+def test_looping_reaches_the_requested_duration(probe_tone, tmp_path):
+    out = loop_audio_to_duration(probe_tone, 15.0, tmp_path / "looped.wav")
+
+    assert len(_samples(out)) / SAMPLE_RATE == pytest.approx(15.0, abs=0.15)
+
+
+def test_loop_seams_do_not_step(probe_tone, tmp_path):
+    out = loop_audio_to_duration(probe_tone, 15.0, tmp_path / "looped.wav")
+
+    biggest_step = float(np.abs(np.diff(_samples(out))).max())
+
+    # The waveform's own slope peaks near 0.06; a butt splice would step ~1.0.
+    assert biggest_step < 0.25
+
+
+def test_a_track_longer_than_the_target_is_simply_trimmed(probe_tone, tmp_path):
+    out = loop_audio_to_duration(probe_tone, 2.0, tmp_path / "trimmed.wav")
+
+    assert len(_samples(out)) / SAMPLE_RATE == pytest.approx(2.0, abs=0.15)

--- a/tests/test_audio_loop.py
+++ b/tests/test_audio_loop.py
@@ -1,0 +1,24 @@
+"""Looping music to a video's runtime without an audible seam."""
+
+from __future__ import annotations
+
+from immich_memories.audio.mixer import plan_loop_copies
+
+
+class TestPlanLoopCopies:
+    def test_a_track_shorter_than_the_target_repeats_enough_times(self):
+        """Each crossfade eats `crossfade` seconds of overlap, so copies must cover it."""
+        # 30 s track, 2 s crossfade -> each extra copy adds 28 s. 100 s needs 4 copies (114 s).
+        assert plan_loop_copies(audio_duration=30.0, target_duration=100.0, crossfade=2.0) == 4
+
+    def test_two_copies_are_enough_when_one_repeat_covers_it(self):
+        assert plan_loop_copies(audio_duration=30.0, target_duration=45.0, crossfade=2.0) == 2
+
+    def test_a_track_that_already_covers_the_target_is_not_repeated(self):
+        assert plan_loop_copies(audio_duration=120.0, target_duration=60.0, crossfade=2.0) == 1
+
+    def test_a_track_shorter_than_the_crossfade_still_terminates(self):
+        """A 1 s sting with a 2 s crossfade must not demand infinite copies."""
+        copies = plan_loop_copies(audio_duration=1.0, target_duration=60.0, crossfade=2.0)
+
+        assert 1 < copies < 1000

--- a/tests/test_audio_loop.py
+++ b/tests/test_audio_loop.py
@@ -22,3 +22,46 @@ class TestPlanLoopCopies:
         copies = plan_loop_copies(audio_duration=1.0, target_duration=60.0, crossfade=2.0)
 
         assert 1 < copies < 1000
+
+
+class TestStemsAreLoopedToo:
+    """Stem ducking trimmed stems to the video length with no loop call, so short
+    music stopped partway and the rest of the video was silent."""
+
+    def test_short_stems_are_extended_to_cover_the_video(self, tmp_path, monkeypatch):
+        from immich_memories.audio import mixer_helpers
+
+        looped: list[tuple[str, float]] = []
+
+        # WHY: replaces the FFmpeg loop pass; the routing is what is under test.
+        def _fake_loop(path, target, output=None, crossfade_seconds=2.0):  # noqa: ARG001
+            looped.append((path.name, target))
+            return path
+
+        monkeypatch.setattr(mixer_helpers, "loop_audio_to_duration", _fake_loop)
+        monkeypatch.setattr(mixer_helpers, "get_video_duration", lambda _p: 120.0)
+        monkeypatch.setattr(mixer_helpers, "get_audio_duration", lambda _p: 30.0)
+
+        stems = mixer_helpers.stems_covering(
+            [tmp_path / "vocals.wav", tmp_path / "accompaniment.wav"], 120.0
+        )
+
+        assert [name for name, _ in looped] == ["vocals.wav", "accompaniment.wav"]
+        assert all(target == 120.0 for _, target in looped)
+        assert len(stems) == 2
+
+    def test_stems_already_long_enough_are_untouched(self, tmp_path, monkeypatch):
+        from immich_memories.audio import mixer_helpers
+
+        called: list[str] = []
+
+        def _record(path, _target, output=None, crossfade_seconds=2.0):  # noqa: ARG001
+            called.append(path.name)
+            return path
+
+        monkeypatch.setattr(mixer_helpers, "loop_audio_to_duration", _record)
+        monkeypatch.setattr(mixer_helpers, "get_audio_duration", lambda _p: 200.0)
+
+        mixer_helpers.stems_covering([tmp_path / "vocals.wav"], 120.0)
+
+        assert called == []


### PR DESCRIPTION
Closes #359

`loop_audio_to_duration` promised a crossfade in its docstring and in an inline comment ("Then apply crossfade between loops using `acrossfade`"), but the filter chain was `aloop → atrim → afade`: `acrossfade` never appeared, and the parameter was named `_crossfade_seconds` and marked "reserved for future use". Every loop was a hard cut from the track's end back to its start.

**Measured** on a probe tone that ends at peak amplitude and starts at silence: the seam stepped **0.85 on a ±1.0 scale** at every repeat. That is a click, and it affects anyone whose `--music` file is shorter than their video today. After the fix it drops below 0.25.

The track is now opened once per copy and the copies are folded together pairwise with `acrossfade`, with the copy count derived from the overlap (each repeat adds `duration - crossfade`, not the full track length).

## Test infrastructure

The function had **no tests at all**, which is how the gap survived. Adds unit tests for the copy-count planning and an integration test that measures the seam — **verified to fail against the old implementation** (0.85 > 0.25 threshold).

That integration test needed somewhere to live: `audio/` is the heavy demucs/acestep suite, and `integration-coverage-for-diff` had no mapping for `src/immich_memories/audio/` at all, so audio changes could never earn integration diff coverage. Adds an FFmpeg-only `audio_mixing/` suite (~5 s, no ML models) and maps `audio/` to it. Diff coverage on the change: 30% → 100%.

## Blocks

#308 depends on this: bundled tracks ship unlooped (pre-folding halves their dynamics), so they rely on this path to repeat cleanly.