### PR TITLE
fix(ci): fit pull-request CI inside the macOS concurrency cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,9 +272,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+      # WHY the event-dependent matrix: this repo is public, so hosted runners
+      # are free but capped, and macOS is capped at 5 concurrent jobs. Three
+      # macOS cells per pull request meant ~30 jobs queueing for 5 slots once a
+      # handful of PRs were open; runs sat for hours and GitHub reclaimed them
+      # mid-job ("runner has received a shutdown signal", then Error 137).
+      # Ubuntu keeps every Python; macOS keeps one per PR and the full grid on
+      # main, where runs are serialised anyway.
+      matrix: ${{ fromJSON(github.event_name == 'pull_request'
+        && '{"include":[{"os":"ubuntu-latest","python-version":"3.11"},{"os":"ubuntu-latest","python-version":"3.12"},{"os":"ubuntu-latest","python-version":"3.13"},{"os":"macos-latest","python-version":"3.13"}]}'
+        || '{"include":[{"os":"ubuntu-latest","python-version":"3.11"},{"os":"ubuntu-latest","python-version":"3.12"},{"os":"ubuntu-latest","python-version":"3.13"},{"os":"macos-latest","python-version":"3.11"},{"os":"macos-latest","python-version":"3.12"},{"os":"macos-latest","python-version":"3.13"}]}') }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2

--- a/tests/test_ci_concurrency_contract.py
+++ b/tests/test_ci_concurrency_contract.py
@@ -1,0 +1,55 @@
+"""Pull-request CI must fit inside GitHub's macOS concurrency allowance.
+
+This repo is public, so hosted runners are free — but capped, and **macOS is
+capped at 5 concurrent jobs**. A 3-Python x 2-OS test matrix asks for 3 macOS
+jobs per pull request; with ten PRs open that is ~30 macOS jobs queueing for 5
+slots. Runs then sit for hours and GitHub reclaims them mid-job, which surfaces
+as `The runner has received a shutdown signal` followed by `Error 137` — a
+symptom of the runner going away, not of anything the tests did.
+
+Ubuntu keeps every Python version. macOS keeps one per pull request, and the
+full matrix still runs on main via `workflow_call`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_MACOS_CONCURRENCY_LIMIT = 5
+
+
+def _ci() -> dict:
+    return yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+
+
+def _pull_request_matrix() -> list[dict]:
+    """The cells a pull request actually schedules."""
+    raw = _ci()["jobs"]["test"]["strategy"]["matrix"]
+    if isinstance(raw, str):  # a fromJSON expression, evaluated per event
+        pr_branch = raw.split("&&", 1)[1].split("||", 1)[0]
+        return json.loads(pr_branch.strip().strip("'"))["include"]
+    return [
+        {"os": os_name, "python-version": version}
+        for os_name in raw["os"]
+        for version in raw["python-version"]
+    ]
+
+
+def test_a_pull_request_asks_for_at_most_one_macos_test_cell() -> None:
+    macos = [cell for cell in _pull_request_matrix() if "macos" in cell["os"]]
+
+    assert len(macos) <= 1, (
+        f"{len(macos)} macOS cells per PR; ten open PRs would queue "
+        f"{len(macos) * 10} jobs against a limit of {_MACOS_CONCURRENCY_LIMIT}"
+    )
+
+
+def test_ubuntu_still_covers_every_supported_python() -> None:
+    """Trimming macOS must not quietly drop version coverage."""
+    ubuntu = {cell["python-version"] for cell in _pull_request_matrix() if "ubuntu" in cell["os"]}
+
+    assert ubuntu == {"3.11", "3.12", "3.13"}


### PR DESCRIPTION
Fixes the systematic CI failures. Follows #383, #384 and #385, and this is the one that addresses the actual cause.

## It isn't the code

CI collapsed on 08-19. The bisect settles it: the **last passing run and the first failing one tested the same tree** at `806a475` — nothing merged to main between them.

| Date | runs | successes |
|---|---|---|
| 08-16 | 3 | 1 |
| 08-18 | 32 | **16** |
| 08-19 | 33 | **1** |

What changed is volume — several agents began working PRs in parallel, roughly a 10× increase.

## The cap

The repo is **public**, so hosted runners are free but capped, and **macOS is capped at 5 concurrent jobs**. A 3-Python × 2-OS matrix asks for 3 macOS `Test` cells per PR plus a macOS `Test Extras`. With eleven runs in flight that is **~44 macOS jobs queueing for 5 slots**.

That single cap accounts for every symptom we chased:

- queues six to eight hours deep
- `The runner has received a shutdown signal` arriving **before** `Error 137` — the runner reclaimed, `make`'s child killed during teardown, not an OOM
- random matrix cells dying while others pass on **identical code** (3.11 pass, 3.12 fail, 3.13 pass)
- a job that ran **51 minutes** instead of 13, logs lost to `BlobNotFound`

## What changed

The matrix becomes event-dependent:

| | ubuntu | macOS | macOS jobs/PR |
|---|---|---|---|
| **before** | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 | 4 |
| **pull request** | 3.11, 3.12, 3.13 | 3.13 | **2** |
| **main** (`workflow_call`) | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 | unchanged |

Ubuntu keeps every supported Python. The full grid still runs on main, where runs serialise anyway.

## Guarding it

Two tests, because the tempting future edit is to trim macOS *and* lose version coverage with it:

1. A pull request may ask for **at most one** macOS cell.
2. Ubuntu must still cover **3.11, 3.12 and 3.13**.

## Methodology note for whoever debugs this next

`/usr/bin/time -l` **sums `ru_maxrss` across waited children**. A suite spawning thousands of ffmpeg processes therefore reports tens of GB that were never concurrent — I measured 55 GB for the full suite and nearly acted on it. In isolation, `test_streaming_assembler` peaks at **2.12 GB** and nothing else exceeds **0.3 GB**.

There is no memory problem. `Error 137` here is a symptom of the runner going away, and it does **not** always come with a `shutdown signal` line — some logs show only the 137, which is exactly what makes it read as OOM.

## Testing

`make ci` green locally (4981 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM