### PR TITLE
fix(auto): give up on an undeliverable upload instead of retrying it forever

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -351,17 +351,9 @@
       {
         "name": "AutoRunner::suggest",
         "complexity": 21,
-        "line_start": 736,
-        "line_end": 826,
+        "line_start": 738,
+        "line_end": 828,
         "line_complexities": [
-          {
-            "line": 740,
-            "complexity": 0
-          },
-          {
-            "line": 741,
-            "complexity": 0
-          },
           {
             "line": 742,
             "complexity": 0
@@ -380,7 +372,7 @@
           },
           {
             "line": 746,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 747,
@@ -395,11 +387,11 @@
             "complexity": 0
           },
           {
-            "line": 751,
-            "complexity": 0
+            "line": 750,
+            "complexity": 1
           },
           {
-            "line": 752,
+            "line": 751,
             "complexity": 0
           },
           {
@@ -411,32 +403,32 @@
             "complexity": 0
           },
           {
-            "line": 760,
+            "line": 755,
             "complexity": 0
           },
           {
-            "line": 763,
+            "line": 756,
             "complexity": 0
           },
           {
-            "line": 766,
+            "line": 762,
             "complexity": 0
           },
           {
-            "line": 771,
+            "line": 765,
             "complexity": 0
           },
           {
-            "line": 772,
+            "line": 768,
+            "complexity": 0
+          },
+          {
+            "line": 773,
+            "complexity": 0
+          },
+          {
+            "line": 774,
             "complexity": 3
-          },
-          {
-            "line": 775,
-            "complexity": 0
-          },
-          {
-            "line": 776,
-            "complexity": 4
           },
           {
             "line": 777,
@@ -451,12 +443,12 @@
             "complexity": 0
           },
           {
-            "line": 782,
-            "complexity": 0
+            "line": 780,
+            "complexity": 4
           },
           {
-            "line": 783,
-            "complexity": 3
+            "line": 781,
+            "complexity": 0
           },
           {
             "line": 784,
@@ -464,7 +456,7 @@
           },
           {
             "line": 785,
-            "complexity": 4
+            "complexity": 3
           },
           {
             "line": 786,
@@ -472,15 +464,19 @@
           },
           {
             "line": 787,
+            "complexity": 4
+          },
+          {
+            "line": 788,
             "complexity": 0
           },
           {
-            "line": 795,
+            "line": 789,
+            "complexity": 0
+          },
+          {
+            "line": 797,
             "complexity": 1
-          },
-          {
-            "line": 796,
-            "complexity": 0
           },
           {
             "line": 798,
@@ -491,19 +487,23 @@
             "complexity": 0
           },
           {
-            "line": 811,
+            "line": 802,
             "complexity": 0
           },
           {
-            "line": 815,
+            "line": 813,
             "complexity": 0
           },
           {
-            "line": 820,
+            "line": 817,
             "complexity": 0
           },
           {
-            "line": 826,
+            "line": 822,
+            "complexity": 0
+          },
+          {
+            "line": 828,
             "complexity": 0
           }
         ]
@@ -511,56 +511,48 @@
       {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 854,
-        "line_end": 995,
+        "line_start": 856,
+        "line_end": 997,
         "line_complexities": [
           {
-            "line": 864,
+            "line": 866,
             "complexity": 0
-          },
-          {
-            "line": 868,
-            "complexity": 0
-          },
-          {
-            "line": 869,
-            "complexity": 2
           },
           {
             "line": 870,
             "complexity": 0
           },
           {
-            "line": 872,
-            "complexity": 0
+            "line": 871,
+            "complexity": 2
           },
           {
-            "line": 873,
-            "complexity": 2
+            "line": 872,
+            "complexity": 0
           },
           {
             "line": 874,
             "complexity": 0
           },
           {
+            "line": 875,
+            "complexity": 2
+          },
+          {
             "line": 876,
             "complexity": 0
           },
           {
-            "line": 880,
-            "complexity": 3
+            "line": 878,
+            "complexity": 0
           },
           {
-            "line": 881,
-            "complexity": 0
+            "line": 882,
+            "complexity": 3
           },
           {
             "line": 883,
             "complexity": 0
-          },
-          {
-            "line": 884,
-            "complexity": 2
           },
           {
             "line": 885,
@@ -568,31 +560,31 @@
           },
           {
             "line": 886,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 887,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 888,
             "complexity": 0
           },
           {
-            "line": 896,
-            "complexity": 2
+            "line": 889,
+            "complexity": 1
+          },
+          {
+            "line": 890,
+            "complexity": 0
           },
           {
             "line": 898,
-            "complexity": 0
+            "complexity": 2
           },
           {
-            "line": 908,
+            "line": 900,
             "complexity": 0
-          },
-          {
-            "line": 909,
-            "complexity": 1
           },
           {
             "line": 910,
@@ -600,38 +592,42 @@
           },
           {
             "line": 911,
-            "complexity": 0
-          },
-          {
-            "line": 915,
-            "complexity": 0
-          },
-          {
-            "line": 921,
             "complexity": 1
           },
           {
-            "line": 922,
-            "complexity": 1
+            "line": 912,
+            "complexity": 0
+          },
+          {
+            "line": 913,
+            "complexity": 0
+          },
+          {
+            "line": 917,
+            "complexity": 0
           },
           {
             "line": 923,
-            "complexity": 0
+            "complexity": 1
+          },
+          {
+            "line": 924,
+            "complexity": 1
           },
           {
             "line": 925,
             "complexity": 0
           },
           {
-            "line": 932,
-            "complexity": 2
-          },
-          {
-            "line": 933,
+            "line": 927,
             "complexity": 0
           },
           {
             "line": 934,
+            "complexity": 2
+          },
+          {
+            "line": 935,
             "complexity": 0
           },
           {
@@ -639,40 +635,36 @@
             "complexity": 0
           },
           {
-            "line": 943,
+            "line": 938,
             "complexity": 0
           },
           {
-            "line": 947,
-            "complexity": 2
-          },
-          {
-            "line": 948,
+            "line": 945,
             "complexity": 0
           },
           {
             "line": 949,
-            "complexity": 0
-          },
-          {
-            "line": 955,
             "complexity": 2
           },
           {
-            "line": 956,
+            "line": 950,
+            "complexity": 0
+          },
+          {
+            "line": 951,
             "complexity": 0
           },
           {
             "line": 957,
-            "complexity": 0
-          },
-          {
-            "line": 964,
-            "complexity": 0
-          },
-          {
-            "line": 965,
             "complexity": 2
+          },
+          {
+            "line": 958,
+            "complexity": 0
+          },
+          {
+            "line": 959,
+            "complexity": 0
           },
           {
             "line": 966,
@@ -680,18 +672,18 @@
           },
           {
             "line": 967,
+            "complexity": 2
+          },
+          {
+            "line": 968,
             "complexity": 0
           },
           {
-            "line": 975,
+            "line": 969,
             "complexity": 0
           },
           {
-            "line": 983,
-            "complexity": 1
-          },
-          {
-            "line": 984,
+            "line": 977,
             "complexity": 0
           },
           {
@@ -699,21 +691,29 @@
             "complexity": 1
           },
           {
+            "line": 986,
+            "complexity": 0
+          },
+          {
             "line": 987,
+            "complexity": 1
+          },
+          {
+            "line": 989,
             "complexity": 0
           },
           {
-            "line": 994,
+            "line": 996,
             "complexity": 0
           },
           {
-            "line": 995,
+            "line": 997,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 116
+    "complexity": 117
   },
   {
     "path": "src/immich_memories/cli/_analyze_export.py",
@@ -5485,7 +5485,7 @@
         ]
       }
     ],
-    "complexity": 100
+    "complexity": 103
   },
   {
     "path": "src/immich_memories/ui/pages/step2_review.py",

--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -92,6 +92,18 @@ immich-memories auto suggest [OPTIONS]
 
 Connects to Immich, fetches library stats + people + GPS assets, runs all detectors, scores and ranks. Takes about 30 seconds (GPS fetch for trip detection is the slow part).
 
+### Uploads that keep failing
+
+A pending Immich upload is retried before anything else on each wake, and that
+retry ends the invocation. An upload that can never succeed — an API key without
+upload scope, an album that no longer accepts writes — would therefore consume
+every night and generate nothing.
+
+After `max_delivery_attempts` failures (default 5) the upload is abandoned: the
+run is marked `abandoned` rather than `pending`, a notification is sent with the
+original error, and the next wake goes back to making memories. The video itself
+is untouched and still on disk — only its delivery gave up.
+
 ### Candidates that keep failing
 
 A candidate that fails twice in a row is held back for a while instead of being
@@ -263,6 +275,7 @@ Under `advanced:` in `config.yaml`:
 advanced:
   automation:
     cooldown_hours: 24              # min hours between auto-run starts (daily timer + 24 = once a day)
+    max_delivery_attempts: 5        # give up on an upload after this many failures
     upload_to_immich: false         # auto-upload generated videos
     album_name: null                # album for uploads
     detect_monthly: true

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -515,6 +515,7 @@ automation:
   enabled: false                  # run the daily auto-run decision inside the web UI process (Docker)
   daily_at: "09:00"               # HH:MM, local time of that process (container TZ)
   cooldown_hours: 24              # min hours between auto-generated memories (1-168)
+  max_delivery_attempts: 5        # give up on an Immich upload after this many failures (1-50)
   upload_to_immich: false         # auto-upload results
   album_name: null                # target album for uploads
   detect_monthly: true            # monthly highlights candidates

--- a/src/immich_memories/automation/delivery_retry.py
+++ b/src/immich_memories/automation/delivery_retry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -13,6 +14,7 @@ from immich_memories.automation.models import (
     AutoOutcome,
     AutoRunResult,
 )
+from immich_memories.automation.notifications import send_configured_notification
 from immich_memories.automation.state_store import AutomationStateStore
 from immich_memories.config_loader import Config
 from immich_memories.operations.phases import OperationalPhase, PhaseEvent
@@ -276,3 +278,31 @@ class PendingDeliveryRetry:
             run_id=pending.run_id,
             output_path=output_path,
         )
