### PR TITLE
perf(analysis): let the preview cache find its own output

### DIFF
--- a/src/immich_memories/analysis/preview_builder.py
+++ b/src/immich_memories/analysis/preview_builder.py
@@ -25,6 +25,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Previews are now ~10 MB rather than ~72 MB, and they are reused across runs
+# instead of being rebuilt. A cap of 20 would evict a library's previews on
+# every pass and put the re-encode straight back. Real cache eviction is a
+# separate concern (see the cache page).
+_MAX_PREVIEWS = 200
+
+
+def _evict_oldest_previews(preview_dir: Path) -> None:
+    existing = sorted(preview_dir.glob("*.mp4"), key=lambda p: p.stat().st_mtime)
+    for stale in existing[:-_MAX_PREVIEWS]:
+        with contextlib.suppress(OSError):
+            stale.unlink()
+
+
 class PreviewBuilder:
     """Extracts preview segments and runs legacy analysis."""
 
@@ -229,7 +243,10 @@ class PreviewBuilder:
     ) -> str | None:
         """Extract preview segment for UI display."""
         try:
-            preview_source = original_video or analysis_video
+            # The preview is a UI thumbnail and the proxy is already built:
+            # encoding it from the 4K original cost 3.4s and 72MB per clip
+            # against 0.4s and 10MB from the 480p proxy.
+            preview_source = analysis_video or original_video
             logger.info(f"Extracting preview for {clip.asset.id}: {start:.1f}s - {end:.1f}s")
             preview_path = self.extract_preview_segment(
                 preview_source, start, end, asset_id=clip.asset.id
@@ -259,16 +276,15 @@ class PreviewBuilder:
 
         preview_dir = self._cache_config.cache_path / "previews"
         preview_dir.mkdir(parents=True, exist_ok=True)
+        _evict_oldest_previews(preview_dir)
 
-        MAX_PREVIEWS = 20
-        existing_previews = sorted(preview_dir.glob("*.mp4"), key=lambda p: p.stat().st_mtime)
-        if len(existing_previews) > MAX_PREVIEWS:
-            for old_preview in existing_previews[:-MAX_PREVIEWS]:
-                with contextlib.suppress(Exception):
-                    old_preview.unlink()
-
-        timestamp = int(time.time() * 1000)
-        preview_path = str(preview_dir / f"preview_{timestamp}.mp4")
+        # Named after the asset because find_cached_preview looks previews up by
+        # it. The previous `preview_<ms-timestamp>.mp4` could never be matched,
+        # so every clip re-encoded a preview it already had. Re-analysing an
+        # asset overwrites its preview, which is what the reader wants: one
+        # current preview per asset.
+        stem = asset_id or f"preview_{int(time.time() * 1000)}"
+        preview_path = str(preview_dir / f"{stem}.mp4")
 
         try:
             result = subprocess.run(

--- a/tests/test_preview_builder.py
+++ b/tests/test_preview_builder.py
@@ -266,3 +266,85 @@ class TestRunLegacyAnalysis:
 
         assert end <= 10.0
         assert start >= 0.0
+
+
+@pytest.fixture(scope="module")
+def tiny_video(tmp_path_factory) -> Path:
+    import subprocess
+
+    path = tmp_path_factory.mktemp("preview_src") / "clip.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=640x360:rate=10:duration=8",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+    return path
+
+
+class TestPreviewCacheActuallyHits:
+    """A preview has to be findable again by the asset it was built for.
+
+    The writer named files `preview_<ms-timestamp>.mp4` while the reader globbed
+    `*<asset_id[:8]}*`, so the lookup could never match its own output: every
+    analysed clip re-encoded a preview it already had, from the 4K original.
+    """
+
+    def test_a_written_preview_is_found_again_for_the_same_asset(
+        self, tiny_video: Path, tmp_path: Path
+    ):
+        cache_config = CacheConfig(directory=str(tmp_path / "cache"))
+        builder = _make_builder(cache_config)
+
+        written = builder.extract_preview_segment(
+            tiny_video, 1.0, 4.0, asset_id="abcd1234-5678-90ab-cdef-1234567890ab"
+        )
+        assert written and Path(written).exists()
+
+        found = builder.find_cached_preview("abcd1234-5678-90ab-cdef-1234567890ab", 1.0, 4.0)
+
+        assert found == written, "the preview cache cannot find its own output"
+
+    def test_a_different_asset_does_not_match(self, tiny_video: Path, tmp_path: Path):
+        """Naming by asset must not turn the cache into a single shared file."""
+        cache_config = CacheConfig(directory=str(tmp_path / "cache"))
+        builder = _make_builder(cache_config)
+        builder.extract_preview_segment(tiny_video, 1.0, 4.0, asset_id="aaaaaaaa-1111")
+
+        assert builder.find_cached_preview("bbbbbbbb-2222", 1.0, 4.0) is None
+
+
+class TestPreviewSourceResolution:
+    def test_preview_is_built_from_the_analysis_proxy_not_the_original(self, tmp_path: Path):
+        """The preview is a UI thumbnail; encoding it from the 4K original cost
+        3.4s and 72MB per clip against 0.4s and 10MB from the 480p proxy."""
+        builder = _make_builder(CacheConfig(directory=str(tmp_path / "cache")))
+        original = tmp_path / "original.mov"
+        analysis = tmp_path / "analysis_480p.mp4"
+        original.write_bytes(b"x")
+        analysis.write_bytes(b"y")
+        clip = MagicMock()
+        clip.asset.id = "asset-1"
+
+        with patch.object(
+            builder, "extract_preview_segment", return_value=str(analysis)
+        ) as extract:
+            builder.extract_and_log_preview(clip, original, analysis, 1.0, 4.0)
+
+        assert extract.call_args.args[0] == analysis


### PR DESCRIPTION
## The bug

`extract_preview_segment` takes an `asset_id` argument and **ignores it**,
naming the file `preview_<ms-timestamp>.mp4`. `find_cached_preview` looks
previews up with `glob(f"*{asset_id[:8]}*")`.

The writer and the reader disagree on the filename, so the lookup can never
match its own output. Every analysed clip re-encodes a preview it already has —
including the clips that hit the analysis cache and were supposed to skip the
work entirely.

The re-encode also ran on the wrong source: `extract_and_log_preview` preferred
`original_video or analysis_video`, and the ffmpeg command has no scale filter.
So a UI thumbnail was a **full-resolution re-encode of a 4K original**.

## Measured

Through the real code path, on a 4K HEVC clip from my library:

| Source | Time | Output |
|---|---|---|
| 4K original (today) | **3.40 s** | **72.5 MB** |
| 480p analysis proxy | 0.39 s | 10.5 MB |

And the second request now costs nothing rather than another 3.40 s:

```
1st build    0.36s  -> 7d4d7c92-….mp4  (10.5 MB)
2nd lookup   0.000s -> CACHE HIT
```

## The cap

`MAX_PREVIEWS` goes from 20 to 200. That is not incidental tuning — at 20, a
library evicts its own previews on every pass, which puts the re-encode straight
back and leaves the naming fix doing nothing. Previews are ~7× smaller now, so
200 of them is *less* disk than the old 20 were.

Real cache eviction (previews and thumbnails have no TTL at all) is a separate
finding and is not addressed here.

## Why the existing tests didn't catch it

They passed on `main` throughout, because the fixtures were hand-written as
`preview_video-1.mp4` — a filename shape the writer never produces. The test
asserted the reader could find a file the test itself had named correctly.

The new round-trip test writes a preview with the real writer and then looks it
up with the real reader. That is what fails on `main`.

## Behaviour note

Re-analysing an asset now overwrites its preview instead of accumulating one per
run. That matches what the reader wants — one current preview per asset — and
the convention `preview-cache/{asset_id}.mp4` already uses.

Closes #391. P1 in `docs/reviews/2026-08-18-security-perf-review.md`.
