### PR TITLE
test(photos): render 30 frames to check a caption field, not 120

### DIFF
--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -876,9 +876,17 @@ class TestPhotoPlaceCaption:
         asset = _make_asset(id="place-001", exifInfo=exif, originalFileName="IMG_1.jpg")
 
         def download(asset_id, path):
-            cv2.imwrite(str(path), np.full((240, 320, 3), 128, dtype=np.uint8))
+            cv2.imwrite(str(path), np.full((120, 160, 3), 128, dtype=np.uint8))
 
-        clip = _render_single_photo(asset, PhotoConfig(), 640, 360, tmp_path, download)
+        # WHY the tiny frame and the shortest legal duration: this asserts
+        # which function supplies location_name, but reaches it through a real
+        # Ken Burns render so the test survives a refactor of the call site. At
+        # the 4s default that is 120 encoded frames to check one string -- 5.8s
+        # on CI, heavy enough that this test was the one in flight when a runner
+        # was OOM-killed. 30 frames at 320x180 prove the same thing.
+        config = PhotoConfig(duration=1.0)
+
+        clip = _render_single_photo(asset, config, 320, 180, tmp_path, download)
 
         assert clip is not None
         assert clip.location_name == clip_location_name(exif) == "Ghent, Belgium"


### PR DESCRIPTION
Follow-up to #421.

That PR's regression test rendered a real 4-second Ken Burns clip — **120
encoded frames** — to assert one string on the returned `AssemblyClip`. On a CI
runner that cost **5.8s**.

It was the test in flight when a Linux runner was OOM-killed:

```
TestRenderSinglePhoto::test_returns_none_on_download_failure PASSED   18:57:56
                          ← 2m22s
##[error]The runner has received a shutdown signal
make: *** Error 137
TestPhotoPlaceCaption::test_a_photo_captions_a_place_like_a_video_does
```

**The test is not at fault** — the same test passed on Python 3.11 and 3.13 in
that same run, on the same OS, in 5.8s. But a heavy test is the one that gets
caught when a runner is reclaimed, and heavy is not something this assertion
needs.

Same coverage, still through the real render so it survives a refactor of the
call site: the shortest legal duration (1.0s — the field's own `ge=1.0` bound)
at 320×180 from a 160×120 source.

**0.92s → 0.29s locally**, 30 frames instead of 120.

Consistent with the call already made on `test_loudnorm_does_not_eat_duration_at_scale`:
if a test's weight is what makes CI flaky, the weight is the thing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
