### PR TITLE
fix(security): stop Save writing environment-provided secrets into config.yaml

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3756,71 +3756,71 @@
       {
         "name": "configured_secret_values",
         "complexity": 23,
-        "line_start": 44,
-        "line_end": 67,
+        "line_start": 45,
+        "line_end": 68,
         "line_complexities": [
-          {
-            "line": 46,
-            "complexity": 0
-          },
           {
             "line": 47,
             "complexity": 0
           },
           {
             "line": 48,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 49,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 50,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 51,
-            "complexity": 3
+            "complexity": 2
           },
           {
             "line": 52,
-            "complexity": 0
-          },
-          {
-            "line": 53,
-            "complexity": 4
-          },
-          {
-            "line": 54,
-            "complexity": 6
-          },
-          {
-            "line": 56,
-            "complexity": 1
-          },
-          {
-            "line": 58,
-            "complexity": 1
-          },
-          {
-            "line": 60,
-            "complexity": 1
-          },
-          {
-            "line": 63,
-            "complexity": 0
-          },
-          {
-            "line": 64,
-            "complexity": 1
-          },
-          {
-            "line": 65,
             "complexity": 3
           },
           {
-            "line": 67,
+            "line": 53,
+            "complexity": 0
+          },
+          {
+            "line": 54,
+            "complexity": 4
+          },
+          {
+            "line": 55,
+            "complexity": 6
+          },
+          {
+            "line": 57,
+            "complexity": 1
+          },
+          {
+            "line": 59,
+            "complexity": 1
+          },
+          {
+            "line": 61,
+            "complexity": 1
+          },
+          {
+            "line": 64,
+            "complexity": 0
+          },
+          {
+            "line": 65,
+            "complexity": 1
+          },
+          {
+            "line": 66,
+            "complexity": 3
+          },
+          {
+            "line": 68,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -14,7 +14,7 @@ import stat
 from pathlib import Path
 
 import yaml
-from pydantic import Field, model_validator
+from pydantic import Field, PrivateAttr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from immich_memories.config_models import (
@@ -43,7 +43,7 @@ from immich_memories.config_models import (
 from immich_memories.config_models_auth import AuthConfig
 from immich_memories.config_presets import PresetName, apply_preset
 from immich_memories.scheduling.models import SchedulerConfig
-from immich_memories.security import write_secret_file
+from immich_memories.security import CREDENTIAL_FIELD_NAMES, write_secret_file
 
 # Tier 2 sections — grouped under `advanced:` in YAML, flat on Config at runtime.
 _TIER2_SECTIONS = frozenset(
@@ -110,6 +110,64 @@ class _YamlSettingsSource(PydanticBaseSettingsSource):
         return _yaml_source_data.copy()
 
 
+# Environment variables the loader reads for a credential beyond the mechanical
+# IMMICH_MEMORIES_<SECTION>__<FIELD> form (see _apply_env_overrides).
+_CREDENTIAL_ENV_ALIASES: dict[str, tuple[str, ...]] = {
+    "immich.api_key": ("IMMICH_API_KEY",),
+    "llm.api_key": ("OPENAI_API_KEY",),
+    "musicgen.api_key": ("MUSICGEN_API_KEY",),
+    "ace_step.api_key": ("ACE_STEP_API_KEY",),
+    "auth.password": ("IMMICH_MEMORIES_AUTH_PASSWORD",),
+}
+
+
+def _feeder_env_vars(path: str) -> tuple[str, ...]:
+    section, _, field = path.partition(".")
+    settings_name = f"IMMICH_MEMORIES_{section.upper()}__{field.upper()}"
+    return (*_CREDENTIAL_ENV_ALIASES.get(path, ()), settings_name)
+
+
+def _credential_templates(data: dict) -> dict[str, str]:
+    """Record the `${VAR}` forms written in the file before expansion loses them."""
+    templates: dict[str, str] = {}
+    for section, values in data.items():
+        if not isinstance(values, dict):
+            continue
+        for field, value in values.items():
+            if field in CREDENTIAL_FIELD_NAMES and isinstance(value, str) and "$" in value:
+                templates[f"{section}.{field}"] = value
+    return templates
+
+
+def _text_to_persist(path: str, value: str, templates: dict[str, str]) -> str | None:
+    """What to write for a credential, or None to write the value verbatim."""
+    if not value:
+        return None
+    if template := templates.get(path):
+        return template
+    for name in _feeder_env_vars(path):
+        if os.environ.get(name) == value:
+            return f"${{{name}}}"
+    return None
+
+
+def _keep_env_secrets_out(data: dict, templates: dict[str, str]) -> None:
+    """Replace env-provided credentials with the reference that supplied them.
+
+    A key the user deliberately kept in the environment must not be written to
+    disk by pressing Save -- the file outlives the container that had the env
+    var, and it is the one artifact most likely to be copied or backed up.
+    """
+    for section, values in data.items():
+        if not isinstance(values, dict):
+            continue
+        for field, value in values.items():
+            if field not in CREDENTIAL_FIELD_NAMES or not isinstance(value, str):
+                continue
+            if replacement := _text_to_persist(f"{section}.{field}", value, templates):
+                values[field] = replacement
+
+
 class Config(BaseSettings):
     """Main configuration for Immich Memories.
 
@@ -164,6 +222,10 @@ class Config(BaseSettings):
     automation: AutomationConfig = Field(default_factory=AutomationConfig)
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
 
+    # `${VAR}` forms as written in config.yaml, so Save can put them back
+    # instead of the secrets they expanded to.
+    _credential_templates: dict[str, str] = PrivateAttr(default_factory=dict)
+
     @model_validator(mode="after")
     def _apply_preset(self) -> Config:
         apply_preset(self)
@@ -180,7 +242,9 @@ class Config(BaseSettings):
         global _yaml_source_data
         _yaml_source_data = _load_yaml_data(path)
         try:
-            return cls()
+            config = cls()
+            config._credential_templates = _credential_templates(_yaml_source_data)
+            return config
         finally:
             _yaml_source_data = {}
 
@@ -201,6 +265,7 @@ class Config(BaseSettings):
         """Save configuration to a YAML file (tiered format)."""
         path.parent.mkdir(parents=True, exist_ok=True)
         data = self.model_dump()
+        _keep_env_secrets_out(data, self._credential_templates)
 
         # Group tier 2 sections under advanced:
         advanced: dict = {}

--- a/src/immich_memories/security.py
+++ b/src/immich_memories/security.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 # Control characters for sanitizing filenames
 _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
-_CREDENTIAL_FIELD_NAMES = frozenset({"api_key", "password", "client_secret"})
+# Field names that hold a secret, wherever they appear in the config tree.
+CREDENTIAL_FIELD_NAMES = frozenset({"api_key", "password", "client_secret"})
 
 
 def write_secret_file(path: Path, text: str) -> None:
@@ -50,7 +51,7 @@ def configured_secret_values(config: BaseModel) -> tuple[str, ...]:
         if isinstance(value, BaseModel):
             for field_name in type(value).model_fields:
                 field_value = getattr(value, field_name)
-                if field_name in _CREDENTIAL_FIELD_NAMES:
+                if field_name in CREDENTIAL_FIELD_NAMES:
                     if isinstance(field_value, str) and field_value:
                         secrets.add(field_value)
                 else:

--- a/tests/test_config_env_secrets.py
+++ b/tests/test_config_env_secrets.py
@@ -1,0 +1,82 @@
+"""Saving config must not bake environment-provided secrets into config.yaml.
+
+Docker and Kubernetes users deliberately keep the Immich API key out of the
+config file and supply it through the environment, either as `${VAR}` inside the
+YAML or as `IMMICH_API_KEY`. Pressing Save in the UI dumped the *resolved*
+values, writing the secret to disk permanently and silently undoing that choice
+-- and the file then outlives the container that had the env var.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.config_loader import Config
+
+FROM_ENV = "sk-do-not-write-me-to-disk"
+
+
+def test_a_templated_key_is_saved_as_its_template(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MY_IMMICH_KEY", FROM_ENV)
+    source = tmp_path / "config.yaml"
+    source.write_text("immich:\n  url: http://immich.invalid\n  api_key: ${MY_IMMICH_KEY}\n")
+    config = Config.from_yaml(source)
+    assert config.immich.api_key == FROM_ENV, "expansion should still work in memory"
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+
+    text = out.read_text()
+    assert FROM_ENV not in text, "the resolved secret was written to disk"
+    assert "${MY_IMMICH_KEY}" in text
+
+
+def test_a_key_supplied_by_an_env_var_is_not_written(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("IMMICH_API_KEY", FROM_ENV)
+    config = Config()
+    config.immich.api_key = FROM_ENV
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+
+    text = out.read_text()
+    assert FROM_ENV not in text
+    assert "${IMMICH_API_KEY}" in text
+
+
+def test_a_key_typed_by_hand_is_preserved(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("IMMICH_API_KEY", raising=False)
+    config = Config()
+    config.immich.api_key = "typed-by-a-human"
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+
+    assert "typed-by-a-human" in out.read_text()
+    assert Config.from_yaml(out).immich.api_key == "typed-by-a-human"
+
+
+def test_a_templated_secret_round_trips(tmp_path: Path, monkeypatch):
+    """Saving then loading must not lose the value."""
+    monkeypatch.setenv("MY_IMMICH_KEY", FROM_ENV)
+    source = tmp_path / "config.yaml"
+    source.write_text("immich:\n  api_key: ${MY_IMMICH_KEY}\n")
+
+    out = tmp_path / "saved.yaml"
+    Config.from_yaml(source).save_yaml(out)
+
+    assert Config.from_yaml(out).immich.api_key == FROM_ENV
+
+
+def test_other_credential_fields_are_covered_too(tmp_path: Path, monkeypatch):
+    """auth.password and the tier-2 api_keys are secrets by the same rule."""
+    monkeypatch.setenv("IMMICH_MEMORIES_AUTH_PASSWORD", FROM_ENV)
+    monkeypatch.setenv("OPENAI_API_KEY", FROM_ENV)
+    config = Config()
+    config.auth.password = FROM_ENV
+    config.llm.api_key = FROM_ENV
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+
+    assert FROM_ENV not in out.read_text()


### PR DESCRIPTION
## The problem

Docker and Kubernetes users deliberately keep the Immich API key **out** of the
config file, supplying it as `${VAR}` inside the YAML or as `IMMICH_API_KEY`.
`save_yaml` dumped the resolved model, so pressing **Save** in the UI wrote the
real secret to disk and silently undid that choice.

That file then outlives the container that had the env var, and `config.yaml` is
the single artifact most likely to be copied, backed up, or pasted into a GitHub
issue.

Three separate paths put an environment value into the model, and all three were
being persisted:

| Path | Example |
|---|---|
| `${VAR}` expansion in field validators | `api_key: ${MY_IMMICH_KEY}` |
| `_apply_env_overrides` | `IMMICH_API_KEY`, `OPENAI_API_KEY`, `MUSICGEN_API_KEY`, auth password |
| pydantic-settings | `IMMICH_MEMORIES_IMMICH__API_KEY` |

## The fix

Save writes back **the reference that supplied the value**, not the value:

1. The `${VAR}` form exactly as written in `config.yaml`. Expansion happens in
   validators and discards it, so `from_yaml` records the templates from the raw
   YAML *before* constructing the model.
2. Otherwise, if the current value equals an environment variable the loader
   reads for that field, `${THAT_VAR}`. This catches the other two paths without
   having to track where every value came from.

A credential typed by hand is written verbatim, unchanged — that case has a test.

## Coverage

Applies to every field named `api_key`, `password` or `client_secret` anywhere
in the tree (six today: `immich`, `llm`, `musicgen`, `ace_step`, `auth.password`,
`auth.client_secret`) by reusing the same set `security.configured_secret_values`
uses, so the two definitions cannot drift. That constant is now public
(`CREDENTIAL_FIELD_NAMES`) rather than config_loader reaching across modules for
a private name.

## Tests

`tests/test_config_env_secrets.py` — a templated key saves as its template; an
env-var-supplied key is never written; a hand-typed key is preserved; a
templated secret round-trips through save → load; `auth.password` and the tier-2
`api_key`s are covered by the same rule. Three of the five fail on `main`.

## Note for the reviewer

This is the second half of #320; [#380](https://github.com/sam-dumont/immich-video-memory-generator/pull/380)
is the first (creating those files 0600 rather than chmod-ing them after). Both
touch `save_yaml`, so whichever merges second will need a trivial rebase — the
changes are adjacent but independent: #380 changes *how the bytes are written*,
this changes *what the bytes contain*. Closes #320 together with #380.
