### PR TITLE
fix(cli): read the memory type from the date flags instead of ignoring --month

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1080,192 +1080,168 @@
       {
         "name": "register_generate_commands",
         "complexity": 179,
-        "line_start": 228,
-        "line_end": 944,
+        "line_start": 229,
+        "line_end": 958,
         "line_complexities": [
-          {
-            "line": 521,
-            "complexity": 0
-          },
           {
             "line": 522,
             "complexity": 0
           },
           {
-            "line": 529,
-            "complexity": 2
+            "line": 523,
+            "complexity": 0
           },
           {
             "line": 530,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 531,
             "complexity": 0
           },
           {
-            "line": 533,
+            "line": 532,
+            "complexity": 0
+          },
+          {
+            "line": 534,
             "complexity": 2
           },
           {
-            "line": 535,
-            "complexity": 3
-          },
-          {
-            "line": 539,
+            "line": 536,
             "complexity": 3
           },
           {
             "line": 540,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 542,
+            "line": 541,
             "complexity": 0
           },
           {
             "line": 543,
-            "complexity": 2
-          },
-          {
-            "line": 544,
-            "complexity": 1
-          },
-          {
-            "line": 549,
-            "complexity": 3
-          },
-          {
-            "line": 550,
             "complexity": 0
           },
           {
-            "line": 554,
+            "line": 544,
+            "complexity": 2
+          },
+          {
+            "line": 545,
+            "complexity": 1
+          },
+          {
+            "line": 550,
+            "complexity": 3
+          },
+          {
+            "line": 551,
             "complexity": 0
           },
           {
             "line": 555,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 556,
+            "complexity": 1
+          },
+          {
+            "line": 557,
             "complexity": 0
           },
           {
-            "line": 558,
+            "line": 559,
             "complexity": 2
           },
           {
-            "line": 572,
+            "line": 575,
+            "complexity": 0
+          },
+          {
+            "line": 586,
             "complexity": 3
           },
           {
-            "line": 576,
+            "line": 590,
             "complexity": 3
           },
           {
-            "line": 580,
+            "line": 594,
             "complexity": 4
           },
           {
-            "line": 584,
+            "line": 598,
             "complexity": 3
           },
           {
-            "line": 588,
+            "line": 602,
             "complexity": 3
           },
           {
-            "line": 592,
+            "line": 606,
             "complexity": 0
-          },
-          {
-            "line": 608,
-            "complexity": 2
-          },
-          {
-            "line": 609,
-            "complexity": 0
-          },
-          {
-            "line": 610,
-            "complexity": 1
-          },
-          {
-            "line": 612,
-            "complexity": 0
-          },
-          {
-            "line": 613,
-            "complexity": 1
-          },
-          {
-            "line": 614,
-            "complexity": 0
-          },
-          {
-            "line": 615,
-            "complexity": 3
-          },
-          {
-            "line": 620,
-            "complexity": 1
-          },
-          {
-            "line": 621,
-            "complexity": 3
           },
           {
             "line": 622,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 623,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 624,
+            "complexity": 1
+          },
+          {
+            "line": 626,
             "complexity": 0
           },
           {
             "line": 627,
+            "complexity": 1
+          },
+          {
+            "line": 628,
             "complexity": 0
           },
           {
-            "line": 631,
-            "complexity": 2
+            "line": 629,
+            "complexity": 3
+          },
+          {
+            "line": 634,
+            "complexity": 1
+          },
+          {
+            "line": 635,
+            "complexity": 3
           },
           {
             "line": 636,
             "complexity": 0
           },
           {
-            "line": 639,
-            "complexity": 0
+            "line": 637,
+            "complexity": 1
           },
           {
-            "line": 640,
-            "complexity": 2
+            "line": 638,
+            "complexity": 0
           },
           {
             "line": 641,
             "complexity": 0
           },
           {
-            "line": 644,
-            "complexity": 1
+            "line": 645,
+            "complexity": 2
           },
           {
-            "line": 647,
-            "complexity": 3
-          },
-          {
-            "line": 648,
-            "complexity": 3
-          },
-          {
-            "line": 652,
-            "complexity": 3
+            "line": 650,
+            "complexity": 0
           },
           {
             "line": 653,
@@ -1273,86 +1249,86 @@
           },
           {
             "line": 654,
-            "complexity": 3
+            "complexity": 2
           },
           {
             "line": 655,
             "complexity": 0
           },
           {
-            "line": 657,
-            "complexity": 0
-          },
-          {
-            "line": 681,
+            "line": 658,
             "complexity": 1
           },
           {
-            "line": 682,
-            "complexity": 2
-          },
-          {
-            "line": 686,
-            "complexity": 1
-          },
-          {
-            "line": 697,
+            "line": 661,
             "complexity": 3
           },
           {
-            "line": 698,
+            "line": 662,
+            "complexity": 3
+          },
+          {
+            "line": 666,
+            "complexity": 3
+          },
+          {
+            "line": 667,
             "complexity": 0
           },
           {
-            "line": 699,
+            "line": 668,
+            "complexity": 3
+          },
+          {
+            "line": 669,
             "complexity": 0
           },
           {
-            "line": 701,
+            "line": 671,
             "complexity": 0
           },
           {
-            "line": 703,
-            "complexity": 0
+            "line": 695,
+            "complexity": 1
           },
           {
-            "line": 705,
-            "complexity": 0
+            "line": 696,
+            "complexity": 2
+          },
+          {
+            "line": 700,
+            "complexity": 1
+          },
+          {
+            "line": 711,
+            "complexity": 3
           },
           {
             "line": 712,
+            "complexity": 0
+          },
+          {
+            "line": 713,
+            "complexity": 0
+          },
+          {
+            "line": 715,
+            "complexity": 0
+          },
+          {
+            "line": 717,
+            "complexity": 0
+          },
+          {
+            "line": 719,
+            "complexity": 0
+          },
+          {
+            "line": 726,
             "complexity": 5
           },
           {
-            "line": 753,
-            "complexity": 6
-          },
-          {
-            "line": 796,
-            "complexity": 0
-          },
-          {
-            "line": 797,
-            "complexity": 5
-          },
-          {
-            "line": 798,
-            "complexity": 6
-          },
-          {
-            "line": 799,
-            "complexity": 0
-          },
-          {
-            "line": 800,
-            "complexity": 0
-          },
-          {
-            "line": 801,
-            "complexity": 7
-          },
-          {
-            "line": 809,
+            "line": 767,
             "complexity": 6
           },
           {
@@ -1361,23 +1337,43 @@
           },
           {
             "line": 811,
-            "complexity": 7
+            "complexity": 5
           },
           {
             "line": 812,
+            "complexity": 6
+          },
+          {
+            "line": 813,
             "complexity": 0
           },
           {
             "line": 814,
-            "complexity": 1
+            "complexity": 0
           },
           {
-            "line": 819,
+            "line": 815,
             "complexity": 7
           },
           {
-            "line": 820,
+            "line": 823,
+            "complexity": 6
+          },
+          {
+            "line": 824,
             "complexity": 0
+          },
+          {
+            "line": 825,
+            "complexity": 7
+          },
+          {
+            "line": 826,
+            "complexity": 0
+          },
+          {
+            "line": 828,
+            "complexity": 1
           },
           {
             "line": 833,
@@ -1388,24 +1384,20 @@
             "complexity": 0
           },
           {
-            "line": 835,
+            "line": 847,
+            "complexity": 7
+          },
+          {
+            "line": 848,
             "complexity": 0
           },
           {
-            "line": 838,
+            "line": 849,
+            "complexity": 0
+          },
+          {
+            "line": 852,
             "complexity": 1
-          },
-          {
-            "line": 839,
-            "complexity": 0
-          },
-          {
-            "line": 840,
-            "complexity": 0
-          },
-          {
-            "line": 843,
-            "complexity": 0
           },
           {
             "line": 853,
@@ -1413,70 +1405,82 @@
           },
           {
             "line": 854,
-            "complexity": 5
+            "complexity": 0
           },
           {
-            "line": 855,
-            "complexity": 6
+            "line": 857,
+            "complexity": 0
           },
           {
-            "line": 856,
-            "complexity": 7
-          },
-          {
-            "line": 860,
-            "complexity": 6
-          },
-          {
-            "line": 863,
-            "complexity": 6
+            "line": 867,
+            "complexity": 0
           },
           {
             "line": 868,
-            "complexity": 0
+            "complexity": 5
+          },
+          {
+            "line": 869,
+            "complexity": 6
           },
           {
             "line": 870,
-            "complexity": 5
+            "complexity": 7
           },
           {
-            "line": 872,
-            "complexity": 5
+            "line": 874,
+            "complexity": 6
           },
           {
-            "line": 876,
-            "complexity": 5
+            "line": 877,
+            "complexity": 6
           },
           {
-            "line": 879,
-            "complexity": 1
-          },
-          {
-            "line": 881,
+            "line": 882,
             "complexity": 0
           },
           {
-            "line": 883,
+            "line": 884,
+            "complexity": 5
+          },
+          {
+            "line": 886,
+            "complexity": 5
+          },
+          {
+            "line": 890,
+            "complexity": 5
+          },
+          {
+            "line": 893,
+            "complexity": 1
+          },
+          {
+            "line": 895,
             "complexity": 0
           },
           {
-            "line": 927,
-            "complexity": 1
-          },
-          {
-            "line": 930,
-            "complexity": 1
-          },
-          {
-            "line": 933,
-            "complexity": 1
-          },
-          {
-            "line": 934,
+            "line": 897,
             "complexity": 0
           },
           {
-            "line": 935,
+            "line": 941,
+            "complexity": 1
+          },
+          {
+            "line": 944,
+            "complexity": 1
+          },
+          {
+            "line": 947,
+            "complexity": 1
+          },
+          {
+            "line": 948,
+            "complexity": 0
+          },
+          {
+            "line": 949,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -33,7 +33,7 @@ immich-memories generate [OPTIONS]
 | `--person` | `-p` | string | — | Person name from Immich face recognition (repeatable: `--person "Alice" --person "Bob"`) |
 | `--birthday` | `-b` | flag/string | — | Use birthday-based year. Bare flag auto-detects from Immich; or pass `MM/DD` to override |
 | `--season` | — | choice | — | `spring`, `summer`, `fall`, `autumn`, `winter` (use with `--memory-type season`) |
-| `--month` | — | int | — | Month 1-12 (narrows any yearly memory type; selects trip by month) |
+| `--month` | — | int | — | Month 1-12 (with `--year`, generates that month; selects trip by month) |
 | `--hemisphere` | — | choice | `north` | `north` or `south` (for season date calculation) |
 | `--years-back` | — | int | all | Years to look back for `on_this_day` (default: all years) |
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -223,7 +223,7 @@ immich-memories generate [OPTIONS]
 | `--person`, `-p` | text | - | Person name (repeatable) |
 | `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` | - | Memory type preset |
 | `--season` | choice: `spring` \| `summer` \| `fall` \| `autumn` \| `winter` | - | Season (use with --memory-type season) |
-| `--month` | integer | - | Month 1-12 (narrows any yearly memory type; selects trip by month) |
+| `--month` | integer | - | Month 1-12 (with --year, generates that month; selects trip by month) |
 | `--hemisphere` | choice: `north` \| `south` | north | Hemisphere for season calculation |
 | `--duration`, `-d` | integer | - | Target duration in seconds (default: from memory type preset) |
 | `--orientation`, `-o` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -51,6 +51,40 @@ def _resolve_manual_dates(
     return None
 
 
+def infer_memory_type(
+    memory_type: str | None,
+    *,
+    year: int | None,
+    month: int | None,
+    has_person: bool = False,
+    season: str | None = None,
+    birthday: str | None = None,
+    from_album: str | None = None,
+) -> str | None:
+    """Work out which memory the date flags describe.
+
+    `--month` used to do nothing unless `--memory-type` was also given, so
+    `--year 2025 --month 7` quietly rendered the whole year. Inferring the type
+    from the dates means the combination a user naturally types does what it
+    looks like it does, without `--month` depending on a second flag.
+
+    An explicit `--memory-type` always wins, so existing invocations are
+    unchanged. A year on its own is only read as a yearly review when nothing
+    else narrows the selection -- with a person, a season or a birthday the user
+    has asked for something specific, and guessing would override it. An album
+    brings its own assets, so the date flags say nothing about it.
+    """
+    if memory_type or from_album:
+        return memory_type
+    if year is None:
+        return None
+    if month is not None:
+        return "monthly_highlights"
+    if has_person or season or birthday:
+        return None
+    return "year_in_review"
+
+
 def resolve_date_range(
     year: int | None,
     start: str | None,

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -13,6 +13,7 @@ from rich.table import Table
 from immich_memories.cli._date_resolution import (
     default_duration_for_type,
     duration_from_date_range,
+    infer_memory_type,
     resolve_date_range,
 )
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
@@ -277,7 +278,7 @@ def register_generate_commands(main: click.Group) -> None:
         "--month",
         type=int,
         default=None,
-        help="Month 1-12 (narrows any yearly memory type; selects trip by month)",
+        help="Month 1-12 (with --year, generates that month; selects trip by month)",
     )
     @click.option(
         "--hemisphere",
@@ -567,6 +568,19 @@ def register_generate_commands(main: click.Group) -> None:
                 memory_type=memory_type,
                 person_names=person_names,
             )
+
+        # Read the memory from the date flags when it was not named. Without
+        # this --month did nothing unless --memory-type was also given, so
+        # `--year 2025 --month 7` rendered the whole year.
+        memory_type = infer_memory_type(
+            memory_type,
+            year=year,
+            month=month,
+            has_person=bool(person_names),
+            season=season,
+            birthday=birthday,
+            from_album=from_album,
+        )
 
         # Validate memory type constraints
         if memory_type in ("person_spotlight", "multi_person") and not person_names:

--- a/tests/test_memory_type_inference.py
+++ b/tests/test_memory_type_inference.py
@@ -1,0 +1,88 @@
+"""`--month` used to need `--memory-type` before it did anything.
+
+`--year 2025 --month 7` and `--month 8` both returned the whole year -- 3269
+videos either way -- because the month never reached the date range. A user
+could render a year-long memory believing they asked for July, with nothing in
+the output contradicting them.
+
+The memory type is now inferred from the date flags, so the combination someone
+naturally types does what it looks like it does.
+"""
+
+from __future__ import annotations
+
+from immich_memories.cli._date_resolution import infer_memory_type
+
+
+def test_a_year_and_a_month_means_monthly_highlights():
+    assert infer_memory_type(None, year=2025, month=7) == "monthly_highlights"
+
+
+def test_a_year_alone_means_the_yearly_review():
+    assert infer_memory_type(None, year=2025, month=None) == "year_in_review"
+
+
+def test_an_explicit_type_always_wins():
+    """Existing invocations must keep doing exactly what they did."""
+    assert infer_memory_type("season", year=2025, month=7) == "season"
+    assert infer_memory_type("trip", year=2025, month=8) == "trip"
+    assert infer_memory_type("person_spotlight", year=2025, month=None) == "person_spotlight"
+
+
+def test_nothing_is_inferred_without_a_year():
+    """--start/--end and friends resolve their own range; leave them alone."""
+    assert infer_memory_type(None, year=None, month=None) is None
+    assert infer_memory_type(None, year=None, month=3) is None
+
+
+def test_another_selector_suppresses_the_inference():
+    """A person or a season means the user is asking for something specific;
+    guessing `year_in_review` would quietly override it."""
+    assert infer_memory_type(None, year=2025, month=None, has_person=True) is None
+    assert infer_memory_type(None, year=2025, month=None, season="summer") is None
+    assert infer_memory_type(None, year=2025, month=None, birthday="02/07") is None
+
+
+def test_a_month_still_wins_over_a_person_filter():
+    """--month is unambiguous: it narrows to one month whatever else is set."""
+    assert infer_memory_type(None, year=2025, month=7, has_person=True) == "monthly_highlights"
+
+
+class TestTheReportedSymptom:
+    """The issue's reproduction: two different months returned the same range.
+
+    `--year 2025 --month 7` and `--month 8` both reported 3269 videos, the whole
+    year, because the range was resolved without the month.
+    """
+
+    @staticmethod
+    def _range_for(month: int | None):
+        from immich_memories.cli._date_resolution import resolve_date_range
+
+        memory_type = infer_memory_type(None, year=2025, month=month)
+        return resolve_date_range(
+            2025, None, None, None, None, memory_type=memory_type, month=month
+        )
+
+    def test_two_months_no_longer_resolve_to_the_same_range(self):
+        july = self._range_for(7)
+        august = self._range_for(8)
+
+        assert (july.start.date(), july.end.date()) != (august.start.date(), august.end.date())
+
+    def test_a_month_resolves_to_that_month(self):
+        july = self._range_for(7)
+
+        assert july.start.date().month == 7
+        assert july.end.date().month == 7
+
+    def test_a_year_without_a_month_is_still_the_whole_year(self):
+        whole = self._range_for(None)
+
+        assert whole.start.date().month == 1
+        assert whole.end.date().month == 12
+
+
+def test_an_album_suppresses_the_inference():
+    """--from-album brings its own assets; the date flags describe nothing."""
+    assert infer_memory_type(None, year=2025, month=7, from_album="Holiday") is None


### PR DESCRIPTION
## The bug

`--month` did nothing unless `--memory-type` was also given, because
`resolve_date_range` only consults the month inside the memory-type branch:

```
--year 2025 --month 7   ->  3269 videos   (the whole year)
--year 2025 --month 8   ->  3269 videos   (the whole year)
```

A user could render a year-long memory believing they asked for July, with
nothing in the output contradicting them.

## The fix

Per Sam: *a year alone is a yearly review, a year with a month is that month.*
The type is inferred from the dates, so `--month` no longer depends on a second
flag to take effect:

| Flags | Inferred | Range |
|---|---|---|
| `--year 2025` | `year_in_review` | 2025-01-01 .. 2025-12-31 |
| `--year 2025 --month 7` | `monthly_highlights` | 2025-07-01 .. 2025-07-31 |
| `--year 2025 --month 8` | `monthly_highlights` | 2025-08-01 .. 2025-08-31 |

**An explicit `--memory-type` always wins**, so existing invocations are
untouched. That has its own test, because it is what keeps every documented
command working.

## The inference is deliberately narrow

"Infer from dates" could easily overreach, so a bare `--year` only becomes
`year_in_review` when nothing else narrows the selection:

- `--person`, `--season`, `--birthday` → no inference. The user has asked for
  something specific and guessing would override it.
- `--from-album` → no inference. The album brings its own assets; the date flags
  describe nothing.
- `--month` → always `monthly_highlights`. Narrowing to a month is the only
  thing that flag can mean.

## The docs were already right

`docs/create/cli/generate.md` has promised `--year 2024 --month 7` → "Jul 1 to
Jul 31 2024" the whole time. The documentation described the intent; the code
did not implement it. That is the good direction for the mismatch to run, and it
means this PR makes an existing promise true rather than changing a contract.

The `--month` help text said it "narrows any yearly memory type" — describing
its effect only in combination with another flag. It now says what it does on
its own.

## Verification beyond the unit tests

The parallel session's capability matrix pins `--memory-type monthly_highlights
--year 2025 --month 8` in its `common` flags. With inference working, that first
flag should be droppable with an identical render — a real regression check
rather than an assertion, and they are running it.

Closes #410.
