### PR TITLE
fix(security): create secret files 0600 instead of chmod-ing them after

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3756,77 +3756,77 @@
       {
         "name": "configured_secret_values",
         "complexity": 23,
-        "line_start": 19,
-        "line_end": 42,
+        "line_start": 44,
+        "line_end": 67,
         "line_complexities": [
           {
-            "line": 21,
+            "line": 46,
             "complexity": 0
           },
           {
-            "line": 22,
+            "line": 47,
             "complexity": 0
           },
           {
-            "line": 23,
+            "line": 48,
             "complexity": 1
           },
           {
-            "line": 24,
+            "line": 49,
             "complexity": 0
           },
           {
-            "line": 25,
+            "line": 50,
             "complexity": 2
           },
           {
-            "line": 26,
+            "line": 51,
             "complexity": 3
           },
           {
-            "line": 27,
+            "line": 52,
             "complexity": 0
           },
           {
-            "line": 28,
+            "line": 53,
             "complexity": 4
           },
           {
-            "line": 29,
+            "line": 54,
             "complexity": 6
           },
           {
-            "line": 31,
+            "line": 56,
             "complexity": 1
           },
           {
-            "line": 33,
+            "line": 58,
             "complexity": 1
           },
           {
-            "line": 35,
+            "line": 60,
             "complexity": 1
           },
           {
-            "line": 38,
+            "line": 63,
             "complexity": 0
           },
           {
-            "line": 39,
+            "line": 64,
             "complexity": 1
           },
           {
-            "line": 40,
+            "line": 65,
             "complexity": 3
           },
           {
-            "line": 42,
+            "line": 67,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 35
+    "complexity": 36
   },
   {
     "path": "src/immich_memories/titles/sdf_font.py",

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -43,6 +43,7 @@ from immich_memories.config_models import (
 from immich_memories.config_models_auth import AuthConfig
 from immich_memories.config_presets import PresetName, apply_preset
 from immich_memories.scheduling.models import SchedulerConfig
+from immich_memories.security import write_secret_file
 
 # Tier 2 sections — grouped under `advanced:` in YAML, flat on Config at runtime.
 _TIER2_SECTIONS = frozenset(
@@ -209,11 +210,7 @@ class Config(BaseSettings):
         if advanced:
             data["advanced"] = advanced
 
-        with path.open("w") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
-        # Restrict config file permissions (contains API keys)
-        with contextlib.suppress(OSError):
-            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600 - owner read/write only
+        write_secret_file(path, yaml.dump(data, default_flow_style=False, sort_keys=False))
 
     @classmethod
     def get_default_path(cls) -> Path:

--- a/src/immich_memories/security.py
+++ b/src/immich_memories/security.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import re
+import stat
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -14,6 +16,29 @@ logger = logging.getLogger(__name__)
 # Control characters for sanitizing filenames
 _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
 _CREDENTIAL_FIELD_NAMES = frozenset({"api_key", "password", "client_secret"})
+
+
+def write_secret_file(path: Path, text: str) -> None:
+    """Write a file that only its owner can read, from the moment it exists.
+
+    `open("w")`/`write_text` create with the process umask -- 0644 on a normal
+    system -- so narrowing the file afterwards with chmod leaves the secret
+    world-readable in between. On a shared box or a NAS that window is the whole
+    exposure, and it is invisible after the fact because the file looks correct
+    by the time anyone inspects it. Creating at 0600 and renaming into place also
+    means a crash mid-write cannot leave a truncated secret behind.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+        raise
 
 
 def configured_secret_values(config: BaseModel) -> tuple[str, ...]:

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -24,7 +24,11 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 from immich_memories import __version__
 from immich_memories.automation.in_process_scheduler import automation_scheduler
 from immich_memories.config import get_config, init_config_dir
-from immich_memories.security import configured_secret_values, sanitize_error_message
+from immich_memories.security import (
+    configured_secret_values,
+    sanitize_error_message,
+    write_secret_file,
+)
 from immich_memories.ui.auth import (
     clear_session,
     is_auth_enabled,
@@ -54,10 +58,8 @@ def _get_storage_secret() -> str:
     secret_path = Path.home() / ".immich-memories" / ".storage_secret"
     if secret_path.exists():
         return secret_path.read_text().strip()
-    secret_path.parent.mkdir(parents=True, exist_ok=True)
     secret = secrets.token_hex(32)
-    secret_path.write_text(secret)
-    secret_path.chmod(0o600)
+    write_secret_file(secret_path, secret)
     return secret
 
 

--- a/tests/test_config_file_permissions.py
+++ b/tests/test_config_file_permissions.py
@@ -1,0 +1,139 @@
+"""config.yaml holds the Immich API key, so it must never exist world-readable.
+
+`open("w")` creates a file with the process umask -- 0644 on a normal system --
+and only a later `chmod` narrows it. Between those two calls the API key is on
+disk readable by every account on the machine. On a NAS or a shared box that is
+the whole exposure, and it is invisible in testing because the file looks
+correct by the time anyone checks.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from immich_memories.config_loader import Config
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_saved_config_is_owner_only(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+
+    Config().save_yaml(path)
+
+    assert _mode(path) == 0o600
+
+
+def test_the_file_is_never_created_wider_than_0600(tmp_path: Path, monkeypatch):
+    """Proves the permissions come from creation, not from a later chmod.
+
+    With chmod disabled, a file created via `open("w")` keeps the umask bits and
+    this fails; a file created at 0600 passes.
+    """
+    path = tmp_path / "config.yaml"
+    monkeypatch.setattr(Path, "chmod", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(os, "chmod", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(os, "umask", lambda _mask: 0)
+
+    Config().save_yaml(path)
+
+    assert _mode(path) == 0o600, "config.yaml was created with umask permissions"
+
+
+def test_replacing_an_existing_config_does_not_widen_it(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    path.write_text("old: value\n")
+    path.chmod(0o644)
+
+    Config().save_yaml(path)
+
+    assert _mode(path) == 0o600
+
+
+def test_the_saved_file_is_still_readable_config(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    config = Config()
+    config.immich.url = "http://example.invalid:2283"
+
+    config.save_yaml(path)
+
+    assert Config.from_yaml(path).immich.url == "http://example.invalid:2283"
+
+
+class TestStorageSecretFile:
+    """`.storage_secret` signs session cookies. A local account that reads it
+    during the window between creation and chmod can forge a session.
+    """
+
+    def test_generated_secret_file_is_owner_only(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("IMMICH_MEMORIES_STORAGE_SECRET", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+        from immich_memories.ui.app import _get_storage_secret
+
+        secret = _get_storage_secret()
+
+        path = tmp_path / ".immich-memories" / ".storage_secret"
+        assert path.read_text() == secret
+        assert _mode(path) == 0o600
+
+    def test_the_secret_file_is_never_created_wider_than_0600(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("IMMICH_MEMORIES_STORAGE_SECRET", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+        monkeypatch.setattr(Path, "chmod", lambda *_a, **_k: None)
+        monkeypatch.setattr(os, "chmod", lambda *_a, **_k: None)
+        from immich_memories.ui.app import _get_storage_secret
+
+        _get_storage_secret()
+
+        path = tmp_path / ".immich-memories" / ".storage_secret"
+        assert _mode(path) == 0o600
+
+    def test_an_existing_secret_is_reused_untouched(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("IMMICH_MEMORIES_STORAGE_SECRET", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+        path = tmp_path / ".immich-memories" / ".storage_secret"
+        path.parent.mkdir(parents=True)
+        path.write_text("existing-secret")
+        from immich_memories.ui.app import _get_storage_secret
+
+        assert _get_storage_secret() == "existing-secret"
+
+
+class TestFailedWriteLeavesNoDebris:
+    def test_a_failure_removes_the_temp_file_and_propagates(self, tmp_path: Path, monkeypatch):
+        """A half-written secret must not survive, and the caller must be told."""
+        from immich_memories import security
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        # WHY: stands in for the filesystem failing mid-save.
+        monkeypatch.setattr(security.os, "replace", boom)
+        target = tmp_path / "config.yaml"
+
+        with pytest.raises(OSError, match="disk full"):
+            security.write_secret_file(target, "secret")
+
+        assert not target.exists()
+        assert list(tmp_path.iterdir()) == [], "a temp file was left behind"
+
+    def test_an_existing_file_survives_a_failed_rewrite(self, tmp_path: Path, monkeypatch):
+        from immich_memories import security
+
+        target = tmp_path / "config.yaml"
+        security.write_secret_file(target, "original")
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(security.os, "replace", boom)
+        with pytest.raises(OSError):
+            security.write_secret_file(target, "replacement")
+
+        assert target.read_text() == "original"


### PR DESCRIPTION
## The window

Both files that hold a secret were created with the process umask and only
narrowed **afterwards**:

```python
# config.yaml
with path.open("w") as f: yaml.dump(data, f)
path.chmod(0o600)                              # ← too late

# .storage_secret
secret_path.write_text(secret)
secret_path.chmod(0o600)                       # ← too late
```

`write_text` produces **0644** on a normal system (verified directly, not
assumed). Between the write and the chmod, the Immich API key and the
session-signing secret are readable by every account on the machine. On a NAS or
any shared host that window *is* the exposure — and it leaves no trace, because
by the time anyone inspects the file the permissions look correct.

`.storage_secret` is the worse of the two: it signs session cookies, so a local
reader who catches the window can **forge a session**, not merely read data.

## The fix

Both now go through `security.write_secret_file`, which creates at 0600 with
`os.open(..., O_CREAT, S_IRUSR | S_IWUSR)` and renames into place. The rename
closes a second failure mode as well: a crash mid-write previously left a
truncated `config.yaml` or a partial secret behind.

## Tests

The one that matters disables `chmod` and asserts the mode is *still* 0600 —
that distinguishes "created correctly" from "fixed up afterwards", which a
plain `assert mode == 0600` does not. It fails on the old code:

| Test | Old | New |
|---|---|---|
| mode after save | 0600 | 0600 |
| **mode with chmod disabled** | **0644** | **0600** |
| replacing an existing 0644 file | stays 0644 until chmod | 0600 |
| failed write | temp debris, possible truncation | temp removed, original intact |

Also covered: an existing `.storage_secret` is reused untouched, and the saved
config still round-trips through `Config.from_yaml`.

## Scope

Part of #320, which stays open. The other half — Save Config persisting
env-provided secrets into `config.yaml` — is a genuinely separate change:
`expand_env_vars` runs inside field validators, so the pre-expansion `${VAR}`
form is discarded at load time and has to be preserved before it can be written
back. Doing that properly is its own PR rather than a rider on this one.

Deliberately avoids `ui/pages/step1_config.py`, which #376 is currently
changing; nothing here needs it.