+
+
+def abandon_if_exhausted(pending: RunMetadata, *, config: Config, db: RunDatabase) -> bool:
+    """Give up on a delivery that has used its attempts, and say why.
+
+    A pending delivery is retried before anything else on a nightly wake and
+    ends it, so one that can never succeed -- an API key without upload scope,
+    an album that no longer accepts writes -- would consume every night and
+    generate nothing. Giving up here, at selection rather than after the retry,
+    means this wake still goes on to make a memory.
+    """
+    if pending.delivery_attempts < config.automation.max_delivery_attempts:
+        return False
+
+    reason = (
+        f"Gave up delivering to Immich after {pending.delivery_attempts} attempts: "
+        f"{pending.delivery_error or 'no error recorded'}"
+    )
+    logger.warning("%s (run %s)", reason, pending.run_id)
+    with contextlib.suppress(Exception):
+        db.mark_delivery_abandoned(pending.run_id, reason)
+    # The original error is what tells an operator whether to fix a scope, an
+    # album name or a server, so it travels with the notification.
+    with contextlib.suppress(Exception):
+        send_configured_notification(
+            config=config, memory_type="delivery", success=False, error=reason
+        )
+    return True

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from immich_memories.automation.candidate_scorer import score_and_rank
 from immich_memories.automation.candidates import MemoryCandidate
