### PR TITLE
perf(analysis): hardware-decode the analysis downscale

### DIFF
--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -272,6 +272,7 @@ class ClipAnalyzer:
                 clip.asset,
                 target_height=config.analysis.analysis_resolution,
                 enable_downscaling=config.analysis.enable_downscaling,
+                gpu_decode=config.hardware.gpu_decode,
             )
         else:
             safe_name = sanitize_filename(clip.asset.original_file_name or "video.mp4")

--- a/src/immich_memories/cache/video_cache.py
+++ b/src/immich_memories/cache/video_cache.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import subprocess
 import threading
 import time
 from collections.abc import Callable, Container
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 
 from immich_memories.api.immich import ImmichAPIError
+from immich_memories.processing.hardware import HWAccelCapabilities
 from immich_memories.processing.probe_cache import ProbeCache, ProbeError
 from immich_memories.security import sanitize_error_message
 
@@ -52,6 +55,98 @@ class _ManifestEntry:
     path: Path
     size: int
     mtime: float
+
+
+@lru_cache(maxsize=1)
+def _detected_capabilities() -> HWAccelCapabilities:
+    from immich_memories.processing.hardware_detection import detect_hardware_acceleration
+
+    return detect_hardware_acceleration()
+
+
+def analysis_decode_hwaccel_args(codec: str) -> list[str]:
+    """Decode-side acceleration for the analysis downscale, empty if unavailable.
+
+    `for_software_filters` matters here: the downscale filters on the CPU, so
+    frames have to come back in system memory.
+    """
+    from immich_memories.processing.hardware import get_ffmpeg_hwaccel_args
+
+    capabilities = _detected_capabilities()
+    if not capabilities.has_decoding:
+        return []
+    return get_ffmpeg_hwaccel_args(
+        capabilities,
+        operation="decode",
+        codec="h265" if codec in ("hevc", "h265") else "h264",
+        for_software_filters=True,
+    )
+
+
+def _run_downscale_attempt(
+    source: Path,
+    dest: Path,
+    target_height: int,
+    stream_map: str,
+    hwaccel_args: list[str],
+    timeout: int,
+) -> bool:
+    cmd = [
+        "ffmpeg",
+        "-y",
+        *hwaccel_args,
+        "-i",
+        str(source),
+        "-map",
+        stream_map,
+        "-vf",
+        f"scale=-2:{target_height}",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-crf",
+        "28",
+        "-movflags",
+        "+faststart",
+        "-an",
+        str(dest),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)  # noqa: S603
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Downscale attempt failed: %s", exc)
+        return False
+    if result.returncode == 0 and dest.exists() and dest.stat().st_size > 1024:
+        return True
+    if hwaccel_args:
+        logger.debug("Hardware-accelerated downscale failed: %s", result.stderr[-300:])
+    dest.unlink(missing_ok=True)
+    return False
+
+
+def downscale_for_analysis(
+    source: Path,
+    dest: Path,
+    target_height: int,
+    *,
+    stream_map: str,
+    hwaccel_args: list[str] | None = None,
+    timeout: int = 120,
+) -> bool:
+    """Encode the reduced-resolution copy analysis runs on.
+
+    Retries in software when a hardware decode attempt fails. ffmpeg advertising
+    a backend is not proof this machine can use it -- a VAAPI node can exist with
+    no working driver, a CUDA build with no GPU -- and giving up would push the
+    whole analysis onto the full-resolution original, which is the cost the
+    acceleration exists to avoid.
+    """
+    if hwaccel_args and _run_downscale_attempt(
+        source, dest, target_height, stream_map, hwaccel_args, timeout
+    ):
+        return True
+    return _run_downscale_attempt(source, dest, target_height, stream_map, [], timeout)
 
 
 class CacheBatch:
@@ -122,6 +217,7 @@ class CacheBatch:
         asset: Asset,
         target_height: int = 480,
         enable_downscaling: bool = True,
