### PR TITLE
feat(audio): ask ACE-Step for a tempo the photo cuts land on

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -88,6 +88,24 @@ production automation; test non-turbo XL only with DCW explicitly disabled in a 
 adapter.
 :::
 
+#### Tempo follows the photo cuts
+
+When a memory contains photos, the tempo asked of ACE-Step is nudged so a photo
+lasts a whole number of beats. Photos hold the screen for a fixed time, so their
+cuts arrive at a steady rate; picking a tempo whose beat divides that rate makes
+the cuts land with the pulse instead of against it.
+
+The nudge stays inside the genre's own tempo range — drum and bass at 70 bpm is
+not a thing — and within 15% of the mood's own tempo, so a run of short photos
+cannot drag a serene track up to dance tempo. Where neither holds, the mood wins
+and nothing changes. At the default 4 s photo duration all ten mood/style
+combinations land on whole beats, the largest shift being 132 → 120 bpm. Videos are never re-timed: they carry speech and laughter the pipeline
+protects, so only photo cadence drives this.
+
+Measured on the 28 bundled tracks, ACE-Step honours a requested tempo to within
+0.4% (median), so asking for an aligned tempo is worth doing — but that residual
+is also why cuts are aligned in *rate*, not yet locked to the beat.
+
 ### MusicGen
 
 Meta's MusicGen handles text-to-music generation and Demucs stem separation via a remote API server. If you're running everything locally with ACE-Step + local Demucs, you don't need MusicGen at all.

--- a/src/immich_memories/audio/beat_grid.py
+++ b/src/immich_memories/audio/beat_grid.py
@@ -1,0 +1,55 @@
+"""Tempo picked so the photo cut cadence lands on whole beats.
+
+The pipeline decides its cuts before it has any music: clips are chosen for
+content, and photos get a fixed screen time. So the music adapts to the cuts
+rather than the other way round — we ask the generator for a tempo whose beat
+divides the photo cadence exactly, instead of moving cuts to fit a track.
+"""
+
+from __future__ import annotations
+
+# How far the tempo may be pulled to reach a whole-beat cadence. Alignment is
+# worth a nudge, not a mood: short photos are a whole beat only at tempos that
+# would turn a serene track into a dance one.
+_MAX_TEMPO_SHIFT = 0.15
+
+
+def beat_aligned_bpm(
+    natural_bpm: float,
+    cadence_seconds: float,
+    tempo_range: tuple[int, int],
+) -> int:
+    """Nearest tempo to ``natural_bpm`` whose beat divides ``cadence_seconds``.
+
+    Only tempos where the cadence is a whole number of beats are considered, so
+    a photo lasts exactly N beats and every cut in a run of photos falls on the
+    same grid. Stays inside the style's own tempo range and within a short reach
+    of the mood's own tempo; where neither holds, the mood wins and the natural
+    tempo is returned unchanged.
+    """
+    if cadence_seconds <= 0 or natural_bpm <= 0:
+        return int(round(natural_bpm))
+
+    low, high = tempo_range
+    beats = _beats_per_cadence(natural_bpm, cadence_seconds)
+    span = natural_bpm * _MAX_TEMPO_SHIFT
+    candidates = [
+        n
+        for n in (beats, beats + 1)
+        if n >= 1
+        and low <= _bpm_for(n, cadence_seconds) <= high
+        and abs(_bpm_for(n, cadence_seconds) - natural_bpm) <= span
+    ]
+    if not candidates:
+        return int(round(natural_bpm))
+
+    best = min(candidates, key=lambda n: abs(_bpm_for(n, cadence_seconds) - natural_bpm))
+    return int(round(_bpm_for(best, cadence_seconds)))
+
+
+def _beats_per_cadence(bpm: float, cadence_seconds: float) -> int:
+    return int(cadence_seconds * bpm / 60.0)
+
+
+def _bpm_for(beats: int, cadence_seconds: float) -> float:
+    return 60.0 * beats / cadence_seconds