-from immich_memories.automation.delivery_retry import PendingDeliveryRetry
+from immich_memories.automation.delivery_retry import PendingDeliveryRetry, abandon_if_exhausted
 from immich_memories.automation.failure_backoff import drop_backed_off
 from immich_memories.automation.models import (
     AutoAction,
@@ -715,6 +715,8 @@ class AutoRunner:
         """Run retry preflight only after selecting an executable artifact."""
         pending = self.db.get_oldest_pending_delivery(source="auto")
         if pending is None or pending.output_path is None:
+            return None
+        if abandon_if_exhausted(pending, config=self.config, db=self.db):
             return None
         retry = self._pending_delivery_retry()
         retry.start_delivery(attempt)

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -905,6 +905,12 @@ class AutomationConfig(BaseModel):
         description="Local wall-clock time (HH:MM) for the in-process daily run",
     )
     cooldown_hours: int = Field(default=24, ge=1, le=168)
+    max_delivery_attempts: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Give up on an Immich upload after this many failed attempts",
+    )
     upload_to_immich: bool = Field(default=False)
     album_name: str | None = Field(default=None)
     detect_monthly: bool = Field(default=True)

--- a/src/immich_memories/tracking/models.py
+++ b/src/immich_memories/tracking/models.py
@@ -22,6 +22,9 @@ class DeliveryStatus(StrEnum):
     NOT_REQUESTED = "not_requested"
     PENDING = "pending"
     DELIVERED = "delivered"
+    # Terminal: retried to the configured limit and given up on, so it stops
+    # occupying the nightly wake. The artifact itself is untouched.
+    ABANDONED = "abandoned"
 
 
 @dataclass

--- a/src/immich_memories/tracking/run_database.py
+++ b/src/immich_memories/tracking/run_database.py
@@ -391,6 +391,31 @@ class RunDatabase:
             )
             conn.commit()
 
+    def mark_delivery_abandoned(self, run_id: str, error: str) -> RunMetadata:
+        """Stop retrying a delivery that has used up its attempts.
+
+        The artifact stays completed and on disk; only its delivery gives up.
+        Leaving it pending would consume every nightly wake forever, because the
+        runner retries a pending delivery before it considers generating.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE pipeline_runs
+                SET delivery_status = ?,
+                    delivery_error = ?
+                WHERE run_id = ? AND status = 'completed'
+                """,
+                (DeliveryStatus.ABANDONED.value, error, run_id),
+            )
+            if cursor.rowcount != 1:
+                _raise_invalid_delivery_transition(conn, run_id)
+            conn.commit()
+        saved = self.get_run(run_id)
+        if saved is None:  # pragma: no cover - the UPDATE just matched this row
+            raise KeyError(f"Unknown pipeline run: {run_id}")
+        return saved
+
     def mark_delivery_pending(
         self,
         run_id: str,

--- a/tests/test_delivery_abandonment.py
+++ b/tests/test_delivery_abandonment.py
@@ -1,0 +1,156 @@
+"""A delivery that cannot succeed must stop consuming every nightly run.
+
+`_run_one_under_lease` retries a pending delivery and returns -- so the wake ends
+there, before candidate selection. `delivery_attempts` was incremented on each
+failure and never compared to anything, so a deterministic upload failure (an
+API key without upload scope, an album ACL) meant one failed upload per night
+and no new memories, indefinitely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from immich_memories.automation.delivery_retry import abandon_if_exhausted
+from immich_memories.tracking.models import DeliveryStatus
+from immich_memories.tracking.run_database import RunDatabase
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> RunDatabase:
+    return RunDatabase(tmp_path / "runs.db")
+
+
+def _completed_run(db: RunDatabase, tmp_path: Path, run_id: str) -> None:
+    from datetime import UTC, datetime
+
+    from immich_memories.tracking.models import RunMetadata
+
+    output = tmp_path / f"{run_id}.mp4"
+    output.write_bytes(b"video")
+    db.save_run(
+        RunMetadata(
+            run_id=run_id,
+            created_at=datetime.now(tz=UTC),
+            status="completed",
+            source="auto",
+            output_path=str(output),
+            delivery_status=DeliveryStatus.PENDING,
+        )
+    )
+
+
+class TestAbandoningAStuckDelivery:
+    def test_an_abandoned_delivery_leaves_the_pending_queue(self, db: RunDatabase, tmp_path: Path):
+        """While it is pending it blocks every wake, so abandoning must clear it."""
+        _completed_run(db, tmp_path, "run-1")
+        assert db.get_oldest_pending_delivery(source="auto") is not None
+
+        db.mark_delivery_abandoned("run-1", "gave up after 5 attempts")
+
+        assert db.get_oldest_pending_delivery(source="auto") is None
+
+    def test_the_reason_is_kept_for_the_operator(self, db: RunDatabase, tmp_path: Path):
+        _completed_run(db, tmp_path, "run-2")
+
+        db.mark_delivery_abandoned("run-2", "upload scope missing")
+
+        saved = db.get_run("run-2")
+        assert saved is not None
+        assert saved.delivery_status is DeliveryStatus.ABANDONED
+        assert "upload scope missing" in (saved.delivery_error or "")
+
+    def test_abandoning_does_not_touch_the_artifact(self, db: RunDatabase, tmp_path: Path):
+        """The video is finished and on disk; only its delivery gave up."""
+        _completed_run(db, tmp_path, "run-3")
+
+        db.mark_delivery_abandoned("run-3", "gave up")
+
+        saved = db.get_run("run-3")
+        assert saved is not None
+        assert saved.status == "completed"
+        assert saved.output_path is not None
+        assert Path(saved.output_path).exists()
+
+
+class TestTheRunnerGivesUpAndMovesOn:
+    """The runner retries a pending delivery *before* it considers generating,
+    and returns afterwards. A delivery that can never succeed therefore consumed
+    every wake, forever, producing nothing.
+    """
+
+    @staticmethod
+    def _runner_with_pending(tmp_path: Path, attempts: int):
+        from datetime import UTC, datetime, timedelta
+        from unittest.mock import MagicMock
+
+        from immich_memories.automation.runner import AutoRunner
+        from immich_memories.config_loader import Config
+        from immich_memories.tracking.models import RunMetadata
+
+        config = Config(
+            immich={"url": "http://immich.test:2283", "api_key": "k"},
+            cache={
+                "database": str(tmp_path / "runs.db"),
+                "directory": str(tmp_path / "cache"),
+            },
+            automation={"upload_to_immich": True},
+        )
+        runner = AutoRunner(config, execute=MagicMock())
+        output = tmp_path / "pending.mp4"
+        output.write_bytes(b"video")
+        now = datetime.now(tz=UTC)
+        runner.db.save_run(
+            RunMetadata(
+                run_id="pending-run",
+                created_at=now - timedelta(minutes=2),
+                completed_at=now - timedelta(minutes=1),
+                status="completed",
+                source="auto",
+                output_path=str(output),
+                delivery_status=DeliveryStatus.PENDING,
+                delivery_attempts=attempts,
+                delivery_error="403 no upload scope",
+            )
+        )
+        return runner
+
+    def test_a_delivery_past_its_limit_is_abandoned(self, tmp_path: Path):
+        runner = self._runner_with_pending(tmp_path, attempts=5)
+
+        abandoned = abandon_if_exhausted(
+            runner.db.get_oldest_pending_delivery(source="auto"),
+            config=runner.config,
+            db=runner.db,
+        )
+
+        assert abandoned is True
+        assert runner.db.get_oldest_pending_delivery(source="auto") is None
+
+    def test_the_original_failure_is_kept_in_the_reason(self, tmp_path: Path):
+        """ "Gave up" without the cause sends the operator back to the logs."""
+        runner = self._runner_with_pending(tmp_path, attempts=5)
+
+        abandon_if_exhausted(
+            runner.db.get_oldest_pending_delivery(source="auto"),
+            config=runner.config,
+            db=runner.db,
+        )
+
+        saved = runner.db.get_run("pending-run")
+        assert saved is not None
+        assert "403 no upload scope" in (saved.delivery_error or "")
+
+    def test_a_delivery_inside_its_limit_is_still_retried(self, tmp_path: Path):
+        runner = self._runner_with_pending(tmp_path, attempts=4)
+
+        abandoned = abandon_if_exhausted(
+            runner.db.get_oldest_pending_delivery(source="auto"),
+            config=runner.config,
+            db=runner.db,
+        )
+
+        assert abandoned is False
+        assert runner.db.get_oldest_pending_delivery(source="auto") is not None


### PR DESCRIPTION
## Automation could stop producing anything, silently

A pending Immich delivery is retried before anything else on each nightly wake,
and that retry **ends the invocation**:

```python
retry_result = self.retry_pending_delivery(attempt, dry_run=dry_run)
if retry_result is not None:
    return retry_result          # never reaches candidate selection
```

`delivery_attempts` was incremented on every failure and **never compared to
anything**. So a delivery that cannot succeed — an API key without upload scope,
an album that no longer accepts writes — meant one failed upload per night and
**no new memories, indefinitely**. Nothing said generation had stopped: each
night looked like a normal run that happened to retry an upload.

## The fix

After `max_delivery_attempts` failures (default 5) the run is marked
`abandoned` rather than `pending`, with a notification carrying **the original
error** rather than a bare "gave up" — the cause is what tells you whether to fix
a scope, an album name, or a server.

**The give-up happens at selection time, not after the retry**, so the same wake
goes on to generate. That keeps the documented *"exactly one action per
invocation"* contract intact: abandoning a stuck item is not an action, it is
declining to spend the wake on one.

`ABANDONED` is a new terminal `DeliveryStatus` rather than a flag alongside
`PENDING`, because `get_oldest_pending_delivery` selects on that column — an
abandoned run drops out of the queue by the same query that put it there, with
no second condition to keep in sync.

**The artifact is untouched**: still completed, still on disk, still playable.
Only its delivery gave up. There is a test asserting exactly that, because
"abandoned" could too easily be read as "discarded".

## Pairs with #386

That one stopped a failed *candidate* being relaunched every night. This is the
same shape one layer up. Together they were the only two ways automation could
silently stop producing anything.

## Structural note

`automation/runner.py` was at 995 lines and this pushed it to 1030, past the
hard gate. Rather than shave, the give-up logic moved to
`automation/delivery_retry.py`, where the delivery machinery already lives —
`runner.py` is back to 999 and the decision sits with the code it belongs to.

That file's size is a real constraint on the next change that touches it, and it
is tracked in #245.

Closes #424. R3 in `docs/reviews/2026-08-18-security-perf-review.md`.
