### PR TITLE
perf(health): serve repeat probes from a snapshot, and keep SQLite off the loop

### DIFF
--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -8,6 +8,7 @@ import os
 import secrets
 import socket
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -465,7 +466,29 @@ def _operational_detail(
     return automation, last_successful_run
 
 
+# /health and /health/ready are unauthenticated so probes work without
+# credentials, and each build costs a network round trip to Immich plus ~12
+# SQLite connections. Serving repeats from a short-lived snapshot keeps a flood
+# of requests from turning into a flood of work, while staying well inside the
+# 15s readiness period so a scheduled probe still reports current truth.
+_HEALTH_SNAPSHOT_TTL_SECONDS = 10.0
+_health_snapshot_cache: tuple[float, dict[str, Any]] | None = None
+
+
 async def _build_health_snapshot() -> dict[str, Any]:
+    """Build the shared detailed health payload, reusing a recent one if fresh."""
+    global _health_snapshot_cache
+
+    cached = _health_snapshot_cache
+    if cached is not None and time.monotonic() - cached[0] < _HEALTH_SNAPSHOT_TTL_SECONDS:
+        return cached[1]
+
+    snapshot = await _compute_health_snapshot()
+    _health_snapshot_cache = (time.monotonic(), snapshot)
+    return snapshot
+
+
+async def _compute_health_snapshot() -> dict[str, Any]:
     """Build the shared detailed health payload for readiness and compatibility."""
     try:
         config = get_config()
@@ -501,7 +524,11 @@ async def _build_health_snapshot() -> dict[str, Any]:
     else:
         immich = _ImmichDependency(status="missing_configuration", reachable=False)
 
-    automation, last_successful_run = _operational_detail(config, secrets_to_redact)
+    # Synchronous SQLite: on the event loop each open waits on the write lock
+    # while a pipeline run holds it, which stalls every other session.
+    automation, last_successful_run = await asyncio.to_thread(
+        _operational_detail, config, secrets_to_redact
+    )
 
     ready = configured and immich.status == "ready"
     api_version_policy = getattr(config.immich.api_version, "value", config.immich.api_version)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from datetime import datetime
@@ -31,6 +32,19 @@ def _config_with_every_secret_class() -> Config:
         },
         notifications={"urls": ["https://notify.test/notification-log-secret"]},
     )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_health_snapshot():
+    """The snapshot cache is process-global, as it must be to serve probes.
+
+    Tests would otherwise read each other's snapshots, so each starts cold.
+    """
+    from immich_memories.ui import app as app_module
+
+    app_module._health_snapshot_cache = None
+    yield
+    app_module._health_snapshot_cache = None
 
 
 class TestHealthEndpoint:
@@ -682,3 +696,115 @@ class TestHealthDisclosure:
 
         assert response.json()["last_automation_attempt"] == {"memory_key": "year_in_review:2024"}
         assert response.json()["last_successful_run"] == "run-123"
+
+
+class TestHealthIsCheapUnderRepeatedProbes:
+    """`/health` and `/health/ready` are unauthenticated and did real work per hit.
+
+    Each request opened ~12 SQLite connections (measured), including migration
+    transactions, synchronously on the event loop, and made a network round trip
+    to Immich with a 5s budget. Anything that can reach the port could make the
+    app do that as fast as it liked, and every one of those connections waits on
+    the write lock while a pipeline run holds it -- freezing the UI for everyone.
+    """
+
+    @staticmethod
+    def _reset_cache() -> None:
+        from immich_memories.ui import app as app_module
+
+        app_module._health_snapshot_cache = None
+
+    @pytest.mark.asyncio
+    async def test_a_burst_of_probes_does_the_work_once(self):
+        from immich_memories.ui import app as app_module
+
+        self._reset_cache()
+        calls = []
+
+        async def counted_dependency(config):  # noqa: ARG001
+            calls.append(1)
+            return app_module._ImmichDependency(status="ready", reachable=True)
+
+        # WHY: the Immich server and the SQLite stores behind the snapshot
+        with (
+            # WHY: external Immich server
+            patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
+            # WHY: reads four SQLite databases
+            patch("immich_memories.ui.app._operational_detail", return_value=(None, None)),
+        ):
+            for _ in range(5):
+                await app_module._health_handler(MagicMock())
+
+        assert len(calls) == 1, f"{len(calls)} dependency probes for 5 requests"
+
+    @pytest.mark.asyncio
+    async def test_the_snapshot_goes_stale_so_readiness_stays_truthful(self, monkeypatch):
+        """A cache that never expires would report a dead Immich as ready."""
+        from immich_memories.ui import app as app_module
+
+        self._reset_cache()
+        calls = []
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(app_module.time, "monotonic", lambda: clock["now"])
+
+        async def counted_dependency(config):  # noqa: ARG001
+            calls.append(1)
+            return app_module._ImmichDependency(status="ready", reachable=True)
+
+        # WHY: the Immich server and the SQLite stores behind the snapshot
+        with (
+            # WHY: external Immich server
+            patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
+            # WHY: reads four SQLite databases
+            patch("immich_memories.ui.app._operational_detail", return_value=(None, None)),
+        ):
+            await app_module._health_handler(MagicMock())
+            clock["now"] += 60.0
+            await app_module._health_handler(MagicMock())
+
+        assert len(calls) == 2, "the snapshot never refreshed"
+
+    @pytest.mark.asyncio
+    async def test_the_database_work_does_not_block_the_event_loop(self):
+        """The SQLite reads are synchronous; on the loop they stall every session."""
+        import asyncio
+        import time as time_module
+
+        from immich_memories.ui import app as app_module
+
+        self._reset_cache()
+        ticks = 0
+
+        async def tick() -> None:
+            nonlocal ticks
+            for _ in range(40):
+                await asyncio.sleep(0.005)
+                ticks += 1
+
+        def slow_blocking_detail(config, secrets):  # noqa: ARG001
+            time_module.sleep(0.2)
+            return None, None
+
+        async def ready_dependency(config):  # noqa: ARG001
+            return app_module._ImmichDependency(status="ready", reachable=True)
+
+        # WHY: stands in for the Immich server and for a slow SQLite read
+        with (
+            # WHY: external Immich server
+            patch("immich_memories.ui.app._check_immich_dependency", ready_dependency),
+            # WHY: a real contended SQLite read, without needing contention
+            patch("immich_memories.ui.app._operational_detail", slow_blocking_detail),
+        ):
+            ticker = asyncio.create_task(tick())
+            await asyncio.sleep(0.01)
+            before = ticks
+            await app_module._health_handler(MagicMock())
+            # Sampled here, not after awaiting the ticker: once the handler
+            # returns the ticker finishes either way, which would make this
+            # pass whether or not the loop was ever blocked.
+            during = ticks - before
+            ticker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker
+
+        assert during > 20, f"loop advanced only {during} ticks during a 200ms health call"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -714,6 +714,18 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
         app_module._health_snapshot_cache = None
 
+    @staticmethod
+    def _configured_config():
+        """A configured Immich, owned by the test.
+
+        The dependency probe only runs when a URL and key are present, so
+        without this the assertions passed on a developer machine with a real
+        config and never probed at all in CI.
+        """
+        from immich_memories.config_loader import Config
+
+        return Config(immich={"url": "http://immich.test:2283", "api_key": "test-key"})
+
     @pytest.mark.asyncio
     async def test_a_burst_of_probes_does_the_work_once(self):
         from immich_memories.ui import app as app_module
@@ -727,6 +739,8 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
         # WHY: the Immich server and the SQLite stores behind the snapshot
         with (
+            # WHY: the probe only runs for a configured Immich
+            patch("immich_memories.ui.app.get_config", self._configured_config),
             # WHY: external Immich server
             patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
             # WHY: reads four SQLite databases
@@ -753,6 +767,8 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
         # WHY: the Immich server and the SQLite stores behind the snapshot
         with (
+            # WHY: the probe only runs for a configured Immich
+            patch("immich_memories.ui.app.get_config", self._configured_config),
             # WHY: external Immich server
             patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
             # WHY: reads four SQLite databases
@@ -790,6 +806,8 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
         # WHY: stands in for the Immich server and for a slow SQLite read
         with (
+            # WHY: the probe only runs for a configured Immich
+            patch("immich_memories.ui.app.get_config", self._configured_config),
             # WHY: external Immich server
             patch("immich_memories.ui.app._check_immich_dependency", ready_dependency),
             # WHY: a real contended SQLite read, without needing contention


### PR DESCRIPTION
## What every probe cost

`/health` and `/health/ready` are unauthenticated so probes work without
credentials — and each request did real work. Measured on a warm, empty
database:

```
_get_automation_status      18.5 ms    9 sqlite connects
_get_last_successful_run     7.0 ms    3 sqlite connects
TOTAL per hit               25.5 ms   12 sqlite connects
```

plus a network round trip to Immich with a 5 s budget — **all synchronously on
the event loop**. `AutoRunner(config)` builds three stores that each run
migrations in their constructor, `status()` opens five more, and
`_get_last_successful_run` a fourth `RunDatabase`.

That is two distinct problems:

- **The UI freezes for everyone.** Each of those opens waits on the SQLite write
  lock while a pipeline run holds it, up to the 5 s busy timeout — on the loop,
  so no other session is served in the meantime.
- **Anything that can reach the port** can make the app do it as fast as it
  likes, including the round trip. Cheap amplification aimed at the user's own
  Immich.

## After

Repeat requests come from a snapshot held for 10 s — well inside the 15 s
readiness period, so a scheduled probe still reports current truth while a flood
collapses into one build:

| 10 requests | Time | SQLite connects |
|---|---|---|
| uncached | 73.0 ms | **120** |
| cached | 7.8 ms | **12** |

The synchronous reads moved to a thread, so the loop keeps serving while they
wait on the lock.

## The test that nearly lied

The non-blocking test samples the loop's progress **at the moment the handler
returns**, not after. Measured afterwards, the ticker finishes either way, so the
assertion reads identically whether or not the loop was ever blocked — which is
exactly how my first version of it passed against unfixed code. It now fails on
`main` as it should.

The snapshot cache is process-global, as it must be to serve probes, so tests
reset it around each case instead of reading each other's snapshots.

## Not included

Migrating once per process rather than in every store constructor. That is a
change to the store classes themselves and belongs in its own PR.

The probe paths the review flagged are **already correct on `main`** — liveness
and the Docker healthcheck both use `/health/live`. That part of S8 is stale.

Closes #399. P4 and S8 in `docs/reviews/2026-08-18-security-perf-review.md`.
