### PR TITLE
perf(analysis): decode LLM frames from the 480p proxy, not the 4K original

### DIFF
--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -385,7 +385,7 @@ class UnifiedSegmentAnalyzer:
         if enable_content_analysis:
             self._run_llm_scoring(
                 scored_segments,
-                audio_video,
+                visual_video,
                 enable_audio_content_analysis=audio_available,
             )
 
@@ -745,7 +745,7 @@ class UnifiedSegmentAnalyzer:
     def _run_llm_scoring(
         self,
         scored_segments: list,
-        audio_video: Path,
+        visual_video: Path,
         *,
         enable_audio_content_analysis: bool = True,
     ) -> None:
@@ -753,7 +753,9 @@ class UnifiedSegmentAnalyzer:
 
         Args:
             scored_segments: Segments to score (modified in place).
-            audio_video: Path to video for content analysis.
+            visual_video: Video to decode frames from -- the 480p analysis
+                proxy, not the original. The provider resizes frames to 480px
+                regardless, so decoding 4K here is pure cost.
         """
         if not (self.content_analyzer and self.content_weight > 0):
             logger.info("  -> LLM content analysis DISABLED")
@@ -767,7 +769,7 @@ class UnifiedSegmentAnalyzer:
                     f"  -> Analyzing candidate {i + 1}/{top_n}: {segment.start_time:.1f}s-{segment.end_time:.1f}s"
                 )
                 segment.content_score = self._score_content(
-                    audio_video, segment.start_time, segment.end_time, segment=segment
+                    visual_video, segment.start_time, segment.end_time, segment=segment
                 )
                 segment.total_score = self._compute_total_score(
                     segment,

--- a/tests/test_unified_analyzer.py
+++ b/tests/test_unified_analyzer.py
@@ -830,3 +830,60 @@ class TestLaughterBonus:
 
         assert total(0.25, True) - total(0.25, False) == pytest.approx(0.25)
         assert total(0.0, True) == pytest.approx(total(0.0, False))
+
+
+class TestLLMFramesComeFromTheProxy:
+    def test_content_analysis_reads_the_visual_proxy_not_the_original(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The LLM only ever looks at frames, and it downsizes them to 480px
+        anyway. Decoding those frames out of the 4K original costs ~22s per clip
+        against ~0.4s from the 480p proxy that analysis already built (measured
+        on a real 4K HEVC clip). The original stays the audio source.
+        """
+        visual = tmp_path / "video_480p.mp4"
+        visual.write_bytes(b"proxy")
+        original = tmp_path / "video.mp4"
+        original.write_bytes(b"original")
+
+        # WHY: the LLM vision provider is an external model/API boundary.
+        content_analyzer = MagicMock()
+        content_analyzer.analyze_segment.return_value = MagicMock(
+            content_score=0.9,
+            description="d",
+            emotion="joy",
+            setting="s",
+            subjects=[],
+            interestingness=0.9,
+            quality=0.9,
+            confidence=1.0,
+        )
+        # WHY: audio analysis shells out to ffmpeg over a real file.
+        audio_analyzer = MagicMock()
+        audio_analyzer.analyze.return_value = MagicMock(
+            audio_score=0.5, has_laughter=False, has_speech=False, protected_ranges=[]
+        )
+        analyzer = UnifiedSegmentAnalyzer(
+            scorer=MagicMock(),
+            content_analyzer=content_analyzer,
+            content_weight=0.3,
+            audio_analyzer=audio_analyzer,
+            audio_content_config=AudioContentConfig(),
+            analysis_config=AnalysisConfig(),
+        )
+        for fn in (
+            "detect_visual_boundaries",
+            "detect_audio_boundaries",
+            "merge_boundaries",
+            "generate_candidate_segments",
+            "generate_fallback_segments",
+        ):
+            monkeypatch.setattr(f"immich_memories.analysis.unified_analyzer.{fn}", lambda *_: [])
+        analyzer._score_segments_visual_only = MagicMock(
+            return_value=[ScoredSegment(start_time=0.0, end_time=5.0, visual_score=0.6)]
+        )
+
+        analyzer.analyze(visual, video_duration=10.0, audio_video_path=original)
+
+        analysed_path = content_analyzer.analyze_segment.call_args.args[0]
+        assert analysed_path == visual, f"LLM frames decoded from {analysed_path}, expected proxy"


### PR DESCRIPTION
## What was wrong

`UnifiedSegmentAnalyzer.analyze()` already separates two video sources:

```python
visual_video = video_path                  # the 480p analysis proxy
audio_video  = audio_video_path or video_path   # the original, for audio fidelity
```

Scene detection and visual scoring use `visual_video`. LLM content scoring was
handed `audio_video` — the 4K original — even though it only ever decodes
**frames**, and the provider resizes every one of them to 480px before the model
sees it. It does that 3 frames × top-5 candidates on every analysed clip, and
each `cv2` seek on 4K HEVC decodes a full GOP.

The parameter was literally named `audio_video` inside a function that never
touches audio, which is how the two drifted apart.

## Measured

Real 4K HEVC clip from my library (3840×2160, 68.7 s), 5 candidates × 3 frames,
mirroring `llm_response_parser`'s seek-and-resize loop:

| Source | 15 frames | Per candidate |
|---|---|---|
| 4K original | **22.43 s** | 4.49 s |
| 480p proxy | **0.43 s** | 0.09 s |

**52×.** The proxy costs nothing extra — analysis has already built it by the
time the LLM runs.

## The check that mattered

The proxy is built with `-an` (`video_cache.py`), so it has **no audio stream**.
If the LLM path touched audio, this change would have silently broken it. It
does not: neither `analyze_segment` implementation in `_content_providers.py`
reads audio — both are purely frame-based. Silence detection, transcription and
audio content analysis continue to read `audio_video` (the original), unchanged.

## Trade-off worth knowing

Frames now come from a `crf 28 ultrafast` encode rather than a high-quality
downscale of the 4K. Same pixel dimensions (480 height either way), slightly
more compression artifacting. Given the model sees a 480px image regardless,
this is the right trade for 52×; flagging it explicitly rather than burying it.

## Test

`test_content_analysis_reads_the_visual_proxy_not_the_original` drives the
public `analyze()` with distinct visual/audio paths and asserts which one
reaches the content analyzer. It fails on `main` with the original's path.
