### PR TITLE
fix(photos): caption a photo's place the way a video's is captioned

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2639,40 +2639,36 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 581,
-        "line_end": 680,
+        "line_start": 582,
+        "line_end": 681,
         "line_complexities": [
           {
-            "line": 602,
+            "line": 603,
             "complexity": 0
           },
           {
-            "line": 603,
-            "complexity": 1
-          },
-          {
-            "line": 605,
+            "line": 604,
             "complexity": 1
           },
           {
             "line": 606,
-            "complexity": 0
-          },
-          {
-            "line": 607,
-            "complexity": 2
-          },
-          {
-            "line": 608,
-            "complexity": 0
-          },
-          {
-            "line": 615,
             "complexity": 1
           },
           {
-            "line": 619,
+            "line": 607,
             "complexity": 0
+          },
+          {
+            "line": 608,
+            "complexity": 2
+          },
+          {
+            "line": 609,
+            "complexity": 0
+          },
+          {
+            "line": 616,
+            "complexity": 1
           },
           {
             "line": 620,
@@ -2680,54 +2676,58 @@
           },
           {
             "line": 621,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 622,
-            "complexity": 0
-          },
-          {
-            "line": 623,
-            "complexity": 2
-          },
-          {
-            "line": 624,
-            "complexity": 0
-          },
-          {
-            "line": 631,
             "complexity": 1
           },
           {
-            "line": 635,
+            "line": 623,
             "complexity": 0
           },
           {
-            "line": 638,
+            "line": 624,
+            "complexity": 2
+          },
+          {
+            "line": 625,
+            "complexity": 0
+          },
+          {
+            "line": 632,
+            "complexity": 1
+          },
+          {
+            "line": 636,
             "complexity": 0
           },
           {
             "line": 639,
-            "complexity": 2
-          },
-          {
-            "line": 640,
-            "complexity": 3
-          },
-          {
-            "line": 642,
-            "complexity": 1
-          },
-          {
-            "line": 645,
             "complexity": 0
           },
           {
-            "line": 679,
+            "line": 640,
+            "complexity": 2
+          },
+          {
+            "line": 641,
+            "complexity": 3
+          },
+          {
+            "line": 643,
             "complexity": 1
           },
           {
+            "line": 646,
+            "complexity": 0
+          },
+          {
             "line": 680,
+            "complexity": 1
+          },
+          {
+            "line": 681,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -29,6 +29,7 @@ from immich_memories.analysis.unified_budget import (
 from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import Asset
 from immich_memories.config_models import PhotoConfig
+from immich_memories.generate_privacy import clip_location_name
 from immich_memories.photos.animator import prepare_photo_source
 from immich_memories.photos.renderer import (
     KenBurnsParams,
@@ -570,7 +571,7 @@ def _render_single_photo(
             is_photo=True,
             latitude=asset.exif_info.latitude if asset.exif_info else None,
             longitude=asset.exif_info.longitude if asset.exif_info else None,
-            location_name=asset.exif_info.city if asset.exif_info else None,
+            location_name=clip_location_name(asset.exif_info),
         )
 
     except (ImmichAPIError, OSError, subprocess.SubprocessError, ValueError) as e:

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -853,6 +853,37 @@ class TestRenderSinglePhoto:
         assert result is None
 
 
+class TestPhotoPlaceCaption:
+    """A photo and a video must caption a place the same way.
+
+    `--add-place` renders "City, Country" for a video, via clip_location_name.
+    The photo path attached the bare city, so one memory containing both showed
+    "Ghent, Belgium" under a video and "Ghent" under the photo beside it.
+    """
+
+    def test_a_photo_captions_a_place_like_a_video_does(self, tmp_path):
+        import cv2
+        import numpy as np
+
+        from immich_memories.api.models import ExifInfo
+        from immich_memories.config_models import PhotoConfig
+        from immich_memories.generate_privacy import clip_location_name
+        from immich_memories.photos.photo_pipeline import _render_single_photo
+
+        exif = ExifInfo(city="Ghent", country="Belgium")
+        # WHY .jpg: the download path takes its suffix from the filename, and
+        # the fixture default (.HEIC) is not something cv2 can write.
+        asset = _make_asset(id="place-001", exifInfo=exif, originalFileName="IMG_1.jpg")
+
+        def download(asset_id, path):
+            cv2.imwrite(str(path), np.full((240, 320, 3), 128, dtype=np.uint8))
+
+        clip = _render_single_photo(asset, PhotoConfig(), 640, 360, tmp_path, download)
+
+        assert clip is not None
+        assert clip.location_name == clip_location_name(exif) == "Ghent, Belgium"
+
+
 class TestStreamRenderToMp4:
     """Lines 377-540: FFmpeg streaming render (SDR and HDR paths)."""
 


### PR DESCRIPTION
Closes #420.

`--add-place` renders `City, Country` for a video, via `clip_location_name`,
which falls back to whichever of the two it has. The photo path attached
`exif_info.city`, so a memory containing both showed "Ghent, Belgium" under
a video and "Ghent" under the photo beside it — and a photo with a country
but no city got no caption at all where a video would have shown the
country.

`docs/create/cli/generate.md` has promised `City, Country` for this flag the
whole time, so this is the code catching up to the docs rather than a change
in behaviour. No docs change needed.

Mine, from #395. Unit tests covered the filter string and the video path;
nothing compared the two sources against each other, which is why it
survived review and surfaced only when a mixed memory was rendered.

The regression test asserts the photo's location equals `clip_location_name`
for the same exif, so the two cannot drift apart again without failing here.
It renders through `_render_single_photo` with a fake download rather than
mocking the construction, following the pattern already in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
