### PR TITLE
fix(live-photos): tolerate an Immich error instead of ending the run

### DIFF
--- a/src/immich_memories/analysis/live_photo_pipeline.py
+++ b/src/immich_memories/analysis/live_photo_pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import VideoClipInfo
 
 if TYPE_CHECKING:
@@ -169,7 +170,10 @@ def fetch_live_photo_clips(
             person_ids=person_ids,
             merge_window_seconds=merge_window,
         )
-    except (OSError, RuntimeError, ValueError) as e:
+    except (OSError, RuntimeError, ValueError, ImmichAPIError) as e:
+        # ImmichAPIError inherits from Exception alone, so the error this call
+        # actually raises -- a 404 for an asset mid-import or just deleted --
+        # was the one error this guard could not catch.
         logger.warning("Failed to fetch live photos: %s", e, exc_info=True)
         return [], set()
 

--- a/tests/test_live_photo_error_tolerance.py
+++ b/tests/test_live_photo_error_tolerance.py
@@ -1,0 +1,42 @@
+"""An Immich error while fetching live photos must not end the run.
+
+`fetch_live_photo_clips` already intends tolerance -- it logs "Failed to fetch
+live photos" and returns empty so the memory is built from what did load. But it
+caught `(OSError, RuntimeError, ValueError)`, and `ImmichAPIError` inherits from
+`Exception` alone, so the one error the call actually raises was the one the
+guard could not catch.
+
+In a large library there is always an asset mid-import or just deleted, so a 404
+here is a Tuesday rather than an edge case.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from immich_memories.analysis.live_photo_pipeline import fetch_live_photo_clips
+from immich_memories.api.immich import ImmichAPIError, ImmichNotFoundError
+from immich_memories.config_loader import Config
+from immich_memories.timeperiod import DateRange
+
+
+def _call_with(error: Exception):
+    date_range = DateRange(start="2026-01-01", end="2026-01-31")
+    # WHY: the Immich server; the point of the test is what it raises.
+    with patch(
+        "immich_memories.analysis.live_photo_pipeline.search_live_photos", side_effect=error
+    ):
+        return fetch_live_photo_clips(MagicMock(), date_range, config=Config())
+
+
+def test_a_missing_asset_costs_the_live_photos_not_the_run():
+    assert _call_with(ImmichNotFoundError("asset 404")) == ([], set())
+
+
+def test_any_immich_api_error_is_tolerated():
+    assert _call_with(ImmichAPIError("500 from Immich")) == ([], set())
+
+
+def test_the_existing_tolerated_errors_still_are():
+    assert _call_with(OSError("socket died")) == ([], set())
+    assert _call_with(ValueError("bad payload")) == ([], set())


### PR DESCRIPTION
## The guard that couldn't catch anything

`fetch_live_photo_clips` already **intends** tolerance — it logs a warning and
returns empty so the memory is built from whatever did load:

```python
except (OSError, RuntimeError, ValueError) as e:
    logger.warning("Failed to fetch live photos: %s", e, exc_info=True)
    return [], set()
```

But `search_live_photos` ends in `client.get_live_photos_for_date_range(...)`,
and `ImmichAPIError` inherits from `Exception` alone. **The one error this call
actually raises is the one error the guard cannot catch**, so a 404 for an asset
mid-import propagated and ended the whole run.

## The audit, not a sweep

This shape came from the parallel session's #401, which found it in `photos/`.
Rather than widen every match, I checked all three occurrences in my column:

| Site | Verdict |
|---|---|
| `analysis/live_photo_pipeline.py:172` | **real** — fixed here |
| `analysis/silence_detection.py:250` | moviepy and audio arrays only, no Immich call. Correctly scoped. |
| `analysis/trip_detection.py:361` | geopy, and its comment already notes `GeocoderServiceError` *is* an `OSError` subclass. Correctly scoped. |

**One of three.** Widening the other two would hide real failures rather than
tolerate expected ones — the same distinction that made #401 revert two of its
own four sites.

## Tests

Three: a missing asset (`ImmichNotFoundError`), any `ImmichAPIError`, and a
check that the errors already tolerated still are. The first two fail on `main`.

Closes #404.
