### PR TITLE
docs(contribute): how to tell a broken test from a dead runner

### DIFF
--- a/docs-site/docs/contribute/testing.md
+++ b/docs-site/docs/contribute/testing.md
@@ -126,3 +126,74 @@ tests/
     ├── processing/          # make test-integration-processing (FFmpeg only)
     └── titles/              # make test-integration-titles     (FFmpeg only, pixel tests)
 ```
+
+## When CI fails but nothing failed
+
+A red `Test (Python 3.12, ubuntu-latest)` usually reads as *your code broke on
+Linux*. Often it means the runner was taken away mid-suite. The two look
+identical on the PR page and are easy to separate one API call down.
+
+### Read the step, not the log
+
+```bash
+gh api repos/<owner>/<repo>/actions/jobs/<job-id> \
+  -q '.steps[] | select(.conclusion=="cancelled" or .conclusion=="failure") | "\(.name) -> \(.conclusion)"'
+```
+
+`Run tests with coverage -> cancelled`, with everything downstream `skipped`, is
+the signature of a runner that died. No assertion ever ran.
+
+`gh run view --log-failed` returns **nothing** in this case — precisely because
+nothing failed. An empty failure log is evidence, not a broken tool.
+
+### Check how far it got
+
+```bash
+gh api repos/<owner>/<repo>/actions/jobs/<job-id> \
+  -q '.steps[] | select(.name=="Run tests with coverage") | "\(.started_at) -> \(.completed_at)"'
+```
+
+Four minutes against a suite that takes eleven means it never finished. A real
+failure stops at the assertion; a reclaimed runner stops at an arbitrary point.
+
+### Use the matrix as a control group
+
+The test matrix runs identical code on several Python versions and two operating
+systems. That is a built-in control:
+
+- **one cell red, siblings green on the same OS** → the runner died. The test in
+  flight gets the blame it does not deserve.
+- **every Linux cell red, macOS green** → a real platform difference.
+
+This settled a real case: a photo-caption test appeared to fail on Python 3.12
+with `Error 137` (SIGKILL/OOM), and passed on 3.11 and 3.13 in the *same run* on
+the *same image*. The test was correct. It was simply the slowest thing running
+when the runner was killed.
+
+### Heavy tests attract the blame
+
+The OOM lands on whatever is running, which skews toward the slow tests. Two
+have been trimmed for this reason rather than because they were wrong: the
+loudnorm fixtures (thirty FFmpeg calls to one) and the photo-caption test (120
+encoded frames to 30, to assert one string).
+
+If a unit test renders video to check metadata, shrink the render. Weight is
+what makes a test the victim.
+
+### `cancelled` is not always ignorable
+
+The `CI Success` gate tolerates `cancelled` because the concurrency group
+cancels superseded runs. That is safe: a runner death produces
+`conclusion=failure` on the *job* — `make` returns 137 — even though the step
+reads `cancelled`. So an OOM still fails the gate, and only genuinely superseded
+runs pass through. Check `gh run list --branch <branch>` to confirm a newer run
+covered the cancelled one.
+
+### Re-running
+
+`gh run rerun <run-id> --failed` is rejected while any job in the run is still
+in progress ("cannot be rerun; its workflow file may be broken" — the message is
+misleading). Wait for the run to complete, then re-run.
+
+If the same cell is reclaimed three times, stop re-running and treat it as a
+resource problem rather than luck.


### PR DESCRIPTION
A red `Test (Python 3.12, ubuntu-latest)` reads as *your code broke on Linux*.
Often it means the runner was taken away mid-suite. The two look identical on
the PR page, and both agents working this repo have burned time on the
difference in the last two days.

Adds a "When CI fails but nothing failed" section to the testing guide:

- **Read `.steps[].conclusion`, not the log.** `Run tests with coverage ->
  cancelled` with everything downstream `skipped` means no assertion ever ran.
- **Check how far it got.** Four minutes against an eleven-minute suite means it
  never finished. A real failure stops at an assertion; a reclaimed runner stops
  at an arbitrary point.
- **Use the matrix as a control group.** One red cell beside green siblings on
  the same image is a dead runner. Every Linux cell red is a real platform
  difference.

That last one settled a real case today: a photo-caption test failed on Python
3.12 with `Error 137` and passed on 3.11 and 3.13 **in the same run on the same
image**. The test was correct — it was simply the slowest thing running when the
runner was killed.

Also documents three things that cost time to work out:

- `gh run view --log-failed` returns nothing here *because nothing failed*. An
  empty failure log is evidence, not a broken tool.
- The `CI Success` gate can safely tolerate `cancelled`: a runner death surfaces
  as job `conclusion=failure` (make returns 137) even though the step reads
  `cancelled`, so only genuinely superseded concurrency runs pass through. I
  checked this before assuming it was a hole — it isn't.
- `gh run rerun --failed` is refused while any job in the run is still in
  progress, behind the misleading message "cannot be rerun; its workflow file
  may be broken".

And the standing lesson: the OOM lands on whatever is running, which skews
toward slow tests. Two have been trimmed for that reason rather than for being
wrong — the loudnorm fixtures (#414) and the photo-caption test (#434).

`make docs-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
