### PR TITLE
fix(assembly): keep the date caption clear of the 9:16 platform chrome

### DIFF
--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -60,6 +60,11 @@ and a 720p one look alike. Title cards and clips without a date are left alone.
 On HDR output the caption is drawn at HLG graphics white rather than full white,
 which would otherwise glare above the picture's own diffuse white.
 
+With `--orientation portrait` the caption is inset further from the bottom —
+about a sixth of the frame height — to clear the captions, handle and action
+rail that Reels, Shorts and Stories draw over the lower part of a 9:16 video.
+Landscape output keeps the tighter inset, having no chrome to dodge.
+
 When `--resolution` is omitted, the command uses `output.resolution` from the config (1080p by
 default). Pass `--resolution auto` explicitly when you want the source clips to choose the output
 tier. `--quality` changes the effective CRF preset; an explicit `output.crf` in config remains the

--- a/src/immich_memories/processing/clip_caption.py
+++ b/src/immich_memories/processing/clip_caption.py
@@ -18,6 +18,12 @@ _MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
 _FONT_RATIO = 0.028
 _MARGIN_RATIO = 0.04
 
+# Vertical renders go to Reels, Shorts and Stories, which paint captions, the
+# handle and an action rail over roughly the bottom sixth of the frame. A
+# short-side inset puts the date underneath all of it, so portrait insets off
+# the height instead.
+_VERTICAL_BOTTOM_RATIO = 0.16
+
 # 0xBF is 75% of full range: HLG graphics white. Measured, plain white@0.85
 # draws at 872/1023 in a 10-bit pipe, which glares above the picture's own
 # diffuse white; this lands at 721.
@@ -42,16 +48,18 @@ def caption_filter(text: str, width: int, height: int, *, is_hdr: bool = False) 
 
     Sized and inset off the short side so the caption holds its proportions
     across output resolutions, with a drop shadow that keeps it legible over a
