### PR TITLE
fix(ui): stop leaking media routes, preview temp dirs and Immich clients

### DIFF
--- a/src/immich_memories/audio/music_sources.py
+++ b/src/immich_memories/audio/music_sources.py
@@ -21,7 +21,6 @@ class MusicTrack:
     artist: str
     duration_seconds: float
     url: str
-    preview_url: str | None = None
     tags: list[str] = field(default_factory=list)
     mood: str | None = None
     genre: str | None = None

--- a/src/immich_memories/ui/pages/_step3_music_preview.py
+++ b/src/immich_memories/ui/pages/_step3_music_preview.py
@@ -91,7 +91,11 @@ async def _generate_music(
         musicgen_config = MusicGenClientConfig.from_app_config(config.musicgen)
         musicgen_config.num_versions = 1
 
+        # Replaces the previous preview: each one is a full mix plus four
+        # stems, and they used to accumulate for the life of the container.
+        state.discard_music_preview()
         output_dir = Path(tempfile.mkdtemp(prefix="immich_music_preview_"))
+        state.music_preview_dir = output_dir
         music_dir = output_dir / "music"
         music_dir.mkdir(exist_ok=True)
 

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -11,7 +11,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from nicegui import app as nicegui_app
 from nicegui import run as run  # re-exported test seam shared by nicegui_compat
 from nicegui import ui
 
@@ -657,14 +656,13 @@ def _show_output(output_container, result_path: Path, state) -> None:
                 )
 
         if result_path.exists():
-            video_url = nicegui_app.add_media_file(local_file=result_path)
             video_wrapper = (
                 ui.element("div")
                 .classes("rounded-xl overflow-hidden mt-4")
                 .style("background: var(--im-bg)")
             )
             with video_wrapper:
-                ui.video(video_url).classes("w-full max-w-2xl").style(
+                ui.video(result_path).classes("w-full max-w-2xl").style(
                     "max-height: 60vh; object-fit: contain"
                 )
             # Auto-scroll to the video player

--- a/src/immich_memories/ui/pages/clip_pipeline.py
+++ b/src/immich_memories/ui/pages/clip_pipeline.py
@@ -525,7 +525,6 @@ def _render_pipeline_progress_ui(clips: list[VideoClipInfo]) -> None:
         "current_asset_id": None,
         "last_completed_asset_id": None,
         "phase_number": -1,
-        "prev_media_url": None,
     }
 
     cancel_btn = (

--- a/src/immich_memories/ui/pages/clip_pipeline_helpers.py
+++ b/src/immich_memories/ui/pages/clip_pipeline_helpers.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import base64
-import contextlib
 import logging
+from pathlib import Path
 from typing import Any
 
 from nicegui import ui
@@ -112,29 +112,17 @@ def _render_segment_and_score(segment: tuple | None, score: float | None) -> Non
             ui.label(f"Score: {score:.2f}").classes("text-sm")
 
 
-def _try_render_video_preview(preview_path: str | None, _rendered_state: dict[str, Any]) -> bool:
+def _try_render_video_preview(preview_path: str | None) -> bool:
     """Attempt to render a video preview. Returns True if successful."""
     if not preview_path:
         return False
     try:
-        from nicegui import app as nicegui_app
-
-        video_url = nicegui_app.add_media_file(local_file=preview_path)
-
-        # Track URLs for cleanup but don't remove routes while they may still be
-        # streaming — Starlette raises RuntimeError if a route is removed mid-request.
-        prev_url = _rendered_state.get("prev_media_url")
-        urls_to_clean = _rendered_state.setdefault("media_urls_to_clean", [])
-        if prev_url and prev_url != video_url:
-            urls_to_clean.append(prev_url)
-        # Only clean up old URLs (2+ cycles stale)
-        while len(urls_to_clean) > 3:
-            old_url = urls_to_clean.pop(0)
-            with contextlib.suppress(Exception):
-                nicegui_app.remove_route(old_url)
-        _rendered_state["prev_media_url"] = video_url
-
-        ui.video(video_url).classes("rounded").props("muted autoplay loop").style(
+        # Passing the Path lets NiceGUI own the media route: it registers one on
+        # assignment and removes it when the element is deleted. That also
+        # answers what the hand-rolled deferral here was guarding against --
+        # Starlette raises if a route is removed mid-request, and a route tied
+        # to the element cannot outlive or predecease the element using it.
+        ui.video(Path(preview_path)).classes("rounded").props("muted autoplay loop").style(
             "max-height: 180px; max-width: 100%; object-fit: contain"
         )
         return True
@@ -158,7 +146,7 @@ def _render_last_analyzed_card(
         )
 
         preview_path = progress_state["last_completed_video_path"]
-        video_shown = _try_render_video_preview(preview_path, _rendered_state)
+        video_shown = _try_render_video_preview(preview_path)
         if not video_shown:
             _render_thumbnail_for(last_asset, detail_container)
 

--- a/src/immich_memories/ui/pages/clip_review.py
+++ b/src/immich_memories/ui/pages/clip_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 
 from nicegui import ui
 
@@ -35,7 +36,6 @@ def _make_preview_loader(video_aid: str, container: ui.element, vid_id: str):
     """Return async loader that swaps thumbnail with video preview."""
 
     async def load_preview():
-        from nicegui import app as nicegui_app
 
         state = get_app_state()
         preview_path = await io_bound_result(_get_preview_path, video_aid, config=state.config)
@@ -45,10 +45,9 @@ def _make_preview_loader(video_aid: str, container: ui.element, vid_id: str):
             )
 
         if preview_path:
-            preview_url = nicegui_app.add_media_file(local_file=preview_path)
             container.clear()
             with container:
-                video_el = ui.video(preview_url).classes("w-full rounded")
+                video_el = ui.video(Path(preview_path)).classes("w-full rounded")
                 video_el.props(f'muted playsinline id="{vid_id}"')
 
     return load_preview

--- a/src/immich_memories/ui/pages/step2_helpers.py
+++ b/src/immich_memories/ui/pages/step2_helpers.py
@@ -148,12 +148,15 @@ def _download_immich_preview(asset_id: str, *, config=None) -> Path | None:
     try:
         from immich_memories.api.immich import SyncImmichClient
 
-        client = SyncImmichClient(
+        # Context-managed: this runs once per preview download, and each client
+        # left to the garbage collector strands an httpx client and its private
+        # event loop.
+        with SyncImmichClient(
             base_url=state.immich_url,
             api_key=state.immich_api_key,
             api_version=state.immich_api_version,
-        )
-        video_bytes: bytes = client.get_video_playback(asset_id)
+        ) as client:
+            video_bytes: bytes = client.get_video_playback(asset_id)
         if video_bytes and len(video_bytes) > 10_000:
             preview_path.write_bytes(video_bytes)
             return preview_path

--- a/src/immich_memories/ui/pages/step4_export.py
+++ b/src/immich_memories/ui/pages/step4_export.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from nicegui import app as nicegui_app
 from nicegui import ui
 
 from immich_memories.ui.components import (
@@ -44,8 +43,7 @@ def _render_existing_result(state) -> None:
     ui.label(f"Immich delivery: {delivery_label}").classes("text-sm").style(
         "color: var(--im-text-secondary)"
     )
-    video_url = nicegui_app.add_media_file(local_file=output_path)
-    ui.video(video_url).classes("w-full rounded-lg").style(
+    ui.video(output_path).classes("w-full rounded-lg").style(
         "max-height: 400px; object-fit: contain; background: var(--im-bg-surface)"
     )
 

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -73,6 +74,9 @@ class AppState:
 
     # Music preview (generated in Step 3, used in Step 4)
     music_preview_result: Any | None = None  # MusicGenerationResult
+    # Kept so the previous preview's stems can be removed when a new one is
+    # generated: a full mix plus four stems is 50-300 MB per click.
+    music_preview_dir: Path | None = None
     music_generating: bool = False
 
     # Cancel support
@@ -174,6 +178,14 @@ class AppState:
         self.cancel_requested = False
         self.scored_photos = []
         self.photo_budget_result = None
+        self.discard_music_preview()
+
+    def discard_music_preview(self) -> None:
+        """Delete a previously generated music preview and its stems."""
+        previous, self.music_preview_dir = self.music_preview_dir, None
+        self.music_preview_result = None
+        if previous is not None:
+            shutil.rmtree(previous, ignore_errors=True)
 
     def get_selected_clips(self) -> list[VideoClipInfo]:
         """Get the list of currently selected clips."""

--- a/tests/test_sidebar_completion.py
+++ b/tests/test_sidebar_completion.py
@@ -77,8 +77,7 @@ def test_step4_rerender_keeps_warning_delivery_truth_and_video_link(
         delivery_status=DeliveryStatus.PENDING,
     )
     labels: list[str] = []
-    media_paths: list[Path] = []
-    video_urls: list[str] = []
+    shown_videos: list[Path] = []
 
     monkeypatch.setattr(step4_export, "im_section_header", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
@@ -87,14 +86,9 @@ def test_step4_rerender_keeps_warning_delivery_truth_and_video_link(
         lambda value, **_kwargs: (labels.append(value), _Element())[1],
     )
     monkeypatch.setattr(
-        step4_export.nicegui_app,
-        "add_media_file",
-        lambda *, local_file: (media_paths.append(local_file), "/video/memory")[1],
-    )
-    monkeypatch.setattr(
         step4_export.ui,
         "video",
-        lambda value, **_kwargs: (video_urls.append(value), _Element())[1],
+        lambda value, **_kwargs: (shown_videos.append(value), _Element())[1],
     )
 
     step4_export._render_existing_result(state)
@@ -102,5 +96,6 @@ def test_step4_rerender_keeps_warning_delivery_truth_and_video_link(
     assert f"Saved to: {output_path}" in labels
     assert warning in labels
     assert "Immich delivery: Pending" in labels
-    assert media_paths == [output_path]
-    assert video_urls == ["/video/memory"]
+    # The element is handed the file, not a pre-registered URL: NiceGUI owns
+    # the route's lifetime that way.
+    assert shown_videos == [output_path]

--- a/tests/test_ui_generation_lifecycle.py
+++ b/tests/test_ui_generation_lifecycle.py
@@ -1137,13 +1137,12 @@ async def test_ui_observer_after_completion_recovers_persisted_session_truth(
     monkeypatch.setattr(step4_generate.ui, "row", lambda *_args, **_kwargs: _Element())
     monkeypatch.setattr(step4_generate.ui, "column", lambda *_args, **_kwargs: _Element())
     monkeypatch.setattr(step4_generate.ui, "icon", lambda *_args, **_kwargs: _Element())
-    monkeypatch.setattr(step4_generate.ui, "video", lambda *_args, **_kwargs: _Element())
-    monkeypatch.setattr(step4_generate.ui, "run_javascript", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
-        step4_generate.nicegui_app,
-        "add_media_file",
-        lambda *, local_file: (linked_paths.append(local_file), "/video")[1],
+        step4_generate.ui,
+        "video",
+        lambda value, **_kwargs: (linked_paths.append(value), _Element())[1],
     )
+    monkeypatch.setattr(step4_generate.ui, "run_javascript", lambda *_args, **_kwargs: None)
     show_output(_Container(), state.output_path, state)
 
     assert linked_paths == [output_path]
@@ -1261,7 +1260,6 @@ def test_completion_screen_keeps_music_warning_and_truthful_pending_delivery(
     )
     monkeypatch.setattr(step4_generate.ui, "video", lambda *_args, **_kwargs: _Element())
     monkeypatch.setattr(step4_generate.ui, "run_javascript", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(step4_generate.nicegui_app, "add_media_file", lambda **_kwargs: "/video")
 
     step4_generate._show_output(_Container(), output_path, state)
 

--- a/tests/test_ui_media_routes.py
+++ b/tests/test_ui_media_routes.py
@@ -1,0 +1,140 @@
+"""Media routes must not outlive the element that needed them.
+
+`app.add_media_file()` registers a FastAPI route and never removes it. NiceGUI
+does not dedupe, so the same file registered twice yields two routes. Step 2
+registered one per clip preview on every render, which meant the route table
+grew for the lifetime of the process -- and Starlette matches routes linearly on
+every request, so every page in the app pays for it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from nicegui import core, ui
+
+
+@pytest.fixture(scope="module")
+def media_file(tmp_path_factory) -> Path:
+    path = tmp_path_factory.mktemp("media") / "clip.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=64x64:rate=5:duration=1",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+    return path
+
+
+def test_a_video_element_releases_its_route_when_deleted(media_file: Path):
+    """Handing ui.video a Path ties the route's lifetime to the element."""
+    before = len(core.app.routes)
+
+    element = ui.video(media_file)
+    assert len(core.app.routes) == before + 1, "no media route was registered"
+
+    element.delete()
+
+    assert len(core.app.routes) == before, "the media route outlived its element"
+
+
+def test_registering_the_file_directly_leaks_the_route(media_file: Path):
+    """The behaviour the pages used to rely on, kept here as the contrast.
+
+    Nothing removes this route, which is why no page may call add_media_file.
+    """
+    before = len(core.app.routes)
+
+    core.app.add_media_file(local_file=media_file)
+
+    assert len(core.app.routes) == before + 1
+    core.app.remove_route(core.app.routes[-1].path)
+
+
+def test_no_ui_page_registers_media_files_by_hand():
+    """A regression guard: the leak returns the moment a page calls this again."""
+    pages = Path(__file__).resolve().parent.parent / "src" / "immich_memories" / "ui"
+    offenders = [
+        f"{path.relative_to(pages.parent.parent)}:{i + 1}"
+        for path in pages.rglob("*.py")
+        for i, line in enumerate(path.read_text().splitlines())
+        if "add_media_file" in line
+    ]
+
+    assert offenders == [], f"pass the Path to ui.video instead: {offenders}"
+
+
+class TestMusicPreviewCleanup:
+    """Each "Generate music" click wrote a full mix plus four stems into a fresh
+    temp dir -- 50-300 MB -- and nothing ever removed them, so they accumulated
+    in the container's /tmp for as long as the process lived.
+    """
+
+    @staticmethod
+    def _preview_dir(tmp_path: Path, name: str) -> Path:
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / "mix.wav").write_bytes(b"x" * 1024)
+        return directory
+
+    def test_discarding_removes_the_previous_preview(self, tmp_path: Path):
+        from immich_memories.ui.state import AppState
+
+        state = AppState()
+        directory = self._preview_dir(tmp_path, "preview-1")
+        state.music_preview_dir = directory
+        state.music_preview_result = object()
+
+        state.discard_music_preview()
+
+        assert not directory.exists()
+        assert state.music_preview_dir is None
+        assert state.music_preview_result is None
+
+    def test_discarding_twice_is_harmless(self, tmp_path: Path):
+        """Called on reset as well as regenerate, so it must tolerate repeats."""
+        from immich_memories.ui.state import AppState
+
+        state = AppState()
+        state.music_preview_dir = self._preview_dir(tmp_path, "preview-2")
+
+        state.discard_music_preview()
+        state.discard_music_preview()
+
+    def test_a_dir_removed_underneath_us_does_not_raise(self, tmp_path: Path):
+        from immich_memories.ui.state import AppState
+
+        state = AppState()
+        state.music_preview_dir = tmp_path / "never-created"
+
+        state.discard_music_preview()
+
+    def test_resetting_clips_discards_the_preview(self, tmp_path: Path):
+        """Changing the selection invalidates music generated for the old one."""
+        from immich_memories.ui.state import AppState
+
+        state = AppState()
+        directory = self._preview_dir(tmp_path, "preview-3")
+        state.music_preview_dir = directory
+
+        state.reset_clips()
+
+        assert not directory.exists()


### PR DESCRIPTION
Three leaks in the long-lived UI process, each bounded only by how long the
container runs.

## Media routes (the expensive one)

Every clip preview called `app.add_media_file()`, which NiceGUI implements as a
route append with **no dedupe and no removal**. Step 2 registered one per clip on
every render, so the table grew for the process lifetime — and Starlette matches
routes linearly on every request, so every page in the app paid for it.

Passing the `Path` to `ui.video()` makes NiceGUI own the route: `SourceElement`
registers it on assignment and `_handle_delete` removes it with the element.

**Verified rather than assumed** — the test asserts the lifecycle directly:

```
routes before=7   with element=8   after delete=7
```

It also resolves what the hand-rolled cleanup in `clip_pipeline_helpers` was
working around. Its comment warned that removing a route mid-stream raises in
Starlette, so it deferred removal by three render cycles and hoped. A route tied
to its element cannot outlive the element using it, so the bookkeeping and the
`prev_media_url` state feeding it are both gone.

A guard test fails if any UI page calls `add_media_file` again — it finds all
four sites on `main`.

## Music previews

Each "Generate music" click created a `mkdtemp` holding a full mix plus four
stems — 50–300 MB — and nothing removed it. The directory now lives on
`AppState`, is replaced on regenerate, and is cleared by `reset_clips`, so a
session holds one instead of one per click.

## Immich clients

The per-preview download built a `SyncImmichClient` without closing it,
stranding an httpx client and a private event loop each time. Now
context-managed, like the other eighteen call sites.

## One incidental deletion, because it looks unrelated

Removing the `preview_url` local in `clip_review.py` made vulture flag
`MusicTrack.preview_url`. Vulture matches by **name**, and that local was the
only other occurrence in the tree, so deleting it unmasked a genuinely dead
dataclass field — the sole `MusicTrack` construction never sets it and nothing
reads it. Deleted rather than whitelisted, since the whitelist is a frozen
one-way ratchet.

## Tests updated, not deleted

Three tests patched `nicegui_app.add_media_file` and asserted the URL it
returned. Their intent — "the completion screen shows the right video" — is
preserved and slightly strengthened: they now assert `ui.video` receives the
output **path**, which names the actual file rather than an opaque URL.

## Not included

`_step4_generate` builds a `SyncImmichClient` handed to `GenerationParams` and
used through generation **and** delivery. A `with` block there would close it
before upload; it needs a `finally` around the whole flow. That is its own
change and is not forgotten.

Closes #396. L1, L2 and L6 in `docs/reviews/2026-08-18-security-perf-review.md`.
