### PR TITLE
fix(ci): make the dependency audit fail closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,17 @@ install-acestep:  ## Install the tested ACE-Step 1.5 inference stack (music gene
 	  'vector-quantize-pytorch>=1.27.15'
 	@uv run python -c "from immich_memories.audio.generators.ace_step_backend import ACEStepBackend; import torch, torchvision.ops as o; o.nms(torch.zeros((0,4)), torch.zeros((0,)), 0.5); print('ACE-Step stack OK')"
 
-# Install dev tools only (no GPU/CUDA/audio-ml/face deps — for CI quality gates)
+# Install dev tools only (no GPU/CUDA/audio-ml/face deps — for CI quality gates).
+# --locked: CI must install exactly what uv.lock pins, since that is what
+# `make pip-audit` audits. Without it a fresh resolve can install something
+# the audit never saw.
 dev-ci:
-	uv sync --extra dev
+	uv sync --extra dev --locked
 
 # Install dev + GPU + speech extras for CI test jobs (taichi/freetype/onnxruntime,
 # no torch/nvidia -- FireRedVAD is the only speech engine and needs neither)
 dev-test:
-	uv sync --extra dev --extra gpu --extra speech
+	uv sync --extra dev --extra gpu --extra speech --locked
 
 # Install with macOS-specific extras (Apple Vision, Metal GPU, etc.)
 dev-mac:
@@ -438,11 +441,21 @@ diff-cover:
 	uvx diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 
 # Dependency vulnerability audit
+# Fails closed: a truncated export or a crashed pip-audit must not read as a clean audit.
 pip-audit:  ## Check dependencies for known vulnerabilities (warns on unfixable, fails on fixable)
-	uv export --frozen --extra dev --no-emit-project --no-hashes \
-		| grep -v -e '^audioop-lts==' > /tmp/pip-audit-reqs.txt
-	uvx pip-audit -r /tmp/pip-audit-reqs.txt --strict 2>&1 | python3 scripts/pip_audit_smart.py; \
-		EXIT=$$?; rm -f /tmp/pip-audit-reqs.txt; exit $$EXIT
+	@set -eu; \
+	REQS=$$(mktemp "$${TMPDIR:-/tmp}/pip-audit-reqs.XXXXXX"); \
+	OUT=$$(mktemp "$${TMPDIR:-/tmp}/pip-audit-out.XXXXXX"); \
+	trap 'rm -f "$$REQS" "$$OUT"' EXIT; \
+	uv export --frozen --extra dev --no-emit-project --no-hashes > "$$REQS"; \
+	COUNT=$$(grep -c '==' "$$REQS" || true); \
+	if [ "$$COUNT" -lt 50 ]; then \
+		echo "uv export produced $$COUNT pinned packages - too few to be the real dependency set, refusing to report a clean audit"; \
+		exit 2; \
+	fi; \
+	echo "auditing $$COUNT pinned packages"; \
+	set +e; uvx pip-audit -r "$$REQS" --strict > "$$OUT" 2>&1; AUDIT_EXIT=$$?; set -e; \
+	python3 scripts/pip_audit_smart.py --audit-exit "$$AUDIT_EXIT" < "$$OUT"
 
 diff-cover-local:  ## Check diff-cover locally before pushing (runs tests + merges integration coverage)
 	@echo "Running unit tests with coverage..."

--- a/scripts/pip_audit_smart.py
+++ b/scripts/pip_audit_smart.py
@@ -1,43 +1,73 @@
 #!/usr/bin/env python3
-"""Smart pip-audit: warns on unfixable vulns, fails only on fixable ones.
+"""Smart pip-audit: warns on unfixable vulns, fails on fixable ones, fails closed.
 
 Parses pip-audit's default text output format:
     Name     Version ID            Fix Versions
     -------- ------- ------------- ------------
     pygments 2.19.2  CVE-2026-4539
 