-    bright sky.
+    bright sky. Vertical output insets further from the bottom, where the
+    platforms draw their own UI.
     """
     short_side = min(width, height)
     font_size = max(12, round(short_side * _FONT_RATIO))
     margin = round(short_side * _MARGIN_RATIO)
+    bottom = round(height * _VERTICAL_BOTTOM_RATIO) if height > width else margin
     colour = _HDR_COLOUR if is_hdr else _SDR_COLOUR
     return (
         f"drawtext=text='{text}'"
         f":fontsize={font_size}"
         f":fontcolor={colour}"
         f":shadowcolor=black@0.6:shadowx=2:shadowy=2"
-        f":x=w-tw-{margin}:y=h-th-{margin}"
+        f":x=w-tw-{margin}:y=h-th-{bottom}"
     )

--- a/tests/integration/processing/test_date_overlay_real.py
+++ b/tests/integration/processing/test_date_overlay_real.py
@@ -42,8 +42,8 @@ def grey_clip(tmp_path_factory) -> Path:
     return out
 
 
-def _first_frame(clip: Path, **kwargs) -> np.ndarray:
-    decoder = FrameDecoder(clip, width=640, height=360, fps=10, **kwargs)
+def _first_frame(clip: Path, width: int = 640, height: int = 360, **kwargs) -> np.ndarray:
+    decoder = FrameDecoder(clip, width=width, height=height, fps=10, **kwargs)
     return next(iter(decoder)).copy()
 
 
@@ -67,3 +67,41 @@ def test_the_caption_lands_in_the_bottom_corner(grey_clip: Path) -> None:
     assert cols.min() > 640 * 0.5, "caption is not on the right"
     assert rows.max() < 360, "caption runs off the bottom edge"
     assert cols.max() < 640, "caption runs off the right edge"
+
+
+@pytest.fixture(scope="module")
+def grey_portrait(tmp_path_factory) -> Path:
+    """A 9:16 clip, the shape Reels/Shorts/Stories actually receive."""
+    out = tmp_path_factory.mktemp("overlay9x16") / "grey.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=gray:size=360x640:rate=10:duration=1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return out
+
+
+def test_a_vertical_caption_sits_above_the_platform_chrome(grey_portrait: Path) -> None:
+    plain = _first_frame(grey_portrait, width=360, height=640)
+    captioned = _first_frame(grey_portrait, width=360, height=640, overlay_text="5 Jan 2026")
+
+    changed = np.argwhere(np.any(plain != captioned, axis=-1))
+    assert changed.size, "overlay changed nothing"
+
+    lowest = changed[:, 0].max()
+    chrome_top = 640 * (1 - 0.15)
+    assert lowest < chrome_top, (
+        f"caption reaches row {lowest}; the platform UI starts around {chrome_top:.0f}"
+    )

--- a/tests/test_vertical_safe_area.py
+++ b/tests/test_vertical_safe_area.py
@@ -1,0 +1,37 @@
+"""Text must clear the platform chrome in vertical output (#313).
+
+A 9:16 render is for Reels, Shorts and Stories, and all three paint their own
+UI over the frame: captions, handles and action buttons across roughly the
+bottom sixth, status and progress across the top. Text inset by a percentage of
+the *short* side — which is what a landscape-shaped rule gives you — lands under
+that chrome and is simply not readable.
+"""
+
+from __future__ import annotations
+
+import re
+
+from immich_memories.processing.clip_caption import caption_filter
+
+# 1080x1920 is the canonical vertical render.
+_W, _H = 1080, 1920
+
+
+def _inset_from_bottom(vf: str) -> int:
+    match = re.search(r"y=h-th-(\d+)", vf)
+    assert match, f"no bottom inset in {vf}"
+    return int(match.group(1))
+
+
+def test_a_vertical_caption_clears_the_bottom_chrome() -> None:
+    """~15% of height is where the caption and action rail sit."""
+    inset = _inset_from_bottom(caption_filter("5 Jan 2026", _W, _H))
+
+    assert inset >= _H * 0.15, f"inset {inset}px of {_H} leaves the date under the platform UI"
+
+
+def test_a_landscape_caption_is_not_pushed_inwards() -> None:
+    """No chrome to dodge on a TV or a laptop; a large inset would just look odd."""
+    inset = _inset_from_bottom(caption_filter("5 Jan 2026", 1920, 1080))
+
+    assert inset < 1080 * 0.10


### PR DESCRIPTION
Second slice of #313, after #379 wired the caption up. This is the "text safe zones" half.

## The bug, in the code I shipped yesterday

`caption_filter` insets by **4% of the frame's short side**. That is right for landscape and wrong for the shape this feature exists to serve.

At 1080×1920 it puts the date **43 px** from the bottom. Reels, Shorts and Stories all paint captions, the account handle and an action rail over roughly the bottom sixth — about **288 px**. The date renders underneath the platform's own UI and simply cannot be read.

Portrait now insets off the **height** instead. Landscape keeps the tighter inset: a television has no chrome to dodge, and a large inset there would only look wrong.

## Titles were checked and left alone

`#313` asks for "text safe zones for titles", and it turns out they already have them:

- text is centred vertically — a subtitle sits `title_size * 1.3` below centre, nowhere near either edge
- `safe_width = width * 0.8` already clamps horizontally

So the existing layout is safe-area correct without help. No change made; reporting it rather than inventing work.

## Testing

- **Unit**: the inset must clear 15% of height in portrait, and must *not* be inflated in landscape.
- **Integration, real FFmpeg**: a 360×640 clip is decoded and the caption's lowest changed pixel row must sit above the chrome line.

The integration test fails without the fix rather than passing by construction — the old inset put the caption at row ~626 of 640 against a 544 threshold.

`make ci` green locally (4986 passed), `make docs-build` passes.

## Still open in #313

Place names in the caption, and the short-form duration presets (15/30/60/90 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM