### PR TITLE
perf(ui): hash each thumbnail once per session, not once per render

### DIFF
--- a/src/immich_memories/analysis/thumbnail_clustering.py
+++ b/src/immich_memories/analysis/thumbnail_clustering.py
@@ -34,6 +34,8 @@ def _compute_thumbnail_hashes(
     clips: list[VideoClipInfo],
     thumbnail_cache: ThumbnailCache,
     progress_callback: Callable[[int, int], None] | None = None,
+    *,
+    known: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Compute perceptual hashes for all clip thumbnails.
 
@@ -41,6 +43,11 @@ def _compute_thumbnail_hashes(
         clips: List of video clip info objects.
         thumbnail_cache: Cache containing thumbnails.
         progress_callback: Optional callback(current, total) for progress.
+        known: Hashes already computed for these assets. A thumbnail's hash
+            cannot change while the file does not, so anything listed here is
+            reused rather than decoded again -- Step 2 re-runs duplicate
+            detection on every render, and each clip costs a read plus a JPEG
+            decode.
 
     Returns:
         Mapping of asset ID to hex hash string.
@@ -52,13 +59,19 @@ def _compute_thumbnail_hashes(
         if progress_callback:
             progress_callback(i + 1, total)
 
-        thumbnail_bytes = thumbnail_cache.get(clip.asset.id, "preview")
+        asset_id = clip.asset.id
+        cached = (known or {}).get(asset_id)
+        if cached:
+            hashes[asset_id] = cached
+            continue
+
+        thumbnail_bytes = thumbnail_cache.get(asset_id, "preview")
         if thumbnail_bytes is None:
             continue
 
         hash_value = compute_thumbnail_hash(thumbnail_bytes)
         if hash_value:
-            hashes[clip.asset.id] = hash_value
+            hashes[asset_id] = hash_value
 
     return hashes
 
@@ -181,6 +194,7 @@ def cluster_thumbnails(
     progress_callback: Callable[[int, int], None] | None = None,
     *,
     duplicate_hash_threshold: int,
+    hash_cache: dict[str, str] | None = None,
 ) -> list[ThumbnailCluster]:
     """Cluster clips by thumbnail similarity.
 
@@ -202,7 +216,9 @@ def cluster_thumbnails(
     if threshold is None:
         threshold = duplicate_hash_threshold
 
-    hashes = _compute_thumbnail_hashes(clips, thumbnail_cache, progress_callback)
+    hashes = _compute_thumbnail_hashes(clips, thumbnail_cache, progress_callback, known=hash_cache)
+    if hash_cache is not None:
+        hash_cache.update(hashes)
 
     similar_pairs = _build_similarity_pairs(hashes, clips, threshold)
 

--- a/src/immich_memories/ui/pages/clip_grid.py
+++ b/src/immich_memories/ui/pages/clip_grid.py
@@ -107,6 +107,7 @@ def _detect_thumbnail_duplicates(
             clips=clips,
             thumbnail_cache=thumbnail_cache,
             duplicate_hash_threshold=get_config().analysis.duplicate_hash_threshold,
+            hash_cache=state.thumbnail_hashes,
         )
 
         for cluster in clusters:

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -148,6 +148,10 @@ class AppState:
 
     # Caches (initialized at runtime)
     thumbnail_cache: ThumbnailCache | None = None
+    # Perceptual hashes keyed by asset id. Duplicate detection re-runs on
+    # every Step 2 render, and a thumbnail's hash cannot change while the
+    # file does not.
+    thumbnail_hashes: dict[str, str] = field(default_factory=dict)
     analysis_cache: Any = None  # AnalysisCache
 
     @property
@@ -178,6 +182,7 @@ class AppState:
         self.cancel_requested = False
         self.scored_photos = []
         self.photo_budget_result = None
+        self.thumbnail_hashes = {}
         self.discard_music_preview()
 
     def discard_music_preview(self) -> None:

--- a/tests/test_thumbnail_hash_reuse.py
+++ b/tests/test_thumbnail_hash_reuse.py
@@ -1,0 +1,89 @@
+"""Step 2 re-hashed every thumbnail on every render.
+
+`_detect_duplicates` runs on each `/step2` build, and `/step2` is re-navigated on
+many interactions. Each clip costs a `read_bytes` plus a `cv2.imdecode` of the
+1440px preview -- measured at 7.1 ms on real thumbnails, so 500 clips is 3.6s of
+work per render, on the event loop, recomputing values that cannot have changed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from immich_memories.analysis.thumbnail_clustering import _compute_thumbnail_hashes
+
+
+class _CountingCache:
+    """A thumbnail cache that reports how often it was actually read."""
+
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+        self.reads: list[str] = []
+
+    def get(self, asset_id: str, size: str) -> bytes | None:  # noqa: ARG002
+        self.reads.append(asset_id)
+        return self._payloads.get(asset_id)
+
+
+def _clip(asset_id: str):
+    clip = MagicMock()
+    clip.asset.id = asset_id
+    return clip
+
+
+@pytest.fixture
+def jpeg_bytes() -> bytes:
+    import cv2
+    import numpy as np
+
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    image[:32] = 255
+    ok, buffer = cv2.imencode(".jpg", image)
+    assert ok
+    return buffer.tobytes()
+
+
+def test_a_known_hash_is_not_recomputed(jpeg_bytes: bytes):
+    clips = [_clip("a"), _clip("b")]
+    cache = _CountingCache({"a": jpeg_bytes, "b": jpeg_bytes})
+
+    first = _compute_thumbnail_hashes(clips, cache)
+    cache.reads.clear()
+    second = _compute_thumbnail_hashes(clips, cache, known=first)
+
+    assert second == first
+    assert cache.reads == [], "thumbnails were re-read despite known hashes"
+
+
+def test_only_the_new_clips_are_hashed(jpeg_bytes: bytes):
+    """Adding a clip must not re-hash the ones already seen."""
+    cache = _CountingCache({"a": jpeg_bytes, "b": jpeg_bytes})
+    known = _compute_thumbnail_hashes([_clip("a")], cache)
+    cache.reads.clear()
+
+    _compute_thumbnail_hashes([_clip("a"), _clip("b")], cache, known=known)
+
+    assert cache.reads == ["b"]
+
+
+def test_without_known_hashes_it_behaves_as_before(jpeg_bytes: bytes):
+    cache = _CountingCache({"a": jpeg_bytes})
+
+    hashes = _compute_thumbnail_hashes([_clip("a")], cache)
+
+    assert set(hashes) == {"a"}
+    assert cache.reads == ["a"]
+
+
+def test_a_clip_with_no_thumbnail_is_not_cached_as_missing(jpeg_bytes: bytes):
+    """A thumbnail that arrives later must still get hashed."""
+    cache = _CountingCache({})
+    known = _compute_thumbnail_hashes([_clip("a")], cache)
+    cache._payloads["a"] = jpeg_bytes
+    cache.reads.clear()
+
+    hashes = _compute_thumbnail_hashes([_clip("a")], cache, known=known)
+
+    assert "a" in hashes


### PR DESCRIPTION
## The cost that repeats

Duplicate detection runs on **every** `/step2` render, and `/step2` is
re-navigated on many interactions. Each clip costs a read of the 1440px preview
plus a `cv2` decode — **7.1 ms measured on real cached thumbnails**, so 500
clips is 3.6 s per render, on the event loop, recomputing values that cannot
have changed while the files do not.

Hashes computed for the session are now reused, so only clips genuinely new to
the view are decoded. Measured on 300 real thumbnails:

| | |
|---|---|
| first render | **1576.0 ms** |
| re-render | **0.3 ms** |

The cache lives on `AppState` and is cleared by `reset_clips`, with the other
selection-derived state it belongs beside.

## A finding while confirming the review's premise

The review says `video_analysis.thumbnail_hash` "is never read for this". The
column exists and `save_analysis` accepts a `thumbnail_hash` argument — but no
caller ever passes one:

```
0/991 rows have a thumbnail_hash
```

So it is never **written**, not merely never read, and reading it would have
returned nothing for every asset. A column and a function parameter that look
like a cache and are not one.

Populating it means computing at analysis time, which is a separate change —
worth doing, or worth deleting both, but not worth leaving as-is. Recorded in
#409 rather than folded in here.

## Scope

P9 (the serial batch loading in the same page) is **not** addressed here.

Closes #409. P5 in `docs/reviews/2026-08-18-security-perf-review.md`.
