### PR TITLE
fix(config): stop bare $NAME expansion from corrupting secrets

### DIFF
--- a/docs-site/docs/deploy/configuration/config-file.md
+++ b/docs-site/docs/deploy/configuration/config-file.md
@@ -134,7 +134,7 @@ See the [Config Reference](../../reference/config-reference.md#video-analysis) f
 
 ## Environment variable substitution
 
-A handful of secret-bearing fields expand `${VAR_NAME}` (or `$VAR_NAME`) at load time:
+A handful of secret-bearing fields expand `${VAR_NAME}` at load time:
 
 | Section | Fields |
 |---------|--------|
@@ -143,6 +143,12 @@ A handful of secret-bearing fields expand `${VAR_NAME}` (or `$VAR_NAME`) at load
 | `musicgen` | `base_url`, `api_key` |
 | `ace_step` | `api_url` (not `api_key`) |
 | `auth` | `password`, `client_secret`, `issuer_url`, `client_id` |
+
+Only the braced form expands. A bare `$VAR_NAME` is left exactly as written,
+because these fields hold passwords and API keys and a `$` in a secret is
+ordinary — `S3cret$USER!` would otherwise pick up your login name and the only
+symptom would be a rejected password. If a value contains a bare `$NAME` that
+matches a variable you have set, a warning says so at load time.
 
 ```yaml
 immich:

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -6,6 +6,7 @@ cache, LLM, audio, music generation, content analysis, title screen, and upload.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -16,16 +17,48 @@ from pydantic import BaseModel, Field, field_serializer, field_validator, model_
 from immich_memories.api.compatibility import ApiVersionPolicy
 from immich_memories.processing.encoding_plan import HdrMode
 
+logger = logging.getLogger(__name__)
+
+_ENV_REFERENCE = re.compile(r"\$\{([^}]+)\}")
+# Only reported, never expanded. `$USER` is set on every login shell, so a
+# password like `S3cret$USER!` used to become `S3cretsam!` -- and the user sees
+# "wrong password" with no path to the cause.
+_BARE_ENV_REFERENCE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
+
 
 def expand_env_vars(value: str) -> str:
-    """Expand environment variables in a string (${VAR} or $VAR format)."""
-    pattern = re.compile(r"\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+    """Expand `${VAR}` references in a config value.
+
+    Only the delimited form expands. A bare `$NAME` is left exactly as written,
+    because these fields hold passwords and API keys, and a `$` in a secret is
+    ordinary: silently turning part of a credential into the value of an
+    environment variable is worse than not expanding it, since the failure
+    surfaces as a rejected login rather than as a config error.
+    """
 
     def replacer(match: re.Match[str]) -> str:
-        var_name = match.group(1) or match.group(2)
-        return os.environ.get(var_name, match.group(0))
+        return os.environ.get(match.group(1), match.group(0))
 
-    return pattern.sub(replacer, value)
+    expanded = _ENV_REFERENCE.sub(replacer, value)
+    _warn_about_bare_references(expanded)
+    return expanded
+
+
+def _warn_about_bare_references(value: str) -> None:
+    """Tell anyone relying on the old bare `$NAME` form why it stopped working.
+
+    Dropping a documented form silently would trade one quiet surprise for
+    another, so a bare reference that names a variable which actually exists is
+    reported. A `$` that matches nothing stays silent -- that is just a password.
+    """
+    for match in _BARE_ENV_REFERENCE.finditer(value):
+        if match.group(1) in os.environ:
+            logger.warning(
+                "Config value contains %s, which is no longer expanded; "
+                "write ${%s} if you meant the environment variable.",
+                match.group(0),
+                match.group(1),
+            )
 
 
 class ImmichConfig(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,11 +29,17 @@ class TestExpandEnvVars:
         result = expand_env_vars("prefix_${TEST_VAR}_suffix")
         assert result == "prefix_test_value_suffix"
 
-    def test_expand_dollar_format(self, monkeypatch):
-        """Test $VAR format expansion."""
+    def test_bare_dollar_format_is_no_longer_expanded(self, monkeypatch):
+        """Deliberately removed: these fields hold passwords and API keys.
+
+        `$USER` is set on every login shell, so a password like `S3cret$USER!`
+        became `S3cretsam!` and auth failed with no path to the cause. The
+        delimited `${VAR}` form cannot collide with a `$` inside a secret, and
+        it is what every documented example uses.
+        """
         monkeypatch.setenv("TEST_VAR2", "another_value")
         result = expand_env_vars("$TEST_VAR2")
-        assert result == "another_value"
+        assert result == "$TEST_VAR2"
 
     def test_missing_var_unchanged(self):
         """Test that missing variables are left unchanged."""

--- a/tests/test_config_env_expansion.py
+++ b/tests/test_config_env_expansion.py
@@ -1,0 +1,80 @@
+"""A secret containing `$` must survive being loaded.
+
+`expand_env_vars` expanded bare `$NAME` as well as `${NAME}`, over `api_key`,
+`password` and `client_secret`. A password like `pa$USERword` silently became
+`pa<login>word`, so auth failed with no indication why -- the user sees "wrong
+password" and has no path to the cause. Silent corruption of a credential is
+worse than a parse error.
+
+Only the delimited `${VAR}` form expands now. It is unambiguous, it is what
+every documented example uses, and a `$` inside a secret cannot collide with it.
+"""
+
+from __future__ import annotations
+
+from immich_memories.config_models import expand_env_vars
+
+
+def test_a_password_containing_a_dollar_is_left_alone(monkeypatch):
+    """`$USER` is set on every login shell, so this is not an exotic password.
+
+    The corruption needs the name to end at a non-word character or at the end
+    of the string; `pa$USERword` happens to survive because the greedy match
+    swallows `word` and `USERword` is unset. These do not survive.
+    """
+    monkeypatch.setenv("USER", "sam")
+
+    assert expand_env_vars("pa$USER-word") == "pa$USER-word"
+    assert expand_env_vars("S3cret$USER!") == "S3cret$USER!"
+    assert expand_env_vars("pa$USER") == "pa$USER"
+
+
+def test_a_path_like_secret_is_left_alone(monkeypatch):
+    """`$HOME/...` expanded to a real path inside a client secret."""
+    monkeypatch.setenv("HOME", "/Users/sam")
+
+    assert expand_env_vars("a$HOME/b") == "a$HOME/b"
+
+
+def test_the_delimited_form_still_expands(monkeypatch):
+    monkeypatch.setenv("IMMICH_API_KEY", "sk-secret")
+
+    assert expand_env_vars("${IMMICH_API_KEY}") == "sk-secret"
+
+
+def test_an_unset_variable_stays_literal(monkeypatch):
+    """Leaving the reference intact is what lets Save write it back."""
+    monkeypatch.delenv("NOT_SET_ANYWHERE", raising=False)
+
+    assert expand_env_vars("${NOT_SET_ANYWHERE}") == "${NOT_SET_ANYWHERE}"
+
+
+def test_a_bare_reference_is_reported_rather_than_silently_ignored(monkeypatch, caplog):
+    """Dropping a documented form quietly would trade one silent surprise for
+    another: someone relying on `$VAR` deserves to be told why it stopped."""
+    monkeypatch.setenv("MY_TOKEN", "value")
+
+    with caplog.at_level("WARNING"):
+        result = expand_env_vars("$MY_TOKEN")
+
+    assert result == "$MY_TOKEN"
+    assert "MY_TOKEN" in caplog.text
+    assert "${" in caplog.text
+
+
+def test_a_dollar_that_matches_nothing_is_silent(monkeypatch, caplog):
+    """A `$` in a password is normal and must not produce noise."""
+    monkeypatch.delenv("USERword", raising=False)
+    monkeypatch.delenv("NOTAVAR", raising=False)
+
+    with caplog.at_level("WARNING"):
+        expand_env_vars("pa$NOTAVARword")
+
+    assert caplog.text == ""
+
+
+def test_mixed_forms_expand_only_the_delimited_one(monkeypatch):
+    monkeypatch.setenv("A", "1")
+    monkeypatch.setenv("B", "2")
+
+    assert expand_env_vars("${A}-$B") == "1-$B"


### PR DESCRIPTION
## Silent credential corruption

`expand_env_vars` expanded bare `$NAME` as well as `${NAME}`, over `api_key`,
`password` and `client_secret`. `$USER` is set on every login shell, so a
password like `S3cret$USER!` became `S3cretsam!` — auth fails, the user sees
"wrong password", and nothing points at the config file.

Only the delimited `${VAR}` form expands now. It cannot collide with a `$`
inside a secret, and it is what every documented example uses.

## A correction to the issue

Its example, `pa$USERword`, **does not reproduce** — the greedy name match
swallows `word`, `USERword` is unset, and the value survives. The corruption
needs the name to end at a non-word character or at the end of the string.
Verified on `main` before changing anything:

```
pa$USERword    -> pa$USERword     (safe)
pa$USER-word   -> pasam-word      ← corrupted
S3cret$USER!   -> S3cretsam!      ← corrupted
a$HOME/b       -> a/Users/sam/b   ← corrupted
```

The tests use the cases that genuinely fail. Had I used the reported one, they
would have passed against the unfixed code.

## This removes documented behaviour

`config-file.md` advertised `${VAR_NAME}` **(or `$VAR_NAME`)`. The issue said the
docs only ever promised the braced form; they did not. So rather than dropping a
documented form silently:

- the doc is corrected, with the reason a secret-bearing field cannot support it;
- a bare `$NAME` that names a variable **which actually exists** logs a warning
  identifying it and suggesting `${NAME}`;
- a `$` that matches nothing stays silent — that is just a password.

That turns a silent behaviour change into a visible one, which is the same
property the fix itself is about.

`test_expand_dollar_format` pinned the old behaviour. It is rewritten to pin the
new one, with the reason, rather than deleted.

Closes #428. S12 in `docs/reviews/2026-08-18-security-perf-review.md`.
