### PR TITLE
ci: cancel a pull request's leftover runs when it closes

### DIFF
--- a/.github/workflows/cancel-on-close.yml
+++ b/.github/workflows/cancel-on-close.yml
@@ -1,0 +1,46 @@
+name: Cancel superseded runs
+
+# WHY: `pull_request` runs keep going after the PR closes, so a batch of merges
+# leaves a tail of runs for branches nobody is waiting on. This repo is public,
+# where GitHub allows 5 concurrent macOS jobs and 20 overall, and that tail
+# starves whatever is still open — eleven of twelve queued runs once belonged to
+# already-merged PRs while the single open one sat behind them.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+concurrency:
+  group: cancel-on-close-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cancel:
+    name: Cancel this branch's leftover runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel queued and running workflows for the closed branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # WHY env rather than inline: a head ref is attacker-controlled on a
+          # fork, and interpolating it into the script would be an injection.
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          for state in queued in_progress; do
+            gh api --paginate \
+              -X GET "repos/$REPO/actions/runs" \
+              -f branch="$BRANCH" -f status="$state" \
+              --jq '.workflow_runs[].id' \
+            | while read -r id; do
+                if [ "$id" = "$THIS_RUN" ]; then continue; fi
+                echo "cancelling $state run $id on $BRANCH"
+                gh api -X POST "repos/$REPO/actions/runs/$id/cancel" >/dev/null || true
+              done
+          done

--- a/tests/test_cancel_on_close_contract.py
+++ b/tests/test_cancel_on_close_contract.py
@@ -1,0 +1,53 @@
+"""A closed pull request must stop paying for runner slots.
+
+`pull_request` runs do not stop when the PR merges, so a batch of merges leaves
+a tail of runs for branches nobody is waiting on. Against GitHub's caps for a
+public repo — 5 concurrent macOS jobs, 20 overall — that tail starves whatever
+is still open: eleven of twelve queued runs once belonged to already-merged PRs
+while the single open one sat behind them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cancel-on-close.yml"
+
+
+def _workflow() -> dict:
+    # PyYAML reads the `on:` key as the boolean True.
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def test_it_fires_when_a_pull_request_closes() -> None:
+    triggers = _workflow()[True]["pull_request"]["types"]
+
+    assert triggers == ["closed"]
+
+
+def test_it_may_cancel_runs() -> None:
+    """Without actions: write the cancel call returns 403 and the tail survives."""
+    assert _workflow()["permissions"]["actions"] == "write"
+
+
+def test_it_cancels_queued_runs_as_well_as_running_ones() -> None:
+    """The starving runs are the *queued* ones; cancelling only in_progress misses them."""
+    body = WORKFLOW.read_text()
+
+    assert "queued" in body
+    assert "in_progress" in body
+
+
+def test_the_branch_name_is_passed_as_an_environment_variable() -> None:
+    """A head ref is attacker-controlled on a fork; interpolating it into the
+    shell would be a command injection. Read through env instead."""
+    body = WORKFLOW.read_text()
+
+    assert (
+        "${{ github.event.pull_request.head.ref }}"
+        not in body.split("env:", 1)[-1].split("run:", 1)[-1]
+    ), "head.ref must not appear inside the run script"
+    assert "BRANCH: ${{ github.event.pull_request.head.ref }}" in body


### PR DESCRIPTION
Follows #383, #385 and #387. Those cut how much CI *asks for*; this stops paying for work nobody is waiting on.

## The problem

`pull_request` runs do not stop when the PR merges. A batch of merges leaves a tail of runs for branches that no longer matter.

This repo is public, so runners are free — but free means **best-effort shared capacity**, not a guaranteed allocation: 5 concurrent macOS jobs, 20 overall, and jobs reclaimed mid-flight under load. That tail directly starves whatever is still open.

Observed: **eleven of twelve queued runs belonged to already-merged PRs** while the single open one sat behind them, and a job on it was reclaimed after seven minutes. Cancelling them by hand worked, and is not a plan.

## What it does

On `pull_request: closed`, cancels that branch's **queued and in-progress** runs.

Queued is the important half — those hold slots while doing nothing at all.

## Details that are easy to get wrong, so tests hold them

| Test | Why |
|---|---|
| fires on `closed` | the whole trigger |
| `permissions: actions: write` | without it the cancel returns **403** and the tail survives silently |
| covers `queued` **and** `in_progress` | cancelling only running jobs misses the ones actually hoarding slots |
| branch name passed via `env` | a head ref is attacker-controlled on a fork; interpolating `${{ }}` into a `run:` block is a **command injection** |

Two bugs found in this workflow before shipping:

- The run **matched its own query** (same head branch) and would have cancelled itself. Now skips its own `run_id`.
- That skip is an `if`, not `[ "$id" = "$THIS_RUN" ] && continue` — under `set -e`, a false test as the loop body's last command aborts the script.

The `gh api -X GET ... -f branch=... -f status=...` form was checked against the live API rather than assumed; it returns the expected run ids.

## Testing

`make ci` green locally (4988 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM