### PR TITLE
test(matrix): a capability matrix, with a pinned baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams
+.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams capability-matrix
 
 # Default target
 help:
@@ -196,6 +196,9 @@ test-integration-live-photos:  ## Run ONLY live photo merge tests (~30s, needs I
 	uv run pytest tests/integration/live_photos/ -v -s -m integration --log-cli-level=INFO --tb=short \
 		--cov=src/immich_memories --cov-branch --cov-report=xml:tests/live-photos-coverage.xml --cov-fail-under=0 \
 		--junitxml=tests/live-photos-junit.xml
+
+capability-matrix:  ## Render one video per capability against your library (local only, ~30min)
+	uv run python scripts/capability_matrix.py --album "$(ALBUM)" $(if $(ONLY),--only $(ONLY),)
 
 test-integration-photos:  ## Run ONLY photo animation tests (~20s, FFmpeg only)
 	uv run pytest tests/integration/photos/ -v -s -m integration --log-cli-level=INFO --tb=short \

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -1,0 +1,264 @@
+"""Render one short video per capability, so a release can be watched.
+
+Unit tests say a filter string contains `drawtext`; only a rendered file says
+the caption is legible, in the right corner, and not underneath the platform's
+own UI. This walks `capability_matrix.yaml`, runs each row through the real CLI
+against the real library, and writes an index next to the results.
+
+Local only. Outputs land under `output/` which is gitignored, because they
+contain real footage.
+
+    make capability-matrix ALBUM="Some Album"
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from immich_memories.config_loader import _TIER2_SECTIONS, Config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = Path(__file__).with_suffix(".yaml")
+
+
+@dataclass
+class Result:
+    name: str
+    why: str
+    command: str
+    seconds: float
+    output: Path | None
+    error: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def _pinned_config(source: Path | None, dest: Path, pins: dict) -> Path:
+    """A copy of the config with the settings the matrix varies pinned to known values.
+
+    WHY at all: inheriting the developer's config means the rows test that
+    config, not the code. The first sweep ran every row at 4K because one local
+    line said so -- never touching 1080p, which is the shipped default and what
+    a NAS actually runs -- and two rows asserted flags their config already set,
+    so they re-rendered the baseline under a different name and reported "ok".
+
+    WHY the section walk: a tier-2 section may sit at top level (legacy) or
+    under `advanced:`, and the loader resolves the clash with `if key not in
+    data` -- top level wins. Writing the modern spelling into a config using the
+    old one leaves the edit inert.
+    """
+    source = source or Config.get_default_path()
+    if not source.exists():
+        raise SystemExit(
+            f"{source} does not exist, and the sweep needs a real config to copy "
+            "for its Immich credentials. Pass --config explicitly."
+        )
+    data = yaml.safe_load(source.read_text()) or {}
+
+    for dotted, value in pins.items():
+        section, _, leaf = dotted.partition(".")
+        if section in data:
+            target = data[section]
+        elif section in data.get("advanced", {}):
+            target = data["advanced"][section]
+        elif section in _TIER2_SECTIONS:
+            target = data.setdefault("advanced", {}).setdefault(section, {})
+        else:
+            target = data.setdefault(section, {})
+        target[leaf] = value
+
+    dest.write_text(yaml.safe_dump(data, sort_keys=False))
+    return dest
+
+
+def _first_real_error(proc: subprocess.CompletedProcess[str]) -> str:
+    """The line that explains the failure, not whatever printed last.
+
+    The tail of a failed run is usually teardown noise -- the first smoke test
+    reported `ggml_metal_free: deallocating` for what was actually a 404 from
+    Immich.
+    """
+    lines = ((proc.stderr or "") + "\n" + (proc.stdout or "")).strip().splitlines()
+    for marker in ("[ERROR]", "Traceback", "Error:", "error:"):
+        hits = [ln.strip() for ln in lines if marker in ln]
+        if hits:
+            return hits[-1][:300]
+    return lines[-1][:300] if lines else ""
+
+
+def _frame_signature(path: Path) -> str:
+    """A hash of one decoded frame, for telling two renders apart.
+
+    Container timestamps differ between runs, so hashing the file says nothing;
+    two rows that rendered identical video had different SHAs and byte-identical
+    sizes. Decoding a frame compares what actually reaches the viewer.
+    """
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-ss", "5", "-i", str(path), "-frames:v", "1", "-f", "md5", "-"],
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip() or f"unreadable:{path.name}"
+
+
+def _duplicate_groups(paths: list[Path]) -> list[list[str]]:
+    """Names of rows whose renders are pixel-identical, grouped.
+
+    A duplicate means a row asserted something the baseline already sets, so it
+    silently re-rendered the baseline and reported "ok".
+    """
+    by_signature: dict[str, list[str]] = {}
+    for path in paths:
+        by_signature.setdefault(_frame_signature(path), []).append(path.name)
+    return [names for names in by_signature.values() if len(names) > 1]
+
+
+def _rendered_file(out_dir: Path, name: str, since: float) -> Path | None:
+    """Where the render actually landed.
+
+    `--output` names a file, but the CLI writes into a run directory beside it
+    named after the recipe (`<name>_<hash>_<timestamp>_<id>/`) so a rerun of the
+    same recipe replaces itself. Find the newest video carrying this row's name.
+    """
+    videos = [p for suffix in ("*.mp4", "*.mov", "*.mkv") for p in out_dir.rglob(suffix)]
+    matches = [p for p in videos if p.name.startswith(name)]
+    if not matches:
+        # WHY: `--from-album` names the file after the album, not after `--output`,
+        # so the first sweep reported "wrote no file" for a render sitting on disk
+        # as album_<name>_<hash>.mp4. Anything written since this row started is it.
+        matches = [p for p in videos if p.stat().st_mtime >= since]
+    return max(matches, key=lambda p: p.stat().st_mtime) if matches else None
+
+
+def _run(
+    row: dict,
+    common: list[str],
+    out_dir: Path,
+    album: str,
+    config: Path | None,
+    baseline: dict,
+) -> Result:
+    name = row["name"]
+    target = out_dir / f"{name}.mp4"
+    args = [str(a).replace("{album}", album) for a in row["args"]]
+    pins = {**baseline, **row.get("config", {})}
+    root = ["--config", str(_pinned_config(config, out_dir / f"{name}.yaml", pins))]
+
+    cmd = [
+        "uv",
+        "run",
+        "immich-memories",
+        *root,
+        "generate",
+        *([] if row.get("skip_common") else common),
+        *args,
+        "--output",
+        str(target),
+        "--quiet",
+    ]
+    started = time.monotonic()
+    wall = time.time()
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    elapsed = time.monotonic() - started
+
+    error = None
+    produced = None
+    if proc.returncode != 0:
+        error = _first_real_error(proc) or f"exit {proc.returncode}"
+    else:
+        produced = _rendered_file(out_dir, name, wall)
+        if produced is None:
+            error = "command succeeded but wrote no file"
+
+    printable = " ".join(cmd[cmd.index("generate") :])
+    return Result(name, row["why"], printable, elapsed, produced, error)
+
+
+def _write_index(results: list[Result], out_dir: Path) -> Path:
+    lines = [
+        f"# Capability matrix — {datetime.now():%Y-%m-%d %H:%M}",
+        "",
+        f"{sum(r.ok for r in results)}/{len(results)} rendered."
+        f" Total {sum(r.seconds for r in results) / 60:.1f} min.",
+        "",
+        "| # | Capability | Why it is here | Time | Result |",
+        "|---|---|---|---|---|",
+    ]
+    for i, r in enumerate(results, 1):
+        outcome = f"[{r.output.name}]({r.output.name})" if r.ok else f"**failed** — {r.error}"
+        lines.append(f"| {i} | `{r.name}` | {r.why} | {r.seconds:.0f}s | {outcome} |")
+    duplicates = _duplicate_groups([r.output for r in results if r.ok and r.output])
+    if duplicates:
+        lines += ["", "## Identical renders", ""]
+        lines += [
+            "These rows produced the same video, so whatever they were meant to vary "
+            "is already the baseline:",
+            "",
+        ]
+        lines += [f"- {' = '.join(names)}" for names in duplicates]
+
+    lines += ["", "## Commands", ""]
+    lines += [f"- `{r.name}`: `immich-memories {r.command}`" for r in results]
+    index = out_dir / "index.md"
+    index.write_text("\n".join(lines) + "\n")
+    return index
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--album", default="", help="album name for the --from-album row")
+    parser.add_argument("--config", type=Path, default=None, help="config file to generate with")
+    parser.add_argument("--only", default="", help="substring filter over row names")
+    parser.add_argument("--out", type=Path, default=None, help="output directory")
+    opts = parser.parse_args()
+
+    manifest = yaml.safe_load(MANIFEST.read_text())
+    rows = [r for r in manifest["rows"] if opts.only in r["name"]]
+    if not rows:
+        print(f"no rows match {opts.only!r}", file=sys.stderr)
+        return 2
+
+    skipped = [r["name"] for r in rows if "{album}" in str(r["args"]) and not opts.album]
+    rows = [r for r in rows if r["name"] not in skipped]
+    for name in skipped:
+        print(f"skipping {name}: needs --album", file=sys.stderr)
+
+    out_dir = (
+        opts.out or REPO_ROOT / "output" / "capability-matrix" / f"{datetime.now():%Y%m%d-%H%M}"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"writing to {out_dir}")
+
+    results = []
+    for i, row in enumerate(rows, 1):
+        print(f"[{i}/{len(rows)}] {row['name']} ...", flush=True)
+        result = _run(
+            row,
+            manifest["common"],
+            out_dir,
+            opts.album,
+            opts.config,
+            manifest.get("baseline_config", {}),
+        )
+        results.append(result)
+        print(
+            f"    {'ok' if result.ok else 'FAILED: ' + (result.error or '')} ({result.seconds:.0f}s)"
+        )
+
+    index = _write_index(results, out_dir)
+    print(f"\n{sum(r.ok for r in results)}/{len(results)} rendered — {index}")
+    return 0 if all(r.ok for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capability_matrix.py
+++ b/scripts/capability_matrix.py
@@ -14,6 +14,7 @@ contain real footage.
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 import time
@@ -24,6 +25,7 @@ from pathlib import Path
 import yaml
 
 from immich_memories.config_loader import _TIER2_SECTIONS, Config
+from immich_memories.config_presets import PRESETS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = Path(__file__).with_suffix(".yaml")
@@ -65,8 +67,23 @@ def _pinned_config(source: Path | None, dest: Path, pins: dict) -> Path:
         )
     data = yaml.safe_load(source.read_text()) or {}
 
+    # WHY: `apply_preset` fills only fields the user has NOT set, so any key the
+    # local config happens to carry silently outranks the preset -- and the row
+    # renders a partial profile while claiming to show the whole one. Clearing
+    # the keys the preset owns hands them back to it. Explicit pins are applied
+    # after, so a row can still override one.
+    if "preset" in pins:
+        for section_name, values in PRESETS[pins["preset"]].items():
+            section = data.get(section_name)
+            if isinstance(section, dict):
+                for field in values:
+                    section.pop(field, None)
+
     for dotted, value in pins.items():
         section, _, leaf = dotted.partition(".")
+        if not leaf:
+            data[section] = value
+            continue
         if section in data:
             target = data[section]
         elif section in data.get("advanced", {}):
@@ -79,6 +96,20 @@ def _pinned_config(source: Path | None, dest: Path, pins: dict) -> Path:
 
     dest.write_text(yaml.safe_dump(data, sort_keys=False))
     return dest
+
+
+def _low_power_prefix() -> list[str]:
+    """Run a row on the efficiency cores, to stand in for a NAS.
+
+    macOS has no taskset and thread affinity is a hint the scheduler may ignore,
+    so a core count cannot be pinned. Background QoS can be, and it is honoured:
+    the same 1080p encode takes 1.36s unrestricted and 5.78s under it, because
+    the process tree is kept off the performance cores. Children inherit it, so
+    ffmpeg is covered without touching its -threads flags.
+
+    Absent elsewhere; the row then renders at full speed rather than not at all.
+    """
+    return ["taskpolicy", "-b"] if shutil.which("taskpolicy") else []
 
 
 def _first_real_error(proc: subprocess.CompletedProcess[str]) -> str:
@@ -155,6 +186,7 @@ def _run(
     root = ["--config", str(_pinned_config(config, out_dir / f"{name}.yaml", pins))]
 
     cmd = [
+        *(_low_power_prefix() if row.get("low_power") else []),
         "uv",
         "run",
         "immich-memories",

--- a/scripts/capability_matrix.yaml
+++ b/scripts/capability_matrix.yaml
@@ -1,0 +1,83 @@
+# One short render per capability, so a release can be eyeballed end to end
+# rather than trusted to unit tests alone. The runner reads this file; nothing
+# is hard-coded in the script, so add or reorder rows freely.
+#
+# Deliberately ONE music-generation row. ACE-Step dominates the runtime of the
+# whole matrix and every other row exercises the pipeline just as well without
+# it.
+#
+# `args` are appended to `immich-memories generate` verbatim, after `common`.
+# A row may add `config:` to pin extra settings for itself alone.
+
+# Pinned for every row, over a copy of your own config, so the sweep varies what
+# the rows say it varies and reproduces on another machine.
+#
+# WHY this exists: the first sweep inherited a local config and rendered all 13
+# rows at 4K -- never touching 1080p, the shipped default and what a NAS runs --
+# while two rows asserted flags that config already set, so they re-rendered the
+# baseline under a different name and reported "ok" in 218s.
+#
+# Both music backends ship disabled, so pinning them off makes `--music auto`
+# mean the bundled track. The one row that generates music turns ACE-Step back
+# on for itself.
+baseline_config:
+  output.resolution: 1080p
+  analysis.include_live_photos: true
+  ace_step.enabled: false
+  musicgen.enabled: false
+
+# Keep the pool small: the point is to see each capability, not to wait.
+# `--month` is silently ignored without a memory type -- it narrows a yearly
+# type rather than standing alone, so without this the pool is the whole year.
+# Photos are on by config, and they outnumber videos ~2:1, so every row would
+# be a slideshow. Rows that are about photos opt back in.
+common: ["--memory-type", "monthly_highlights", "--year", "2025", "--month", "8",
+         "--duration", "25", "--no-photos"]
+
+rows:
+  - name: 01-landscape-video-cuts
+    why: Baseline. Videos only, hard cuts, no music - the simplest path through.
+    args: ["--orientation", "landscape", "--transition", "cut", "--no-music"]
+
+  - name: 02-landscape-photos-crossfade
+    why: Photos interleaved with video, crossfaded. Ken Burns and the photo budget.
+    args: ["--orientation", "landscape", "--include-photos", "--transition", "crossfade", "--no-music"]
+
+  - name: 03-landscape-date-caption
+    why: Date caption in landscape, inset off the short side, bottom right.
+    args: ["--orientation", "landscape", "--add-date", "--no-music"]
+
+  - name: 04-landscape-date-place-caption
+    why: Both captions on one line, "City, Country - D Mon YYYY", in landscape.
+    args: ["--orientation", "landscape", "--add-date", "--add-place", "--no-music"]
+
+  - name: 05-portrait-date-place-caption
+    why: The 9:16 case. The caption must clear the platform chrome along the bottom.
+    args: ["--orientation", "portrait", "--include-photos", "--add-date", "--add-place", "--no-music"]
+
+  - name: 06-square
+    why: Square output, the third orientation.
+    args: ["--orientation", "square", "--no-music"]
+
+  - name: 08-4k
+    why: 4K path. Watch HDR sources for the red cast partial metadata causes.
+    args: ["--resolution", "4k", "--no-music"]
+
+  - name: 09-privacy-mode
+    why: Frosted blur plus muted speech - the demo and screenshot path.
+    args: ["--privacy-mode", "--no-music"]
+
+  - name: 10-from-album
+    why: An album as the whole pool, titled after the album, no date range.
+    # --from-album cannot be combined with a time period, so this row drops it.
+    skip_common: true
+    args: ["--duration", "25", "--from-album", "{album}", "--no-music"]
+
+  - name: 11-bundled-music
+    why: The Docker/NAS default - a bundled track, mastered and looped to length.
+    args: ["--music", "auto"]
+
+  - name: 13-generated-music
+    config: {ace_step.enabled: true}
+    why: The ONLY ACE-Step run. Tempo should follow the photo cadence (#312).
+    args: ["--include-photos", "--music", "auto"]

--- a/scripts/capability_matrix.yaml
+++ b/scripts/capability_matrix.yaml
@@ -81,3 +81,18 @@ rows:
     config: {ace_step.enabled: true}
     why: The ONLY ACE-Step run. Tempo should follow the photo cadence (#312).
     args: ["--include-photos", "--music", "auto"]
+
+  - name: 14-fast-preset-low-power
+    why: The CPU-only NAS profile, on the efficiency cores. Slow on purpose.
+    # `preset: fast` is config rather than a flag: 1080p h264 medium, no speech
+    # analysis, static title backgrounds, the fast encoder preset, fewer photos,
+    # and analysis_depth auto resolving to favourites-first.
+    #
+    # `low_power` drops the process tree to background QoS, which macOS honours
+    # by keeping it off the performance cores -- 4.2x slower on a measured 1080p
+    # encode. There is no taskset on macOS and thread affinity is only a hint, so
+    # a core count cannot be pinned; slow cores stand in for few cores. Expect
+    # this row to take several times any other.
+    low_power: true
+    config: {preset: fast}
+    args: ["--include-photos", "--add-date", "--no-music"]

--- a/tests/test_capability_matrix.py
+++ b/tests/test_capability_matrix.py
@@ -1,0 +1,90 @@
+"""The capability matrix must pin settings where the config already spells them.
+
+A tier-2 section may sit at top level (legacy) or under `advanced:`, and the
+loader resolves the clash with `if key not in data` — top level wins. Writing
+the modern spelling into a config using the old one leaves the edit inert, so
+a pin has to land wherever the section already lives.
+
+This is not hypothetical: the first version of the sweep wrote
+`advanced.ace_step.enabled: false` into a config carrying a top-level
+`ace_step:`, and the row that was supposed to exercise the bundled-music
+fallback would have quietly generated music instead — passing, and testing the
+wrong thing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from capability_matrix import _pinned_config  # noqa: E402
+
+from immich_memories.config_loader import _load_yaml_data  # noqa: E402
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    source = tmp_path / "config.yaml"
+    source.write_text(yaml.safe_dump(data))
+    return source
+
+
+def test_a_pin_reaches_a_section_spelled_at_top_level(tmp_path: Path) -> None:
+    source = _write(tmp_path, {"immich": {"url": "http://x"}, "ace_step": {"enabled": True}})
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"ace_step.enabled": False})
+
+    assert _load_yaml_data(dest)["ace_step"]["enabled"] is False
+
+
+def test_a_pin_reaches_a_section_spelled_under_advanced(tmp_path: Path) -> None:
+    source = _write(
+        tmp_path, {"immich": {"url": "http://x"}, "advanced": {"ace_step": {"enabled": True}}}
+    )
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"ace_step.enabled": False})
+
+    assert _load_yaml_data(dest)["ace_step"]["enabled"] is False
+
+
+def test_pinning_keeps_the_credentials_the_run_needs(tmp_path: Path) -> None:
+    """Every row generates against the real library; a pin must not drop the key."""
+    source = _write(tmp_path, {"immich": {"url": "http://x", "api_key": "k"}})
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"output.resolution": "1080p"})
+
+    loaded = _load_yaml_data(dest)
+    assert loaded["immich"] == {"url": "http://x", "api_key": "k"}
+    assert loaded["output"]["resolution"] == "1080p"
+
+
+def test_a_missing_config_is_named_rather_than_silently_empty(tmp_path: Path) -> None:
+    """Starting from `{}` produced a config with no URL and a 0s 'not configured' run."""
+    with pytest.raises(SystemExit, match="does not exist"):
+        _pinned_config(tmp_path / "absent.yaml", tmp_path / "out.yaml", {})
+
+
+def test_rows_that_render_the_same_video_are_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two rows produced pixel-identical files and both reported "ok" for 218s.
+
+    A duplicate is a row asserting something the config already sets, so it is a
+    silent hole in the sweep rather than a failure anyone would notice.
+    """
+    import capability_matrix as cm
+
+    same, other = Path("a.mp4"), Path("b.mp4")
+    monkeypatch.setattr(cm, "_frame_signature", lambda p: "X" if p != other else "Y")
+
+    assert cm._duplicate_groups([same, Path("c.mp4"), other]) == [["a.mp4", "c.mp4"]]
+
+
+def test_distinct_renders_are_not_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    import capability_matrix as cm
+
+    monkeypatch.setattr(cm, "_frame_signature", lambda p: p.name)
+
+    assert cm._duplicate_groups([Path("a.mp4"), Path("b.mp4")]) == []

--- a/tests/test_capability_matrix.py
+++ b/tests/test_capability_matrix.py
@@ -88,3 +88,64 @@ def test_distinct_renders_are_not_reported(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(cm, "_frame_signature", lambda p: p.name)
 
     assert cm._duplicate_groups([Path("a.mp4"), Path("b.mp4")]) == []
+
+
+def test_a_low_power_row_runs_on_the_efficiency_cores(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Measured 1.36s -> 5.78s on a real encode, so this is a limit, not a hint."""
+    import capability_matrix as cm
+
+    monkeypatch.setattr(cm.shutil, "which", lambda tool: f"/usr/sbin/{tool}")
+
+    assert cm._low_power_prefix() == ["taskpolicy", "-b"]
+
+
+def test_a_low_power_row_still_runs_where_taskpolicy_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linux has no taskpolicy; the row should render anyway rather than fail."""
+    import capability_matrix as cm
+
+    monkeypatch.setattr(cm.shutil, "which", lambda _tool: None)
+
+    assert cm._low_power_prefix() == []
+
+
+def test_a_top_level_scalar_can_be_pinned(tmp_path: Path) -> None:
+    """`preset: fast` is a bare key, not a section, so the dotted walk must not apply."""
+    source = _write(tmp_path, {"immich": {"url": "http://x"}})
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"preset": "fast"})
+
+    assert _load_yaml_data(dest)["preset"] == "fast"
+
+
+def test_a_preset_row_lets_the_preset_own_its_keys(tmp_path: Path) -> None:
+    """`apply_preset` skips any field the user set, so a local key silently wins.
+
+    Sam's config sets `codec` and `animated_background`, two of the five knobs
+    the fast preset exists to change. Left in place the row would render a
+    partial preset and call it "the NAS profile" -- machine-specific again.
+    """
+    source = _write(
+        tmp_path,
+        {
+            "immich": {"url": "http://x"},
+            "output": {"codec": "hevc", "directory": "~/Videos"},
+            "title_screens": {"animated_background": True},
+        },
+    )
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"preset": "fast"})
+
+    loaded = _load_yaml_data(dest)
+    assert "codec" not in loaded["output"], "the preset must be free to set codec"
+    assert "animated_background" not in loaded.get("title_screens", {})
+    assert loaded["output"]["directory"] == "~/Videos", "unrelated keys must survive"
+
+
+def test_an_explicit_pin_still_beats_the_preset(tmp_path: Path) -> None:
+    source = _write(tmp_path, {"immich": {"url": "http://x"}, "output": {"codec": "hevc"}})
+
+    dest = _pinned_config(source, tmp_path / "out.yaml", {"preset": "fast", "output.codec": "av1"})
+
+    assert _load_yaml_data(dest)["output"]["codec"] == "av1"


### PR DESCRIPTION
Closes #417.

Renders one short video per capability against a real library, so a release
can be watched rather than trusted to unit tests alone.

    make capability-matrix ALBUM="Some Album"

Local only. Output contains real footage and lands under the gitignored
`output/`. A first sweep of 13 rows found four bugs in the app (#408, #410,
#411, #412) and then four in itself; this PR is the version after those.

## The one worth reading

The sweep inherited the developer's config, so every row rendered at 4K
because one local line said so. The shipped default is 1080p — what a fresh
install and a NAS get — so 66 minutes exercised the heaviest path and never
the common one, and every timing it produced was inflated.

Two rows asserted flags that config already set. Precedence is *not* the
problem: CLI beats env beats config, checked at all three layers. The flags
won and won nothing, so both rows re-rendered the baseline under a different
name and reported `ok` in 218s — pixel-identical at every timestamp sampled.
The tell was two byte-identical file sizes.

So settings are pinned over a copy of your config, and a row has to differ
from a **known** baseline. `_duplicate_groups` hashes a decoded frame per
render and names any two that match, because a duplicate is a silent hole
rather than a failure. Hashing the files themselves proves nothing — the
container timestamps differ between runs, which is why two identical renders
had different SHAs.

## Config spellings

Pinning the backends off makes `--music auto` mean the bundled track, which
deletes the helper that used to force it along with both of its bugs. One
was instructive: it wrote `advanced.ace_step.enabled` into a config carrying
a top-level `ace_step:`, and the loader resolves that clash with `if key not
in data`, so the edit was inert — the row would have generated music while
claiming to test the fallback. A pin now lands wherever the section already
lives. That is what the tests cover, since it is the part that bit twice.

`Config.save()` does not have this bug; it pops tier-2 keys rather than
shadowing them, normalising the file. The trap only catches outside tools
that append.

## Also

- The live-photos row is gone — its flag matches the shipped default, so it
  can never differ from baseline.
- The ProRes row is gone — no use case.
- An album render is found by mtime: `--from-album` names the file after the
  album rather than after `--output`, and the runner called a successful
  206s render a failure.

## Verification

- `make test` green (5061 passed) under `HOME=$(mktemp -d)`, so the new
  tests do not depend on a local config.
- `make lint`, `make format`, `make typecheck` clean; all pre-commit gates
  passed including diff coverage.
- `_duplicate_groups` was run against the real 11 renders on disk and found
  exactly the pair identified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
