### PR TITLE
test(assembler): build the loudnorm fixtures in one ffmpeg call, not thirty

### DIFF
--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -1140,31 +1140,18 @@ class TestAudioFilterChain:
         fade_dur = 0.5
         frame_dur = int(clip_dur * fps) / fps
 
-        # Create short WAV files.
-        # WHY timeout=30 for a 2s sine: this spawns 30 processes in a row, and
-        # a loaded CI runner has taken >5s just to start one of them. The
-        # generous budget only fires on a genuinely wedged process.
-        wavs: list[Path] = []
+        # One ffmpeg process with thirty inputs and thirty outputs, not thirty
+        # processes. The clips need distinct tones, but they do not need
+        # separate spawns, and the spawns were the problem: on a throttled CI
+        # runner a single one of them exceeded even a 30s budget, which is what
+        # kept reclaiming this job. Byte-identical output to the per-clip loop.
+        wavs = [tmp_path / f"clip_{i}.wav" for i in range(n_clips)]
+        command = ["ffmpeg", "-y"]
         for i in range(n_clips):
-            wav = tmp_path / f"clip_{i}.wav"
-            subprocess.run(  # noqa: S603, S607
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-f",
-                    "lavfi",
-                    "-i",
-                    f"sine=frequency={300 + i * 40}:duration={clip_dur}",
-                    "-ar",
-                    "48000",
-                    "-ac",
-                    "2",
-                    str(wav),
-                ],
-                capture_output=True,
-                timeout=30,
-            )
-            wavs.append(wav)
+            command += ["-f", "lavfi", "-i", f"sine=frequency={300 + i * 40}:duration={clip_dur}"]
+        for i, wav in enumerate(wavs):
+            command += ["-map", f"{i}:a", "-ar", "48000", "-ac", "2", str(wav)]
+        subprocess.run(command, capture_output=True, timeout=120, check=True)  # noqa: S603, S607
 
         clips = [AssemblyClip(path=wavs[i], duration=clip_dur) for i in range(n_clips)]
         transitions = ["fade"] * (n_clips - 1)


### PR DESCRIPTION
## Raising the budget was the wrong fix

This test has been the most-reclaimed job in CI. In #384 I raised its per-spawn
budget from 5 s to 30 s. On #407 it **timed out at 30 s too**, on macOS, at
`clip_20` of 30.

A 30-second budget to synthesise a 2-second sine is not a budget problem. It
means starting a process is the expensive thing on a throttled runner — and the
test was starting **thirty of them in a row**. I raised the ceiling when I should
have removed the spawns.

## One ffmpeg call, thirty outputs

| | |
|---|---|
| 30 spawns | 0.74 s |
| 1 spawn | **0.08 s** |

The clips still need distinct tones, but they never needed separate processes.
Output is **byte-identical** to the per-clip loop — verified, not assumed — so
the test measures exactly what it measured before.

`subprocess.run` calls in the test: **31 → 3**.

## Deliberately unchanged

`n_clips` stays 30. The test detects a per-clip loudnorm loss that only
accumulates to measurable drift across that many clips, so shrinking the loop to
make it faster would leave a green test detecting nothing. That was the trap
last time this test was touched, and it is still the trap.

## Something the reviewer should know about this test

The parallel session found — and I reproduced independently before writing this
— that **the guard's regression value is version-dependent**. Replacing the
pre-loudnorm clamp with `anull` leaves this test **green on ffmpeg 8.1**:
loudnorm no longer loses ~35 ms a clip there, and the tolerance is never
approached.

CI installs Ubuntu's older ffmpeg, which likely still exhibits the loss, so the
guard still has value *there*. But anyone relying on it to catch a regression
locally on a modern ffmpeg would be relying on nothing. That is worth knowing
before someone spends time hardening it, and it is not something this PR
changes — the test is exactly as strong as it was, just thirty spawns cheaper.

Credit to the parallel session, which independently reached the same diagnosis
and dropped its own version of this change because keeping ffmpeg as the
generator (byte-identical fixtures) beat replacing it with numpy (equivalent
tones, different bytes).