+        gpu_decode: bool = True,
     ) -> tuple[Path, Path]:
         """Download and optionally downscale within this batch lifecycle."""
         return self._run_operation(
@@ -131,6 +227,7 @@ class CacheBatch:
                 target_height=target_height,
                 enable_downscaling=enable_downscaling,
                 batch=self,
+                gpu_decode=gpu_decode,
             )
         )
 
@@ -339,6 +436,7 @@ class VideoDownloadCache:
         asset: Asset,
         target_height: int = 480,
         enable_downscaling: bool = True,
+        gpu_decode: bool = True,
     ) -> tuple[Path, Path]:
         """Download and optionally create a downscaled copy for analysis.
 
@@ -354,6 +452,7 @@ class VideoDownloadCache:
                 asset,
                 target_height=target_height,
                 enable_downscaling=enable_downscaling,
+                gpu_decode=gpu_decode,
             )
 
     def _get_analysis_video(
@@ -363,6 +462,7 @@ class VideoDownloadCache:
         target_height: int,
         enable_downscaling: bool,
         batch: CacheBatch,
+        gpu_decode: bool = True,
     ) -> tuple[Path, Path]:
         """Batch-aware implementation for an analysis source video."""
         original = self._download_or_get(client, asset, batch)
@@ -384,49 +484,32 @@ class VideoDownloadCache:
         # Try to create downscaled version
         downscaled = sub_path / f"{video_id}_480p{original.suffix}"
         try:
-            import subprocess
-
             from immich_memories.processing.clip_probing import get_main_video_stream_map
 
             stream_map = get_main_video_stream_map(original)
-            cmd = [
-                "ffmpeg",
-                "-y",
-                "-i",
-                str(original),
-                "-map",
-                stream_map,
-                "-vf",
-                f"scale=-2:{target_height}",
-                "-c:v",
-                "libx264",
-                "-preset",
-                "ultrafast",
-                "-crf",
-                "28",
-                "-movflags",
-                "+faststart",
-                "-an",
-                str(downscaled),
-            ]
-            result = subprocess.run(  # noqa: S603
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            if result.returncode == 0 and downscaled.exists() and downscaled.stat().st_size > 1024:
+            hwaccel_args = self._downscale_hwaccel_args(original) if gpu_decode else []
+            if downscale_for_analysis(
+                original,
+                downscaled,
+                target_height,
+                stream_map=stream_map,
+                hwaccel_args=hwaccel_args,
+            ):
                 batch._record_manifest_entry(downscaled)
                 return downscaled, original
-            if downscaled.exists():
-                downscaled.unlink()  # Remove corrupted file
-                logger.warning("Downscaled file too small/corrupt for %s, using original", asset.id)
+            logger.warning("Downscale produced nothing usable for %s, using original", asset.id)
         except (OSError, subprocess.SubprocessError) as e:
             logger.debug("Downscaling failed for %s: %s, using original", asset.id, e)
-            if downscaled.exists():
-                downscaled.unlink()
+            downscaled.unlink(missing_ok=True)
 
         return original, original
+
+    def _downscale_hwaccel_args(self, source: Path) -> list[str]:
+        try:
+            codec = self._probe_cache.get(source).codec
+        except (ProbeError, OSError, ValueError):
+            return []
+        return analysis_decode_hwaccel_args(codec)
 
     def _scan_manifest(self) -> dict[Path, _ManifestEntry]:
         """Scan once, dropping expired files and abandoned partial downloads."""

--- a/src/immich_memories/processing/hardware.py
+++ b/src/immich_memories/processing/hardware.py
@@ -151,6 +151,8 @@ def get_ffmpeg_hwaccel_args(
     capabilities: HWAccelCapabilities,
     operation: Literal["decode", "encode", "both"] = "both",
     codec: str = "h264",
+    *,
+    for_software_filters: bool = False,
 ) -> list[str]:
     """Get FFmpeg arguments for hardware acceleration.
 