--- a/src/immich_memories/audio/generators/ace_step_backend.py
+++ b/src/immich_memories/audio/generators/ace_step_backend.py
@@ -345,6 +345,7 @@ def _mood_to_structured_prompt(
     mood: str,
     scene_moods: list[str] | None = None,
     memory_type: str | None = None,
+    cadence_seconds: float | None = None,
 ):
     """Convert mood to structured ACE-Step caption with explicit musical params.
 
@@ -353,6 +354,7 @@ def _mood_to_structured_prompt(
     return build_ace_caption_structured(
         mood,
         season=_detect_season(mood),
+        cadence_seconds=cadence_seconds,
         scene_moods=scene_moods,
         memory_type=memory_type,
     )
@@ -579,12 +581,17 @@ class ACEStepBackend(MusicGenerator):
             scene_moods = [s.get("mood", "upbeat") for s in request.scenes]
             primary_mood = scene_moods[0] if scene_moods else "upbeat"
             caption_result = _mood_to_structured_prompt(
-                primary_mood, scene_moods=scene_moods, memory_type=request.memory_type
+                primary_mood,
+                scene_moods=scene_moods,
+                memory_type=request.memory_type,
+                cadence_seconds=request.photo_cadence_seconds,
             )
             duration = sum(s.get("duration", 30) for s in request.scenes)
         else:
             caption_result = _mood_to_structured_prompt(
-                request.prompt, memory_type=request.memory_type
+                request.prompt,
+                memory_type=request.memory_type,
+                cadence_seconds=request.photo_cadence_seconds,
             )
             duration = request.duration_seconds
 
@@ -693,12 +700,17 @@ class ACEStepBackend(MusicGenerator):
             scene_moods = [s.get("mood", "upbeat") for s in request.scenes]
             primary_mood = scene_moods[0] if scene_moods else "upbeat"
             caption_result = _mood_to_structured_prompt(
-                primary_mood, scene_moods=scene_moods, memory_type=request.memory_type
+                primary_mood,
+                scene_moods=scene_moods,
+                memory_type=request.memory_type,
+                cadence_seconds=request.photo_cadence_seconds,
             )
             duration = sum(s.get("duration", 30) for s in request.scenes)
         else:
             caption_result = _mood_to_structured_prompt(
-                request.prompt, memory_type=request.memory_type
+                request.prompt,
+                memory_type=request.memory_type,
+                cadence_seconds=request.photo_cadence_seconds,
             )
             duration = request.duration_seconds
 

--- a/src/immich_memories/audio/generators/ace_step_captions.py
+++ b/src/immich_memories/audio/generators/ace_step_captions.py
@@ -193,13 +193,23 @@ def pick_style(memory_type: str | None = None, style: str | None = None) -> str:
     return random.choice(sorted(STYLE_PROFILES))
 
 
-def compose_caption(mood_key: str, style_key: str) -> tuple[str, int, str]:
+def compose_caption(
+    mood_key: str, style_key: str, cadence_seconds: float | None = None
+) -> tuple[str, int, str]:
     """Build the caption on ACE-Step's documented order, with its tempo and key.
+
+    A cadence nudges the tempo within the style's own range so a photo lasts a
+    whole number of beats — the cuts are already fixed by the time music is
+    chosen, so the music is what adapts.
 
     Returns (caption, bpm, key_scale).
     """
+    from immich_memories.audio.beat_grid import beat_aligned_bpm
+
     profile, style = MOOD_PROFILES[mood_key], STYLE_PROFILES[style_key]
     bpm = style.bpm_for(profile.energy)
+    if cadence_seconds:
+        bpm = beat_aligned_bpm(bpm, cadence_seconds, style.tempo_range)
     key_scale = f"{_key_root(mood_key, style_key)} {profile.mode}"
     caption = (
         f"{style.genre_for(mood_key)}, {profile.word}, {style.instruments}, "
@@ -255,6 +265,7 @@ def build_ace_caption_structured(
     scene_moods: list[str] | None = None,
     memory_type: str | None = None,
     style: str | None = None,
+    cadence_seconds: float | None = None,
 ) -> ACECaptionResult:
     """Build a structured ACE-Step caption from the mood x style matrix.
 
@@ -264,7 +275,7 @@ def build_ace_caption_structured(
     """
     mood_key = resolve_mood(scene_moods[0] if scene_moods else mood)
     style_key = pick_style(memory_type=memory_type, style=style)
-    caption, bpm, key_scale = compose_caption(mood_key, style_key)
+    caption, bpm, key_scale = compose_caption(mood_key, style_key, cadence_seconds)
 
     if season:
         modifier = _SEASON_TAG_MODIFIERS.get(season.lower(), "")

--- a/src/immich_memories/audio/generators/base.py
+++ b/src/immich_memories/audio/generators/base.py
@@ -35,6 +35,8 @@ class GenerationRequest:
     variation_index: int = 0
     crossfade_duration: float = 2.0
     memory_type: str | None = None
+    # How often a photo cut lands, so the tempo can be chosen to match it.
+    photo_cadence_seconds: float | None = None
 
     # Output
     output_dir: Path = field(default_factory=lambda: Path(tempfile.gettempdir()) / "musicgen")

--- a/src/immich_memories/audio/music_generator.py
+++ b/src/immich_memories/audio/music_generator.py
@@ -103,6 +103,7 @@ async def generate_music_for_video(
     hemisphere: str = "north",
     app_config: object | None = None,
     memory_type: str | None = None,
+    photo_cadence_seconds: float | None = None,
 ) -> MusicGenerationResult:
     """Generate multiple music versions for a video with per-clip moods.
 
@@ -137,6 +138,7 @@ async def generate_music_for_video(
                 crossfade_duration=crossfade_duration,
                 hemisphere=hemisphere,
                 memory_type=memory_type,
+                photo_cadence_seconds=photo_cadence_seconds,
             )
 
     # Legacy path: direct MusicGen client

--- a/src/immich_memories/audio/music_pipeline.py
+++ b/src/immich_memories/audio/music_pipeline.py
@@ -72,6 +72,7 @@ class MusicPipeline:
         crossfade_duration: float = 2.0,
         hemisphere: str = "north",
         memory_type: str | None = None,
+        photo_cadence_seconds: float | None = None,
     ) -> MusicGenerationResult:
         """Generate music using the first available backend, with fallback."""
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -95,6 +96,7 @@ class MusicPipeline:
                 crossfade_duration=crossfade_duration,
                 output_dir=output_dir,
                 memory_type=memory_type,
+                photo_cadence_seconds=photo_cadence_seconds,
             )
 
             result = await self._try_generate(request, progress_callback, i, num_versions)

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -159,6 +159,19 @@ def _master(track: Path, run_output_dir: Path) -> Path:
     return master_music_track(track, run_output_dir / f"mastered_{track.stem}.wav")
 
 
+def photo_cadence_seconds(assembly_clips: list[AssemblyClip]) -> float | None:
+    """How often a photo cut lands, or None when there is no rhythm to sync to.
+
+    Read off the clips rather than ``config.photos.duration`` because the final
+    budget trim rescales every clip: by the time music is chosen, a photo the
+    config called 4 s may be 3.7 s on screen.
+    """
+    durations = sorted(clip.duration for clip in assembly_clips if clip.is_photo)
+    if len(durations) < 2:
+        return None
+    return durations[len(durations) // 2]
+
+
 def _mood_for_clips(assembly_clips: list[AssemblyClip]) -> str | None:
     """Mood to pick bundled music by, taken from the clips when they carry one."""
     for clip in assembly_clips:
@@ -225,6 +238,7 @@ def auto_generate_music(
                 progress_callback=music_progress,
                 app_config=config,
                 memory_type=memory_type,
+                photo_cadence_seconds=photo_cadence_seconds(assembly_clips),
             )
         )
 

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -1,0 +1,160 @@
+"""Tempo chosen so the photo cut cadence lands on whole beats."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.audio.beat_grid import beat_aligned_bpm
+from immich_memories.generate_music import photo_cadence_seconds
+from immich_memories.processing.assembly_config import AssemblyClip
+
+
+class TestBeatAlignedBpm:
+    def test_cadence_becomes_a_whole_number_of_beats(self):
+        bpm = beat_aligned_bpm(natural_bpm=123, cadence_seconds=4.0, tempo_range=(72, 150))
+
+        beats = cadence_in_beats(bpm, 4.0)
+        assert abs(beats - round(beats)) < 1e-9
+
+
+def cadence_in_beats(bpm: float, cadence_seconds: float) -> float:
+    return cadence_seconds / (60.0 / bpm)
+
+
+class TestNearestTempo:
+    def test_picks_the_aligned_tempo_closest_to_the_natural_one(self):
+        """4.0s is 8 beats at 120 and 9 at 135; 123 should land on 120."""
+        assert beat_aligned_bpm(natural_bpm=123, cadence_seconds=4.0, tempo_range=(72, 150)) == 120
+
+    def test_never_leaves_the_styles_tempo_range(self):
+        """A 150-bpm jazz track would be aligned and wrong."""
+        bpm = beat_aligned_bpm(natural_bpm=70, cadence_seconds=4.0, tempo_range=(68, 132))
+
+        assert 68 <= bpm <= 132
+
+    def test_falls_back_to_the_natural_tempo_when_nothing_aligns_in_range(self):
+        """A narrow range can exclude every whole-beat tempo; the mood still wins."""
+        bpm = beat_aligned_bpm(natural_bpm=100, cadence_seconds=0.37, tempo_range=(99, 101))
+
+        assert bpm == 100
+
+
+def _clip(duration: float, *, is_photo: bool) -> AssemblyClip:
+    return AssemblyClip(path=Path("/x.mp4"), duration=duration, asset_id="x", is_photo=is_photo)
+
+
+class TestPhotoCadence:
+    def test_reads_the_rendered_photo_length_not_the_config_value(self):
+        """The final budget trim scales every clip, so config.photos.duration lies."""
+        clips = [_clip(3.7, is_photo=True), _clip(3.7, is_photo=True), _clip(9.1, is_photo=False)]
+
+        assert photo_cadence_seconds(clips) == 3.7
+
+    def test_a_single_photo_has_no_cadence(self):
+        """One photo is not a rhythm; syncing tempo to it would be arbitrary."""
+        clips = [_clip(4.0, is_photo=True), _clip(9.1, is_photo=False)]
+
+        assert photo_cadence_seconds(clips) is None
+
+
+class TestCaptionTempoFollowsTheCadence:
+    """The caption is where the tempo is decided, so that is where it must adapt."""
+
+    def test_tempo_shifts_so_the_cadence_is_whole_beats(self):
+        from immich_memories.audio.generators.ace_step_captions import (
+            build_ace_caption_structured,
+        )
+
+        natural = build_ace_caption_structured("happy", style="electronic")
+        aligned = build_ace_caption_structured("happy", style="electronic", cadence_seconds=4.0)
+
+        beats = 4.0 / (60.0 / aligned.bpm)
+        assert abs(beats - round(beats)) < 0.05
+        assert aligned.bpm != natural.bpm
+
+    def test_the_stated_tempo_matches_the_one_we_ask_the_model_for(self):
+        """The caption text conditions the model; a mismatch would fight itself."""
+        from immich_memories.audio.generators.ace_step_captions import (
+            build_ace_caption_structured,
+        )
+
+        result = build_ace_caption_structured("happy", style="electronic", cadence_seconds=4.0)
+
+        assert f"{result.bpm} bpm" in result.caption
+
+    def test_no_cadence_leaves_the_mood_tempo_untouched(self):
+        from immich_memories.audio.generators.ace_step_captions import (
+            build_ace_caption_structured,
+        )
+
+        assert (
+            build_ace_caption_structured("calm", style="acoustic").bpm
+            == build_ace_caption_structured("calm", style="acoustic", cadence_seconds=None).bpm
+        )
+
+
+class TestCadenceReachesTheModel:
+    """The tempo is only useful if it survives the trip to the backend."""
+
+    def test_the_requested_bpm_is_aligned_to_the_photo_cadence(self):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import httpx
+
+        from immich_memories.audio.generators.ace_step_backend import (
+            ACEStepBackend,
+            ACEStepConfig,
+        )
+        from immich_memories.audio.generators.base import GenerationRequest
+
+        backend = ACEStepBackend(ACEStepConfig(mode="api", api_url="http://fake:8000"))
+        payload: dict = {}
+
+        async def fake_post(url, json=None, **kwargs):
+            if "/release_task" in url:
+                payload.update(json)
+                resp = MagicMock()
+                resp.json.return_value = {"data": {"task_id": "t"}}
+                resp.raise_for_status = MagicMock()
+                return resp
+            raise httpx.HTTPError("unexpected url")
+
+        with (
+            # WHY: replaces the poll-and-download loop against a real ACE-Step server.
+            patch.object(backend, "_poll_and_download", new_callable=AsyncMock),
+            # WHY: replaces the HTTP transport so the request never leaves the process.
+            patch("httpx.AsyncClient") as client_cls,
+        ):
+            client = AsyncMock()
+            client.post = fake_post
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            client_cls.return_value = client
+
+            asyncio.run(
+                backend._generate_api(
+                    GenerationRequest(
+                        prompt="happy",
+                        duration_seconds=30,
+                        output_dir=Path("/tmp/beat_grid_test"),
+                        photo_cadence_seconds=4.0,
+                    )
+                )
+            )
+
+        beats = 4.0 / (60.0 / payload["bpm"])
+        assert abs(beats - round(beats)) < 0.05, f"{payload['bpm']} bpm leaves {beats} beats"
+
+
+class TestMoodOutranksAlignment:
+    """Alignment is a nicety; the mood's tempo is the point of the track."""
+
+    def test_a_short_cadence_does_not_drag_a_calm_mood_up_to_dance_tempo(self):
+        """1s photos are 1 beat at 60 and 2 at 120; neither belongs under "serene"."""
+        bpm = beat_aligned_bpm(natural_bpm=68, cadence_seconds=1.0, tempo_range=(68, 132))
+
+        assert bpm == 68
+
+    def test_a_small_nudge_is_still_taken(self):
+        assert beat_aligned_bpm(natural_bpm=123, cadence_seconds=4.0, tempo_range=(72, 150)) == 120


### PR DESCRIPTION
First half of #312 — the "BPM-aware ACE-Step prompts" the issue title names. Beat-sync proper (locking cuts onto beats) follows in a second PR; see **Scope** below.

## The problem

Photos hold the screen for a fixed time, so their cuts arrive at a steady rate. Nothing related that rate to the music. A 4 s photo against a 123 bpm track is **8.2 beats** — so every cut landed somewhere different in the bar.

## Why the music adapts instead of the cuts

The pipeline decides its cuts long before it has any music:

1. the timeline is planned *before* analysis (`_pipeline_runner.py:338`)
2. Ken Burns motion is baked into the photo at render time (`photo_pipeline.py:536-542` — `n_frames = fps * duration`)
3. music is resolved *after* the video is already encoded (`generate.py:906`)

Re-timing photos would mean re-rendering them, or hoisting music resolution ahead of assembly and losing the property that a music failure can never invalidate the finished artifact. Choosing the *tempo* costs none of that — and it is the approach `docs/plans/future-features.md` #7 already settled on.

## Verified before building on it

ACE-Step is text-conditioned, so a requested tempo is **not** a guarantee — worth checking rather than assuming.

Measured across all 28 bundled tracks (generated at known requested BPMs) using a spectral-flux onset envelope and autocorrelation. A first pass looked mixed until every outlier turned out to sit at ratios like 0.667 and 1.33 — my estimator picking a different metric level, not the music being off-tempo. So I ran the non-circular test instead: score the autocorrelation at *exactly* the requested beat period.

| | result |
|---|---|
| tracks with strong periodicity at the requested period | **28/28** (median 0.97 of the global peak, min 0.68) |
| refined tempo error | **median 0.39%**, max 3.0% |
| within 2% | 27/28 |

ACE-Step honours the request. That also sets the honest ceiling on this PR — see Scope.

## Two guards so this never damages the music

- **Genre range.** The nudge stays inside the style's own `tempo_range`, so drum and bass is never asked for 70 bpm.
- **Mood range.** It also stays within 15% of the mood's tempo. The genre ranges are wide (acoustic is 68–132), so alignment *alone* would drag a serene 68 bpm mood up to 120 just to make a 1 s cadence whole. Alignment is a nicety; the mood is the point of the track. Where nothing fits, the mood wins unchanged.

## It actually fires

At the default 4 s photo duration, **all ten mood × style combinations land on whole beats**, largest shift 132 → 120:

| cadence | aligned | note |
|---|---|---|
| 4.0 s (default) | 10/10 | largest shift 132 → 120 bpm |
| 3.7 s (after budget trim) | 8/10 | guard correctly refuses a +19% jump on calm/acoustic |
| 5.0 s | 10/10 | |

The cadence is read off the **rendered clips**, not `config.photos.duration`: the final budget trim rescales every clip, so a "4 s" photo is often 3.7 s by the time music is chosen.

Self-gating — no photos means no cadence means no change, so no config knob was added.

## Scope — what this does not do

This aligns the cut **rate** to the pulse. It does not yet lock cuts **onto** beats: that needs a phase offset and each track's *measured* tempo, because the 0.39% residual accumulates across a long photo run. Separate concern, separate PR. Bundled-track selection by tempo belongs there too.

## Testing

- `make ci` green locally (4914 passed), `make docs-build` passes
- 12 new tests in `tests/test_beat_grid.py`, each checked for vacuity — the end-to-end one (cadence reaching the actual API payload) was verified to **fail** when the thread is cut and pass when restored
- Threading follows exactly how `memory_type` already travels to the caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM