### PR TITLE
ci: run the quality gates in one job instead of thirteen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,174 +36,73 @@ jobs:
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - run: make dev-ci
 
-  # ── Tier 1: Cheap quality gates (all parallel, ~10s each) ─────────────────
-  commitlint:
-    name: Commit Messages
-    runs-on: ubuntu-latest
-    if: github.repository == 'sam-dumont/immich-video-memory-generator' && github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: COMMIT_RANGE="origin/${{ github.base_ref }}..HEAD" make commitlint
-
-  lint:
-    name: Lint + Format
+  # ── Tier 1: Quality gates ─────────────────────────────────────────────────
+  # One job, not thirteen. Each gate takes 10-35s but held its own runner slot,
+  # and the account gets 20 concurrent jobs: with several PRs in flight, ~65
+  # slots were occupied by half-minute jobs while the test matrix queued behind
+  # them and got reclaimed mid-run. Sequenced here they cost the same four
+  # minutes of work and one slot, and `make dev-ci` runs once instead of
+  # thirteen times.
+  #
+  # Every gate runs even after one fails (`!cancelled()`), so a red build still
+  # reports all of them at once, the way thirteen parallel jobs did.
+  quality:
+    name: Quality Gates
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0  # commitlint needs the base branch
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           prune-cache: false
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - run: make dev-ci
+
       - name: Ruff check
+        if: '!cancelled()'
         run: make lint
       - name: Ruff format check
+        if: '!cancelled()'
         run: make format-check
       - name: CLI reference drift
+        if: '!cancelled()'
         run: make docs-cli-check
-
-  typecheck:
-    name: Type Check (mypy)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make typecheck
-
-  dead-code:
-    name: Dead Code (Vulture)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make dead-code
-
-  complexity:
-    name: Cyclomatic Complexity (Xenon)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make complexity
-
-  cognitive-complexity:
-    name: Cognitive Complexity
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make cognitive-complexity
-
-  file-length:
-    name: File Length (≤800 lines)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make file-length
-
-  refurb:
-    name: Modernization (refurb)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make refurb
-
-  dep-check:
-    name: Dependency Hygiene (deptry)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make dep-check
-
-  arch-check:
-    name: Architecture (import-linter)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make arch-check
-
-  duplication:
-    name: Code Duplication (≤5%)
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - run: make duplication
-
-  critique:
-    name: AI Smell Audit
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          prune-cache: false
-      - run: uv python install ${{ env.PYTHON_VERSION }}
-      - run: make dev-ci
-      - run: make critique
+      - name: Type Check (mypy)
+        if: '!cancelled()'
+        run: make typecheck
+      - name: Dead Code (Vulture)
+        if: '!cancelled()'
+        run: make dead-code
+      - name: Cyclomatic Complexity (Xenon)
+        if: '!cancelled()'
+        run: make complexity
+      - name: Cognitive Complexity
+        if: '!cancelled()'
+        run: make cognitive-complexity
+      - name: File Length (≤800 lines)
+        if: '!cancelled()'
+        run: make file-length
+      - name: Modernization (refurb)
+        if: '!cancelled()'
+        run: make refurb
+      - name: Dependency Hygiene (deptry)
+        if: '!cancelled()'
+        run: make dep-check
+      - name: Architecture (import-linter)
+        if: '!cancelled()'
+        run: make arch-check
+      - name: Code Duplication (≤5%)
+        if: '!cancelled()'
+        run: make duplication
+      - name: AI Smell Audit
+        if: '!cancelled()'
+        run: make critique
+      - name: Commit Messages
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        run: COMMIT_RANGE="origin/${{ github.base_ref }}..HEAD" make commitlint
 
   # ── Tier 1: Security (parallel with quality gates) ────────────────────────
   security:
@@ -265,7 +164,7 @@ jobs:
   # ── Tier 2: Tests (after all quality gates pass) ──────────────────────────
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [lint, typecheck, security, dead-code, complexity, cognitive-complexity, file-length, refurb, dep-check, arch-check, duplication, critique]
+    needs: [quality, security]
     permissions:
       contents: read
       pull-requests: write
@@ -385,7 +284,7 @@ jobs:
 
   test-extras:
     name: Test Extras (${{ matrix.os }})
-    needs: [lint, typecheck, security, dead-code, complexity, cognitive-complexity, file-length, refurb, dep-check, arch-check, duplication, critique]
+    needs: [quality, security]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -567,7 +466,7 @@ jobs:
   # ── Summary gate ──────────────────────────────────────────────────────────
   ci-success:
     name: CI Success
-    needs: [setup, lint, typecheck, security, dead-code, complexity, cognitive-complexity, file-length, refurb, dep-check, arch-check, duplication, critique, test, test-extras, build, docker, docs, launch-check]
+    needs: [setup, quality, security, test, test-extras, build, docker, docs, launch-check]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -582,18 +481,8 @@ jobs:
             exit 1
           fi
           results=(
-            "${{ needs.lint.result }}"
-            "${{ needs.typecheck.result }}"
+            "${{ needs.quality.result }}"
             "${{ needs.security.result }}"
-            "${{ needs.dead-code.result }}"
-            "${{ needs.complexity.result }}"
-            "${{ needs.cognitive-complexity.result }}"
-            "${{ needs.file-length.result }}"
-            "${{ needs.refurb.result }}"
-            "${{ needs.dep-check.result }}"
-            "${{ needs.arch-check.result }}"
-            "${{ needs.duplication.result }}"
-            "${{ needs.critique.result }}"
             "${{ needs.test.result }}"
             "${{ needs.test-extras.result }}"
             "${{ needs.build.result }}"

--- a/tests/test_quality_gate_consolidation_contract.py
+++ b/tests/test_quality_gate_consolidation_contract.py
@@ -1,0 +1,111 @@
+"""The quality gates share one runner slot, not thirteen.
+
+Each gate takes 10-35 seconds, but each used to hold its own job. This repo is
+public, so the account gets 20 concurrent jobs; with several pull requests in
+flight roughly 65 slots were occupied by half-minute jobs while the test matrix
+queued behind them and was reclaimed mid-run -- `The runner has received a
+shutdown signal` followed by `Error 137`, which is the runner going away rather
+than anything the tests did.
+
+Sequenced in one job the gates cost the same four minutes of work and one slot,
+and `make dev-ci` -- most of each old job's wall time -- runs once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every gate that used to be its own job. Losing one silently would be the
+# failure this consolidation could plausibly cause.
+_REQUIRED_GATES = (
+    "make lint",
+    "make format-check",
+    "make docs-cli-check",
+    "make typecheck",
+    "make dead-code",
+    "make complexity",
+    "make cognitive-complexity",
+    "make file-length",
+    "make refurb",
+    "make dep-check",
+    "make arch-check",
+    "make duplication",
+    "make critique",
+    "make commitlint",
+)
+
+
+def _ci() -> dict:
+    return yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+
+
+def _quality_steps() -> list[dict]:
+    return _ci()["jobs"]["quality"]["steps"]
+
+
+def _run_lines() -> str:
+    return "\n".join(str(step.get("run", "")) for step in _quality_steps())
+
+
+def test_every_gate_still_runs():
+    commands = _run_lines()
+
+    missing = [gate for gate in _REQUIRED_GATES if gate not in commands]
+
+    assert missing == [], f"gates dropped in consolidation: {missing}"
+
+
+def test_one_failing_gate_does_not_hide_the_others():
+    """Thirteen parallel jobs reported every failure at once; steps stop at the
+    first by default, which would make a red build tell you one thing at a time.
+    """
+    unguarded = [
+        step.get("name", step.get("run", "?"))
+        for step in _quality_steps()
+        if any(gate in str(step.get("run", "")) for gate in _REQUIRED_GATES)
+        and "cancelled()" not in str(step.get("if", ""))
+    ]
+
+    assert unguarded == [], f"these gates stop the run when an earlier one fails: {unguarded}"
+
+
+def test_the_environment_is_built_once():
+    """Repeating `make dev-ci` per gate was most of the old wall time."""
+    assert _run_lines().count("make dev-ci") == 1
+
+
+def test_the_gates_do_not_fan_back_out_into_their_own_jobs():
+    jobs = _ci()["jobs"]
+    gate_named_jobs = [
+        name
+        for name in jobs
+        if name
+        in {
+            "lint",
+            "typecheck",
+            "dead-code",
+            "complexity",
+            "cognitive-complexity",
+            "file-length",
+            "refurb",
+            "dep-check",
+            "arch-check",
+            "duplication",
+            "critique",
+            "commitlint",
+        }
+    ]
+
+    assert gate_named_jobs == [], f"gates split back into separate slots: {gate_named_jobs}"
+
+
+def test_the_aggregate_gate_still_watches_the_quality_job():
+    """`ci-success` is the required check; it must fail when the gates fail."""
+    ci_success = _ci()["jobs"]["ci-success"]
+
+    assert "quality" in ci_success["needs"]
+    assert "needs.quality.result" in str(ci_success["steps"])


### PR DESCRIPTION
## Why test jobs keep getting reclaimed

Red checks across our PRs have been ending with `The runner has received a
shutdown signal` and `Error 137`, with **zero failing tests** in the job. That is
the runner going away, not a defect — and the reason it kept recurring is
measurable.

**A pull request run was 22 jobs. Thirteen finish in under 35 seconds:**

```
10s  Code Duplication        19s  AI Smell Audit
12s  File Length             19s  Architecture (import-linter)
13s  Dead Code (Vulture)     21s  Cognitive Complexity
14s  Commit Messages         22s  Lint + Format
17s  Dependency Hygiene      31s  Type Check (mypy)
18s  Cyclomatic Complexity   35s  Modernization (refurb)
```

Four minutes of work spread across **thirteen runner slots**. This repo is
public, so the account gets **20 concurrent jobs**. With five runs in flight —
normal with several sessions pushing — roughly **65 slots** were held by jobs
finishing in half a minute, while the test matrix and the launch check queued
behind them and were reclaimed mid-run.

Twelve of those jobs were byte-identical apart from the final `make` target, and
each paid for its own `make dev-ci` — most of their wall time. The gates
themselves are seconds: the whole sequence runs in **49 s** locally.

**22 jobs → 10.**

## The one thing consolidation could make worse

Steps stop at the first failure, so a naive fold would report one failing gate
per CI cycle — strictly worse feedback than thirteen parallel jobs gave. Every
gate carries `if: '!cancelled()'`, so a red build still names all of them at
once, and each gate is a named step so the failure still says which gate.

## Left alone

`Security Scan` (75 s), `Docs Build` (56 s), `Hermetic Launch Check`, and the
test matrix. Folding those in would make the combined job as long as the thing
it exists to stop starving.

## Contract test

Pins what this change could plausibly break: no gate silently dropped, no gate
able to hide a later one, `dev-ci` run once, the gates not fanning back out into
separate jobs, and `ci-success` — the required check — still watching the
result.

All five existing workflow contract suites still pass
(`test_extras_marker_contract`, `test_version_contract`,
`test_ci_concurrency_contract`, `test_cancel_on_close_contract`,
`test_docker_contract`), and every `needs:` target still resolves with no
dangling references.

Same reasoning as #383 (the launch gate re-running eight other jobs' work) and
the macOS matrix trim: the cost is not the work, it is how many slots it is
spread across.

Closes #406.
