### PR TITLE
fix(generate): check the duration budget before music, and scale its tolerance

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2102,48 +2102,56 @@
     "functions": [
       {
         "name": "_generate_memory_inner",
-        "complexity": 21,
-        "line_start": 734,
-        "line_end": 978,
+        "complexity": 19,
+        "line_start": 732,
+        "line_end": 977,
         "line_complexities": [
           {
-            "line": 745,
+            "line": 743,
             "complexity": 1
           },
           {
-            "line": 752,
+            "line": 750,
             "complexity": 1
           },
           {
-            "line": 753,
+            "line": 751,
             "complexity": 0
           },
           {
-            "line": 756,
+            "line": 754,
             "complexity": 0
           },
           {
-            "line": 757,
+            "line": 755,
             "complexity": 0
           },
           {
-            "line": 762,
+            "line": 760,
             "complexity": 0
           },
           {
-            "line": 777,
+            "line": 775,
             "complexity": 0
           },
           {
-            "line": 780,
+            "line": 778,
             "complexity": 0
           },
           {
-            "line": 781,
+            "line": 779,
             "complexity": 0
           },
           {
-            "line": 784,
+            "line": 782,
+            "complexity": 0
+          },
+          {
+            "line": 786,
+            "complexity": 0
+          },
+          {
+            "line": 787,
             "complexity": 0
           },
           {
@@ -2151,39 +2159,35 @@
             "complexity": 0
           },
           {
-            "line": 789,
-            "complexity": 0
-          },
-          {
-            "line": 790,
-            "complexity": 0
-          },
-          {
-            "line": 803,
+            "line": 801,
             "complexity": 2
           },
           {
-            "line": 804,
+            "line": 802,
             "complexity": 0
           },
           {
-            "line": 811,
+            "line": 809,
             "complexity": 0
           },
           {
-            "line": 812,
+            "line": 810,
             "complexity": 0
           },
           {
-            "line": 818,
+            "line": 816,
             "complexity": 1
           },
           {
-            "line": 821,
+            "line": 819,
             "complexity": 0
           },
           {
-            "line": 837,
+            "line": 835,
+            "complexity": 0
+          },
+          {
+            "line": 839,
             "complexity": 0
           },
           {
@@ -2191,79 +2195,75 @@
             "complexity": 0
           },
           {
-            "line": 843,
+            "line": 842,
             "complexity": 0
           },
           {
-            "line": 844,
+            "line": 846,
             "complexity": 0
           },
           {
             "line": 848,
-            "complexity": 0
-          },
-          {
-            "line": 850,
             "complexity": 2
           },
           {
-            "line": 851,
+            "line": 849,
+            "complexity": 0
+          },
+          {
+            "line": 852,
+            "complexity": 2
+          },
+          {
+            "line": 853,
             "complexity": 0
           },
           {
             "line": 854,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 855,
             "complexity": 0
           },
           {
-            "line": 856,
+            "line": 861,
             "complexity": 0
           },
           {
-            "line": 857,
+            "line": 864,
             "complexity": 0
           },
           {
-            "line": 863,
+            "line": 865,
             "complexity": 0
           },
           {
-            "line": 866,
+            "line": 868,
             "complexity": 0
           },
           {
-            "line": 867,
+            "line": 873,
             "complexity": 0
           },
           {
-            "line": 870,
+            "line": 877,
             "complexity": 0
           },
           {
-            "line": 875,
+            "line": 882,
             "complexity": 0
           },
           {
-            "line": 879,
+            "line": 885,
             "complexity": 0
           },
           {
-            "line": 884,
+            "line": 891,
             "complexity": 0
           },
           {
-            "line": 887,
-            "complexity": 0
-          },
-          {
-            "line": 893,
-            "complexity": 0
-          },
-          {
-            "line": 894,
+            "line": 892,
             "complexity": 0
           },
           {
@@ -2299,73 +2299,73 @@
             "complexity": 0
           },
           {
-            "line": 930,
-            "complexity": 2
-          },
-          {
-            "line": 944,
+            "line": 929,
             "complexity": 0
           },
           {
-            "line": 950,
+            "line": 943,
             "complexity": 0
+          },
+          {
+            "line": 949,
+            "complexity": 0
+          },
+          {
+            "line": 951,
+            "complexity": 1
           },
           {
             "line": 952,
-            "complexity": 1
-          },
-          {
-            "line": 953,
             "complexity": 0
           },
           {
-            "line": 954,
+            "line": 953,
             "complexity": 1
           },
           {
-            "line": 955,
+            "line": 954,
+            "complexity": 0
+          },
+          {
+            "line": 956,
             "complexity": 0
           },
           {
             "line": 957,
-            "complexity": 0
-          },
-          {
-            "line": 958,
             "complexity": 1
           },
           {
-            "line": 961,
+            "line": 960,
             "complexity": 0
           },
           {
-            "line": 964,
+            "line": 963,
             "complexity": 0
           },
           {
-            "line": 968,
+            "line": 967,
             "complexity": 1
           },
           {
-            "line": 971,
+            "line": 970,
             "complexity": 3
           },
           {
-            "line": 973,
+            "line": 972,
             "complexity": 1
           },
           {
-            "line": 977,
+            "line": 976,
             "complexity": 0
           },
           {
-            "line": 978,
+            "line": 977,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 89
+    "complexity": 87
   },
   {
     "path": "src/immich_memories/generate_clips.py",

--- a/src/immich_memories/generate.py
+++ b/src/immich_memories/generate.py
@@ -52,13 +52,11 @@ from immich_memories.generate_settings import (
 from immich_memories.generate_timeline import (
     apply_final_content_budget as _apply_final_content_budget,
 )
-from immich_memories.generate_timeline import (
-    validate_final_duration as _validate_final_duration,
-)
+from immich_memories.generate_timeline import publish_and_check_duration
 from immich_memories.operations.phases import OperationalPhase, PhaseEvent
 from immich_memories.processing.clip_validation import validate_clips
 from immich_memories.processing.output_canvas import OutputCanvas
-from immich_memories.processing.output_contract import publish_output_metrics, validate_output
+from immich_memories.processing.output_contract import validate_output
 from immich_memories.security import configured_secret_values, sanitize_error_message
 
 if TYPE_CHECKING:
@@ -891,7 +889,9 @@ def _generate_memory_inner(
             frame_preview_callback=params.frame_preview_callback,
         )
         plan = settings.encoding_plan
-        metrics = publish_output_metrics(staged_result_path, result_output_path, plan)
+        metrics, duration_warning = publish_and_check_duration(
+            params, staged_result_path, result_output_path, plan
+        )
         result_path = result_output_path
         run_tracker.complete_phase(items_processed=len(assembly_clips), extra_metrics=metrics)
         operational.emit(
@@ -926,8 +926,7 @@ def _generate_memory_inner(
         _phase_times["music"] = _time.monotonic() - _t
 
         final_probe = validate_output(result_path, settings.encoding_plan)
-        _validate_final_duration(params, final_probe.duration_seconds)
-        artifact_warnings = [music_result.warning] if music_result.warning else []
+        artifact_warnings = [w for w in (duration_warning, music_result.warning) if w]
         run_tracker.complete_artifact(
             result_path,
             final_probe,

--- a/src/immich_memories/generate_timeline.py
+++ b/src/immich_memories/generate_timeline.py
@@ -7,21 +7,50 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from immich_memories.generate_clips import MIN_CLIP_DURATION
+from immich_memories.processing.output_contract import publish_validated_output
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from immich_memories.generate import GenerationParams
     from immich_memories.processing.assembly_config import AssemblyClip
+    from immich_memories.processing.encoding_plan import EncodingPlan
 
 logger = logging.getLogger(__name__)
 
 
-def validate_final_duration(params: GenerationParams, actual_duration: float) -> None:
-    """Reject a completed artifact that violates the requested final runtime."""
+# Crossfades and frame rounding move the final runtime by a fraction of a second
+# per clip, so a fixed one-second budget is a tighter bound on a 150s memory made
+# of 30 clips than on a 20s one. Past a point an overshoot is a planning bug
+# rather than jitter, and only then is discarding a finished render the right
+# answer.
+_DURATION_JITTER_FLOOR = 1.0
+_DURATION_JITTER_RATIO = 0.02
+# A floor on the hard limit too, so short memories keep a band where an
+# overshoot is reported rather than thrown away.
+_DURATION_HARD_FLOOR = 3.0
+_DURATION_HARD_RATIO = 0.05
+
+
+def _duration_limits(target: float) -> tuple[float, float]:
+    """Return the tolerated limit and the limit past which we refuse the render."""
+    tolerated = target + max(_DURATION_JITTER_FLOOR, target * _DURATION_JITTER_RATIO)
+    return tolerated, target + max(_DURATION_HARD_FLOOR, target * _DURATION_HARD_RATIO)
+
+
+def validate_final_duration(params: GenerationParams, actual_duration: float) -> str | None:
+    """Check a render against its runtime budget.
+
+    Returns a warning for an overshoot worth reporting, or None. Raises only
+    when the artifact is far enough over that it indicates a planning fault --
+    a finished render is expensive, and throwing one away for jitter costs the
+    whole run.
+    """
     target = params.target_duration_seconds
     if target is None:
-        return
+        return None
 
-    limit = target + 1.0
+    budget = target
     plan = params.timeline_plan
     if (
         plan is not None
@@ -29,14 +58,21 @@ def validate_final_duration(params: GenerationParams, actual_duration: float) ->
         and plan.eligible_dividers > 0
         and plan.soft_max_duration is not None
     ):
-        limit = plan.soft_max_duration + 1.0
+        budget = plan.soft_max_duration
 
-    if actual_duration > limit:
+    tolerated, hard_limit = _duration_limits(budget)
+    if actual_duration > hard_limit:
         from immich_memories.generate import GenerationError
 
         raise GenerationError(
-            f"Final artifact exceeds duration budget: {actual_duration:.1f}s > {limit:.1f}s"
+            f"Final artifact exceeds duration budget: {actual_duration:.1f}s > {hard_limit:.1f}s"
         )
+    if actual_duration > tolerated:
+        return (
+            f"Final artifact ran {actual_duration:.1f}s against a {budget:.1f}s budget "
+            f"({actual_duration - budget:.1f}s over)"
+        )
+    return None
 
 
 def _sample_for_minimum_duration(
@@ -91,3 +127,19 @@ def apply_final_content_budget(
         len(assembly_clips),
     )
     return [replace(clip, duration=clip.duration * ratio) for clip in assembly_clips]
+
+
+def publish_and_check_duration(
+    params: GenerationParams,
+    staged_path: Path,
+    final_path: Path,
+    plan: EncodingPlan,
+) -> tuple[dict[str, object], str | None]:
+    """Publish the rendered artifact and check its runtime against the budget.
+
+    Checked here rather than after the music phase: the runtime is already final
+    (music remuxes audio with `-c:v copy`), and rejecting later means discarding
+    a render that has also paid for ACE-Step, Demucs and the mix.
+    """
+    probe = publish_validated_output(staged_path, final_path, plan)
+    return probe.render_metrics(plan), validate_final_duration(params, probe.duration_seconds)

--- a/src/immich_memories/processing/output_contract.py
+++ b/src/immich_memories/processing/output_contract.py
@@ -249,12 +249,3 @@ def publish_validated_output(
     os.replace(staged_path, final_path)
     _fsync_directory(final_path.parent)
     return probe
-
-
-def publish_output_metrics(
-    staged_path: Path,
-    final_path: Path,
-    plan: EncodingPlan,
-) -> dict[str, object]:
-    """Publish a validated artifact and describe the effective render contract."""
-    return publish_validated_output(staged_path, final_path, plan).render_metrics(plan)

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -462,10 +462,10 @@ async def finalize_ui_generation(
             message=music_result.warning or "Music ready",
         )
     final_probe = await io_bound_result(validate_output, prepared.path, prepared.encoding_plan)
-    from immich_memories.generate import _validate_final_duration
+    from immich_memories.generate_timeline import validate_final_duration
 
-    _validate_final_duration(params, final_probe.duration_seconds)
-    warnings = [music_result.warning] if music_result.warning else []
+    duration_warning = validate_final_duration(params, final_probe.duration_seconds)
+    warnings = [w for w in (duration_warning, music_result.warning) if w]
     completed = run_tracker.complete_artifact(
         prepared.path,
         final_probe,
@@ -475,7 +475,7 @@ async def finalize_ui_generation(
         clips_analyzed=prepared.clips_analyzed,
         clips_selected=prepared.clips_selected,
     )
-    state.generation_warning = music_result.warning
+    state.generation_warning = music_result.warning or duration_warning
     state.delivery_status = completed.delivery_status
     emit_operational_phase(
         params,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -18,11 +18,13 @@ from immich_memories.generate import (
     _build_assembly_settings,
     _report,
     _total_clip_duration,
-    _validate_final_duration,
     assets_to_clips,
 )
 from immich_memories.generate_music import music_config_available
 from immich_memories.generate_privacy import clip_location_name
+from immich_memories.generate_timeline import (
+    validate_final_duration as _validate_final_duration,
+)
 from tests.conftest import make_asset, make_clip
 
 
@@ -145,7 +147,7 @@ class TestGenerationError:
             raise GenerationError("test error")
 
 
-def test_generation_rejects_artifact_more_than_one_second_over_target(tmp_path: Path) -> None:
+def test_generation_rejects_artifact_far_enough_over_target(tmp_path: Path) -> None:
     params = GenerationParams(
         clips=[make_clip("clip-1")],
         output_path=tmp_path / "memory.mp4",
@@ -154,10 +156,10 @@ def test_generation_rejects_artifact_more_than_one_second_over_target(tmp_path: 
     )
 
     with pytest.raises(GenerationError, match="duration budget"):
-        _validate_final_duration(params, 61.1)
+        _validate_final_duration(params, 64.0)
 
 
-def test_generation_accepts_one_second_duration_tolerance(tmp_path: Path) -> None:
+def test_generation_accepts_a_render_inside_the_jitter_tolerance(tmp_path: Path) -> None:
     params = GenerationParams(
         clips=[make_clip("clip-1")],
         output_path=tmp_path / "memory.mp4",
@@ -215,8 +217,8 @@ def test_generation_rejects_finalized_month_plan_above_soft_tolerance(tmp_path: 
         ),
     )
 
-    with pytest.raises(GenerationError, match=r"71\.1s > 71\.0s"):
-        _validate_final_duration(params, 71.1)
+    with pytest.raises(GenerationError, match=r"74\.0s > 73\.5s"):
+        _validate_final_duration(params, 74.0)
 
 
 def test_generation_without_dividers_keeps_normal_duration_limit(tmp_path: Path) -> None:
@@ -241,7 +243,7 @@ def test_generation_without_dividers_keeps_normal_duration_limit(tmp_path: Path)
         ),
     )
 
-    with pytest.raises(GenerationError, match=r"65\.0s > 61\.0s"):
+    with pytest.raises(GenerationError, match=r"65\.0s > 63\.0s"):
         _validate_final_duration(params, 65.0)
 
 
@@ -1016,3 +1018,48 @@ class TestApplyMusicFileAtomic:
 
         mix.assert_not_called()
         assert video.read_bytes() == b"original video"
+
+
+class TestDurationBudgetTolerance:
+    """A 0.7s overshoot on a 150s memory is not a defect.
+
+    The budget was a hard fail at target + 1.0s, checked after music. One real
+    run rendered ~30 clips, generated music, mixed it, then failed at 151.7s
+    against 151.0s and threw the finished file away. 0.5% is below the jitter
+    that crossfades and frame rounding produce across that many clips.
+    """
+
+    @staticmethod
+    def _params(tmp_path: Path, target: float) -> GenerationParams:
+        return GenerationParams(
+            clips=[make_clip("clip-1")],
+            output_path=tmp_path / "memory.mp4",
+            config=Config(),
+            target_duration_seconds=target,
+        )
+
+    def test_a_sub_percent_overshoot_is_accepted(self, tmp_path: Path) -> None:
+        """The exact case from the log: 151.7s rendered, limit was 151.0s."""
+        assert _validate_final_duration(self._params(tmp_path, 150.0), 151.7) is None
+
+    def test_tolerance_scales_with_the_target(self, tmp_path: Path) -> None:
+        """2% of 150s is 3s; the same 3s on a 20s memory is not tolerable."""
+        assert _validate_final_duration(self._params(tmp_path, 150.0), 152.5) is None
+
+        assert _validate_final_duration(self._params(tmp_path, 20.0), 22.5) is not None
+
+    def test_a_short_memory_keeps_the_one_second_floor(self, tmp_path: Path) -> None:
+        """2% of 10s is 0.2s, which is below frame rounding."""
+        assert _validate_final_duration(self._params(tmp_path, 10.0), 10.9) is None
+
+    def test_a_moderate_overshoot_warns_instead_of_failing(self, tmp_path: Path) -> None:
+        """Worth telling the operator, not worth discarding a finished render."""
+        warning = _validate_final_duration(self._params(tmp_path, 100.0), 103.0)
+
+        assert warning is not None
+        assert "103.0" in warning
+
+    def test_a_large_overshoot_still_fails(self, tmp_path: Path) -> None:
+        """Past a point it is a planning bug, not jitter."""
+        with pytest.raises(GenerationError, match="duration budget"):
+            _validate_final_duration(self._params(tmp_path, 100.0), 130.0)


### PR DESCRIPTION
## What happened on 08-17

The run rendered ~30 clips, generated music with ACE-Step, separated stems with
Demucs, mixed the result — and then failed at **151.7 s against a 151.0 s
limit**, marking the run failed with the finished file still on disk.

0.7 s is **0.5%** on a 150 s memory. Crossfades and frame rounding move the
final runtime by a fraction of a second per clip, so a flat one-second budget is
a far tighter bound on a 150 s memory made of 30 clips than on a 20 s one. It
was measuring jitter and calling it a defect — and, until #386, the same
candidate was then retried the next night.

## Two changes

**The check moved before music.** It now runs immediately after assembly against
the probe `publish_validated_output` already takes. The duration is final at
that point — music remuxes audio with `-c:v copy` — so nothing is lost by
checking early, and a render that will be rejected no longer pays for ACE-Step,
Demucs and the mix first.

**The tolerance scales, and a moderate overshoot warns instead of failing.**

| Target | Tolerated | Fails above |
|---|---|---|
| 10 s | 11.0 s | 13.0 s |
| 60 s | 61.2 s | 63.0 s |
| 150 s | 153.0 s | 157.5 s |

`max(1.0, 2%)` to tolerate, `max(3.0, 5%)` to fail. The hard *floor* of 3 s
matters: without it the two limits collapse into each other below ~60 s and
short memories lose the band where an overshoot is reported rather than thrown
away.

## Existing tests were updated, not deleted

Three tests encoded the old flat-second rule. Each keeps its original intent
with values moved past the new threshold:

- "an over-budget artifact is rejected" — 61.1 s → 64.0 s on a 60 s target
- "the soft maximum applies with dividers" — 71.1 s → 74.0 s against a 70 s soft max
- "the normal limit applies without dividers" — expected message 61.0 s → 63.0 s

## Structural note

`generate.py` was at **exactly 1000 lines** on `main` — the hard gate — so the
first version of this change broke it at 1009. Rather than mix a file split into
a behaviour fix, the publish-and-check pair moved to `generate_timeline.py`
where the budget policy already lives, which brings `generate.py` to **999**.

Two things fell out of that and are worth noting rather than hiding:

- `publish_output_metrics` is deleted. It was a one-line wrapper whose only
  caller now needs the probe itself, not just the metrics derived from it.
- The UI finalisation path imported `_validate_final_duration` — a private alias
  — from `generate`. It now imports `validate_final_duration` from its home
  module, and surfaces the warning alongside the music one instead of discarding
  the return value.

The 1000-line ceiling on `generate.py` is a real problem for the next change
that touches it; that split is #245 and is not attempted here.

## Not covered by a test

The *ordering* (check before music) has no direct test. Driving `generate()` far
enough to observe it would need mocking well past the three-boundary limit in
CLAUDE.md. The tolerance change — the part that actually prevented this
failure — is covered by six tests, including the exact 151.7 s case.

Closes #393. R2 in `docs/reviews/2026-08-18-security-perf-review.md`.
