### PR TITLE
fix(cli): write config where --config points, and stop printing the API key

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -857,39 +857,15 @@
       {
         "name": "register_config_commands",
         "complexity": 52,
-        "line_start": 14,
-        "line_end": 227,
+        "line_start": 41,
+        "line_end": 250,
         "line_complexities": [
           {
-            "line": 31,
+            "line": 58,
             "complexity": 0
           },
           {
-            "line": 32,
-            "complexity": 0
-          },
-          {
-            "line": 34,
-            "complexity": 2
-          },
-          {
-            "line": 37,
-            "complexity": 0
-          },
-          {
-            "line": 38,
-            "complexity": 3
-          },
-          {
-            "line": 39,
-            "complexity": 3
-          },
-          {
-            "line": 45,
-            "complexity": 2
-          },
-          {
-            "line": 47,
+            "line": 59,
             "complexity": 0
           },
           {
@@ -897,128 +873,128 @@
             "complexity": 2
           },
           {
-            "line": 62,
-            "complexity": 0
-          },
-          {
-            "line": 63,
-            "complexity": 2
-          },
-          {
             "line": 64,
             "complexity": 0
+          },
+          {
+            "line": 65,
+            "complexity": 3
           },
           {
             "line": 66,
             "complexity": 3
           },
           {
-            "line": 69,
-            "complexity": 1
+            "line": 72,
+            "complexity": 2
           },
           {
             "line": 74,
             "complexity": 0
           },
           {
-            "line": 78,
+            "line": 88,
+            "complexity": 2
+          },
+          {
+            "line": 89,
             "complexity": 0
           },
           {
-            "line": 84,
-            "complexity": 0
-          },
-          {
-            "line": 85,
-            "complexity": 0
+            "line": 90,
+            "complexity": 2
           },
           {
             "line": 91,
+            "complexity": 0
+          },
+          {
+            "line": 93,
             "complexity": 3
           },
           {
-            "line": 95,
-            "complexity": 0
-          },
-          {
-            "line": 100,
-            "complexity": 0
-          },
-          {
-            "line": 102,
+            "line": 96,
             "complexity": 1
           },
           {
-            "line": 109,
+            "line": 101,
             "complexity": 0
           },
           {
-            "line": 111,
+            "line": 105,
+            "complexity": 0
+          },
+          {
+            "line": 107,
+            "complexity": 0
+          },
+          {
+            "line": 108,
+            "complexity": 0
+          },
+          {
+            "line": 114,
             "complexity": 3
           },
           {
-            "line": 117,
+            "line": 118,
             "complexity": 0
           },
           {
-            "line": 122,
+            "line": 123,
             "complexity": 0
           },
           {
-            "line": 124,
+            "line": 125,
+            "complexity": 1
+          },
+          {
+            "line": 132,
             "complexity": 0
           },
           {
-            "line": 128,
+            "line": 134,
             "complexity": 3
           },
           {
-            "line": 129,
-            "complexity": 4
-          },
-          {
-            "line": 139,
+            "line": 140,
             "complexity": 0
           },
           {
-            "line": 141,
-            "complexity": 3
+            "line": 145,
+            "complexity": 0
           },
           {
             "line": 147,
             "complexity": 0
           },
           {
-            "line": 152,
-            "complexity": 0
-          },
-          {
-            "line": 155,
+            "line": 151,
             "complexity": 3
           },
           {
-            "line": 172,
+            "line": 152,
+            "complexity": 4
+          },
+          {
+            "line": 162,
             "complexity": 0
           },
           {
-            "line": 177,
+            "line": 164,
+            "complexity": 3
+          },
+          {
+            "line": 170,
             "complexity": 0
           },
           {
-            "line": 180,
+            "line": 175,
             "complexity": 0
           },
           {
-            "line": 184,
-            "complexity": 2
-          },
-          {
-            "line": 187,
-            "complexity": 0
-          },
-          {
-            "line": 194,
-            "complexity": 2
+            "line": 178,
+            "complexity": 3
           },
           {
             "line": 195,
@@ -1026,52 +1002,76 @@
           },
           {
             "line": 200,
-            "complexity": 3
-          },
-          {
-            "line": 208,
             "complexity": 0
           },
           {
-            "line": 209,
+            "line": 203,
             "complexity": 0
+          },
+          {
+            "line": 207,
+            "complexity": 2
           },
           {
             "line": 210,
             "complexity": 0
           },
           {
-            "line": 211,
-            "complexity": 0
-          },
-          {
-            "line": 213,
-            "complexity": 0
-          },
-          {
-            "line": 214,
-            "complexity": 0
-          },
-          {
-            "line": 216,
+            "line": 217,
             "complexity": 2
           },
           {
-            "line": 217,
-            "complexity": 3
-          },
-          {
-            "line": 221,
-            "complexity": 1
+            "line": 218,
+            "complexity": 0
           },
           {
             "line": 223,
+            "complexity": 3
+          },
+          {
+            "line": 231,
+            "complexity": 0
+          },
+          {
+            "line": 232,
+            "complexity": 0
+          },
+          {
+            "line": 233,
+            "complexity": 0
+          },
+          {
+            "line": 234,
+            "complexity": 0
+          },
+          {
+            "line": 236,
+            "complexity": 0
+          },
+          {
+            "line": 237,
+            "complexity": 0
+          },
+          {
+            "line": 239,
+            "complexity": 2
+          },
+          {
+            "line": 240,
+            "complexity": 3
+          },
+          {
+            "line": 244,
+            "complexity": 1
+          },
+          {
+            "line": 246,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 52
+    "complexity": 55
   },
   {
     "path": "src/immich_memories/cli/generate.py",

--- a/src/immich_memories/cli/config_cmd.py
+++ b/src/immich_memories/cli/config_cmd.py
@@ -3,12 +3,39 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import click
 from rich.table import Table
 
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
 from immich_memories.config import Config
+
+
+def _config_write_path(ctx: click.Context) -> Path:
+    """Where `config` saves: the file it was told to use.
+
+    The values being edited came from --config when it was given, so the write
+    has to go back to the same file. Saving to the default path regardless meant
+    `--config other.yaml config` silently replaced ~/.immich-memories/config.yaml
+    with the other file's contents.
+    """
+    return ctx.obj.get("config_path") or Config.get_default_path()
+
+
+def _prompt_for_api_key(existing: str) -> str:
+    """Ask for an API key without ever showing the one already configured.
+
+    `hide_input` hides what is typed, not the default, so Click renders
+    `API key [sk-live-...]:` -- and that key has full library access, so the line
+    reaches the terminal, scrollback and any recording. Nothing is shown; an
+    empty answer keeps the existing key, and the notice keeps an empty prompt
+    from looking like an empty setting.
+    """
+    if existing:
+        console.print("[dim]An API key is already configured — press enter to keep it.[/dim]")
+    entered = click.prompt("API key", default="", hide_input=True, show_default=False)
+    return entered or existing
 
 
 def register_config_commands(main: click.Group) -> None:
@@ -29,7 +56,7 @@ def register_config_commands(main: click.Group) -> None:
     ) -> None:
         """Configure Immich connection settings."""
         cfg = ctx.obj["config"]
-        config_path = Config.get_default_path()
+        config_path = _config_write_path(ctx)
 
         if action == "test":
             from immich_memories.preflight import CheckStatus, check_immich
@@ -75,11 +102,7 @@ def register_config_commands(main: click.Group) -> None:
                 "Immich server URL",
                 default=cfg.immich.url or "https://photos.example.com",
             )
-            new_api_key = click.prompt(
-                "API key",
-                default=cfg.immich.api_key or "",
-                hide_input=True,
-            )
+            new_api_key = _prompt_for_api_key(cfg.immich.api_key)
 
             cfg.immich.url = new_url
             cfg.immich.api_key = new_api_key

--- a/tests/test_config_command_path.py
+++ b/tests/test_config_command_path.py
@@ -1,0 +1,45 @@
+"""`--config PATH` must be where `config` writes, not just where it reads.
+
+The command loaded the config the context resolved -- honouring `--config` --
+and then saved to `Config.get_default_path()` regardless. So
+`immich-memories --config ./test.yaml config` edited the test file's values and
+wrote them over `~/.immich-memories/config.yaml`.
+
+Anyone keeping more than one config has their real one silently replaced by
+whichever they thought they were editing. It cost me Sam's config while testing
+an unrelated fix; the backup is what saved it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from immich_memories.cli import main
+
+
+def test_the_named_config_is_the_one_written(tmp_path: Path):
+    target = tmp_path / "alternate.yaml"
+    target.write_text("immich:\n  url: http://named.invalid:2283\n  api_key: named-key\n")
+    default = tmp_path / "home" / ".immich-memories" / "config.yaml"
+    default.parent.mkdir(parents=True)
+    default.write_text("immich:\n  url: http://default.invalid:2283\n  api_key: default-key\n")
+
+    # WHY: the real home and the real Immich server
+    with (
+        # WHY: the default location must be observable without touching a real home.
+        patch.object(Path, "home", classmethod(lambda _cls: tmp_path / "home")),
+        # WHY: the command offers to contact Immich after saving.
+        patch("immich_memories.api.immich.SyncImmichClient"),
+    ):
+        CliRunner().invoke(
+            main,
+            ["--config", str(target), "config", "--url", "http://edited.invalid:2283"],
+            input="n\n",
+        )
+
+    assert "edited.invalid" in target.read_text(), "the named config was not updated"
+    assert "default-key" in default.read_text(), "the default config was overwritten"
+    assert "edited.invalid" not in default.read_text()

--- a/tests/test_config_command_secrecy.py
+++ b/tests/test_config_command_secrecy.py
@@ -1,0 +1,64 @@
+"""`immich-memories config` must not print the API key it already has.
+
+`hide_input=True` hides what the user types, not the default, so Click rendered:
+
+    API key [SECRET-KEY-12345]:
+
+The key has full library access, and that line goes to the terminal, to
+scrollback, and to any recording or screen share.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from immich_memories.cli import main
+
+_KEY = "sk-live-full-library-access"
+
+
+def _run(tmp_path: Path, answers: str):
+    config = tmp_path / "config.yaml"
+    config.write_text(f"immich:\n  url: http://immich.test:2283\n  api_key: {_KEY}\n")
+    # WHY: the real home and the real Immich server
+    with (
+        # WHY: this command writes config. Pinning home as well as --config means
+        # a regression in the save path cannot reach a real one -- an earlier
+        # version of this test overwrote mine.
+        patch.object(Path, "home", classmethod(lambda _cls: tmp_path / "home")),
+        # WHY: the command offers to contact Immich after saving.
+        patch("immich_memories.api.immich.SyncImmichClient"),
+    ):
+        result = CliRunner().invoke(main, ["--config", str(config), "config"], input=answers)
+    return result, config
+
+
+def test_the_existing_key_is_never_printed(tmp_path: Path):
+    result, _ = _run(tmp_path, answers="\n\nn\n")
+
+    assert _KEY not in result.output
+
+
+def test_pressing_enter_keeps_the_existing_key(tmp_path: Path):
+    """Not showing it must not mean losing it."""
+    _, config = _run(tmp_path, answers="\n\nn\n")
+
+    assert _KEY in config.read_text()
+
+
+def test_the_user_is_told_a_key_is_already_set(tmp_path: Path):
+    """Otherwise an empty prompt looks like there is nothing configured."""
+    result, _ = _run(tmp_path, answers="\n\nn\n")
+
+    assert "configured" in result.output.lower()
+
+
+def test_a_new_key_replaces_the_old_one(tmp_path: Path):
+    _, config = _run(tmp_path, answers="\nsk-replacement\nn\n")
+
+    saved = config.read_text()
+    assert "sk-replacement" in saved
+    assert _KEY not in saved


### PR DESCRIPTION
Two faults in the same command. One of them destroys data, and I found it by
doing it.

## `--config PATH` was read but not written

```python
cfg = ctx.obj["config"]                    # honours --config
config_path = Config.get_default_path()    # does not
```

So `immich-memories --config other.yaml config` showed and edited *other.yaml's*
values, then wrote the result over `~/.immich-memories/config.yaml` — replacing
its contents, including sections the named file never had.

**This is not hypothetical.** A test of the prompt fix below ran the command
against a temp config and overwrote my own real one: URL and API key became the
test values, and 17 configured sections collapsed to 13 defaults. A backup
recovered it, incompletely — the live file was ~5.4 KB and the newest backup
4.3 KB, so about 1 KB is gone.

Anyone keeping a second config — a NAS profile, a test profile — loses their
main one the first time they edit the other. There is no warning, and the
success message names the file it *wrote* rather than the one you asked for, so
the mistake is visible only if you read it closely.

The path now comes from `ctx.obj["config_path"]`, which is where every other
command already takes it from, and is the same value the load used.

## The API key was printed as the prompt default

```
API key [sk-live-...]:
```

`hide_input=True` hides what is **typed**, not the default — verified directly
against Click before changing anything. That key has full library access and
that line reaches the terminal, scrollback, and any recording or screen share.

Nothing is shown now. An empty answer keeps the existing key, and a notice says
one is configured so an empty prompt does not read as an empty setting.

## Why these ship together

They are the same command, and the second could not be tested safely until the
first was fixed — the failing test in that pair was failing *precisely because*
it was writing to the real config rather than the temp one.

Those tests now pin `Path.home` as well as passing `--config`, so a regression
in the save path cannot reach a real config again. That guard exists because the
earlier version of the test did not have it.

`CliRunner` isolates stdin and stdout, not the filesystem — anything resolving a
path from `Path.home()` reaches the developer's real one.

Closes #439, closes #427. S11 in `docs/reviews/2026-08-18-security-perf-review.md`.
