### PR TITLE
perf(cache): give thumbnails and previews a real size budget

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -5490,27 +5490,23 @@
       {
         "name": "_render_step2_content",
         "complexity": 16,
-        "line_start": 415,
-        "line_end": 481,
+        "line_start": 418,
+        "line_end": 484,
         "line_complexities": [
           {
-            "line": 423,
+            "line": 426,
             "complexity": 0
           },
           {
-            "line": 426,
+            "line": 429,
             "complexity": 1
           },
           {
-            "line": 427,
+            "line": 430,
             "complexity": 0
           },
           {
-            "line": 428,
-            "complexity": 0
-          },
-          {
-            "line": 437,
+            "line": 431,
             "complexity": 0
           },
           {
@@ -5518,32 +5514,24 @@
             "complexity": 0
           },
           {
-            "line": 441,
+            "line": 443,
+            "complexity": 0
+          },
+          {
+            "line": 444,
             "complexity": 3
           },
           {
-            "line": 442,
+            "line": 445,
             "complexity": 0
           },
           {
-            "line": 446,
+            "line": 449,
             "complexity": 0
           },
           {
-            "line": 447,
+            "line": 450,
             "complexity": 0
-          },
-          {
-            "line": 451,
-            "complexity": 0
-          },
-          {
-            "line": 452,
-            "complexity": 0
-          },
-          {
-            "line": 453,
-            "complexity": 3
           },
           {
             "line": 454,
@@ -5554,35 +5542,47 @@
             "complexity": 0
           },
           {
-            "line": 464,
-            "complexity": 1
+            "line": 456,
+            "complexity": 3
           },
           {
-            "line": 466,
-            "complexity": 1
-          },
-          {
-            "line": 467,
+            "line": 457,
             "complexity": 0
           },
           {
-            "line": 468,
-            "complexity": 2
+            "line": 458,
+            "complexity": 0
+          },
+          {
+            "line": 467,
+            "complexity": 1
+          },
+          {
+            "line": 469,
+            "complexity": 1
           },
           {
             "line": 470,
+            "complexity": 0
+          },
+          {
+            "line": 471,
+            "complexity": 2
+          },
+          {
+            "line": 473,
             "complexity": 1
           },
           {
-            "line": 474,
+            "line": 477,
             "complexity": 1
           },
           {
-            "line": 476,
+            "line": 479,
             "complexity": 1
           },
           {
-            "line": 480,
+            "line": 483,
             "complexity": 2
           }
         ]

--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -107,7 +107,20 @@ cache:
   video_cache_enabled: true
   video_cache_max_size_gb: 10.0     # Max disk usage for downloaded videos
   video_cache_max_age_days: 7       # Evict videos older than this
+  thumbnail_cache_max_size_mb: 500  # Max disk for Immich thumbnails
+  preview_cache_max_size_mb: 2000   # Max disk for clip previews
 ```
+
+### Thumbnails and previews
+
+Thumbnails (`thumbnails/`) and clip previews (`preview-cache/`, `previews/`) are
+derived from your library rather than downloaded from it, so they are cheap to
+rebuild and get smaller budgets than the video cache. Each is evicted
+least-recently-used once it goes over its limit.
+
+Before these limits existed neither directory had a cap or an expiry, so both
+grew for as long as the app ran — on one real library, 5.2 GB of previews and
+3.5 GB of thumbnails.
 
 The `max_age_days` at the top level controls the analysis database cache (SQLite), not the video file cache. The `video_cache_*` fields control the file-based video cache.
 

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -459,9 +459,13 @@ cache:
   video_cache_enabled: true      # Cache downloaded videos locally
   video_cache_max_size_gb: 10.0  # Max disk usage for video cache (1-500 GB)
   video_cache_max_age_days: 7    # Auto-delete cached videos older than this (1-365)
+  thumbnail_cache_max_size_mb: 500.0   # Max disk for Immich thumbnails (50 MB-100 GB)
+  preview_cache_max_size_mb: 2000.0    # Max disk for clip previews (100 MB-100 GB)
 ```
 
 The video cache defaults to 10 GB. If you're tight on disk, lower `video_cache_max_size_gb` or disable it entirely with `video_cache_enabled: false`.
+
+Thumbnails and clip previews are derived from your library and are cheap to rebuild, so they get their own smaller budgets. Each is evicted least-recently-used once it exceeds its limit — a file you keep opening keeps earning its place.
 
 ## Server (UI)
 

--- a/src/immich_memories/analysis/preview_builder.py
+++ b/src/immich_memories/analysis/preview_builder.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.cache.disk_budget import evict_to_budget
 from immich_memories.processing.hardware import fast_encoder_args
 from immich_memories.security import sanitize_filename
 
@@ -25,18 +26,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Previews are now ~10 MB rather than ~72 MB, and they are reused across runs
-# instead of being rebuilt. A cap of 20 would evict a library's previews on
-# every pass and put the re-encode straight back. Real cache eviction is a
-# separate concern (see the cache page).
-_MAX_PREVIEWS = 200
+def _evict_oldest_previews(preview_dir: Path, max_size_mb: float) -> None:
+    """Bound the pipeline preview directory by size rather than file count.
 
-
-def _evict_oldest_previews(preview_dir: Path) -> None:
-    existing = sorted(preview_dir.glob("*.mp4"), key=lambda p: p.stat().st_mtime)
-    for stale in existing[:-_MAX_PREVIEWS]:
-        with contextlib.suppress(OSError):
-            stale.unlink()
+    A count cap cannot answer "how much disk will this cost", which is the
+    question the cache page has to answer; a preview's size varies with the clip
+    it came from.
+    """
+    evict_to_budget(preview_dir, max_bytes=int(max_size_mb * 1_000_000), pattern="*.mp4")
 
 
 class PreviewBuilder:
@@ -276,7 +273,7 @@ class PreviewBuilder:
 
         preview_dir = self._cache_config.cache_path / "previews"
         preview_dir.mkdir(parents=True, exist_ok=True)
-        _evict_oldest_previews(preview_dir)
+        _evict_oldest_previews(preview_dir, self._cache_config.preview_cache_max_size_mb)
 
         # Named after the asset because find_cached_preview looks previews up by
         # it. The previous `preview_<ms-timestamp>.mp4` could never be matched,

--- a/src/immich_memories/cache/disk_budget.py
+++ b/src/immich_memories/cache/disk_budget.py
@@ -1,0 +1,61 @@
+"""Keep a cache directory inside a size budget, oldest first.
+
+The video cache has enforced a cap since it was written; `preview-cache/`,
+`thumbnails/` and the pipeline's `previews/` never had one. On a real library
+that was 9 GB of 19 unbounded, while the cache page reported thumbnails as
+"x / 500 MB" -- a limit nothing applied.
+
+Eviction is least-recently-used by mtime rather than by age alone: a cap answers
+"how much disk may this cost", which is the question a user actually has, and a
+file that is still being read keeps earning its place.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def evict_to_budget(directory: Path, *, max_bytes: int, pattern: str = "*") -> int:
+    """Delete the least recently used files until the directory fits.
+
+    Returns the number of bytes freed. Stops as soon as the budget is met --
+    evicting past it throws away work that would have been reused.
+    """
+    if max_bytes < 0 or not directory.exists():
+        return 0
+
+    entries = []
+    total = 0
+    for path in directory.rglob(pattern):
+        if not path.is_file():
+            continue
+        with contextlib.suppress(OSError):
+            stat = path.stat()
+            entries.append((stat.st_mtime, stat.st_size, path))
+            total += stat.st_size
+
+    if total <= max_bytes:
+        return 0
+
+    freed = 0
+    for _mtime, size, path in sorted(entries):
+        if total - freed <= max_bytes:
+            break
+        try:
+            path.unlink()
+        except OSError:  # noqa: PERF203 - a file that vanished is already evicted
+            continue
+        freed += size
+
+    if freed:
+        logger.info(
+            "Evicted %.1f MB from %s (budget %.1f MB)",
+            freed / 1_000_000,
+            directory.name,
+            max_bytes / 1_000_000,
+        )
+    return freed

--- a/src/immich_memories/cache/thumbnail_cache.py
+++ b/src/immich_memories/cache/thumbnail_cache.py
@@ -6,14 +6,23 @@ import contextlib
 import logging
 from pathlib import Path
 
+from immich_memories.cache.disk_budget import evict_to_budget
+
 logger = logging.getLogger(__name__)
 
 
 class ThumbnailCache:
     """Simple file-based cache for Immich thumbnails."""
 
-    def __init__(self, cache_dir: Path) -> None:
+    # Scanning the tree on every put would make each thumbnail O(cache size).
+    # Checking every so often bounds the overshoot to roughly this many files'
+    # worth of data, which at thumbnail sizes is a few MB.
+    _PUTS_BETWEEN_BUDGET_CHECKS = 200
+
+    def __init__(self, cache_dir: Path, max_size_mb: float = 500.0) -> None:
         self.cache_dir = cache_dir
+        self.max_size_mb = max_size_mb
+        self._puts_since_check = 0
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _path(self, asset_id: str, size: str) -> Path:
@@ -41,7 +50,19 @@ class ThumbnailCache:
         path = self._path(asset_id, size)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
+        self._puts_since_check += 1
+        if self._puts_since_check >= self._PUTS_BETWEEN_BUDGET_CHECKS:
+            self.enforce_budget()
         return path
+
+    def enforce_budget(self) -> int:
+        """Drop the least recently used thumbnails until the cache fits."""
+        self._puts_since_check = 0
+        return evict_to_budget(
+            self.cache_dir,
+            max_bytes=int(self.max_size_mb * 1_000_000),
+            pattern="*.jpg",
+        )
 
     def clear(self) -> int:
         """Remove all cached thumbnails. Returns count of removed files."""
@@ -59,7 +80,7 @@ class ThumbnailCache:
         return count
 
     def get_stats(self) -> dict:
-        max_size_mb = 500.0  # Default max thumbnail cache size
+        max_size_mb = self.max_size_mb
         if not self.cache_dir.exists():
             return {"file_count": 0, "total_size_bytes": 0, "max_size_mb": max_size_mb}
 

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -358,7 +358,10 @@ def run_pipeline_and_generate(
     )
 
     analysis_cache = VideoAnalysisCache(db_path=config.cache.database_path)
-    thumbnail_cache = ThumbnailCache(cache_dir=config.cache.cache_path / "thumbnails")
+    thumbnail_cache = ThumbnailCache(
+        cache_dir=config.cache.cache_path / "thumbnails",
+        max_size_mb=config.cache.thumbnail_cache_max_size_mb,
+    )
     pipeline = SmartPipeline(
         client=client,
         analysis_cache=analysis_cache,

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -351,6 +351,17 @@ class CacheConfig(BaseModel):
         default=7, ge=1, le=365, description="Maximum age of cached video files in days"
     )
 
+    # Derived-media caches. These had no limit at all: on a real library that was
+    # 5.2 GB of previews and 3.5 GB of thumbnails, while the cache page reported
+    # thumbnails as capped at 500 MB. 500 is kept because it is the number users
+    # have already been shown -- it is now true.
+    thumbnail_cache_max_size_mb: float = Field(
+        default=500.0, ge=50, le=100_000, description="Maximum thumbnail cache size in MB"
+    )
+    preview_cache_max_size_mb: float = Field(
+        default=2000.0, ge=100, le=100_000, description="Maximum clip preview cache size in MB"
+    )
+
     @property
     def cache_path(self) -> Path:
         """Get the expanded cache directory path."""

--- a/src/immich_memories/ui/pages/step1_cache.py
+++ b/src/immich_memories/ui/pages/step1_cache.py
@@ -86,7 +86,10 @@ def render_cache_management() -> None:
                 _cfg = get_config()
                 analysis = VideoAnalysisCache(db_path=_cfg.cache.database_path)
                 video = VideoDownloadCache(cache_dir=_cfg.cache.video_cache_path)
-                thumbnail = ThumbnailCache(cache_dir=_cfg.cache.cache_path / "thumbnails")
+                thumbnail = ThumbnailCache(
+                    cache_dir=_cfg.cache.cache_path / "thumbnails",
+                    max_size_mb=_cfg.cache.thumbnail_cache_max_size_mb,
+                )
                 return {
                     "analysis": analysis.get_stats(),
                     "video": video.get_stats(),
@@ -147,7 +150,10 @@ def render_cache_management() -> None:
 
                     _cfg = get_config()
                     count = await io_bound_result(
-                        ThumbnailCache(cache_dir=_cfg.cache.cache_path / "thumbnails").clear
+                        ThumbnailCache(
+                            cache_dir=_cfg.cache.cache_path / "thumbnails",
+                            max_size_mb=_cfg.cache.thumbnail_cache_max_size_mb,
+                        ).clear
                     )
                     ui.notify(f"Cleared {count} cached thumbnails", type="positive")
                     await refresh_stats()
@@ -181,7 +187,10 @@ def render_cache_management() -> None:
                         _cfg = get_config()
                         a = VideoAnalysisCache(db_path=_cfg.cache.database_path).clear_all()
                         v = VideoDownloadCache(cache_dir=_cfg.cache.video_cache_path).clear()
-                        t = ThumbnailCache(cache_dir=_cfg.cache.cache_path / "thumbnails").clear()
+                        t = ThumbnailCache(
+                            cache_dir=_cfg.cache.cache_path / "thumbnails",
+                            max_size_mb=_cfg.cache.thumbnail_cache_max_size_mb,
+                        ).clear()
                         p = _clear_preview_cache()
                         return a + v + t + p
 

--- a/src/immich_memories/ui/pages/step2_helpers.py
+++ b/src/immich_memories/ui/pages/step2_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from nicegui import ui
 
+from immich_memories.cache.disk_budget import evict_to_budget
 from immich_memories.ui.state import get_app_state
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,14 @@ def _download_immich_preview(asset_id: str, *, config=None) -> Path | None:
             video_bytes: bytes = client.get_video_playback(asset_id)
         if video_bytes and len(video_bytes) > 10_000:
             preview_path.write_bytes(video_bytes)
+            # This directory had no cap and no TTL; it reached 5.2 GB on a
+            # real library. Enforced on write because that is the only
+            # moment it grows.
+            evict_to_budget(
+                preview_dir,
+                max_bytes=int(config.cache.preview_cache_max_size_mb * 1_000_000),
+                pattern="*.mp4",
+            )
             return preview_path
         logger.warning(f"Immich preview too small for {asset_id}: {len(video_bytes)} bytes")
     except Exception as e:  # WHY: UI graceful degradation

--- a/src/immich_memories/ui/pages/step2_review.py
+++ b/src/immich_memories/ui/pages/step2_review.py
@@ -99,7 +99,10 @@ def _render_step2_header(state) -> bool:
         from immich_memories.config import get_config
 
         _cfg = get_config()
-        state.thumbnail_cache = ThumbnailCache(cache_dir=_cfg.cache.cache_path / "thumbnails")
+        state.thumbnail_cache = ThumbnailCache(
+            cache_dir=_cfg.cache.cache_path / "thumbnails",
+            max_size_mb=_cfg.cache.thumbnail_cache_max_size_mb,
+        )
 
     # Load clips if not already loaded
     if not state.clips:

--- a/tests/test_disk_budget.py
+++ b/tests/test_disk_budget.py
@@ -1,0 +1,121 @@
+"""Keeping a cache directory inside a size budget.
+
+Three cache directories had no cap and no TTL at all. On a real library that was
+5.2 GB of preview-cache and 3.5 GB of thumbnails -- 9 of 19 GB unbounded -- while
+the cache page told the user thumbnails were capped at 500 MB, a number nothing
+enforced.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from immich_memories.cache.disk_budget import evict_to_budget
+
+
+def _file(directory: Path, name: str, size: int, age_seconds: float) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_bytes(b"x" * size)
+    stamp = 1_000_000.0 - age_seconds
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def test_a_directory_inside_its_budget_is_left_alone(tmp_path: Path):
+    kept = _file(tmp_path, "a.bin", 1000, age_seconds=100)
+
+    freed = evict_to_budget(tmp_path, max_bytes=10_000)
+
+    assert freed == 0
+    assert kept.exists()
+
+
+def test_the_oldest_files_go_first(tmp_path: Path):
+    oldest = _file(tmp_path, "old.bin", 1000, age_seconds=300)
+    middle = _file(tmp_path, "mid.bin", 1000, age_seconds=200)
+    newest = _file(tmp_path, "new.bin", 1000, age_seconds=100)
+
+    evict_to_budget(tmp_path, max_bytes=2000)
+
+    assert not oldest.exists()
+    assert middle.exists() and newest.exists()
+
+
+def test_it_stops_as_soon_as_the_budget_is_met(tmp_path: Path):
+    """Evicting more than necessary throws away work that would be reused."""
+    for i in range(5):
+        _file(tmp_path, f"f{i}.bin", 1000, age_seconds=500 - i * 10)
+
+    evict_to_budget(tmp_path, max_bytes=3000)
+
+    assert len(list(tmp_path.glob("*.bin"))) == 3
+
+
+def test_it_reports_what_it_freed(tmp_path: Path):
+    _file(tmp_path, "old.bin", 4000, age_seconds=300)
+    _file(tmp_path, "new.bin", 1000, age_seconds=100)
+
+    assert evict_to_budget(tmp_path, max_bytes=1000) == 4000
+
+
+def test_a_missing_directory_is_not_an_error(tmp_path: Path):
+    assert evict_to_budget(tmp_path / "never-created", max_bytes=1000) == 0
+
+
+def test_only_matching_files_are_considered(tmp_path: Path):
+    """A cache directory may hold bookkeeping that is not cache content."""
+    _file(tmp_path, "old.jpg", 4000, age_seconds=300)
+    manifest = _file(tmp_path, "manifest.json", 4000, age_seconds=400)
+
+    evict_to_budget(tmp_path, max_bytes=1000, pattern="*.jpg")
+
+    assert manifest.exists()
+
+
+def test_nested_files_count_toward_the_budget(tmp_path: Path):
+    """Caches shard into subdirectories; a per-directory view would miss most."""
+    _file(tmp_path / "ab", "old.jpg", 4000, age_seconds=300)
+    newest = _file(tmp_path / "cd", "new.jpg", 1000, age_seconds=100)
+
+    freed = evict_to_budget(tmp_path, max_bytes=1000, pattern="*.jpg")
+
+    assert freed == 4000
+    assert newest.exists()
+
+
+class TestThumbnailCacheStaysInsideItsBudget:
+    """The cache page reported thumbnails as "x / 500 MB" while nothing applied
+    that limit; the directory reached 3.5 GB on a real library.
+    """
+
+    @staticmethod
+    def _cache(tmp_path: Path, max_size_mb: float):
+        from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+        return ThumbnailCache(cache_dir=tmp_path / "thumbnails", max_size_mb=max_size_mb)
+
+    def test_the_reported_limit_is_the_configured_one(self, tmp_path: Path):
+        """The number shown to the user has to be the number enforced."""
+        cache = self._cache(tmp_path, max_size_mb=250.0)
+
+        assert cache.get_stats()["max_size_mb"] == 250.0
+
+    def test_writing_past_the_budget_evicts_the_oldest(self, tmp_path: Path):
+        cache = self._cache(tmp_path, max_size_mb=0.05)  # 50 KB
+        payload = b"x" * 10_000
+
+        for i in range(20):
+            cache.put(f"asset-{i:04d}", "preview", payload)
+        cache.enforce_budget()
+
+        assert cache.get_stats()["total_size_bytes"] <= 50_000
+
+    def test_a_cache_inside_its_budget_keeps_everything(self, tmp_path: Path):
+        cache = self._cache(tmp_path, max_size_mb=10.0)
+        cache.put("asset-1", "preview", b"x" * 1000)
+
+        cache.enforce_budget()
+
+        assert cache.get("asset-1", "preview") is not None


### PR DESCRIPTION
## Measured on a real library

```
9.9G  video-cache      ← the 10 GB cap working
5.2G  preview-cache    ← no cap, no TTL
3.5G  thumbnails       ← no cap, no TTL
454M  previews         ← file-count cap only
141M  photo_scoring    ← never pruned
 19G  total
```

**About 9 of the 19 GB was unbounded.** The video cache's 9.9 GB is the one
number under control, precisely because it is the only one with a limit.

## The UI was reporting a limit that did not exist

```python
def get_stats(self) -> dict:
    max_size_mb = 500.0  # Default max thumbnail cache size
```

`step1_cache.py` renders `"{size} / {max_size_mb} MB"` — so the cache page has
been telling users thumbnails are capped at 500 MB against a directory **seven
times past it**. That number is now configurable and enforced, which makes the
display true rather than decorative. 500 stays as the default precisely because
it is the figure users have already been shown.

## How eviction works

Least-recently-used by mtime, not age alone. A cap answers *"how much disk may
this cost"* — the question the cache page exists to answer — and a file still
being read keeps earning its place. It stops the moment the budget is met;
evicting past it throws away work that would have been reused.

Thumbnails enforce every 200 puts rather than on each one: scanning the tree per
put would make every thumbnail cost O(cache size), and the overshoot between
checks is a few MB at thumbnail sizes.

## Closing my own debt

The pipeline's `previews/` moves from a file-count cap to the same size budget.
That count was mine, from #392 — I raised it 20 → 200 because at 20 a library
evicted its own previews on every pass and the naming fix would have done
nothing. A count can't answer the disk question, since a preview's size varies
with the clip it came from, so this replaces it properly.

## Not included

- The video cache's own eviction quirks — it evicts clips the run just
  *selected*, so generation re-downloads them.
- `photo_scoring/` (141 MB), which is not on the cache page at all.

Both are real and both are separate.

## Note

`make critique` flagged the log string `"…to stay within %.1f MB"` as a
mechanical split comment — its heuristic looks for that phrasing in
`extracted to stay within the 500-line limit`. Reworded rather than suppressed.

Closes #402. P7 in `docs/reviews/2026-08-18-security-perf-review.md`.
