### PR TITLE
fix(music): fall back to a bundled track when a generator fails

### DIFF
--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -133,10 +133,19 @@ def resolve_music_file(
     if not music_path and music_config_available(config):
         if report_fn:
             report_fn("music", 0.85, "Generating AI music...")
-        generated = auto_generate_music(
-            config, assembly_clips, run_output_dir, memory_type, report_fn
-        )
-        return _master(generated, run_output_dir) if generated else generated
+        try:
+            generated = auto_generate_music(
+                config, assembly_clips, run_output_dir, memory_type, report_fn
+            )
+        except Exception as exc:  # WHY: optional music must not invalidate the base artifact
+            # A configured generator that fails used to be worse than no generator
+            # at all: the exception unwound past the bundled branch below and the
+            # whole music phase was abandoned, so the most-configured setup got
+            # the only silent video. Fall through to bundled and keep the warning.
+            logger.warning("%s; using a bundled track", optional_music_warning(exc, config))
+            generated = None
+        if generated:
+            return _master(generated, run_output_dir)
 
     if music_path is not None:
         # An explicit track that is missing is a user error; substituting bundled

--- a/tests/test_music_bundled_fallback.py
+++ b/tests/test_music_bundled_fallback.py
@@ -1,0 +1,90 @@
+"""A failing generator must fall back to the bundled track, not to silence.
+
+Configuring a generator currently makes the failure mode worse than not
+configuring one: with none configured `resolve_music_file` returns a bundled
+track, but with ACE-Step enabled and unreachable the exception unwinds past
+that branch and the whole music phase is abandoned. The run exits 0 with a
+silent video, and under `--quiet` nothing surfaces.
+
+Found by the capability matrix: the ACE-Step row reported ok in 64s — faster
+than the bundled-music row — with an empty music/ directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from immich_memories.config_loader import Config
+from immich_memories.generate_music import resolve_music_file
+
+
+def _library(tmp_path: Path) -> Path:
+    """A bundled library shaped like the shipped one: mood folders holding tracks."""
+    folder = tmp_path / "library" / "happy"
+    folder.mkdir(parents=True)
+    (folder / "track.mp3").write_bytes(b"not really an mp3")
+    return tmp_path / "library"
+
+
+@pytest.fixture
+def generator_enabled() -> Config:
+    config = Config()
+    config.ace_step.enabled = True
+    return config
+
+
+def test_a_failing_generator_falls_back_to_the_bundled_track(
+    tmp_path: Path, generator_enabled: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # WHY: stands in for the ACE-Step backend — no library installed and no API
+    # listening, which is the default state of a machine that just enabled it.
+    def unreachable(*args: object, **kwargs: object) -> Path:
+        raise ConnectionError("All connection attempts failed")
+
+    monkeypatch.setattr("immich_memories.generate_music.auto_generate_music", unreachable)
+
+    result = resolve_music_file(
+        generator_enabled,
+        None,
+        no_music=False,
+        assembly_clips=[],
+        run_output_dir=tmp_path,
+        memory_type=None,
+        bundled_library=_library(tmp_path),
+    )
+
+    assert result is not None, "a failed generator must not produce silence"
+    assert result.suffix == ".mp3"
+
+
+def test_an_explicit_missing_track_is_still_a_user_error(
+    tmp_path: Path, generator_enabled: Config
+) -> None:
+    """Substituting bundled music for a typo'd --music path would hide the typo."""
+    result = resolve_music_file(
+        generator_enabled,
+        tmp_path / "absent.mp3",
+        no_music=False,
+        assembly_clips=[],
+        run_output_dir=tmp_path,
+        memory_type=None,
+        bundled_library=_library(tmp_path),
+    )
+
+    assert result is None
+
+
+def test_no_music_still_means_no_music(tmp_path: Path, generator_enabled: Config) -> None:
+    result = resolve_music_file(
+        generator_enabled,
+        None,
+        no_music=True,
+        assembly_clips=[],
+        run_output_dir=tmp_path,
+        memory_type=None,
+        bundled_library=_library(tmp_path),
+    )
+
+    assert result is None

--- a/tests/test_music_output_paths.py
+++ b/tests/test_music_output_paths.py
@@ -1530,9 +1530,13 @@ def test_optional_music_logs_never_include_raw_backend_secret(
             encoding_plan=_h264_output_plan(),
         )
 
-    assert result.warning == "Optional music failed: backend rejected ***"
+    # A generator failure no longer ends the phase — it falls through to a
+    # bundled track (#422) — so the sanitized backend warning lands in the log
+    # rather than in the phase result. The property under test is that the raw
+    # secret reaches neither, whatever the phase ends on.
     assert "Optional music failed: backend rejected ***" in caplog.text
     assert "top-secret" not in caplog.text
+    assert result.warning is None or "top-secret" not in result.warning
 
 
 def test_music_phase_passes_exact_encoding_plan_to_publication(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #422.

Configuring a music generator made the failure mode **worse** than not
configuring one:

| setup | result |
|---|---|
| no generator configured | bundled track |
| generator configured, unreachable | **silence** |

`resolve_music_file` returns a bundled track when nothing is configured — a
case fixed deliberately, per its own comment, because the Docker/NAS path used
to get silence. But `auto_generate_music` *raises* rather than returning None,
so the exception unwinds past the bundled branch below it and is caught a level
up in `generate_settings._complete_music_failure`, which abandons the whole
music phase.

Exit code 0, finished video, no music. Under `--quiet` — what automation and
the scheduler use — nothing surfaces.

Reproduced from the default state of a machine that has merely switched the
flag on: library not installed, no API listening.

```
ACE-Step library not installed. Falling back to API at http://localhost:8000
Optional music failed: All connection attempts failed
Pipeline timing (5 clips, 58.0s): ... music=0.0s (0%)
```

A failed generator now falls through to the bundled track and keeps the
warning. The separate "explicit `--music path` that doesn't exist" branch still
returns None — substituting there would hide a typo, as its comment says.

`except Exception` matches the contract the phase handler above already uses,
for the same stated reason: optional music must not invalidate the base
artifact.

## One test changed, deliberately

`test_optional_music_logs_never_include_raw_backend_secret` asserted the phase
result carried the sanitized backend warning. The run now gets *further* —
reaching the mixing step — so the phase ends on a different error.

Its security property is untouched, and I verified it directly before editing:
the secret is still sanitized to `***`, and the raw value appears in neither
the log nor the result. Both assertions for that are kept; only the one
assuming a generator failure ends the phase is gone.

## Verification

- `make test` green (5067 passed) under `HOME=$(mktemp -d)`
- `make lint`, `make typecheck` clean; all pre-commit gates passed
- Three new tests: the fallback, plus guardrails that an explicit missing track
  is still a user error and `--no-music` still means no music

Found by the capability matrix (#417): the ACE-Step row reported `ok` in 64s —
faster than the bundled-music row it should have cost more than — with an empty
`music/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
