### PR TITLE
perf(ui): stop reading the thumbnail cache to ask what it contains

### DIFF
--- a/src/immich_memories/cache/thumbnail_cache.py
+++ b/src/immich_memories/cache/thumbnail_cache.py
@@ -38,13 +38,14 @@ class ThumbnailCache:
     def has(self, asset_id: str, size: str) -> bool:
         return self._path(asset_id, size).exists()
 
-    def get_batch(self, asset_ids: set[str] | list[str], size: str) -> dict[str, bytes]:
-        result: dict[str, bytes] = {}
-        for asset_id in asset_ids:
-            data = self.get(asset_id, size)
-            if data is not None:
-                result[asset_id] = data
-        return result
+    def cached_ids(self, asset_ids: set[str] | list[str], size: str) -> set[str]:
+        """Which of these assets have a cached thumbnail.
+
+        Existence only: callers that just need the set were using `get_batch`
+        and discarding the bytes, which reads the whole cache off disk to
+        answer a question `stat` already answers.
+        """
+        return {asset_id for asset_id in asset_ids if self.has(asset_id, size)}
 
     def put(self, asset_id: str, size: str, data: bytes) -> Path:
         path = self._path(asset_id, size)

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -289,7 +289,7 @@ async def _load_thumbnails_and_metadata_async(
 
     all_asset_ids = [c.asset.id for c in clips]
 
-    cached_thumbnail_ids = set(thumbnail_cache.get_batch(all_asset_ids, "preview").keys())
+    cached_thumbnail_ids = thumbnail_cache.cached_ids(all_asset_ids, "preview")
     cached_metadata = analysis_cache.get_video_metadata_batch(all_asset_ids)
 
     for clip in clips:
@@ -337,29 +337,32 @@ async def _fetch_thumbnails_batched(
     batch_size: int,
 ) -> int:
     """Fetch thumbnails in batches. Returns updated done count."""
-    for i in range(0, len(need_thumbs), batch_size):
-        batch = need_thumbs[i : i + batch_size]
+    # One client for the whole fetch rather than one per batch of ten: each
+    # carries an httpx connection pool and a private event loop, and 500
+    # thumbnails meant fifty of them, all discarded after ten requests.
+    with SyncImmichClient(
+        base_url=state.immich_url,
+        api_key=state.immich_api_key,
+        api_version=state.immich_api_version,
+    ) as client:
+        for i in range(0, len(need_thumbs), batch_size):
+            batch = need_thumbs[i : i + batch_size]
 
-        def fetch_thumb_batch(clips_batch=batch):
-            with SyncImmichClient(
-                base_url=state.immich_url,
-                api_key=state.immich_api_key,
-                api_version=state.immich_api_version,
-            ) as client:
+            def fetch_thumb_batch(clips_batch=batch, client=client):
                 for clip in clips_batch:
                     with contextlib.suppress(Exception):
                         thumb = client.get_asset_thumbnail(clip.asset.id, size="preview")
                         if thumb:
                             thumbnail_cache.put(clip.asset.id, "preview", thumb)
 
-        await run.io_bound(fetch_thumb_batch)
-        done += len(batch)
-        frac = done / total_work
-        status_label.set_text(
-            f"Thumbnails: {min(i + batch_size, len(need_thumbs))}/{len(need_thumbs)}"
-        )
-        if progress_bar:
-            progress_bar.value = 0.1 + frac * 0.85
+            await run.io_bound(fetch_thumb_batch)
+            done += len(batch)
+            frac = done / total_work
+            status_label.set_text(
+                f"Thumbnails: {min(i + batch_size, len(need_thumbs))}/{len(need_thumbs)}"
+            )
+            if progress_bar:
+                progress_bar.value = 0.1 + frac * 0.85
     return done
 
 
@@ -480,7 +483,7 @@ async def _load_photo_thumbnails_async(
         return
 
     photo_ids = [a.id for a in photo_assets]
-    cached = set(thumbnail_cache.get_batch(photo_ids, "preview").keys())
+    cached = thumbnail_cache.cached_ids(photo_ids, "preview")
     need = [a for a in photo_assets if a.id not in cached]
 
     if not need:

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -340,29 +340,29 @@ async def _fetch_thumbnails_batched(
     # One client for the whole fetch rather than one per batch of ten: each
     # carries an httpx connection pool and a private event loop, and 500
     # thumbnails meant fifty of them, all discarded after ten requests.
-    with SyncImmichClient(
-        base_url=state.immich_url,
-        api_key=state.immich_api_key,
-        api_version=state.immich_api_version,
-    ) as client:
-        for i in range(0, len(need_thumbs), batch_size):
-            batch = need_thumbs[i : i + batch_size]
+    for i in range(0, len(need_thumbs), batch_size):
+        batch = need_thumbs[i : i + batch_size]
 
-            def fetch_thumb_batch(clips_batch=batch, client=client):
+        def fetch_thumb_batch(clips_batch=batch):
+            with SyncImmichClient(
+                base_url=state.immich_url,
+                api_key=state.immich_api_key,
+                api_version=state.immich_api_version,
+            ) as client:
                 for clip in clips_batch:
                     with contextlib.suppress(Exception):
                         thumb = client.get_asset_thumbnail(clip.asset.id, size="preview")
                         if thumb:
                             thumbnail_cache.put(clip.asset.id, "preview", thumb)
 
-            await run.io_bound(fetch_thumb_batch)
-            done += len(batch)
-            frac = done / total_work
-            status_label.set_text(
-                f"Thumbnails: {min(i + batch_size, len(need_thumbs))}/{len(need_thumbs)}"
-            )
-            if progress_bar:
-                progress_bar.value = 0.1 + frac * 0.85
+        await run.io_bound(fetch_thumb_batch)
+        done += len(batch)
+        frac = done / total_work
+        status_label.set_text(
+            f"Thumbnails: {min(i + batch_size, len(need_thumbs))}/{len(need_thumbs)}"
+        )
+        if progress_bar:
+            progress_bar.value = 0.1 + frac * 0.85
     return done
 
 

--- a/tests/test_step2_loading_cost.py
+++ b/tests/test_step2_loading_cost.py
@@ -1,0 +1,100 @@
+"""Step 2 did redundant work before it fetched anything.
+
+Two costs measured on a real cache, neither of them the network:
+
+* The set of already-cached thumbnails was built with `get_batch(...).keys()`,
+  which reads every cached thumbnail's *bytes* off disk to answer a question
+  about which ids exist. On 1583 real thumbnails that is 543 MB read and thrown
+  away, 244 ms against 7 ms -- and at 5000 clips, ~1.7 GB.
+* Each batch of ten built its own `SyncImmichClient`, so 500 thumbnails meant 50
+  HTTP clients, each with its own connection pool and private event loop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+
+async def _call_directly(func, *args, **kwargs):
+    """Stand in for nicegui.run.io_bound without a worker pool."""
+    return func(*args, **kwargs)
+
+
+class TestFindingCachedThumbnails:
+    @staticmethod
+    def _cache_with(tmp_path: Path, ids: list[str]) -> ThumbnailCache:
+        cache = ThumbnailCache(cache_dir=tmp_path / "thumbnails")
+        for asset_id in ids:
+            cache.put(asset_id, "preview", b"x" * 4096)
+        return cache
+
+    def test_it_reports_which_ids_are_cached(self, tmp_path: Path):
+        cache = self._cache_with(tmp_path, ["a", "b"])
+
+        assert cache.cached_ids(["a", "b", "c"], "preview") == {"a", "b"}
+
+    def test_it_does_not_read_the_thumbnails(self, tmp_path: Path, monkeypatch):
+        """Reading bytes to answer an existence question is the whole bug."""
+        cache = self._cache_with(tmp_path, ["a", "b"])
+
+        def fail_on_read(*_args, **_kwargs):
+            raise AssertionError("thumbnail bytes were read to build an id set")
+
+        monkeypatch.setattr(Path, "read_bytes", fail_on_read)
+
+        assert cache.cached_ids(["a", "b", "c"], "preview") == {"a", "b"}
+
+    def test_an_empty_request_is_not_an_error(self, tmp_path: Path):
+        assert self._cache_with(tmp_path, []).cached_ids([], "preview") == set()
+
+
+class TestFetchingThumbnails:
+    """Each batch of ten built its own client, so 500 thumbnails meant 50 of
+    them -- each an httpx connection pool and a private event loop, discarded
+    after ten requests, and none of them reusing a connection.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_client_serves_the_whole_fetch(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from immich_memories.ui.pages import step2_loading
+
+        built = []
+
+        class _Client:
+            def __init__(self, **_kwargs):
+                built.append(1)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def get_asset_thumbnail(self, asset_id, size):  # noqa: ARG002
+                return b"jpeg"
+
+        # WHY: the Immich server; the point of the test is how many clients open.
+        monkeypatch.setattr(step2_loading, "SyncImmichClient", _Client)
+        # WHY: NiceGUI's worker pool; run the callable directly instead.
+        monkeypatch.setattr(step2_loading.run, "io_bound", _call_directly)
+
+        clips = []
+        for i in range(35):
+            clip = MagicMock()
+            clip.asset.id = f"asset-{i}"
+            clips.append(clip)
+        cache = MagicMock()
+        state = MagicMock(immich_url="http://immich.test", immich_api_key="k")
+
+        await step2_loading._fetch_thumbnails_batched(
+            clips, cache, state, MagicMock(), None, 0, len(clips), 10
+        )
+
+        assert built == [1], f"{len(built)} clients opened for 4 batches"
+        assert cache.put.call_count == 35

--- a/tests/test_step2_loading_cost.py
+++ b/tests/test_step2_loading_cost.py
@@ -1,27 +1,16 @@
-"""Step 2 did redundant work before it fetched anything.
+"""Step 2 read its whole thumbnail cache to ask what was in it.
 
-Two costs measured on a real cache, neither of them the network:
-
-* The set of already-cached thumbnails was built with `get_batch(...).keys()`,
-  which reads every cached thumbnail's *bytes* off disk to answer a question
-  about which ids exist. On 1583 real thumbnails that is 543 MB read and thrown
-  away, 244 ms against 7 ms -- and at 5000 clips, ~1.7 GB.
-* Each batch of ten built its own `SyncImmichClient`, so 500 thumbnails meant 50
-  HTTP clients, each with its own connection pool and private event loop.
+The set of already-cached thumbnails was built with `get_batch(...).keys()`,
+which reads every cached thumbnail's *bytes* off disk to answer a question about
+which ids exist. On 1583 real thumbnails that is 543 MB read and thrown away,
+244 ms against 7 ms -- and at 5000 clips, ~1.7 GB.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from immich_memories.cache.thumbnail_cache import ThumbnailCache
-
-
-async def _call_directly(func, *args, **kwargs):
-    """Stand in for nicegui.run.io_bound without a worker pool."""
-    return func(*args, **kwargs)
 
 
 class TestFindingCachedThumbnails:
@@ -50,51 +39,3 @@ class TestFindingCachedThumbnails:
 
     def test_an_empty_request_is_not_an_error(self, tmp_path: Path):
         assert self._cache_with(tmp_path, []).cached_ids([], "preview") == set()
-
-
-class TestFetchingThumbnails:
-    """Each batch of ten built its own client, so 500 thumbnails meant 50 of
-    them -- each an httpx connection pool and a private event loop, discarded
-    after ten requests, and none of them reusing a connection.
-    """
-
-    @pytest.mark.asyncio
-    async def test_one_client_serves_the_whole_fetch(self, monkeypatch):
-        from unittest.mock import MagicMock
-
-        from immich_memories.ui.pages import step2_loading
-
-        built = []
-
-        class _Client:
-            def __init__(self, **_kwargs):
-                built.append(1)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_exc):
-                return False
-
-            def get_asset_thumbnail(self, asset_id, size):  # noqa: ARG002
-                return b"jpeg"
-
-        # WHY: the Immich server; the point of the test is how many clients open.
-        monkeypatch.setattr(step2_loading, "SyncImmichClient", _Client)
-        # WHY: NiceGUI's worker pool; run the callable directly instead.
-        monkeypatch.setattr(step2_loading.run, "io_bound", _call_directly)
-
-        clips = []
-        for i in range(35):
-            clip = MagicMock()
-            clip.asset.id = f"asset-{i}"
-            clips.append(clip)
-        cache = MagicMock()
-        state = MagicMock(immich_url="http://immich.test", immich_api_key="k")
-
-        await step2_loading._fetch_thumbnails_batched(
-            clips, cache, state, MagicMock(), None, 0, len(clips), 10
-        )
-
-        assert built == [1], f"{len(built)} clients opened for 4 batches"
-        assert cache.put.call_count == 35

--- a/tests/test_thumbnail_cache.py
+++ b/tests/test_thumbnail_cache.py
@@ -43,13 +43,6 @@ class TestThumbnailCache:
         """Missing thumbnail returns None."""
         assert cache.get("nonexistent", "preview") is None
 
-    def test_get_batch(self, cache):
-        """Batch retrieval returns only cached items."""
-        cache.put("a1", "preview", b"data-a1")
-        cache.put("a2", "preview", b"data-a2")
-        result = cache.get_batch(["a1", "a2", "a3"], "preview")
-        assert set(result.keys()) == {"a1", "a2"}
-
     def test_clear(self, cache):
         """Clear removes all thumbnails and returns count."""
         cache.put("a1", "preview", b"data1")


### PR DESCRIPTION
## Reading the cache to ask whether it has something

```python
cached_thumbnail_ids = set(thumbnail_cache.get_batch(all_asset_ids, "preview").keys())
```

`get_batch` reads every cached thumbnail's **bytes** off disk; the caller keeps
only the keys. `has()` answers the same question with `stat`:

```
1583 cached thumbnails, 543 MB on disk
  get_batch().keys()   243.8 ms   (reads 543 MB and discards it)
  has() per id           7.2 ms
  same answer: True
```

**34×** — and at 5000 clips, roughly **1.7 GB** read to produce a set of ids, on
the event loop, so every session waits for it. Two call sites did this.

`get_batch` is **deleted**: with both callers moved to the new `cached_ids()`,
its only remaining user was its own test, and the vulture whitelist is a frozen
ratchet so an unused method would have failed the gate anyway.

## What this PR *no longer* does, and why

It originally also shared one `SyncImmichClient` across the batched thumbnail
fetch instead of building one per batch of ten. **That broke Step 2 loading**,
and the Hermetic E2E caught it: both launch-smoke tests timed out waiting for the
`2 Videos, 2 Photos Found` summary, because loading never finished.

Bisected rather than guessed:

| | |
|---|---|
| `main` | passes, 14 s |
| both halves | **fails, 60 s timeout** |
| only the client hoisting reverted | passes, 14 s |

The mechanism fits a hang rather than an error, which is what the E2E saw: the
client was constructed on the event-loop thread and then used inside
`run.io_bound` worker threads. httpx's `AsyncClient` builds its connection pool
with primitives bound to the loop that created them, so driving it from another
thread's loop blocks instead of raising.

Worth recording: **a two-thread reproduction I wrote first did not show the
bug** — both threads returned a clean connection error. Failing to connect never
exercises a pooled connection, so that repro was testing the error path while
reporting on the success path. The bisect was worth more than the reasoning.

The per-batch client therefore stays. Fixing it properly means running the whole
fetch inside a single `io_bound` call so one thread owns the client throughout,
then getting progress updates back onto the event loop — a different change,
noted rather than left as a silent regression.

Closes #415 for the disk-read half; the client-per-batch half of that issue
remains open.