@@ -158,33 +160,45 @@ def get_ffmpeg_hwaccel_args(
         capabilities: Detected hardware capabilities.
         operation: Which operation to accelerate.
         codec: Video codec to use.
+        for_software_filters: Keep decoded frames in system memory. CUDA
+            otherwise hands them back in GPU memory, where a CPU filter such
+            as `scale` cannot reach them and ffmpeg fails. Only NVIDIA is
+            affected; the other backends already decode to system memory.
 
     Returns:
         List of FFmpeg arguments.
     """
-    args: list[str] = []
+    if capabilities.backend == HWAccelBackend.NONE or operation not in ("decode", "both"):
+        return []
+    return _decode_hwaccel_args(capabilities, codec, for_software_filters=for_software_filters)
 
-    if capabilities.backend == HWAccelBackend.NONE:
-        return args
 
-    # Hardware decode arguments (input side)
-    if operation in ("decode", "both"):
-        if capabilities.backend == HWAccelBackend.NVIDIA:
-            if (codec == "h264" and capabilities.supports_h264_decode) or (
-                codec == "h265" and capabilities.supports_h265_decode
-            ):
-                args.extend(["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"])
+def _decode_hwaccel_args(
+    capabilities: HWAccelCapabilities,
+    codec: str,
+    *,
+    for_software_filters: bool,
+) -> list[str]:
+    if capabilities.backend == HWAccelBackend.NVIDIA:
+        if (codec == "h264" and capabilities.supports_h264_decode) or (
+            codec == "h265" and capabilities.supports_h265_decode
+        ):
+            args = ["-hwaccel", "cuda"]
+            if not for_software_filters:
+                args.extend(["-hwaccel_output_format", "cuda"])
+            return args
+        return []
 
-        elif capabilities.backend == HWAccelBackend.APPLE:
-            args.extend(["-hwaccel", "videotoolbox"])
+    if capabilities.backend == HWAccelBackend.APPLE:
+        return ["-hwaccel", "videotoolbox"]
 
-        elif capabilities.backend == HWAccelBackend.VAAPI:
-            args.extend(["-hwaccel", "vaapi", "-hwaccel_device", "/dev/dri/renderD128"])
+    if capabilities.backend == HWAccelBackend.VAAPI:
+        return ["-hwaccel", "vaapi", "-hwaccel_device", "/dev/dri/renderD128"]
 
-        elif capabilities.backend == HWAccelBackend.QSV:
-            args.extend(["-hwaccel", "qsv"])
+    if capabilities.backend == HWAccelBackend.QSV:
+        return ["-hwaccel", "qsv"]
 
-    return args
+    return []
 
 
 def get_ffmpeg_encoder(

--- a/tests/test_analysis_downscale.py
+++ b/tests/test_analysis_downscale.py
@@ -1,0 +1,161 @@
+"""The analysis downscale must survive a hardware decoder that does not work.
+
+Hardware acceleration is detected from what ffmpeg advertises, which is not the
+same as what actually decodes on this machine: a VAAPI node can exist without a
+usable driver, and a CUDA build can be present with no GPU attached. When that
+happens ffmpeg exits non-zero, and a downscale that gave up would push the whole
+analysis onto the 4K original -- the exact cost the acceleration was added to
+avoid.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from immich_memories.cache import video_cache as video_cache_module
+from immich_memories.cache.video_cache import (
+    VideoDownloadCache,
+    analysis_decode_hwaccel_args,
+    downscale_for_analysis,
+)
+from immich_memories.processing.hardware import HWAccelBackend, HWAccelCapabilities
+
+
+@pytest.fixture(scope="module")
+def source_video(tmp_path_factory) -> Path:
+    """A real 720p clip, so ffmpeg does real work."""
+    path = tmp_path_factory.mktemp("downscale") / "source.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=1280x720:rate=10:duration=1",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+    return path
+
+
+def _height(path: Path) -> int:
+    out = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=height",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return int(out.stdout.strip().rstrip(","))
+
+
+def test_downscales_to_the_target_height(source_video: Path, tmp_path: Path):
+    dest = tmp_path / "out.mp4"
+
+    assert downscale_for_analysis(source_video, dest, 480, stream_map="0:v:0") is True
+    assert _height(dest) == 480
+
+
+def test_falls_back_to_software_when_the_hardware_decoder_fails(source_video: Path, tmp_path: Path):
+    dest = tmp_path / "out.mp4"
+
+    ok = downscale_for_analysis(
+        source_video,
+        dest,
+        480,
+        stream_map="0:v:0",
+        hwaccel_args=["-hwaccel", "definitely_not_a_real_hwaccel"],
+    )
+
+    assert ok is True, "a broken hardware decoder must not cost us the downscale"
+    assert _height(dest) == 480
+
+
+def test_reports_failure_when_the_source_is_not_decodable(tmp_path: Path):
+    broken = tmp_path / "broken.mp4"
+    broken.write_bytes(b"not a video")
+    dest = tmp_path / "out.mp4"
+
+    assert downscale_for_analysis(broken, dest, 480, stream_map="0:v:0") is False
+    assert not dest.exists()
+
+
+class TestDecodeArgsForTheDownscale:
+    @staticmethod
+    def _pretend(monkeypatch, capabilities: HWAccelCapabilities) -> None:
+        # WHY: detection shells out to ffmpeg and reports whatever this machine
+        # has, which is not something a test can assert against.
+        monkeypatch.setattr(video_cache_module, "_detected_capabilities", lambda: capabilities)
+
+    def test_hevc_source_asks_for_the_h265_decoder(self, monkeypatch):
+        self._pretend(
+            monkeypatch,
+            HWAccelCapabilities(backend=HWAccelBackend.NVIDIA, supports_h265_decode=True),
+        )
+
+        assert analysis_decode_hwaccel_args("hevc") == ["-hwaccel", "cuda"]
+
+    def test_no_decoder_means_no_args(self, monkeypatch):
+        self._pretend(monkeypatch, HWAccelCapabilities(backend=HWAccelBackend.NONE))
+
+        assert analysis_decode_hwaccel_args("h264") == []
+
+    def test_a_probeable_source_yields_this_machine_s_decoder(
+        self, source_video: Path, tmp_path: Path
+    ):
+        cache = VideoDownloadCache(cache_dir=tmp_path / "cache")
+
+        args = cache._downscale_hwaccel_args(source_video)
+
+        # Whether this machine has a decoder is not something a test can assert.
+        assert args == [] or args[0] == "-hwaccel"
+
+    def test_an_unprobeable_source_is_decoded_in_software(self, tmp_path: Path):
+        """No codec means no informed choice of decoder, so do not guess one."""
+        cache = VideoDownloadCache(cache_dir=tmp_path / "cache")
+        not_a_video = tmp_path / "junk.mp4"
+        not_a_video.write_bytes(b"junk")
+
+        assert cache._downscale_hwaccel_args(not_a_video) == []
+
+
+def test_downscale_reports_failure_when_ffmpeg_cannot_be_run(
+    source_video: Path, tmp_path: Path, monkeypatch
+):
+    """A missing or unexecutable ffmpeg must not raise through the cache."""
+
+    def explode(*_args, **_kwargs):
+        raise OSError("ffmpeg not found")
+
+    # WHY: stands in for ffmpeg being absent from PATH.
+    monkeypatch.setattr(video_cache_module.subprocess, "run", explode)
+
+    assert (
+        downscale_for_analysis(source_video, tmp_path / "o.mp4", 480, stream_map="0:v:0") is False
+    )

--- a/tests/test_hardware_detection.py
+++ b/tests/test_hardware_detection.py
@@ -450,3 +450,43 @@ class TestGetOpencvBackend:
     def test_no_cuda(self):
         caps = HWAccelCapabilities()
         assert get_opencv_backend(caps) == "cpu"
+
+
+class TestHwaccelArgsForSoftwareFilters:
+    """`-hwaccel cuda -hwaccel_output_format cuda` leaves decoded frames in GPU
+    memory, where a CPU filter like `scale=-2:480` cannot reach them and ffmpeg
+    fails outright. Callers that filter on the CPU need the decode acceleration
+    without the output-format pin.
+    """
+
+    def test_nvidia_keeps_frames_in_system_memory_when_asked(self):
+        caps = HWAccelCapabilities(
+            backend=HWAccelBackend.NVIDIA,
+            supports_h264_decode=True,
+            supports_h265_decode=True,
+        )
+
+        args = get_ffmpeg_hwaccel_args(caps, operation="decode", for_software_filters=True)
+
+        assert "-hwaccel" in args, "hardware decode should still be requested"
+        assert "cuda" in args
+        assert "-hwaccel_output_format" not in args
+
+    def test_nvidia_default_still_pins_frames_on_the_gpu(self):
+        caps = HWAccelCapabilities(
+            backend=HWAccelBackend.NVIDIA,
+            supports_h264_decode=True,
+            supports_h265_decode=True,
+        )
+
+        args = get_ffmpeg_hwaccel_args(caps, operation="decode")
+
+        assert "-hwaccel_output_format" in args
+
+    def test_apple_is_unaffected_because_it_already_decodes_to_system_memory(self):
+        caps = HWAccelCapabilities(backend=HWAccelBackend.APPLE)
+
+        plain = get_ffmpeg_hwaccel_args(caps, operation="decode")
+        for_filters = get_ffmpeg_hwaccel_args(caps, operation="decode", for_software_filters=True)
+
+        assert plain == for_filters == ["-hwaccel", "videotoolbox"]


### PR DESCRIPTION
## What was wrong

The 480p analysis proxy — the thing every clip's scene detection, scoring and
(after #375) LLM frames read from — was built with a fully software decode of
the 4K HEVC original. `get_ffmpeg_hwaccel_args` has existed for a while and four
other call sites already use it; this path never did.

Measured through the actual function on a real 4K HEVC clip (3840×2160, 68.7 s):

| | |
|---|---|
| software | **67.1 s** |
| hwaccel (videotoolbox) | **20.6 s** |

## It also fixes a silent failure

The downscale runs under `timeout=120`. At 67 s for a 69 s clip, anything past
roughly two minutes of 4K blew that timeout, hit `return original, original`,
and left the *entire rest of analysis* — scene detection, scoring, frame
extraction — working on the 4K file. The proxy exists precisely to avoid that,
and on long clips it was quietly not happening. At 20.6 s the budget is no
longer close.

## Two things that needed care

**CUDA would have broken the filter.** `get_ffmpeg_hwaccel_args` couples
`-hwaccel cuda` with `-hwaccel_output_format cuda`, which leaves decoded frames
in GPU memory where the CPU `scale=-2:480` filter cannot reach them — ffmpeg
fails outright. A new `for_software_filters` flag drops the output-format pin.
Only NVIDIA is affected; videotoolbox, VAAPI and QSV already decode to system
memory, and there's a test asserting Apple's args are byte-identical either way.

**Advertised ≠ working.** ffmpeg listing a backend is not proof this machine can
use it — a VAAPI node with no working driver, a CUDA build with no GPU.
`downscale_for_analysis` retries in software when the accelerated attempt fails,
so a broken decoder costs one fast failure rather than the whole downscale.
Tested by passing a deliberately invalid `-hwaccel` and asserting a real 480p
file still appears.

## Config

`config.hardware.gpu_decode` is honoured. It threads from the caller alongside
`target_height` and `enable_downscaling`, so the cache keeps deciding nothing
about policy — it only carries out what it's told.

## Note for reviewers

The cognitive-complexity gate caught the first version of this: adding one
branch pushed `get_ffmpeg_hwaccel_args` from under the limit to 17. The
backend dispatch is now extracted into `_decode_hwaccel_args`, and the snapshot
watermark passes with no new violations.

Part of the P3 finding in `docs/reviews/2026-08-18-security-perf-review.md`.
The streaming assembler's decoder is the other half of P3 and is not in this PR.