-Usage: uvx pip-audit -r reqs.txt --strict 2>/dev/null | python3 scripts/pip_audit_smart.py
+Exits 0 only when pip-audit gave an answer we understood. Anything else -- a
+crash, a changed format, an empty stream -- is inconclusive, not clean. An
+earlier version printed "No known vulnerabilities found" in those cases, which
+turned a crashed audit into a green check.
+
+--audit-exit carries pip-audit's own exit code, which a shell pipeline discards.
+`pipefail` cannot be used instead: --strict exits non-zero for *any* finding,
+which would override the policy of passing when nothing has an upstream fix.
+
+Usage: uvx pip-audit -r reqs.txt --strict > out 2>&1; code=$?
+       python3 scripts/pip_audit_smart.py --audit-exit "$code" < out
 """
 
+import argparse
 import re
 import sys
 
+EXIT_OK = 0
+EXIT_VULNERABLE = 1
+EXIT_INCONCLUSIVE = 2
+
+CLEAN_MARKER = "No known vulnerabilities found"
+VULN_PATTERN = re.compile(r"^(\S+)\s+(\S+)\s+((?:CVE|GHSA|PYSEC)-\S+)\s*(.*?)$", re.MULTILINE)
+
+
+def _inconclusive(reason: str, output: str) -> None:
+    print(reason)
+    print("Treating that as a failure: an audit that did not happen is not a pass.")
+    print("--- pip-audit output ---")
+    print(output.strip()[:2000] or "(empty)")
+    sys.exit(EXIT_INCONCLUSIVE)
+
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--audit-exit",
+        type=int,
+        default=None,
+        help="exit code pip-audit itself returned (0 clean, 1 vulnerabilities, other crash)",
+    )
+    args = parser.parse_args()
     text = sys.stdin.read()
 
-    if "No known vulnerabilities found" in text:
+    # pip-audit only uses 0 and 1 as considered answers. Anything else means it
+    # died before finishing, so whatever it printed first does not get a vote.
+    crashed = args.audit_exit is not None and args.audit_exit not in (0, 1)
+    if crashed:
+        _inconclusive(
+            f"pip-audit exited {args.audit_exit} - it crashed rather than finishing.", text
+        )
+
+    if CLEAN_MARKER in text:
         print("No known vulnerabilities found.")
-        sys.exit(0)
+        sys.exit(EXIT_OK)
 
-    # Parse vulnerability lines: "name version CVE-ID fix_versions?"
-    # Skip header lines (----, Name, etc.)
-    vuln_pattern = re.compile(r"^(\S+)\s+(\S+)\s+((?:CVE|GHSA|PYSEC)-\S+)\s*(.*?)$", re.MULTILINE)
-    matches = vuln_pattern.findall(text)
-
+    matches = VULN_PATTERN.findall(text)
     if not matches:
-        # pip-audit may have failed to run (dep resolution error)
-        # In that case, pass — we can't audit what we can't resolve
-        if "Failed to install" in text or "ResolutionImpossible" in text:
-            print("⚠️  pip-audit could not resolve dependencies (Python version mismatch)")
-            print("   Skipping vulnerability check — run manually with matching Python")
-            sys.exit(0)
-        print("No known vulnerabilities found.")
-        sys.exit(0)
+        _inconclusive("pip-audit produced no result this script recognises.", text)
 
     fixable = []
     unfixable = []
-
     for name, version, vuln_id, fix_versions in matches:
         fix_versions = fix_versions.strip()
         if fix_versions:
@@ -46,20 +76,21 @@ def main() -> None:
             unfixable.append((name, version, vuln_id))
 
     for name, version, vuln_id in unfixable:
-        print(f"⚠️  {name} {version} ({vuln_id}) — no fix available yet")
-
+        print(f"WARN  {name} {version} ({vuln_id}) - no fix available yet")
     for name, version, vuln_id, fix in fixable:
-        print(f"❌ {name} {version} ({vuln_id}) — fix available: {fix}")
+        print(f"FAIL  {name} {version} ({vuln_id}) - fix available: {fix}")
 
     total = len(fixable) + len(unfixable)
     print(f"\n{total} vulnerabilities: {len(fixable)} fixable, {len(unfixable)} unfixable")
 
     if fixable:
-        print("\nFailing — fixable vulnerabilities exist. Update the affected packages.")
-        sys.exit(1)
-    else:
-        print("\nPassing — all vulnerabilities are unfixable (no upstream fix yet).")
-        sys.exit(0)
+        print("\nFailing - fixable vulnerabilities exist. Update the affected packages.")
+        sys.exit(EXIT_VULNERABLE)
+
+    # Deliberate: there is nothing to update to, and failing here would only
+    # teach people to ignore the gate.
+    print("\nPassing - every vulnerability found is unfixable upstream.")
+    sys.exit(EXIT_OK)
 
 
 if __name__ == "__main__":

--- a/tests/test_pip_audit_gate.py
+++ b/tests/test_pip_audit_gate.py
@@ -1,0 +1,82 @@
+"""The vulnerability gate must fail closed.
+
+Three paths through pip_audit_smart.py used to exit 0 without auditing
+anything, and the worst of them printed "No known vulnerabilities found" when
+the regex simply hadn't matched -- turning a crashed or reformatted pip-audit
+into a clean bill of health. A security gate that reports success on absence of
+evidence is worse than no gate, because it is believed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "pip_audit_smart.py"
+
+
+def run(stdin_text: str, audit_exit: int | None = None) -> int:
+    argv = [sys.executable, str(SCRIPT)]
+    if audit_exit is not None:
+        argv += ["--audit-exit", str(audit_exit)]
+    result = subprocess.run(argv, input=stdin_text, capture_output=True, text=True)
+    return result.returncode
+
+
+CLEAN = "No known vulnerabilities found\n"
+FIXABLE = (
+    "Name     Version ID            Fix Versions\n"
+    "-------- ------- ------------- ------------\n"
+    "pygments 2.19.2  CVE-2026-4539 2.19.3\n"
+)
+UNFIXABLE = (
+    "Name     Version ID            Fix Versions\n"
+    "-------- ------- ------------- ------------\n"
+    "pygments 2.19.2  CVE-2026-4539\n"
+)
+
+
+def test_an_explicit_all_clear_passes() -> None:
+    assert run(CLEAN) == 0
+
+
+def test_a_fixable_vulnerability_fails() -> None:
+    assert run(FIXABLE) == 1
+
+
+def test_vulnerabilities_with_no_upstream_fix_still_pass() -> None:
+    """Deliberate policy: nothing to update to, so failing would only teach
+    people to ignore the gate."""
+    assert run(UNFIXABLE) == 0
+
+
+def test_unresolvable_dependencies_fail_instead_of_skipping() -> None:
+    assert run("ERROR: ResolutionImpossible: could not resolve\n") != 0
+
+
+def test_output_the_parser_does_not_recognise_fails() -> None:
+    """pip-audit crashing, changing format, or being killed all land here. The
+    old code answered 'No known vulnerabilities found'."""
+    assert run("Traceback (most recent call last):\n  ValueError: boom\n") != 0
+
+
+def test_empty_input_fails() -> None:
+    """An empty requirements file audits nothing and used to read as clean."""
+    assert run("") != 0
+
+
+def test_a_crashed_audit_fails_even_if_its_output_looks_clean() -> None:
+    """pip-audit's exit code is the authoritative signal. If it died, the text
+    it managed to emit first does not get to say the dependencies are fine."""
+    assert run(CLEAN, audit_exit=2) != 0
+
+
+def test_a_nonzero_exit_with_only_unfixable_vulns_still_passes() -> None:
+    """pip-audit --strict exits 1 on any vulnerability, including ones with no
+    fix. The unfixable policy has to survive that."""
+    assert run(UNFIXABLE, audit_exit=1) == 0
+
+
+def test_a_clean_exit_code_passes() -> None:
+    assert run(CLEAN, audit_exit=0) == 0


