### PR TITLE
refactor(mypy): delete six override blocks and fix what they were hiding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,13 +434,6 @@ disable_error_code = ["attr-defined", "call-overload", "union-attr", "assignment
 # API client with dynamic JSON responses
 [[tool.mypy.overrides]]
 module = [
-    "immich_memories.api.immich",
-]
-disable_error_code = ["attr-defined", "arg-type", "return-value"]
-
-# Streamlit UI with dynamic session state
-[[tool.mypy.overrides]]
-module = [
     "immich_memories.ui.components",
     "immich_memories.ui.app",
     "immich_memories.ui.pages._step4_music",
@@ -451,14 +444,6 @@ module = [
 disable_error_code = ["assignment", "misc", "arg-type", "import-untyped", "attr-defined", "func-returns-value"]
 
 # Audio mood analyzer with dynamic LLM outputs
-[[tool.mypy.overrides]]
-module = [
-    "immich_memories.audio.mood_analyzer",
-    "immich_memories.audio.mood_analyzer_backends",
-]
-disable_error_code = ["dict-item"]
-
-# Audio content analyzer with PANNs
 [[tool.mypy.overrides]]
 module = [
     "immich_memories.audio.content_analyzer",
@@ -474,21 +459,6 @@ module = [
 disable_error_code = ["valid-type", "misc", "call-arg"]
 
 # Audio mixer with optional path types
-[[tool.mypy.overrides]]
-module = ["immich_memories.audio.mixer_class"]
-disable_error_code = ["assignment"]
-
-# Local Demucs backend imports its optional package lazily at runtime.
-[[tool.mypy.overrides]]
-module = ["immich_memories.audio.generators.demucs_local"]
-disable_error_code = ["import-not-found"]
-
-# Video cache with Immich client compatibility
-[[tool.mypy.overrides]]
-module = ["immich_memories.cache.video_cache"]
-disable_error_code = ["attr-defined"]
-
-# Taichi GPU renderers (uses Taichi-specific type annotations, absorbed particle/text mixins)
 [[tool.mypy.overrides]]
 module = [
     "immich_memories.titles.renderer_taichi",
@@ -519,11 +489,6 @@ module = ["immich_memories.titles.rendering_service"]
 disable_error_code = ["assignment", "misc", "attr-defined", "arg-type"]
 
 # Speech/audio-content analysis service (dynamic AudioContentAnalyzer typing)
-[[tool.mypy.overrides]]
-module = ["immich_memories.analysis.speech_analysis"]
-disable_error_code = ["var-annotated", "assignment", "attr-defined"]
-
-# Title generator with optional Taichi imports
 [[tool.mypy.overrides]]
 module = ["immich_memories.titles.generator"]
 disable_error_code = ["assignment", "misc"]

--- a/src/immich_memories/analysis/speech_analysis.py
+++ b/src/immich_memories/analysis/speech_analysis.py
@@ -11,7 +11,7 @@ import logging
 import operator
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 
@@ -103,6 +103,18 @@ def transcription_window(audio_len_seconds: float, start: float, end: float) -> 
     return (hi - TRANSCRIPTION_WINDOW_SECONDS, hi)
 
 
+class AudioAnalyzer(Protocol):
+    """What this module needs from a PANNs analyzer.
+
+    Stated as a Protocol rather than importing the concrete class: PANNs is an
+    optional dependency, so the type has to be describable without it. The
+    parameter used to be `object`, which is honest about the import and useless
+    about the contract -- calling .analyze on it needed the error suppressed.
+    """
+
+    def analyze(self, video_path: Path, duration: float | None = ...) -> AudioAnalysisResult: ...
+
+
 class SpeechAnalysisService:
     """Audio-content (PANNs) and VAD speech-boundary analysis.
 
@@ -116,7 +128,7 @@ class SpeechAnalysisService:
         audio_content_config: AudioContentConfig,
         speech_config: SpeechConfig | None = None,
         audio_content_enabled: bool = False,
-        audio_analyzer: object | None = None,
+        audio_analyzer: AudioAnalyzer | None = None,
         transcription_config: TranscriptionConfig | None = None,
         transcriber: Transcriber | None = None,
     ):

--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -35,7 +35,7 @@ from immich_memories.analysis.segment_generation import (
     score_segment_audio,
 )
 from immich_memories.analysis.segment_transcription import transcribe_top_segments
-from immich_memories.analysis.speech_analysis import SpeechAnalysisService
+from immich_memories.analysis.speech_analysis import AudioAnalyzer, SpeechAnalysisService
 
 if TYPE_CHECKING:
     from immich_memories.analysis.content_analyzer import ContentAnalyzer
@@ -98,7 +98,7 @@ class UnifiedSegmentAnalyzer:
         max_optimal_duration: float = 10.0,
         target_extraction_ratio: float = 0.15,
         duration_weight: float = 0.15,
-        audio_analyzer: object | None = None,
+        audio_analyzer: AudioAnalyzer | None = None,
         *,
         audio_content_config: AudioContentConfig,
         analysis_config: AnalysisConfig,

--- a/src/immich_memories/api/immich.py
+++ b/src/immich_memories/api/immich.py
@@ -312,6 +312,10 @@ class ImmichClient:
     async def get_current_user(self) -> UserInfo:
         """Get current user information."""
         data = await self._request("GET", "/users/me")
+        if not isinstance(data, dict):
+            raise ImmichAPIError(
+                f"Unexpected API response format: expected object, got {type(data).__name__}"
+            )
         try:
             return UserInfo(**data)
         except ValidationError as e:

--- a/src/immich_memories/audio/mixer_class.py
+++ b/src/immich_memories/audio/mixer_class.py
@@ -72,6 +72,7 @@ class AudioMixer:
         video_duration = get_video_duration(video_path)
 
         # Get or select music
+        selected_music: Path | None
         if music_path and music_path.exists():
             selected_music = music_path
         elif auto_select:

--- a/src/immich_memories/audio/mood_analyzer_backends.py
+++ b/src/immich_memories/audio/mood_analyzer_backends.py
@@ -187,7 +187,9 @@ class OpenAICompatibleMoodAnalyzer(MoodAnalyzer):
     ) -> VideoMood:
         """Analyze frames using OpenAI Vision."""
         # Build content with images
-        content = [{"type": "text", "text": MOOD_ANALYSIS_PROMPT}]
+        # Vision message parts: a text part, then one image_url part per frame,
+        # so the values are not all strings.
+        content: list[dict[str, object]] = [{"type": "text", "text": MOOD_ANALYSIS_PROMPT}]
 
         for path in frame_paths[:4]:  # Limit to 4 images
             with path.open("rb") as f:


### PR DESCRIPTION
Closes the rest of #253 — suppressing override blocks on our own modules go **17 → 11**, past the "under 12" target.

## Measured before touching anything

I removed each block in a throwaway worktree and counted what surfaced, rather than guessing which were worth attacking:

| errors if removed | block |
|---:|---|
| **0** | `demucs_local`, `video_cache` |
| **1** | `api/immich`, `mixer_class`, `mood_analyzer`, `speech_analysis` |
| 2–6 | `video_encoding`, `content_analyzer`, `rendering_service`, `renderer_pil` |
| 9–12 | `music_generator`, `search_service`+`sync_client`, `clip_analyzer` group |
| 18–73 | `scenes`/`scoring`, UI layer, **taichi stack (73)** |

Two blocks were suppressing **nothing at all**. Four hid a single error each.

## The four are fixed, not re-suppressed

- **`api/immich.py`** — `_request` returns `dict | list | bytes`, so `UserInfo(**data)` had no guarantee of a mapping. It now checks and raises `ImmichAPIError` on anything else. That's a real robustness fix, not just a type one.
- **`mood_analyzer_backends`** — the vision `content` list holds a text part *and* image parts, so its values were never all strings.
- **`mixer_class`** — `selected_music` is genuinely Optional until the auto-select branch resolves it.
- **`speech_analysis`** — `audio_analyzer` was typed `object`, which is honest about PANNs being an optional dependency and useless about the contract; calling `.analyze` on it is exactly why the suppression existed. It's a **Protocol** now, stating the one method this module needs without importing the package, and the caller in `unified_analyzer` follows.

## Deliberately left

The taichi stack (73), the UI layer (30) and `scenes`/`scoring` (18) are projects rather than a tidy-up. The table above is in this PR so whoever takes them doesn't have to redo the measurement.

`make ci` green.

## Note

My first attempt at this probe ran in the background against the same worktree I was editing, and left `pyproject.toml` mutated when it timed out — which produced a phantom 34-error mypy run I nearly chased. This one ran in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ASSG7KkRsTqq4kvYQyX3