### PR TITLE
fix(scheduler): report the stream the child actually writes to

### DIFF
--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -158,6 +158,9 @@ The typed terminal outcomes are `skipped`, `dry_run`, `completed`, and `failed`.
 `dry_run`, and `completed` exit 0; `failed` exits 1. Quiet output is a stable JSON object, not a
 bare path. Its `action` is `generation` or `delivery_retry` when work was selected:
 
+`error` carries the cause of a failure and is always present, so a wrapper
+script never has to tell "no error" from "field missing".
+
 ```json
 {
   "outcome": "dry_run",
@@ -166,6 +169,7 @@ bare path. Its `action` is `generation` or `delivery_retry` when work was select
   "candidate_key": "trip:2026-07-02:2026-07-09:",
   "category": "trip",
   "run_id": null,
+  "error": null,
   "output_path": null,
   "recent_categories": ["monthly_review", "birthday"],
   "rejections": [

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -69,6 +69,9 @@ def _auto_result_to_json(result: AutoRunResult) -> str:
             "candidate_key": result.candidate.memory_key if result.candidate else None,
             "category": result.candidate.category.value if result.candidate else None,
             "run_id": result.run_id,
+            # Always present, so a consumer never has to tell "no error"
+            # from "field missing".
+            "error": result.error,
             "output_path": str(result.output_path) if result.output_path else None,
             "recent_categories": list(result.recent_categories),
             "rejections": [

--- a/src/immich_memories/scheduling/daemon.py
+++ b/src/immich_memories/scheduling/daemon.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import signal
 import subprocess
 import time
@@ -17,6 +18,7 @@ from pathlib import Path
 from immich_memories.scheduling.engine import PendingJob, Scheduler
 from immich_memories.scheduling.executor import resolve_schedule_params
 from immich_memories.scheduling.models import SchedulerConfig
+from immich_memories.security import sanitize_filename
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +95,38 @@ def run_daemon_loop(
     logger.info("Scheduler daemon stopped")
 
 
+_STREAM_TAIL = 500
+
+
+def describe_process_failure(stdout: str | None, stderr: str | None) -> str:
+    """Summarise why a child process failed, from whichever stream carries it.
+
+    The child logs to stdout -- `setup_logging` installs a StreamHandler there
+    and `print_error` goes through Rich, also stdout -- so reading only stderr
+    reported "no stderr" for every failure while the cause sat in the stream
+    being discarded.
+    """
+    parts = []
+    if stderr and stderr.strip():
+        parts.append(f"stderr: {stderr.strip()[-_STREAM_TAIL:]}")
+    if stdout and stdout.strip():
+        parts.append(f"stdout: {stdout.strip()[-_STREAM_TAIL:]}")
+    if not parts:
+        return "no output on stdout or stderr"
+    return " | ".join(parts)
+
+
+def _child_log_path(schedule_name: str) -> Path:
+    """Where a scheduled generation writes its own log.
+
+    The daemon keeps a 500-character tail, which is enough to say what went
+    wrong and never enough to work out why. FileHandler appends, so this is
+    one growing file per schedule rather than one per firing.
+    """
+    safe = sanitize_filename(schedule_name) or "schedule"
+    return Path.home() / ".immich-memories" / "logs" / f"generate-{safe}.log"
+
+
 def execute_job(
     job: PendingJob,
     timeout_seconds: int = 3600,
@@ -130,8 +164,22 @@ def execute_job(
     error_msg: str | None = None
     success = False
 
+    # The child logs to its own file as well as to the pipes: the tail the
+    # daemon keeps says what failed, this says why.
+    child_env = os.environ.copy()
+    log_path = _child_log_path(job.schedule.name)
+    with contextlib.suppress(OSError):
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        child_env["IMMICH_MEMORIES_LOG_FILE"] = str(log_path)
+
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=child_env,
+        )
     except subprocess.TimeoutExpired:
         error_msg = f"Timed out after {timeout_seconds // 60} minutes"
         logger.error(f"Job '{job.schedule.name}' {error_msg}")
@@ -140,7 +188,7 @@ def execute_job(
             success = True
             logger.info(f"Job '{job.schedule.name}' completed successfully")
         else:
-            error_msg = result.stderr[-500:] if result.stderr else "no stderr"
+            error_msg = describe_process_failure(result.stdout, result.stderr)
             logger.error(
                 f"Job '{job.schedule.name}' failed (exit {result.returncode}): {error_msg}"
             )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -378,6 +378,7 @@ class TestAutoRunOutput:
             "candidate_key": "monthly:2026-07",
             "category": "monthly_review",
             "run_id": "run-123",
+            "error": None,
             "output_path": str(output),
             "recent_categories": [],
             "rejections": [],
@@ -420,6 +421,7 @@ class TestAutoRunOutput:
             "candidate_key": None,
             "category": None,
             "run_id": None,
+            "error": None,
             "output_path": None,
             "recent_categories": [],
             "rejections": [],
@@ -469,6 +471,7 @@ class TestAutoRunOutput:
             "candidate_key": None,
             "category": None,
             "run_id": None,
+            "error": None,
             "output_path": None,
             "recent_categories": ["monthly_review", "trip"],
             "rejections": [
@@ -525,6 +528,9 @@ class TestAutoRunOutput:
             "candidate_key": "monthly:2026-07",
             "category": "monthly_review",
             "run_id": None,
+            # The cause the child wrote to stdout, which previously reached
+            # stderr only and never the machine-readable result.
+            "error": "root cause on stdout",
             "output_path": None,
             "recent_categories": [],
             "rejections": [],

--- a/tests/test_daemon_failure_reporting.py
+++ b/tests/test_daemon_failure_reporting.py
@@ -1,0 +1,132 @@
+"""A failed scheduled job has to say why it failed.
+
+The daemon reported `result.stderr[-500:] if result.stderr else "no stderr"`,
+and the child writes its logs to **stdout** -- `setup_logging` installs a
+StreamHandler on stdout and `print_error` goes through Rich, also stdout. So the
+one stream the daemon read was reliably empty, and every failure was recorded as
+"no stderr" while the actual error sat in the stream it discarded.
+
+The automation runner already fixed this for its own child; the daemon kept the
+original bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from immich_memories.scheduling.daemon import describe_process_failure
+
+
+def test_the_error_is_taken_from_stdout_when_stderr_is_empty():
+    """The exact shape of a real failure: everything on stdout."""
+    described = describe_process_failure(stdout="[ERROR] Immich API error: 404", stderr="")
+
+    assert "Immich API error: 404" in described
+    assert described != "no stderr"
+
+
+def test_stderr_is_still_used_when_present():
+    described = describe_process_failure(stdout="", stderr="Traceback: boom")
+
+    assert "Traceback: boom" in described
+
+
+def test_both_streams_are_reported_when_both_have_content():
+    """Whichever one carries the cause, the operator gets it."""
+    described = describe_process_failure(stdout="[ERROR] no candidates", stderr="warning: x")
+
+    assert "no candidates" in described
+    assert "warning: x" in described
+
+
+def test_a_silent_failure_says_so_without_pretending():
+    described = describe_process_failure(stdout="", stderr="")
+
+    assert described
+    assert "no output" in described.lower()
+
+
+def test_the_tail_is_bounded():
+    """A runaway child must not put megabytes into the notification."""
+    described = describe_process_failure(stdout="x" * 10_000, stderr="")
+
+    assert len(described) < 2_000
+
+
+class TestTheChildsLogHasSomewhereToGo:
+    """The daemon keeps only a 500-character tail. Without a log file the child's
+    full log exists nowhere, so a failure that needs more context than the tail
+    cannot be investigated at all.
+    """
+
+    def test_the_child_is_given_a_log_file(self, tmp_path, monkeypatch):
+        import subprocess
+
+        from immich_memories.scheduling import daemon
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):  # noqa: ARG001
+            captured["env"] = kwargs.get("env")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        # WHY: spawns a real generation; the point of the test is the env it gets.
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon, "_notify_if_configured", lambda **_kwargs: None)
+        monkeypatch.setattr(
+            daemon, "resolve_schedule_params", lambda *_a: {"memory_type": "monthly_highlights"}
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+
+        job = MagicMock()
+        job.schedule.name = "nightly"
+
+        daemon.execute_job(job, timeout_seconds=60)
+
+        env = captured["env"]
+        assert env is not None, "the child inherited the daemon's environment unchanged"
+        assert str(tmp_path) in env["IMMICH_MEMORIES_LOG_FILE"]
+        assert env["IMMICH_MEMORIES_LOG_FILE"].endswith("generate-nightly.log")
+
+    def test_a_schedule_name_cannot_escape_the_log_directory(self, tmp_path, monkeypatch):
+        """Schedule names are user-supplied and end up in a path."""
+        from immich_memories.scheduling.daemon import _child_log_path
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+
+        path = _child_log_path("../../etc/evil")
+
+        assert tmp_path in path.parents
+
+
+class TestTheMachineReadableResult:
+    """`auto run --json` is what a wrapper script reads. It reported
+    `outcome: failed` with no field carrying the cause, so an automated consumer
+    could see that something broke and never what.
+    """
+
+    @staticmethod
+    def _payload(**kwargs):
+        import json
+
+        from immich_memories.automation.models import AutoOutcome, AutoRunResult
+        from immich_memories.cli.auto_cmd import _auto_result_to_json
+
+        return json.loads(
+            _auto_result_to_json(
+                AutoRunResult(outcome=AutoOutcome.FAILED, reason="generation failed", **kwargs)
+            )
+        )
+
+    def test_a_failure_carries_its_error(self):
+        payload = self._payload(error="Immich API error: 404")
+
+        assert payload["error"] == "Immich API error: 404"
+
+    def test_a_result_without_an_error_says_null_rather_than_omitting_it(self):
+        """A consumer should not have to tell 'no error' from 'field missing'."""
+        payload = self._payload()
+
+        assert "error" in payload
+        assert payload["error"] is None


### PR DESCRIPTION
## Every failed job said "no stderr"

```python
error_msg = result.stderr[-500:] if result.stderr else "no stderr"
```

The child writes its logs to **stdout** — `setup_logging` installs a
`StreamHandler` there, and `print_error` goes through Rich, also stdout. So the
one stream the daemon read was reliably empty, and every failure was recorded
with a plausible-looking message naming a stream that was never going to have
anything in it.

The automation runner fixed this for its own child in #277. `scheduling/daemon.py`
kept the original bug.

Both streams are now reported, each bounded, and a genuinely silent failure says
`no output on stdout or stderr` rather than naming one it did not check.

## Two gaps from the same finding

**The child's full log existed nowhere.** The daemon keeps a 500-character tail
— enough to say what went wrong, never enough to work out why. The child now
gets `IMMICH_MEMORIES_LOG_FILE`, which `setup_logging` already honours and the
docs already describe; it simply was never given one. Logs land in
`~/.immich-memories/logs/generate-<schedule>.log`.

`FileHandler` appends, so that is one growing file per schedule rather than one
per firing. The schedule name goes through `sanitize_filename` because it is
user-supplied and ends up in a path — with a test for the traversal case.

**`auto run --json` had no `error` field.** It reported `outcome: failed` with
nothing carrying the cause, so a wrapper script could see that something broke
and never what. `AutoRunResult.error` already existed and simply was not
serialized. The key is always present, so a consumer never has to tell "no
error" from "field missing".

## The contract test earned its keep

Four pinned payloads in `test_cli_smoke` assert the **exact** JSON, so adding a
key failed them — which made this a deliberate contract change rather than a
silent one. Adding a field is backwards-compatible for anything reading by name,
and the four expectations were updated explicitly.

Worth noting what the failed case now carries: `"root cause on stdout"` — the
child's stdout, the exact string that previously reached stderr only and never
the machine-readable result.

Closes #435. R4 in `docs/reviews/2026-08-18-security-perf-review.md`.