### PR DESCRIPTION
## The bug

`make pip-audit` passed whenever it could not read pip-audit's output — and said so in
the worst possible words. Three paths reached `sys.exit(0)` without an audit having
happened, and the fall-through one printed **"No known vulnerabilities found"** for
*any* unparseable input. A crashed pip-audit produced a green check that reads, in the
CI log, exactly like a clean audit.

Not a hypothetical. While working on this, pip-audit died on its own:

```
$ uvx --python 3.13 pip-audit -r reqs.txt --strict; echo $?
subprocess.CalledProcessError: ... 'ensurepip' ... died with <Signals.SIGABRT: 6>
1

$ <that same output> | python3 scripts/pip_audit_smart.py   # old version
No known vulnerabilities found.
exit=0
```

## What changed

- **Unparseable, empty, or unresolvable output now exits 2** (inconclusive) and prints
  what pip-audit actually said, instead of claiming a clean bill of health.
- **pip-audit's own exit code reaches the parser** via `--audit-exit`. A shell pipeline
  discards it, and `pipefail` cannot substitute here: `--strict` exits non-zero for *any*
  finding, which would override the deliberate policy of passing when nothing has an
  upstream fix. Exit 0/1 are answers; anything else is a crash, and then the text it
  managed to print first does not get a vote.
- **The Makefile aborts on a truncated `uv export`** rather than auditing 1 package and
  reporting clean.
- **Dropped `grep -v '^audioop-lts=='`**, which silently removed a locked package from
  every audit. Verified the full set (161 pinned packages) audits clean without it.
- **`mktemp`** instead of a predictable `/tmp/pip-audit-reqs.txt`.
- **`--locked` on `make dev-ci` / `dev-test`**, so CI installs exactly what `uv.lock`
  pins — which is what the audit covers. Without it a fresh resolve can install
  something the audit never saw.

## Verification

| Path | Before | After |
|---|---|---|
| real run, 161 packages | pass | pass (unchanged) |
| pip-audit crashes (real SIGABRT output) | **"No known vulnerabilities found", exit 0** | exit 2, prints the traceback |
| empty stdin | **"No known vulnerabilities found", exit 0** | exit 2 |
| `ResolutionImpossible` | exit 0 with a skip notice | exit 2 |
| truncated export (1 package) | audited and passed | exit 2 before auditing |
| `uv export` fails outright | audited an empty file, passed | non-zero, no audit reported |
| fixable CVE | exit 1 | exit 1 (unchanged) |
| only unfixable CVEs | exit 0 | exit 0 (unchanged, incl. when pip-audit exits 1) |

9 tests in `tests/test_pip_audit_gate.py` cover the exit-code contract.

One portability note worth flagging for reviewers: `mktemp -t name` works on macOS but
GNU coreutils rejects it (too few `X`s), so this uses the explicit
`mktemp "${TMPDIR:-/tmp}/name.XXXXXX"` form that both accept — otherwise it would have
passed locally and broken on the ubuntu runners.

## Not in this PR

#317 also covers building the Docker image from `uv.lock` with
`pip install --require-hashes`. That is a separate concern in a different file and gets
its own PR; the issue stays open.

Refs #317
