### PR TITLE
fix(ci): stop the launch gate re-running eight other jobs before its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
           uv run playwright install --with-deps chromium
           cd docs-site && npm ci
       - name: Run launch readiness gate
-        run: make launch-check
+        run: make launch-check-ci
       - name: Upload launch diagnostics
         if: failure()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/Makefile
+++ b/Makefile
@@ -531,6 +531,16 @@ launch-check: ENSURE_DEV_COMMAND = echo "Using preinstalled launch-check depende
 launch-check: check build build-check docs-check e2e
 	@echo "Launch readiness checks passed!"
 
+# The same gate for pull-request CI, minus everything that already has its own
+# parallel job there (lint, typecheck, file-length, complexity, the test matrix,
+# Build Package, docs). Repeating them made this the longest job in CI and, under
+# runner starvation, it was killed around 80% of the test suite -- before ever
+# reaching the hermetic browser render it exists to run. Operators keep
+# `launch-check`, which has no parallel jobs to lean on.
+launch-check-ci: ENSURE_DEV_COMMAND = echo "Using preinstalled launch-check dependencies"
+launch-check-ci: ensure-dev e2e
+	@echo "Hermetic launch check passed!"
+
 # Full CI-equivalent pipeline (locally)
 ci: ensure-dev lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint semgrep refurb dep-check arch-check duplication critique docs-cli-check test
 	@echo "Full CI pipeline passed!"

--- a/tests/test_version_contract.py
+++ b/tests/test_version_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import tomllib
 from pathlib import Path
@@ -124,9 +125,10 @@ launch-check: check build build-check docs-check e2e
     }
 
 
-def test_launch_check_consumes_the_preinstalled_ci_environment() -> None:
+@pytest.mark.parametrize("target", ["launch-check", "launch-check-ci"])
+def test_launch_check_consumes_the_preinstalled_ci_environment(target: str) -> None:
     """The launch job must not replace dev-test with every heavyweight extra."""
-    commands = _make_dry_run("launch-check")
+    commands = _make_dry_run(target)
 
     assert "uv sync --all-extras" not in commands
     assert "Using preinstalled launch-check dependencies" in commands
@@ -142,14 +144,18 @@ def test_ci_runs_the_hermetic_launch_check_with_runtime_dependencies() -> None:
     assert launch_job["timeout-minutes"] == 30
     assert "ffmpeg" in commands
     assert "playwright install --with-deps chromium" in commands
-    assert "make launch-check" in commands
+    # Exact target: "make launch-check" is a substring of "make launch-check-ci",
+    # so a loose check would pass whichever one CI pointed at.
+    assert re.search(r"^\s*make launch-check-ci\s*$", commands, re.M)
     assert all("IMMICH_API_KEY" not in str(step) for step in steps)
 
     lfs_pull_index = next(
         index for index, step in enumerate(steps) if "git lfs pull" in str(step.get("run", ""))
     )
     launch_index = next(
-        index for index, step in enumerate(steps) if "make launch-check" in str(step.get("run", ""))
+        index
+        for index, step in enumerate(steps)
+        if "make launch-check-ci" in str(step.get("run", ""))
     )
     assert lfs_pull_index < launch_index
 
@@ -211,3 +217,29 @@ def test_ci_summary_gate_enforces_event_sensitive_launch_result_matrix(
     result = _ci_success_result(event_name, setup_result, launch_result)
 
     assert result.returncode == expected_returncode, result.stdout + result.stderr
+
+
+def test_ci_launch_gate_does_not_rerun_what_has_its_own_job() -> None:
+    """The launch job must contribute the e2e gate, not repeat the whole pipeline.
+
+    `make launch-check` chains check + build + build-check + docs-check + e2e,
+    and CI already runs every one of those as a dedicated parallel job — lint,
+    typecheck, file-length, complexity, a six-cell test matrix, Build Package
+    (which runs build and build-check) and docs. Re-running them made this the
+    longest job in CI, and under runner starvation it was killed at ~80% of the
+    test suite, before ever reaching the browser render it exists for.
+    """
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+    target = next(
+        command
+        for step in workflow["jobs"]["launch-check"]["steps"]
+        for command in [str(step.get("run", ""))]
+        if "launch-check" in command
+    ).split()[-1]
+
+    prerequisites = _make_target_prerequisites(target)
+
+    assert "e2e" in prerequisites, "the launch gate must still run the hermetic render"
+    assert not prerequisites & {"check", "test", "docs-check", "build"}, (
+        f"{target} repeats work that already has its own CI job: {sorted(prerequisites)}"
+    )


### PR DESCRIPTION
Closes #382.

## Hermetic Launch Check never runs the hermetic check

It has been failing on **every open PR** (6 for 6). Not only capacity — the job never reaches the gate it exists for.

`make launch-check` chains `check build build-check docs-check e2e`, where `check` is lint + format-check + typecheck + file-length + complexity + **the full test suite**. CI already runs all of it as dedicated parallel jobs — including a **six-cell test matrix**, and `Build Package` which runs both `build` and `build-check` (ci.yml:433-435). `e2e` is the only unique contribution, and it sits last.

Evidence, job `96195197945`:

```
19:36:58.8  ...::test_yields_frames_with_correct_shape PASSED [ 80%]
19:37:18.2  ##[error]The runner has received a shutdown signal.
```

Killed at **80% of the test suite**, 19m34s in, never reaching the browser render.

Ruled out: job timeout (`timeout-minutes: 30`, died at 19.5), concurrency (correctly keyed per-ref), duplicate runs (triggers only on `pull_request`), dependency failure (`Install with extras: success`).

Queue depth is the amplifier: runs were sitting **six to eight hours** when I looked, so the longest job is the one that always dies. That part is an account-level limit and not fixable here.

## What changed

`launch-check` is **deliberately untouched**. Its contract test says one local target must exercise every artifact required for launch, and an operator running it has no parallel jobs to lean on — the duplication is the point there and waste in CI. CI gets `launch-check-ci` (`ensure-dev e2e`).

| | before | after |
|---|---|---|
| what runs | 8 jobs' work, then maybe e2e | e2e |
| measured | ~20 min, killed at 80% of tests | **55 s**, 25 E2E tests incl. real chromium renders |

## Guarding the invariant

Three tests, because the failure mode here is silent regrowth:

- the CI target must still include `e2e`
- it must not pull in `check` / `test` / `docs-check` / `build`
- it must not `uv sync --all-extras` (parametrised over both targets)

Also tightened one existing assertion while here: `"make launch-check" in commands` kept passing because it is a **substring** of `make launch-check-ci` — it would have accepted either target. Now matched exactly.

## Testing

`make ci` green locally (4904 passed). `make launch-check-ci` run for real: 25 passed in 55.65s.

## Related, not in this PR

- Flaky `test_loudnorm_does_not_eat_duration_at_scale` (two `timeout=5` subprocess calls at `:1165` and `:1211`) — fixed separately.
- macOS `Error 137` OOM on the extras matrix — still unexplained, unowned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM