### PR TITLE
fix(auto): stop relaunching a candidate that keeps failing

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -351,13 +351,9 @@
       {
         "name": "AutoRunner::suggest",
         "complexity": 21,
-        "line_start": 735,
-        "line_end": 820,
+        "line_start": 736,
+        "line_end": 826,
         "line_complexities": [
-          {
-            "line": 739,
-            "complexity": 0
-          },
           {
             "line": 740,
             "complexity": 0
@@ -376,7 +372,7 @@
           },
           {
             "line": 744,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 745,
@@ -391,11 +387,11 @@
             "complexity": 0
           },
           {
-            "line": 749,
-            "complexity": 0
+            "line": 748,
+            "complexity": 1
           },
           {
-            "line": 750,
+            "line": 749,
             "complexity": 0
           },
           {
@@ -407,32 +403,32 @@
             "complexity": 0
           },
           {
-            "line": 758,
+            "line": 753,
             "complexity": 0
           },
           {
-            "line": 761,
+            "line": 754,
             "complexity": 0
           },
           {
-            "line": 764,
+            "line": 760,
             "complexity": 0
           },
           {
-            "line": 769,
+            "line": 763,
             "complexity": 0
           },
           {
-            "line": 770,
+            "line": 766,
+            "complexity": 0
+          },
+          {
+            "line": 771,
+            "complexity": 0
+          },
+          {
+            "line": 772,
             "complexity": 3
-          },
-          {
-            "line": 773,
-            "complexity": 0
-          },
-          {
-            "line": 774,
-            "complexity": 4
           },
           {
             "line": 775,
@@ -447,12 +443,12 @@
             "complexity": 0
           },
           {
-            "line": 780,
-            "complexity": 0
+            "line": 778,
+            "complexity": 4
           },
           {
-            "line": 781,
-            "complexity": 3
+            "line": 779,
+            "complexity": 0
           },
           {
             "line": 782,
@@ -460,7 +456,7 @@
           },
           {
             "line": 783,
-            "complexity": 4
+            "complexity": 3
           },
           {
             "line": 784,
@@ -468,15 +464,19 @@
           },
           {
             "line": 785,
+            "complexity": 4
+          },
+          {
+            "line": 786,
             "complexity": 0
           },
           {
-            "line": 793,
+            "line": 787,
+            "complexity": 0
+          },
+          {
+            "line": 795,
             "complexity": 1
-          },
-          {
-            "line": 794,
-            "complexity": 0
           },
           {
             "line": 796,
@@ -487,15 +487,23 @@
             "complexity": 0
           },
           {
-            "line": 809,
+            "line": 800,
             "complexity": 0
           },
           {
-            "line": 814,
+            "line": 811,
+            "complexity": 0
+          },
+          {
+            "line": 815,
             "complexity": 0
           },
           {
             "line": 820,
+            "complexity": 0
+          },
+          {
+            "line": 826,
             "complexity": 0
           }
         ]
@@ -503,143 +511,131 @@
       {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 848,
-        "line_end": 989,
+        "line_start": 854,
+        "line_end": 995,
         "line_complexities": [
-          {
-            "line": 858,
-            "complexity": 0
-          },
-          {
-            "line": 862,
-            "complexity": 0
-          },
-          {
-            "line": 863,
-            "complexity": 2
-          },
           {
             "line": 864,
             "complexity": 0
-          },
-          {
-            "line": 866,
-            "complexity": 0
-          },
-          {
-            "line": 867,
-            "complexity": 2
           },
           {
             "line": 868,
             "complexity": 0
           },
           {
+            "line": 869,
+            "complexity": 2
+          },
+          {
             "line": 870,
             "complexity": 0
           },
           {
-            "line": 874,
-            "complexity": 3
-          },
-          {
-            "line": 875,
+            "line": 872,
             "complexity": 0
           },
           {
-            "line": 877,
-            "complexity": 0
-          },
-          {
-            "line": 878,
+            "line": 873,
             "complexity": 2
           },
           {
-            "line": 879,
+            "line": 874,
+            "complexity": 0
+          },
+          {
+            "line": 876,
             "complexity": 0
           },
           {
             "line": 880,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 881,
-            "complexity": 1
-          },
-          {
-            "line": 882,
             "complexity": 0
           },
           {
-            "line": 890,
+            "line": 883,
+            "complexity": 0
+          },
+          {
+            "line": 884,
             "complexity": 2
           },
           {
-            "line": 892,
+            "line": 885,
             "complexity": 0
           },
           {
-            "line": 902,
+            "line": 886,
             "complexity": 0
           },
           {
-            "line": 903,
+            "line": 887,
             "complexity": 1
           },
           {
-            "line": 904,
+            "line": 888,
             "complexity": 0
           },
           {
-            "line": 905,
+            "line": 896,
+            "complexity": 2
+          },
+          {
+            "line": 898,
+            "complexity": 0
+          },
+          {
+            "line": 908,
             "complexity": 0
           },
           {
             "line": 909,
+            "complexity": 1
+          },
+          {
+            "line": 910,
+            "complexity": 0
+          },
+          {
+            "line": 911,
             "complexity": 0
           },
           {
             "line": 915,
+            "complexity": 0
+          },
+          {
+            "line": 921,
             "complexity": 1
           },
           {
-            "line": 916,
+            "line": 922,
             "complexity": 1
           },
           {
-            "line": 917,
+            "line": 923,
             "complexity": 0
           },
           {
-            "line": 919,
+            "line": 925,
             "complexity": 0
           },
           {
-            "line": 926,
+            "line": 932,
             "complexity": 2
           },
           {
-            "line": 927,
+            "line": 933,
             "complexity": 0
           },
           {
-            "line": 928,
+            "line": 934,
             "complexity": 0
           },
           {
-            "line": 930,
-            "complexity": 0
-          },
-          {
-            "line": 937,
-            "complexity": 0
-          },
-          {
-            "line": 941,
-            "complexity": 2
-          },
-          {
-            "line": 942,
+            "line": 936,
             "complexity": 0
           },
           {
@@ -647,59 +643,71 @@
             "complexity": 0
           },
           {
+            "line": 947,
+            "complexity": 2
+          },
+          {
+            "line": 948,
+            "complexity": 0
+          },
+          {
             "line": 949,
+            "complexity": 0
+          },
+          {
+            "line": 955,
             "complexity": 2
           },
           {
-            "line": 950,
+            "line": 956,
             "complexity": 0
           },
           {
-            "line": 951,
+            "line": 957,
             "complexity": 0
           },
           {
-            "line": 958,
+            "line": 964,
             "complexity": 0
           },
           {
-            "line": 959,
+            "line": 965,
             "complexity": 2
           },
           {
-            "line": 960,
+            "line": 966,
             "complexity": 0
           },
           {
-            "line": 961,
+            "line": 967,
             "complexity": 0
           },
           {
-            "line": 969,
+            "line": 975,
             "complexity": 0
           },
           {
-            "line": 977,
+            "line": 983,
             "complexity": 1
           },
           {
-            "line": 978,
+            "line": 984,
             "complexity": 0
           },
           {
-            "line": 979,
+            "line": 985,
             "complexity": 1
           },
           {
-            "line": 981,
+            "line": 987,
             "complexity": 0
           },
           {
-            "line": 988,
+            "line": 994,
             "complexity": 0
           },
           {
-            "line": 989,
+            "line": 995,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -92,6 +92,25 @@ immich-memories auto suggest [OPTIONS]
 
 Connects to Immich, fetches library stats + people + GPS assets, runs all detectors, scores and ranks. Takes about 30 seconds (GPS fetch for trip detection is the slow part).
 
+### Candidates that keep failing
+
+A candidate that fails twice in a row is held back for a while instead of being
+proposed again the next night, so one memory that cannot render stops consuming
+every nightly run. The wait grows with the streak — 24 hours after two failures,
+3 days after three, capped at 7 days — and always expires, so a memory broken by
+something temporary (a server that was down, an asset that gets re-uploaded)
+comes back on its own.
+
+A single failure never counts against a candidate, and a successful run clears
+the streak immediately.
+
+`auto suggest` says when this is happening, so a held-back candidate is not
+mistaken for an empty library:
+
+```
+Backing off monthly_highlights:2026-06 — failed 3x, retrying after 3d
+```
+
 ### Detectors
 
 | Detector | What it finds | Score range |

--- a/src/immich_memories/automation/failure_backoff.py
+++ b/src/immich_memories/automation/failure_backoff.py
@@ -1,0 +1,80 @@
+"""Keep a repeatedly-failing candidate out of the nightly slot for a while.
+
+Every automation attempt already records its outcome against a memory key, but
+selection only ever read the *completed* ones. A candidate that cannot render
+therefore stayed permanently eligible and won again every night -- one real log
+shows the same monthly candidate launched nine nights in a row, each attempt
+consuming the whole nightly run and producing nothing.
+
+The backoff grows with the streak and is capped, so a candidate broken by
+something temporary (a missing asset that gets re-uploaded, a server that was
+down) always comes back rather than being written off forever.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from immich_memories.automation.state_store import FailureStreak
+
+if TYPE_CHECKING:
+    from immich_memories.automation.candidates import MemoryCandidate
+
+logger = logging.getLogger(__name__)
+
+# One failure is noise. Two in a row is usually a memory that tonight will not fix.
+_MIN_FAILURES = 2
+_WINDOW_BY_STREAK: dict[int, timedelta] = {
+    2: timedelta(hours=24),
+    3: timedelta(days=3),
+}
+_MAX_WINDOW = timedelta(days=7)
+
+
+def backoff_window(failures: int) -> timedelta | None:
+    """How long a candidate waits after this many consecutive failures."""
+    if failures < _MIN_FAILURES:
+        return None
+    return _WINDOW_BY_STREAK.get(failures, _MAX_WINDOW)
+
+
+def suppressed_keys(
+    streaks: dict[str, FailureStreak],
+    now: datetime,
+) -> dict[str, str]:
+    """Memory keys still inside their backoff window, mapped to a reason.
+
+    A streak with no recorded failure time is never suppressed: incomplete
+    telemetry should not strand a candidate.
+    """
+    suppressed: dict[str, str] = {}
+    for key, streak in streaks.items():
+        window = backoff_window(streak.count)
+        if window is None or streak.last_failed_at is None:
+            continue
+        if now - streak.last_failed_at < window:
+            suppressed[key] = f"failed {streak.count}x, retrying after {_describe(window)}"
+    return suppressed
+
+
+def _describe(window: timedelta) -> str:
+    hours = int(window.total_seconds() // 3600)
+    return f"{hours}h" if hours < 48 else f"{hours // 24}d"
+
+
+def drop_backed_off(
+    candidates: list[MemoryCandidate],
+    streaks: dict[str, FailureStreak],
+    now: datetime,
+) -> tuple[list[MemoryCandidate], dict[str, str]]:
+    """Filter out candidates that are waiting out a failure streak.
+
+    Returns the survivors and the suppressions, so the caller can tell an
+    operator why a memory they expected is missing.
+    """
+    suppressed = suppressed_keys(streaks, now)
+    for key, reason in sorted(suppressed.items()):
+        logger.info("Skipping candidate %s: %s", key, reason)
+    return [c for c in candidates if c.memory_key not in suppressed], suppressed

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -14,6 +14,7 @@ from typing import Any
 from immich_memories.automation.candidate_scorer import score_and_rank
 from immich_memories.automation.candidates import MemoryCandidate
 from immich_memories.automation.delivery_retry import PendingDeliveryRetry
+from immich_memories.automation.failure_backoff import drop_backed_off
 from immich_memories.automation.models import (
     AutoAction,
     AutomationAttempt,
@@ -737,6 +738,7 @@ class AutoRunner:
         from immich_memories.api.immich import SyncImmichClient
 
         self.last_variety_decision = VarietyDecision(eligible=[], rejected=[])
+        self.last_backoff_skips: dict[str, str] = {}
         self.last_recent_categories = ()
         self.last_suggest_status = SuggestStatus()
         immich_result = self._prepared_immich_preflight
@@ -804,6 +806,10 @@ class AutoRunner:
             today,
             person_asset_counts,
             gps_assets,
+        )
+
+        all_candidates, self.last_backoff_skips = drop_backed_off(
+            all_candidates, self.state.consecutive_failures_by_key(), datetime.now(tz=UTC)
         )
 
         self.last_variety_decision = apply_variety_rules(

--- a/src/immich_memories/automation/state_store.py
+++ b/src/immich_memories/automation/state_store.py
@@ -6,6 +6,7 @@ import logging
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -15,6 +16,14 @@ from immich_memories.cache.database import VideoAnalysisCache
 from immich_memories.operations.phases import OperationalPhase, PhaseEvent
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FailureStreak:
+    """How many times a memory key has failed since it last succeeded."""
+
+    count: int
+    last_failed_at: datetime | None
 
 
 class AttemptAlreadyFinishedError(RuntimeError):
@@ -209,3 +218,38 @@ class AutomationStateStore:
                 """
             ).fetchone()
         return _row_to_attempt(row) if row else None
+
+    def consecutive_failures_by_key(self) -> dict[str, FailureStreak]:
+        """Failures per memory key since that key last completed.
+
+        Read by candidate selection so a memory that cannot render stops being
+        chosen every night. Only terminal failures count -- a SKIPPED attempt
+        means the runner declined the candidate, which says nothing about
+        whether it would have rendered.
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT memory_key, outcome, finished_at
+                FROM automation_attempts
+                WHERE memory_key IS NOT NULL
+                  AND outcome IN (?, ?)
+                ORDER BY started_at ASC, rowid ASC
+                """,
+                (AutoOutcome.FAILED.value, AutoOutcome.COMPLETED.value),
+            ).fetchall()
+
+        streaks: dict[str, FailureStreak] = {}
+        for row in rows:
+            key = row["memory_key"]
+            if row["outcome"] == AutoOutcome.COMPLETED.value:
+                streaks.pop(key, None)
+                continue
+            previous = streaks.get(key)
+            streaks[key] = FailureStreak(
+                count=(previous.count if previous else 0) + 1,
+                last_failed_at=(
+                    datetime.fromisoformat(row["finished_at"]) if row["finished_at"] else None
+                ),
+            )
+        return streaks

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -162,6 +162,10 @@ def suggest(ctx: click.Context, as_json: bool, limit: int, memory_type: str | No
             click.echo(error, err=True)
         ctx.exit(1)
 
+    if not as_json:
+        for key, reason in sorted(runner.last_backoff_skips.items()):
+            print_info(f"Backing off {key} — {reason}")
+
     if memory_type:
         candidates = [c for c in candidates if c.memory_type == memory_type]
 

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -1702,3 +1702,68 @@ class TestSuggestOutput:
         rendered = console.export_text()
         assert "Category" in rendered
         assert "monthly_review" in rendered
+
+
+class TestFailedCandidateBackoff:
+    """A candidate that keeps failing must stop winning the nightly slot.
+
+    Every failure was already recorded against its memory key; nothing read it
+    back, so the same monthly candidate went out nine nights in a row in a real
+    log, burning the run each time and producing nothing.
+    """
+
+    @staticmethod
+    def _suggest_with_failures(config: Config, failures: int) -> list:
+        from immich_memories.automation.models import AutoOutcome
+        from immich_memories.preflight import CheckStatus
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get_time_buckets.return_value = [
+            _make_time_bucket(2026, 7, 150),
+            _make_time_bucket(2026, 6, 200),
+        ]
+        mock_client.get_all_people.return_value = []
+
+        runner = AutoRunner(config)
+        first = runner.suggest(limit=10) if failures == 0 else None
+
+        # WHY: Immich server, its preflight check, and the clock
+        with (
+            # WHY: external Immich server
+            patch("immich_memories.api.immich.SyncImmichClient", return_value=mock_client),
+            # WHY: external Immich server (preflight check)
+            patch(
+                "immich_memories.preflight.check_immich",
+                return_value=MagicMock(status=CheckStatus.OK),
+            ),
+            # WHY: pins today so the month fixtures stay in range
+            patch("immich_memories.automation.runner.date") as mock_date,
+        ):
+            mock_date.today.return_value = date(2026, 8, 11)
+            runner = AutoRunner(config)
+            baseline = runner.suggest(limit=10)
+            assert baseline, "fixture must produce candidates before we suppress any"
+            target = baseline[0].memory_key
+
+            for _ in range(failures):
+                attempt = runner.state.start_attempt(reason="daily wake")
+                runner.state.finish_attempt(
+                    attempt.id, AutoOutcome.FAILED, reason="exit 1", memory_key=target
+                )
+
+            after = AutoRunner(config).suggest(limit=10)
+        del first
+        return [target, after]
+
+    def test_a_twice_failed_candidate_is_not_suggested_again(self, config: Config) -> None:
+        target, after = self._suggest_with_failures(config, failures=2)
+
+        assert target not in {c.memory_key for c in after}
+
+    def test_one_failure_does_not_suppress(self, config: Config) -> None:
+        """Transient failures must not cost a candidate its place."""
+        target, after = self._suggest_with_failures(config, failures=1)
+
+        assert target in {c.memory_key for c in after}

--- a/tests/test_automation_state.py
+++ b/tests/test_automation_state.py
@@ -123,3 +123,60 @@ def test_finish_attempt_reports_unknown_id_separately(tmp_path: Path) -> None:
 
     with pytest.raises(KeyError, match="Unknown automation attempt: missing"):
         store.finish_attempt("missing", AutoOutcome.FAILED, reason="not found")
+
+
+class TestConsecutiveFailuresByKey:
+    """The nightly runner has to know which candidates keep failing.
+
+    Every failure is already recorded with its memory_key, but nothing reads it
+    back, so a candidate that cannot succeed is picked again every night -- the
+    same one went out nine nights in a row in a real log.
+    """
+
+    @staticmethod
+    def _attempt(store, key: str, outcome: AutoOutcome) -> None:
+        attempt = store.start_attempt(reason="daily wake")
+        store.finish_attempt(attempt.id, outcome, reason="test", memory_key=key)
+
+    def test_counts_failures_per_key(self, tmp_path: Path) -> None:
+        store = AutomationStateStore(tmp_path / "cache.db")
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+        self._attempt(store, "trip:alps", AutoOutcome.FAILED)
+
+        failures = store.consecutive_failures_by_key()
+
+        assert failures["monthly:2026-06"].count == 2
+        assert failures["trip:alps"].count == 1
+
+    def test_a_success_clears_the_streak(self, tmp_path: Path) -> None:
+        """Backoff must not punish a key that has since worked."""
+        store = AutomationStateStore(tmp_path / "cache.db")
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+        self._attempt(store, "monthly:2026-06", AutoOutcome.COMPLETED)
+
+        assert "monthly:2026-06" not in store.consecutive_failures_by_key()
+
+    def test_a_failure_after_a_success_starts_a_new_streak(self, tmp_path: Path) -> None:
+        store = AutomationStateStore(tmp_path / "cache.db")
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+        self._attempt(store, "monthly:2026-06", AutoOutcome.COMPLETED)
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+
+        assert store.consecutive_failures_by_key()["monthly:2026-06"].count == 1
+
+    def test_skipped_attempts_are_not_failures(self, tmp_path: Path) -> None:
+        """A cooldown skip says nothing about whether the candidate can render."""
+        store = AutomationStateStore(tmp_path / "cache.db")
+        self._attempt(store, "monthly:2026-06", AutoOutcome.SKIPPED)
+
+        assert "monthly:2026-06" not in store.consecutive_failures_by_key()
+
+    def test_reports_when_the_last_failure_happened(self, tmp_path: Path) -> None:
+        store = AutomationStateStore(tmp_path / "cache.db")
+        self._attempt(store, "monthly:2026-06", AutoOutcome.FAILED)
+
+        entry = store.consecutive_failures_by_key()["monthly:2026-06"]
+
+        assert entry.last_failed_at is not None

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -598,6 +598,49 @@ class TestAutoRunOutput:
         assert "server unavailable" in result.stderr
         check.assert_called_once()
 
+    def test_auto_suggest_says_when_a_candidate_is_backing_off(self, tmp_path: Path) -> None:
+        """Silently omitting a suppressed candidate reads as "nothing to do".
+
+        The operator needs to tell "no candidates" apart from "the candidate you
+        expect keeps failing and is waiting", or a stuck memory looks like an
+        idle library.
+        """
+        from immich_memories.automation.models import AutoOutcome
+        from immich_memories.automation.state_store import AutomationStateStore
+        from immich_memories.preflight import CheckStatus
+
+        config = Config(
+            immich={"url": "http://immich.test:2283", "api_key": "test-key"},
+            cache={"database": str(tmp_path / "runs.db")},
+        )
+        store = AutomationStateStore(tmp_path / "runs.db")
+        for _ in range(2):
+            attempt = store.start_attempt(reason="daily wake")
+            store.finish_attempt(
+                attempt.id, AutoOutcome.FAILED, reason="exit 1", memory_key="monthly:2026-06"
+            )
+
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.get_time_buckets.return_value = []
+        client.get_all_people.return_value = []
+
+        # WHY: external Immich server and its preflight check
+        with (
+            # WHY: external Immich server
+            patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
+            # WHY: external Immich server (preflight check)
+            patch(
+                "immich_memories.preflight.check_immich",
+                return_value=MagicMock(status=CheckStatus.OK),
+            ),
+        ):
+            result = _invoke(["auto", "suggest"], config=config)
+
+        assert "Backing off monthly:2026-06" in result.output
+        assert "failed 2x" in result.output
+
 
 class TestPreflightCommand:
     """Test preflight command with real checks (no mocks)."""

--- a/tests/test_failure_backoff.py
+++ b/tests/test_failure_backoff.py
@@ -1,0 +1,57 @@
+"""How long a repeatedly-failing candidate stays out of the running.
+
+One failure is noise -- a transient Immich hiccup, a stalled LLM. A candidate
+that fails twice in a row is usually broken in a way tonight will not fix, and
+without a backoff it wins the selection again every night: a real log shows the
+same monthly candidate launched nine nights running, each time consuming the
+whole nightly slot and producing nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.automation.failure_backoff import suppressed_keys
+from immich_memories.automation.state_store import FailureStreak
+
+NOW = datetime(2026, 8, 20, 3, 0, tzinfo=UTC)
+
+
+def _streak(count: int, hours_ago: float) -> FailureStreak:
+    return FailureStreak(count=count, last_failed_at=NOW - timedelta(hours=hours_ago))
+
+
+def test_a_single_failure_is_not_held_against_a_candidate():
+    """Transient failures happen; one is not evidence of a broken memory."""
+    assert suppressed_keys({"a": _streak(1, hours_ago=1)}, NOW) == {}
+
+
+def test_two_failures_suppress_for_a_day():
+    assert "a" in suppressed_keys({"a": _streak(2, hours_ago=1)}, NOW)
+
+
+def test_the_window_expires_so_a_candidate_gets_another_chance():
+    """Backoff delays a retry; it must never be permanent."""
+    assert suppressed_keys({"a": _streak(2, hours_ago=25)}, NOW) == {}
+
+
+def test_more_failures_back_off_for_longer():
+    """Still suppressed at 25h, where a two-failure streak would have expired."""
+    assert "a" in suppressed_keys({"a": _streak(3, hours_ago=25)}, NOW)
+
+
+def test_backoff_is_capped_so_a_candidate_returns_within_a_week():
+    assert "a" in suppressed_keys({"a": _streak(9, hours_ago=24 * 6)}, NOW)
+    assert suppressed_keys({"a": _streak(9, hours_ago=24 * 8)}, NOW) == {}
+
+
+def test_the_reason_says_how_many_times_it_failed():
+    """The operator has to be able to tell this from 'no candidates found'."""
+    reason = suppressed_keys({"a": _streak(3, hours_ago=1)}, NOW)["a"]
+
+    assert "3" in reason
+
+
+def test_a_streak_with_no_recorded_time_is_not_suppressed():
+    """Never strand a candidate on incomplete data."""
+    assert suppressed_keys({"a": FailureStreak(count=5, last_failed_at=None)}, NOW) == {}


### PR DESCRIPTION
## The bug

Candidate selection read only *completed* runs, so a memory that cannot render
stayed permanently eligible and won the nightly slot again every night.

Every failure was already recorded against its `memory_key` in
`automation_attempts` — nothing ever read it back. The store exposed only
`get_last_attempt()`, for status display. Variety rules, the cooldown, and the
×1.2 "never generated" boost all read the same completed-only history.

What that costs, from `auto.log`:

```
07-17 … 07-25   monthly_highlights, same candidate, 9 nights, "exit 1"
08-16           trip candidate, exit -9
08-17           same trip candidate, duration budget
```

Nine consecutive nights where the run was consumed and nothing was produced —
and the next night picked the same candidate again.

## The fix

A key backs off after **consecutive** failures: 24 h after two, 3 days after
three, **capped at 7 days**.

The cap is the important part. A memory can break for reasons that pass — a
server that was down, an asset since re-uploaded — so a candidate must always
come back on its own rather than being written off forever.

Deliberate non-behaviours, each with a test:

- **One failure never counts.** A transient Immich hiccup or a stalled LLM
  should not cost a candidate its place.
- **A completed run clears the streak immediately**, and a later failure starts
  a fresh one.
- **`SKIPPED` is not a failure.** That means the runner *declined* the
  candidate (cooldown, variety), which says nothing about whether it would have
  rendered.
- **A streak with no recorded timestamp is never suppressed** — incomplete
  telemetry must not strand a candidate.

## Surfacing

`auto suggest` reports the wait:

```
Backing off monthly_highlights:2026-06 — failed 3x, retrying after 3d
```

Silently omitting a suppressed candidate reads as "nothing to do", which makes a
stuck memory look like an idle library.

## A note on the CLI test, for whoever edits it next

It asserts on the **printed** line, not the log message. Both currently reach
stdout — the root handler is a `StreamHandler(sys.stdout)`, which is R4 in the
review — so an assertion on the log text passes whether or not the feature
exists. My first version of this test did exactly that and passed before I'd
written the CLI change. Verified the committed version fails with the print
removed.

## Structural note

`automation/runner.py` was already **989 lines** on `main`, and this change
crossed the 1000-line hard gate. Rather than shaving lines, the filtering now
lives in `failure_backoff.py` with the policy it implements — pure, testable
without a database, and it leaves `runner.py` at 995. The underlying size
problem is real and tracked in #245; this PR does not attempt that split.

`AutoRunner::suggest` stays at its snapshot complexity of 21 (it was 24 before
the extraction).

Closes #386. R1 in `docs/reviews/2026-08-18-security-perf-review.md`.
