### PR TITLE
fix(assembly): draw the date overlay that --add-date always promised

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3178,59 +3178,23 @@
       {
         "name": "streaming_assemble_full",
         "complexity": 16,
-        "line_start": 855,
-        "line_end": 952,
+        "line_start": 879,
+        "line_end": 978,
         "line_complexities": [
           {
-            "line": 874,
+            "line": 899,
             "complexity": 1
           },
           {
-            "line": 875,
+            "line": 900,
             "complexity": 0
           },
           {
-            "line": 878,
+            "line": 903,
             "complexity": 0
           },
           {
-            "line": 879,
-            "complexity": 0
-          },
-          {
-            "line": 880,
-            "complexity": 0
-          },
-          {
-            "line": 884,
-            "complexity": 2
-          },
-          {
-            "line": 890,
-            "complexity": 3
-          },
-          {
-            "line": 891,
-            "complexity": 0
-          },
-          {
-            "line": 892,
-            "complexity": 0
-          },
-          {
-            "line": 893,
-            "complexity": 3
-          },
-          {
-            "line": 894,
-            "complexity": 3
-          },
-          {
-            "line": 895,
-            "complexity": 0
-          },
-          {
-            "line": 896,
+            "line": 904,
             "complexity": 0
           },
           {
@@ -3238,19 +3202,55 @@
             "complexity": 0
           },
           {
-            "line": 923,
+            "line": 909,
             "complexity": 2
           },
           {
-            "line": 929,
+            "line": 915,
+            "complexity": 3
+          },
+          {
+            "line": 916,
             "complexity": 0
           },
           {
-            "line": 944,
+            "line": 917,
+            "complexity": 0
+          },
+          {
+            "line": 918,
+            "complexity": 3
+          },
+          {
+            "line": 919,
+            "complexity": 3
+          },
+          {
+            "line": 920,
+            "complexity": 0
+          },
+          {
+            "line": 921,
+            "complexity": 0
+          },
+          {
+            "line": 930,
+            "complexity": 0
+          },
+          {
+            "line": 949,
             "complexity": 2
           },
           {
-            "line": 950,
+            "line": 955,
+            "complexity": 0
+          },
+          {
+            "line": 970,
+            "complexity": 2
+          },
+          {
+            "line": 976,
             "complexity": 0
           }
         ]
@@ -3258,140 +3258,96 @@
       {
         "name": "assemble_streaming",
         "complexity": 24,
-        "line_start": 619,
-        "line_end": 744,
+        "line_start": 637,
+        "line_end": 765,
         "line_complexities": [
           {
-            "line": 641,
+            "line": 660,
             "complexity": 1
           },
           {
-            "line": 642,
+            "line": 661,
             "complexity": 0
           },
           {
-            "line": 644,
+            "line": 663,
             "complexity": 0
           },
           {
-            "line": 645,
+            "line": 664,
             "complexity": 0
           },
           {
-            "line": 646,
+            "line": 665,
             "complexity": 1
           },
           {
-            "line": 647,
+            "line": 666,
             "complexity": 1
           },
           {
-            "line": 648,
+            "line": 667,
             "complexity": 0
           },
           {
-            "line": 649,
+            "line": 668,
             "complexity": 0
           },
           {
-            "line": 651,
+            "line": 670,
             "complexity": 0
           },
           {
-            "line": 654,
+            "line": 673,
             "complexity": 3
           },
           {
-            "line": 655,
+            "line": 674,
             "complexity": 0
           },
           {
-            "line": 656,
+            "line": 675,
             "complexity": 0
           },
           {
-            "line": 662,
+            "line": 681,
             "complexity": 0
           },
           {
-            "line": 683,
+            "line": 703,
             "complexity": 1
           },
           {
-            "line": 684,
+            "line": 704,
             "complexity": 0
           },
           {
-            "line": 685,
+            "line": 705,
             "complexity": 2
           },
           {
-            "line": 686,
+            "line": 706,
             "complexity": 0
           },
           {
-            "line": 687,
+            "line": 707,
             "complexity": 0
           },
           {
-            "line": 710,
+            "line": 731,
             "complexity": 1
           },
           {
-            "line": 711,
+            "line": 732,
             "complexity": 0
           },
           {
-            "line": 713,
+            "line": 734,
             "complexity": 0
           },
           {
-            "line": 714,
+            "line": 735,
             "complexity": 2
-          },
-          {
-            "line": 715,
-            "complexity": 0
-          },
-          {
-            "line": 716,
-            "complexity": 0
-          },
-          {
-            "line": 717,
-            "complexity": 1
-          },
-          {
-            "line": 718,
-            "complexity": 0
-          },
-          {
-            "line": 720,
-            "complexity": 0
-          },
-          {
-            "line": 724,
-            "complexity": 1
-          },
-          {
-            "line": 725,
-            "complexity": 0
-          },
-          {
-            "line": 726,
-            "complexity": 2
-          },
-          {
-            "line": 727,
-            "complexity": 0
-          },
-          {
-            "line": 728,
-            "complexity": 0
-          },
-          {
-            "line": 730,
-            "complexity": 1
           },
           {
             "line": 736,
@@ -3399,32 +3355,76 @@
           },
           {
             "line": 737,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 738,
-            "complexity": 2
+            "complexity": 1
           },
           {
             "line": 739,
             "complexity": 0
           },
           {
-            "line": 740,
-            "complexity": 3
+            "line": 741,
+            "complexity": 0
           },
           {
-            "line": 742,
+            "line": 745,
             "complexity": 1
           },
           {
-            "line": 744,
+            "line": 746,
+            "complexity": 0
+          },
+          {
+            "line": 747,
+            "complexity": 2
+          },
+          {
+            "line": 748,
+            "complexity": 0
+          },
+          {
+            "line": 749,
+            "complexity": 0
+          },
+          {
+            "line": 751,
+            "complexity": 1
+          },
+          {
+            "line": 757,
+            "complexity": 0
+          },
+          {
+            "line": 758,
+            "complexity": 1
+          },
+          {
+            "line": 759,
+            "complexity": 2
+          },
+          {
+            "line": 760,
+            "complexity": 0
+          },
+          {
+            "line": 761,
+            "complexity": 3
+          },
+          {
+            "line": 763,
+            "complexity": 1
+          },
+          {
+            "line": 765,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 121
+    "complexity": 122
   },
   {
     "path": "src/immich_memories/processing/title_inserter.py",

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -51,7 +51,14 @@ immich-memories generate [OPTIONS]
 | `--output` | `-O` | path | auto | Output file path |
 | `--title` | — | string | — | Override title screen text |
 | `--subtitle` | — | string | — | Override subtitle text |
-| `--add-date` | — | flag | — | Add date overlay to clips |
+| `--add-date` | — | flag | — | Caption each clip with its capture date |
+
+`--add-date` writes the clip's own capture date in the bottom-right corner, as
+`5 Jan 2026` — spelled out rather than formatted by locale, so the caption reads
+the same wherever it runs. Size and inset scale with the frame, so a 4K memory
+and a 720p one look alike. Title cards and clips without a date are left alone.
+On HDR output the caption is drawn at HLG graphics white rather than full white,
+which would otherwise glare above the picture's own diffuse white.
 
 When `--resolution` is omitted, the command uses `output.resolution` from the config (1080p by
 default). Pass `--resolution auto` explicitly when you want the source clips to choose the output

--- a/src/immich_memories/processing/assembly_engine.py
+++ b/src/immich_memories/processing/assembly_engine.py
@@ -256,6 +256,7 @@ class AssemblyEngine:
             ctx=ctx,
             normalize_audio=self.settings.normalize_clip_audio,
             privacy_mode=self.settings.privacy_mode,
+            date_overlay=self.settings.add_date_overlay,
             scale_mode=self.settings.scale_mode,
             progress_callback=progress_callback,
             frame_preview_callback=frame_preview_callback,

--- a/src/immich_memories/processing/clip_caption.py
+++ b/src/immich_memories/processing/clip_caption.py
@@ -1,0 +1,57 @@
+"""The per-clip date caption: what it says and how it is drawn.
+
+Kept apart from the assembler because none of it depends on decoding — it is
+text and geometry, and it is worth testing without spinning up FFmpeg.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+# Spelled out rather than left to strftime so the caption does not change with
+# the machine's locale.
+_MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+# Caption metrics as a share of the frame's short side, so the date reads the
+# same on a 4K memory and a 720p one.
+_FONT_RATIO = 0.028
+_MARGIN_RATIO = 0.04
+
+# 0xBF is 75% of full range: HLG graphics white. Measured, plain white@0.85
+# draws at 872/1023 in a 10-bit pipe, which glares above the picture's own
+# diffuse white; this lands at 721.
+_HDR_COLOUR = "0xBFBFBF"
+_SDR_COLOUR = "white@0.85"
+
+
+def caption_for(clip: Any) -> str:
+    """The clip's capture date, or empty when it does not carry a usable one."""
+    raw = getattr(clip, "date", None)
+    if not raw:
+        return ""
+    try:
+        taken = date.fromisoformat(str(raw)[:10])
+    except ValueError:
+        return ""
+    return f"{taken.day} {_MONTHS[taken.month - 1]} {taken.year}"
+
+
+def caption_filter(text: str, width: int, height: int, *, is_hdr: bool = False) -> str:
+    """An FFmpeg drawtext filter placing ``text`` in the bottom-right corner.
+
+    Sized and inset off the short side so the caption holds its proportions
+    across output resolutions, with a drop shadow that keeps it legible over a
+    bright sky.
+    """
+    short_side = min(width, height)
+    font_size = max(12, round(short_side * _FONT_RATIO))
+    margin = round(short_side * _MARGIN_RATIO)
+    colour = _HDR_COLOUR if is_hdr else _SDR_COLOUR
+    return (
+        f"drawtext=text='{text}'"
+        f":fontsize={font_size}"
+        f":fontcolor={colour}"
+        f":shadowcolor=black@0.6:shadowx=2:shadowy=2"
+        f":x=w-tw-{margin}:y=h-th-{margin}"
+    )

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -38,6 +38,8 @@ from immich_memories.processing.streaming_audio import (
 if TYPE_CHECKING:
     from immich_memories.processing.probe_cache import ProbeCache
 
+from immich_memories.processing.clip_caption import caption_filter, caption_for
+
 logger = logging.getLogger(__name__)
 
 
@@ -90,6 +92,7 @@ class FrameDecoder:
         sdr_to_hdr_filter: str = "",
         input_seek: float = 0.0,
         audio_output: Path | None = None,
+        overlay_text: str = "",
     ) -> None:
         self._clip_path = clip_path
         self._input_seek = input_seek
@@ -109,6 +112,7 @@ class FrameDecoder:
         # Without this, SDR full-range data piped as yuv420p10le gets
         # interpreted as TV-range HLG = red/wrong tint.
         self._sdr_to_hdr_filter = sdr_to_hdr_filter
+        self._overlay_text = overlay_text
 
     def _build_vf(self) -> str:
         """Build the -vf filter chain matching filter_builder.build_clip_video_filter."""
@@ -176,6 +180,18 @@ class FrameDecoder:
         ):
             if color_filter:
                 parts.append(color_filter.removeprefix(","))
+
+        # Drawn last so the text is never scaled, padded or blurred with the
+        # source, and lands in target-frame coordinates.
+        if self._overlay_text:
+            parts.append(
+                caption_filter(
+                    self._overlay_text,
+                    self._width,
+                    self._height,
+                    is_hdr=self._pix_fmt != "rgb24",
+                )
+            )
 
         # Square pixels
         parts.append("setsar=1")
@@ -534,6 +550,7 @@ def _make_decoder(
     fps: int,
     ctx: Any | None = None,
     privacy_mode: bool = False,
+    date_overlay: bool = False,
     scale_mode: str = "black",
     hdr_type: str | None = None,
     audio_work_dir: Path | None = None,
@@ -590,6 +607,7 @@ def _make_decoder(
         sdr_to_hdr_filter=sdr_to_hdr_filter,
         input_seek=getattr(clip, "input_seek", 0.0),
         audio_output=audio_output,
+        overlay_text=caption_for(clip) if date_overlay and not is_title else "",
     )
 
 
@@ -627,6 +645,7 @@ def assemble_streaming(
     encoding_plan: EncodingPlan | None = None,
     ctx: Any | None = None,
     privacy_mode: bool = False,
+    date_overlay: bool = False,
     scale_mode: str = "blur",
     progress_callback: Callable[[int, int], None] | None = None,
     frame_preview_callback: Callable[[bytes], None] | None = None,
@@ -670,6 +689,7 @@ def assemble_streaming(
             fallback_plan,
             ctx,
             privacy_mode,
+            date_overlay,
             scale_mode,
             progress_callback,
             frame_preview_callback,
@@ -701,6 +721,7 @@ def assemble_streaming(
             fps,
             ctx,
             privacy_mode,
+            date_overlay,
             scale_mode,
             hdr_type,
             progress_callback,
@@ -758,6 +779,7 @@ def _encode_clip_sequence(
     fps: int,
     ctx: Any | None,
     privacy_mode: bool,
+    date_overlay: bool,
     scale_mode: str,
     hdr_type: str | None,
     progress_callback: Callable[[int, int], None] | None,
@@ -781,6 +803,7 @@ def _encode_clip_sequence(
                 fps,
                 ctx,
                 privacy_mode,
+                date_overlay,
                 scale_mode,
                 hdr_type,
                 audio_work_dir=audio_work_dir,
@@ -815,6 +838,7 @@ def _encode_clip_sequence(
                 fps,
                 ctx,
                 privacy_mode,
+                date_overlay,
                 scale_mode,
                 hdr_type,
                 audio_work_dir=audio_work_dir,
@@ -864,6 +888,7 @@ def streaming_assemble_full(
     ctx: Any | None = None,
     normalize_audio: bool = True,
     privacy_mode: bool = False,
+    date_overlay: bool = False,
     scale_mode: str = "blur",
     progress_callback: Callable[[float, str], None] | None = None,
     frame_preview_callback: Callable[[bytes], None] | None = None,
@@ -913,6 +938,7 @@ def streaming_assemble_full(
             encoding_plan=plan,
             ctx=ctx,
             privacy_mode=privacy_mode,
+            date_overlay=date_overlay,
             scale_mode=scale_mode,
             progress_callback=_frame_progress,
             frame_preview_callback=frame_preview_callback,

--- a/tests/integration/processing/test_date_overlay_real.py
+++ b/tests/integration/processing/test_date_overlay_real.py
@@ -1,0 +1,69 @@
+"""The date overlay renders actual pixels (#313).
+
+The unit tests assert the filter string; only FFmpeg can say whether the text
+is really drawn. That distinction is the whole point here: the option was
+plumbed end to end and drew nothing for its entire life.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from immich_memories.processing.streaming_assembler import FrameDecoder
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def grey_clip(tmp_path_factory) -> Path:
+    """A flat mid-grey clip, so any pixel variation comes from the caption."""
+    out = tmp_path_factory.mktemp("overlay") / "grey.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=gray:size=640x360:rate=10:duration=1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return out
+
+
+def _first_frame(clip: Path, **kwargs) -> np.ndarray:
+    decoder = FrameDecoder(clip, width=640, height=360, fps=10, **kwargs)
+    return next(iter(decoder)).copy()
+
+
+def test_the_caption_is_actually_drawn(grey_clip: Path) -> None:
+    plain = _first_frame(grey_clip)
+    captioned = _first_frame(grey_clip, overlay_text="5 Jan 2026")
+
+    assert not np.array_equal(plain, captioned), "overlay changed nothing"
+
+
+def test_the_caption_lands_in_the_bottom_corner(grey_clip: Path) -> None:
+    """Bottom-right, inset — not centred over the subject's face."""
+    plain = _first_frame(grey_clip)
+    captioned = _first_frame(grey_clip, overlay_text="5 Jan 2026")
+
+    changed = np.argwhere(np.any(plain != captioned, axis=-1))
+    assert changed.size, "overlay changed nothing"
+    rows, cols = changed[:, 0], changed[:, 1]
+
+    assert rows.min() > 360 * 0.7, "caption is not in the lower part of the frame"
+    assert cols.min() > 640 * 0.5, "caption is not on the right"
+    assert rows.max() < 360, "caption runs off the bottom edge"
+    assert cols.max() < 640, "caption runs off the right edge"

--- a/tests/test_date_overlay.py
+++ b/tests/test_date_overlay.py
@@ -1,0 +1,136 @@
+"""The per-clip date overlay (#313).
+
+`--add-date` and the Step 3 switch have always been plumbed as far as
+``AssemblySettings.add_date_overlay`` and then read by nothing, while the CLI
+run summary printed "Date Overlay: Enabled". These cover the wiring that makes
+the option mean something.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.processing.streaming_assembler import FrameDecoder
+
+
+def _decoder(**kwargs) -> FrameDecoder:
+    return FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30, **kwargs)
+
+
+class TestOverlayIsDrawn:
+    def test_the_date_reaches_the_filter_chain(self):
+        vf = _decoder(overlay_text="5 Jan 2026")._build_vf()
+
+        assert "drawtext=" in vf
+        assert "5 Jan 2026" in vf
+
+    def test_no_overlay_without_text(self):
+        assert "drawtext" not in _decoder()._build_vf()
+
+
+class TestOverlayScalesWithTheFrame:
+    """A fixed 24 px date is unreadable at 4K and huge on a phone-sized render."""
+
+    def test_font_size_grows_with_the_frame(self):
+        hd = FrameDecoder(Path("/f.mp4"), width=1920, height=1080, fps=30, overlay_text="x")
+        uhd = FrameDecoder(Path("/f.mp4"), width=3840, height=2160, fps=30, overlay_text="x")
+
+        assert _font_size(uhd._build_vf()) > _font_size(hd._build_vf())
+
+    def test_text_stays_clear_of_the_frame_edge(self):
+        vf = _decoder(overlay_text="x")._build_vf()
+
+        assert "x=w-tw-" in vf
+        assert "y=h-th-" in vf
+
+    def test_text_is_readable_over_a_bright_background(self):
+        """White-on-white is invisible; the shadow is what guarantees contrast."""
+        vf = _decoder(overlay_text="x")._build_vf()
+
+        assert "shadowcolor=" in vf
+
+
+def _font_size(vf: str) -> int:
+    import re
+
+    match = re.search(r"fontsize=(\d+)", vf)
+    assert match, f"no fontsize in {vf}"
+    return int(match.group(1))
+
+
+class TestWhatGetsCaptioned:
+    """The date comes off the clip; the option decides whether it is drawn."""
+
+    def test_the_clips_date_is_captioned_when_the_option_is_on(self):
+        from immich_memories.processing.streaming_assembler import _make_decoder
+
+        decoder = _make_decoder(_fake_clip(date="2026-01-05"), 0, 1920, 1080, 30, date_overlay=True)
+
+        assert "5 Jan 2026" in decoder._build_vf()
+
+    def test_nothing_is_drawn_when_the_option_is_off(self):
+        from immich_memories.processing.streaming_assembler import _make_decoder
+
+        decoder = _make_decoder(_fake_clip(date="2026-01-05"), 0, 1920, 1080, 30)
+
+        assert "drawtext" not in decoder._build_vf()
+
+    def test_a_title_card_gets_no_date(self):
+        """The title card is not a moment; stamping it with a date reads as a bug."""
+        from immich_memories.processing.streaming_assembler import _make_decoder
+
+        clip = _fake_clip(date="2026-01-05", is_title_screen=True)
+        decoder = _make_decoder(clip, 0, 1920, 1080, 30, date_overlay=True)
+
+        assert "drawtext" not in decoder._build_vf()
+
+    def test_a_clip_with_no_date_is_left_alone(self):
+        from immich_memories.processing.streaming_assembler import _make_decoder
+
+        decoder = _make_decoder(_fake_clip(date=None), 0, 1920, 1080, 30, date_overlay=True)
+
+        assert "drawtext" not in decoder._build_vf()
+
+
+def _fake_clip(date, is_title_screen=False):
+    from immich_memories.processing.assembly_config import AssemblyClip
+
+    return AssemblyClip(
+        path=Path("/does-not-exist.mp4"),
+        duration=4.0,
+        date=date,
+        asset_id="a",
+        is_title_screen=is_title_screen,
+    )
+
+
+class TestHdrCaptionBrightness:
+    """Measured: white@0.85 lands at 872/1023 in a 10-bit pipeline.
+
+    HLG puts graphics white at 75% of code range (~203 nits); anything above
+    that glares next to the picture instead of sitting on it. SDR has no such
+    headroom, so its caption stays white.
+    """
+
+    def test_hdr_output_draws_the_caption_below_graphics_white(self):
+        hdr = FrameDecoder(
+            Path("/f.mp4"),
+            width=1920,
+            height=1080,
+            fps=30,
+            pix_fmt="yuv420p10le",
+            overlay_text="x",
+        )
+
+        assert "fontcolor=white" not in hdr._build_vf()
+
+    def test_sdr_output_keeps_a_white_caption(self):
+        assert "fontcolor=white" in _decoder(overlay_text="x")._build_vf()
+
+
+class TestMalformedDates:
+    def test_an_unparseable_date_captions_nothing_rather_than_raising(self):
+        """Clip dates come from Immich metadata; a broken one must not stop a render."""
+        from immich_memories.processing.clip_caption import caption_for
+
+        assert caption_for(_fake_clip(date="not-a-date")) == ""


### PR DESCRIPTION
First slice of #313 — the per-clip date overlay. Place names, 9:16 title safe zones and short-form duration presets are the issue's other parts and are **not** in this PR.

## `--add-date` has never drawn anything

The flag is plumbed through six files to `AssemblySettings.add_date_overlay` (`assembly_config.py:122`) and read by **nothing**. The only per-clip `drawtext` in the tree, `transforms_ffmpeg.add_date_overlay:421`, is reachable only via `transforms.py:372`, which has no callers. Every other `drawtext` is title rendering.

Worse than dead — two surfaces claim it works:

- `cli/generate.py:166` prints **"Date Overlay: Enabled"** in the run summary
- `step3_options.py:254` offers an **"Add date overlay"** switch

Both tell the user the option is on while nothing draws a pixel. (Independently logged as S17 in the local security/perf review, flagged for #309's wire-or-delete list. Wiring it is the resolution; the streaming path simply never had a drawtext.)

## The wiring

The setting now reaches `_make_decoder`, which **already receives the whole clip** — so the date itself needs no new plumbing. Only the boolean travels, by the same route `privacy_mode` already takes.

Deliberately **no `config` object in `streaming_assembler.py`**: that file has never had one, and threading it in just for a date format would build the same plumbing that belongs with the hwaccel work. Coordinated with the session working on that file.

## Caption choices, each with a reason

| Choice | Why |
|---|---|
| Month spelled out (`5 Jan 2026`), not `strftime` | Otherwise the same memory captions differently depending on the machine's locale. Same reason the titles code carries its own `_MONTH_NAMES`. |
| Size + inset scale off the frame's short side | A fixed 24 px date is unreadable at 4K and oversized on a phone-sized render. |
| HDR draws `0xBFBFBF`, SDR keeps white | **Measured**: `white@0.85` through a real 10-bit pipe peaks at **872/1023**. HLG puts graphics white at 75% of code range (~203 nits), so plain white glares *above* the picture's own diffuse white. The HDR colour re-measures at **721/1023**. SDR has no headroom to give away. |
| Title cards and dateless clips skipped | A date stamped on the title card reads as a bug. |

## The file-length gate, and why this split

Adding 65 lines took `streaming_assembler.py` from 952 to **1017**, past the 1000-line hard limit. Rather than shave lines to squeeze under, the caption logic moved to `processing/clip_caption.py` — a real cohesion boundary: text and geometry, no dependency on decoding, and testable without FFmpeg. File is back to 978.

Every existing test survived that move unmodified, which is the evidence they describe behaviour rather than structure.

## Testing

- `make ci` green locally (4914 passed), `make docs-build` passes
- 12 unit tests in `tests/test_date_overlay.py`
- **An integration test that decodes a flat grey clip through real FFmpeg** (`tests/integration/processing/test_date_overlay_real.py`) and asserts the pixels actually change and land in the lower-right corner. Asserting `"drawtext" in vf` is exactly the check that would have passed for this option's entire broken life — hence pixels.

## Note for reviewers

`streaming_assembler.py` now has ~22 lines of headroom under the hard gate, not 48. The hwaccel work planned for that file will likely need its own extraction rather than an inline addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM