### PR TITLE
fix(photos): a missing asset costs one photo, not the whole run

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2639,40 +2639,36 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 580,
-        "line_end": 679,
+        "line_start": 581,
+        "line_end": 680,
         "line_complexities": [
           {
-            "line": 601,
+            "line": 602,
             "complexity": 0
           },
           {
-            "line": 602,
-            "complexity": 1
-          },
-          {
-            "line": 604,
+            "line": 603,
             "complexity": 1
           },
           {
             "line": 605,
-            "complexity": 0
-          },
-          {
-            "line": 606,
-            "complexity": 2
-          },
-          {
-            "line": 607,
-            "complexity": 0
-          },
-          {
-            "line": 614,
             "complexity": 1
           },
           {
-            "line": 618,
+            "line": 606,
             "complexity": 0
+          },
+          {
+            "line": 607,
+            "complexity": 2
+          },
+          {
+            "line": 608,
+            "complexity": 0
+          },
+          {
+            "line": 615,
+            "complexity": 1
           },
           {
             "line": 619,
@@ -2680,54 +2676,58 @@
           },
           {
             "line": 620,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 621,
-            "complexity": 0
-          },
-          {
-            "line": 622,
-            "complexity": 2
-          },
-          {
-            "line": 623,
-            "complexity": 0
-          },
-          {
-            "line": 630,
             "complexity": 1
           },
           {
-            "line": 634,
+            "line": 622,
             "complexity": 0
           },
           {
-            "line": 637,
+            "line": 623,
+            "complexity": 2
+          },
+          {
+            "line": 624,
+            "complexity": 0
+          },
+          {
+            "line": 631,
+            "complexity": 1
+          },
+          {
+            "line": 635,
             "complexity": 0
           },
           {
             "line": 638,
-            "complexity": 2
-          },
-          {
-            "line": 639,
-            "complexity": 3
-          },
-          {
-            "line": 641,
-            "complexity": 1
-          },
-          {
-            "line": 644,
             "complexity": 0
           },
           {
-            "line": 678,
+            "line": 639,
+            "complexity": 2
+          },
+          {
+            "line": 640,
+            "complexity": 3
+          },
+          {
+            "line": 642,
             "complexity": 1
           },
           {
+            "line": 645,
+            "complexity": 0
+          },
+          {
             "line": 679,
+            "complexity": 1
+          },
+          {
+            "line": 680,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/photos/moment_suppression.py
+++ b/src/immich_memories/photos/moment_suppression.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import Any
 
 from immich_memories.analysis.duplicate_hashing import compute_thumbnail_hash, hamming_distance
+from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import Asset, VideoClipInfo
 from immich_memories.config_models import PhotoConfig
 
@@ -195,7 +196,7 @@ def _thumbnail_hash_resolver(
         if data is None and thumbnail_fn is not None:
             try:
                 data = thumbnail_fn(asset_id, size="preview")
-            except (OSError, RuntimeError, ValueError):
+            except (ImmichAPIError, OSError, RuntimeError, ValueError):
                 return None
             if data and thumbnail_cache is not None:
                 thumbnail_cache.put(asset_id, "preview", data)

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -26,6 +26,7 @@ from immich_memories.analysis.unified_budget import (
     estimate_title_overhead,
     select_within_budget,
 )
+from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import Asset
 from immich_memories.config_models import PhotoConfig
 from immich_memories.photos.animator import prepare_photo_source
@@ -442,7 +443,7 @@ def _llm_score_photo(
         try:
             thumb_bytes = thumbnail_fn(asset.id, size="preview")
             thumb_path.write_bytes(thumb_bytes)
-        except (OSError, RuntimeError, ValueError):
+        except (ImmichAPIError, OSError, RuntimeError, ValueError):
             thumbnail_fn = None  # Fall back to full download
 
     if thumb_path.exists():
@@ -463,7 +464,7 @@ def _llm_score_photo(
     if not raw_path.exists():
         try:
             download_fn(asset.id, raw_path)
-        except (OSError, RuntimeError, ValueError):
+        except (ImmichAPIError, OSError, RuntimeError, ValueError):
             return None
 
     try:
@@ -572,7 +573,7 @@ def _render_single_photo(
             location_name=asset.exif_info.city if asset.exif_info else None,
         )
 
-    except (OSError, subprocess.SubprocessError, ValueError) as e:
+    except (ImmichAPIError, OSError, subprocess.SubprocessError, ValueError) as e:
         logger.warning(f"Failed to render photo {asset.id}: {e}")
         return None
 

--- a/tests/test_thumbnail_404_survives.py
+++ b/tests/test_thumbnail_404_survives.py
@@ -1,0 +1,84 @@
+"""A missing asset must cost one photo, not the whole run.
+
+Found by the capability matrix: after 409 seconds of analysis a single
+`GET /assets/<id>/thumbnail` returning 404 ended the generation. In a library
+of tens of thousands of assets something is always mid-import or just deleted,
+so this is routine rather than exceptional.
+
+Both photo call sites already meant to be tolerant — the comment at the moment
+suppression site says a bad thumbnail "must cost this photo its comparison, not
+the run" — but they catch `(OSError, RuntimeError, ValueError)`, and Immich
+raises `ImmichNotFoundError`, which inherits from `ImmichAPIError` and none of
+those.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from immich_memories.api.immich import ImmichNotFoundError
+from immich_memories.photos import moment_suppression, photo_pipeline
+
+# Every place these modules reach Immich. Enumerated rather than pattern-matched,
+# because one of them had no guard at all.
+_NETWORK_CALLS = ("thumbnail_fn(", "download_fn(")
+
+
+def _raise_404(*args: object, **kwargs: object) -> bytes:
+    raise ImmichNotFoundError("Resource not found", status_code=404)
+
+
+def test_the_hash_resolver_skips_a_missing_thumbnail() -> None:
+    resolve = moment_suppression._thumbnail_hash_resolver(
+        thumbnail_cache=None, thumbnail_fn=_raise_404
+    )
+
+    assert resolve("gone") is None
+
+
+def test_rendering_skips_a_photo_whose_original_is_gone(tmp_path: Path) -> None:
+    """`_render_single_photo` returns None for a skip; callers do `if clip:`."""
+    asset = pytest.importorskip("immich_memories.api.models").Asset(
+        id="gone",
+        type="IMAGE",
+        fileCreatedAt="2026-01-05T00:00:00Z",
+        fileModifiedAt="2026-01-05T00:00:00Z",
+        updatedAt="2026-01-05T00:00:00Z",
+        width=4032,
+        height=3024,
+    )
+    config = photo_pipeline.PhotoConfig()
+
+    result = photo_pipeline._render_single_photo(
+        asset, config, 1920, 1080, tmp_path, download_fn=_raise_404
+    )
+
+    assert result is None
+
+
+def test_every_immich_call_is_guarded_against_a_missing_asset() -> None:
+    """Each network call must sit under a guard naming ImmichAPIError.
+
+    Scoped to the enclosing `try` of an actual Immich call: guards around JPEG
+    decoding should stay narrow, and swallowing an API error there would hide a
+    real fault rather than tolerate an expected one.
+    """
+    for module in (moment_suppression, photo_pipeline):
+        lines = inspect.getsource(module).splitlines()
+        calls = [
+            i
+            for i, ln in enumerate(lines)
+            if any(c in ln for c in _NETWORK_CALLS) and "def " not in ln
+        ]
+        assert calls, f"{module.__name__} no longer calls Immich"
+
+        for i in calls:
+            guard = next((ln for ln in lines[i : i + 80] if ln.strip().startswith("except ")), None)
+            assert guard and "ImmichAPIError" in guard, (
+                f"{module.__name__} line {i + 1} ({lines[i].strip()}) is guarded by "
+                f"{guard!r} — a 404 raises ImmichNotFoundError, which inherits from "
+                "ImmichAPIError and from none of those"
+            )


### PR DESCRIPTION
Found by the capability matrix, on its very first smoke row.

## What happens

A run died after **409 seconds** of analysis because one asset's thumbnail returned 404:

```
GET /api/assets/<id>/thumbnail?size=preview → 404 Not Found
[ERROR] immich_memories.cli: Immich API error: Resource not found
```

In a library of tens of thousands of assets something is always mid-import or just deleted. This is a Tuesday, not an edge case, and it destroys a seven-minute render.

## Why the existing guards missed it

Both photo call sites **already meant to be tolerant**. The comment at the moment-suppression site says a bad thumbnail *"must cost this photo its comparison, not the run"*.

They catch `(OSError, RuntimeError, ValueError)`. Immich raises `ImmichNotFoundError`, which inherits from `ImmichAPIError` — and from **none of those**. The intent was right; the exception tuple never matched what actually gets raised.

## Enumerated, not pattern-matched

Four call sites reach Immich from these two modules. That distinction mattered:

| site | had a guard? |
|---|---|
| `moment_suppression.py:197` thumbnail | yes, wrong types |
| `photo_pipeline.py:443` thumbnail | yes, wrong types |
| `photo_pipeline.py:465` download | yes, wrong types |
| `photo_pipeline.py:509` download | **none at all** |

A blanket edit over existing `except` lines would have left the fourth raising and shipped a partial fix. It is covered by `_render_single_photo`'s outer guard, which already returns `None` — the established "skip this photo" contract, since callers do `if clip: clips.append(clip)`.

**Two guards deliberately left alone**: those wrapping `score_photo_with_llm`. Swallowing an API error there would hide a real fault rather than tolerate an expected one.

## Testing

The regression test enumerates the network calls and asserts each sits under a guard naming `ImmichAPIError`, so a new call added without one fails here rather than in a seven-minute render. Plus behavioural tests: the hash resolver returns `None` for a missing thumbnail, and `_render_single_photo` returns `None` when the original is gone.

`make ci` green locally — **5018 passed**. Six lines of source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM