### PR TITLE
feat(photos): collapse a burst to its best frame before scoring

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2631,87 +2631,59 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 532,
-        "line_end": 631,
+        "line_start": 580,
+        "line_end": 679,
         "line_complexities": [
           {
-            "line": 553,
+            "line": 601,
             "complexity": 0
           },
           {
-            "line": 554,
+            "line": 602,
             "complexity": 1
           },
           {
-            "line": 556,
+            "line": 604,
             "complexity": 1
           },
           {
-            "line": 557,
+            "line": 605,
             "complexity": 0
           },
           {
-            "line": 558,
+            "line": 606,
             "complexity": 2
           },
           {
-            "line": 559,
+            "line": 607,
             "complexity": 0
           },
           {
-            "line": 566,
+            "line": 614,
             "complexity": 1
           },
           {
-            "line": 570,
+            "line": 618,
             "complexity": 0
           },
           {
-            "line": 571,
+            "line": 619,
             "complexity": 0
           },
           {
-            "line": 572,
+            "line": 620,
             "complexity": 1
           },
           {
-            "line": 573,
+            "line": 621,
             "complexity": 0
           },
           {
-            "line": 574,
+            "line": 622,
             "complexity": 2
           },
           {
-            "line": 575,
-            "complexity": 0
-          },
-          {
-            "line": 582,
-            "complexity": 1
-          },
-          {
-            "line": 586,
-            "complexity": 0
-          },
-          {
-            "line": 589,
-            "complexity": 0
-          },
-          {
-            "line": 590,
-            "complexity": 2
-          },
-          {
-            "line": 591,
-            "complexity": 3
-          },
-          {
-            "line": 593,
-            "complexity": 1
-          },
-          {
-            "line": 596,
+            "line": 623,
             "complexity": 0
           },
           {
@@ -2719,13 +2691,41 @@
             "complexity": 1
           },
           {
-            "line": 631,
+            "line": 634,
+            "complexity": 0
+          },
+          {
+            "line": 637,
+            "complexity": 0
+          },
+          {
+            "line": 638,
+            "complexity": 2
+          },
+          {
+            "line": 639,
+            "complexity": 3
+          },
+          {
+            "line": 641,
+            "complexity": 1
+          },
+          {
+            "line": 644,
+            "complexity": 0
+          },
+          {
+            "line": 678,
+            "complexity": 1
+          },
+          {
+            "line": 679,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 78
+    "complexity": 85
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/docs-site/docs/create/pipeline/photo-support.md
+++ b/docs-site/docs/create/pipeline/photo-support.md
@@ -64,12 +64,30 @@ photos:
   enabled: true           # Include photos in memories
   max_ratio: 0.50         # Max 50% of clips can be photos
   duration: 4.0           # Seconds per photo clip
+  burst_window_seconds: 300  # Photos this close and near-identical are one burst
+  burst_hash_threshold: 8    # Hash bits two frames may differ by and still be one burst
   moment_gap_seconds: 120 # Window for "same moment as a video" (seconds)
   moment_hash_threshold: 10  # Bits a photo may differ from that video and still match
   score_penalty: 0.2      # Photos score 80% of equivalent videos
 ```
 
 Older configs may still contain `collage_duration`, `animation_mode`, `enable_collage`, `series_gap_seconds` or `zoom_factor`; those keys were removed in 0.41 and are ignored (the zoom amount is randomized per photo, and collages are not wired in).
+
+## One photo per burst
+
+A held shutter produces near-identical frames seconds apart. Before scoring, photos
+within `burst_window_seconds` of each other whose thumbnails are within
+`burst_hash_threshold` bits are treated as one burst, and only the best-scored frame
+survives. On a real June library that removed **64 of 303 photos — 21% of the pool**,
+in groups of up to five.
+
+Both conditions are required. Time alone would collapse a busy minute at a party;
+similarity alone would merge the same kitchen photographed a month apart. A photo with
+no cached thumbnail is always kept — redundancy is measured, never assumed. Set
+`burst_window_seconds: 0` to turn it off.
+
+Because this runs before the LLM shortlist, every photo it removes is also an LLM call
+saved.
 
 ## Photos a video already shows
 

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -652,6 +652,7 @@ def _merge_photos_into_pool(
             app_config=config,
             thumbnail_fn=client.get_asset_thumbnail,
             provider_circuit=provider_circuit,
+            thumbnail_cache=thumbnail_cache,
         )
 
     photo_candidates = []

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -841,6 +841,21 @@ class PhotoConfig(BaseModel):
         le=10.0,
         description="Duration per single photo clip in seconds",
     )
+    burst_window_seconds: float = Field(
+        default=300.0,
+        ge=0.0,
+        le=3600.0,
+        description=(
+            "Photos this close together and visually near-identical are one burst; "
+            "only the best-scored frame is kept (0 disables burst de-duplication)"
+        ),
+    )
+    burst_hash_threshold: int = Field(
+        default=8,
+        ge=0,
+        le=64,
+        description="Perceptual-hash bits two photos may differ by and still be one burst",
+    )
     moment_gap_seconds: float = Field(
         default=120.0,
         ge=0.0,

--- a/src/immich_memories/photos/burst_dedup.py
+++ b/src/immich_memories/photos/burst_dedup.py
@@ -1,0 +1,91 @@
+"""One photo per burst, not five.
+
+A phone shutter held down produces near-identical frames seconds apart. Nothing
+removed them from the photo pool: `deduplicate_by_thumbnails` exists but is only
+ever called on video clips, and it clusters on hash distance alone, so pointing
+it at photos would merge the same kitchen photographed a month apart.
+
+Measured on a real June pool: 64 of 303 photos are near-duplicates of another
+shot within five minutes -- 21% of the pool, in groups of up to five.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+from immich_memories.analysis.duplicate_hashing import hamming_distance
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PhotoCandidate:
+    """A photo reduced to what burst detection needs."""
+
+    key: str
+    taken_at: datetime
+    thumbnail_hash: str | None
+    score: float = 0.0
+
+
+def drop_burst_duplicates(
+    photos: list[PhotoCandidate],
+    *,
+    window_seconds: float,
+    hash_threshold: int,
+) -> list[str]:
+    """Keep the best-scored photo from each burst, in input order.
+
+    A burst is photos taken within ``window_seconds`` of each other whose
+    thumbnails are within ``hash_threshold`` bits. Both conditions are required:
+    time alone would collapse a busy minute at a party, and similarity alone
+    would merge the same room across months.
+
+    A photo with no thumbnail hash is always kept. Redundancy is measured, never
+    assumed -- a missing thumbnail says nothing about the picture.
+    """
+    if not photos:
+        return []
+
+    by_time = sorted((p for p in photos if p.thumbnail_hash), key=lambda p: p.taken_at)
+
+    superseded: set[str] = set()
+    for index, candidate in enumerate(by_time):
+        if candidate.key in superseded:
+            continue
+        burst = _burst_starting_at(by_time, index, window_seconds, hash_threshold, superseded)
+        if len(burst) > 1:
+            best = max(burst, key=lambda p: p.score)
+            superseded.update(p.key for p in burst if p.key != best.key)
+
+    if superseded:
+        logger.info(
+            "Burst de-duplication: %d of %d photos dropped as near-identical frames within %.0fs",
+            len(superseded),
+            len(photos),
+            window_seconds,
+        )
+    return [p.key for p in photos if p.key not in superseded]
+
+
+def _burst_starting_at(
+    by_time: list[PhotoCandidate],
+    index: int,
+    window_seconds: float,
+    hash_threshold: int,
+    superseded: set[str],
+) -> list[PhotoCandidate]:
+    """Photos from `index` onward that belong to the same burst as it."""
+    first = by_time[index]
+    burst = [first]
+    for other in by_time[index + 1 :]:
+        if (other.taken_at - first.taken_at).total_seconds() > window_seconds:
+            break  # sorted by time: nothing further can be in this burst
+        if other.key in superseded:
+            continue
+        distance = hamming_distance(first.thumbnail_hash or "", other.thumbnail_hash or "")
+        if distance <= hash_threshold:
+            burst.append(other)
+    return burst

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -59,6 +59,7 @@ def score_photos(
     app_config: Any = None,
     thumbnail_fn: Any = None,
     provider_circuit: Any = None,
+    thumbnail_cache: Any = None,
 ) -> list[tuple[Asset, float]]:
     """Score photos (metadata + LLM) without rendering.
 
@@ -71,6 +72,11 @@ def score_photos(
     # Phase 1: Fast metadata scoring (no I/O). Keep this complete pool so the
     # final optimizer can use unshortlisted photos when preferred media is sparse.
     metadata_scored = [(a, score_photo(a, config)) for a in assets]
+
+    # A held shutter yields near-identical frames seconds apart, and on a real
+    # June pool 21% of the photos were one. Collapsing bursts here rather than
+    # after scoring means each one dropped is also an LLM call saved.
+    metadata_scored = _drop_burst_duplicates(metadata_scored, config, thumbnail_cache)
 
     # Cap only the expensive semantic-scoring shortlist.
     shortlist_size = llm_shortlist_size(video_clip_count, len(metadata_scored), config.max_ratio)
@@ -233,6 +239,48 @@ def render_photo_clips(
 # shortlist to place a few dozen photos, which ran for hours.
 LLM_SHORTLIST_CEILING = 200
 _LLM_SHORTLIST_HEADROOM = 3
+
+
+def _drop_burst_duplicates(
+    scored: list[tuple[Asset, float]],
+    config: PhotoConfig,
+    thumbnail_cache: Any,
+) -> list[tuple[Asset, float]]:
+    """Keep the best-scored frame of each burst, when thumbnails are available."""
+    if thumbnail_cache is None or len(scored) < 2:
+        return scored
+
+    from immich_memories.analysis.duplicate_hashing import compute_thumbnail_hash
+    from immich_memories.photos.burst_dedup import PhotoCandidate, drop_burst_duplicates
+
+    candidates = []
+    for asset, score in scored:
+        data = thumbnail_cache.get(asset.id, "preview")
+        digest = None
+        if data:
+            # WHY: thumbnails come off disk -- a truncated JPEG costs this photo
+            # its comparison, not the run.
+            try:
+                digest = compute_thumbnail_hash(data) or None
+            except (OSError, TypeError, ValueError):
+                digest = None
+        candidates.append(
+            PhotoCandidate(
+                key=asset.id,
+                taken_at=asset.file_created_at,
+                thumbnail_hash=digest,
+                score=score,
+            )
+        )
+
+    kept = set(
+        drop_burst_duplicates(
+            candidates,
+            window_seconds=config.burst_window_seconds,
+            hash_threshold=config.burst_hash_threshold,
+        )
+    )
+    return [(asset, score) for asset, score in scored if asset.id in kept]
 
 
 def _compute_max_photos(video_count: int, max_ratio: float) -> int:

--- a/tests/test_photo_burst_dedup.py
+++ b/tests/test_photo_burst_dedup.py
@@ -1,0 +1,82 @@
+"""One photo per burst, not five.
+
+Measured on a real June pool: 64 of 303 photos are near-duplicates of another
+shot within five minutes -- 21% of the pool, in groups of up to five. Nothing
+removed them. `deduplicate_by_thumbnails` exists but is only ever called on
+video clips, and it clusters on hash alone with no time bound, so reusing it
+here would merge the same room photographed months apart.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from immich_memories.photos.burst_dedup import PhotoCandidate, drop_burst_duplicates
+
+BASE = datetime(2026, 6, 14, 11, 0, 0)
+SCENE = "ff00ff00ff00ff00"
+SCENE_SHIFTED = "ff00ff00ff00ff03"  # 2 bits away — the next frame of the same burst
+OTHER = "00ff00ff00ff00ff"  # 64 bits away
+
+
+def photo(key: str, offset: float, digest: str | None, score: float = 0.5) -> PhotoCandidate:
+    return PhotoCandidate(
+        key=key, taken_at=BASE + timedelta(seconds=offset), thumbnail_hash=digest, score=score
+    )
+
+
+def test_a_burst_collapses_to_its_best_frame() -> None:
+    kept = drop_burst_duplicates(
+        [
+            photo("a", 0, SCENE, score=0.4),
+            photo("b", 1.5, SCENE_SHIFTED, score=0.9),
+            photo("c", 3.0, SCENE, score=0.6),
+        ],
+        window_seconds=300,
+        hash_threshold=8,
+    )
+
+    assert kept == ["b"]
+
+
+def test_the_same_scene_on_another_day_is_not_a_burst() -> None:
+    """A kitchen photographed twice in a month is two memories."""
+    kept = drop_burst_duplicates(
+        [photo("monday", 0, SCENE), photo("friday", 4 * 86400, SCENE)],
+        window_seconds=300,
+        hash_threshold=8,
+    )
+
+    assert kept == ["monday", "friday"]
+
+
+def test_different_subjects_seconds_apart_both_survive() -> None:
+    kept = drop_burst_duplicates(
+        [photo("cake", 0, SCENE), photo("faces", 2, OTHER)],
+        window_seconds=300,
+        hash_threshold=8,
+    )
+
+    assert kept == ["cake", "faces"]
+
+
+def test_a_photo_without_a_hash_is_kept() -> None:
+    """Redundancy is measured, never assumed -- the same rule the moment filter
+    follows. A missing thumbnail must not delete the photo."""
+    kept = drop_burst_duplicates(
+        [photo("hashed", 0, SCENE), photo("unhashed", 1, None)],
+        window_seconds=300,
+        hash_threshold=8,
+    )
+
+    assert "unhashed" in kept
+
+
+def test_input_order_survives() -> None:
+    kept = drop_burst_duplicates(
+        [photo("x", 0, SCENE), photo("y", 9999, OTHER), photo("z", 20000, SCENE)],
+        window_seconds=300,
+        hash_threshold=8,
+    )
+
+    assert kept == ["x", "y", "z"]


### PR DESCRIPTION
The last item from the selection-quality list.

## The gap

A held shutter produces near-identical frames seconds apart, and nothing removed them. `deduplicate_by_thumbnails` exists — but `git grep` shows it is called from exactly one place, `smart_pipeline.py:397`, the **video-clip** path. Photos were never deduplicated on any route.

Measured on a real June pool before writing anything:

```
303 photos, 303 with cached thumbnails
44 duplicate groups covering 108 photos
64 photos redundant — 21% of the pool
group sizes: {2: 32, 3: 6, 4: 4, 5: 2}
```

The implemented path drops exactly those 64.

## Why not just reuse the video function

It clusters on hash distance alone, with no time bound. Pointed at photos it would merge the same kitchen photographed a month apart. This pass requires **both** time proximity and visual similarity:

- time alone would collapse a busy minute at a party
- similarity alone would merge two visits to the same room

The best-scored frame of each burst survives. A photo with no cached thumbnail is always kept — redundancy is measured, never assumed, the same rule the moment filter follows.

It runs **before** the LLM shortlist, so every frame dropped is also an LLM call saved.

## My own gate caught this

The complexity ratchet from #356 rejected the first version:

```
Snapshot watermark: drop_burst_duplicates exceeds 15 but was not part of the snapshot.
```

16, one over the limit. The correct response to that gate is to simplify, not to widen the snapshot — the burst walk is now its own function. Behaviour unchanged, still exactly 64 dropped, verified after the refactor.

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3