### PR TITLE
test(assembler): give the loudnorm drift test room on a loaded runner

### DIFF
--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -1143,7 +1143,10 @@ class TestAudioFilterChain:
         fade_dur = 0.5
         frame_dur = int(clip_dur * fps) / fps
 
-        # Create short WAV files
+        # Create short WAV files.
+        # WHY timeout=30 for a 2s sine: this spawns 30 processes in a row, and
+        # a loaded CI runner has taken >5s just to start one of them. The
+        # generous budget only fires on a genuinely wedged process.
         wavs: list[Path] = []
         for i in range(n_clips):
             wav = tmp_path / f"clip_{i}.wav"
@@ -1162,7 +1165,7 @@ class TestAudioFilterChain:
                     str(wav),
                 ],
                 capture_output=True,
-                timeout=5,
+                timeout=30,
             )
             wavs.append(wav)
 
@@ -1208,7 +1211,7 @@ class TestAudioFilterChain:
             ],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=30,
         )
         actual = float(dur_result.stdout.strip())
         expected = n_clips * frame_dur - (n_clips - 1) * fade_dur


### PR DESCRIPTION
## This is why every PR is red

`test_loudnorm_does_not_eat_duration_at_scale` has been failing on **every open
PR**, on both ubuntu and macOS, across branches with nothing in common — one
touching only a Makefile and a shell script, another only a single analysis
module, another only config/security.

It is not the code under test:

```
subprocess.TimeoutExpired: Command '['ffmpeg', '-y', '-f', 'lavfi',
  '-i', 'sine=frequency=860:duration=2.0', ... 'clip_14.wav']'
  timed out after 5 seconds
```

The test builds its fixtures by spawning **30 ffmpeg processes in a row**, each
with a 5-second budget. Generating a 2-second sine takes milliseconds, so that
budget is really measuring how long a loaded runner takes to *start* a process.
It died on clip **14 of 30** — mid-loop, which is what contention looks like,
not a wedged command.

There were **two** such calls, not one: the setup loop and the closing `ffprobe`
that reads the assembled duration. Raising only the first would have moved the
flake to the end of the test rather than removing it. (Credit to the peer
session working on #313 for catching the second.) Every other subprocess call in
this file already uses a larger budget.

Both are now 30s, which only fires on a genuinely stuck process.

## Deliberately not done

**`n_clips` stays at 30.** The obvious "make it faster" fix is to shrink the
loop, and it would be wrong: the test detects a ~35 ms per-clip loss in one-pass
loudnorm that only accumulates to a measurable >0.5 s of drift over 30 clips
(docstring at :1134-1136). A smaller loop would leave a green test that detects
nothing.

## Scope

One test file, two timeout values, plus a comment explaining why a 2-second sine
gets a 30-second budget. No production code. Worth merging ahead of the feature
PRs since it unblocks all of them.

Separately, the `Hermetic Launch Check` failures have their own root cause and
their own fix in flight (`make launch-check` re-runs eight other CI jobs' work
before reaching the E2E step it uniquely provides). The macOS `Error 137` OOM on
the torch-heavy extras matrix is a third, still-unexplained issue and is **not**
addressed here.
