### PR TITLE
feat(music): pick the bundled track whose beat fits the photo cadence

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -106,6 +106,16 @@ Measured on the 28 bundled tracks, ACE-Step honours a requested tempo to within
 0.4% (median), so asking for an aligned tempo is worth doing — but that residual
 is also why cuts are aligned in *rate*, not yet locked to the beat.
 
+A bundled track cannot be asked for a tempo; its own is already fixed. So the
+choice runs the other way — the tracks are measured and the one whose beat
+divides the photo cadence is picked, instead of one at random. With no photos
+there is no rhythm to sync to, and the pick stays random so repeats differ.
+
+Tempo is measured with an onset envelope and autocorrelation over an FFmpeg
+decode, using numpy alone. librosa would be a line, but it is not a dependency
+of this project — it only arrives transitively with the torch extras — and a
+plain install with the `music` extra has to work without them.
+
 ### MusicGen
 
 Meta's MusicGen handles text-to-music generation and Demucs stem separation via a remote API server. If you're running everything locally with ACE-Step + local Demucs, you don't need MusicGen at all.

--- a/src/immich_memories/audio/bundled_music.py
+++ b/src/immich_memories/audio/bundled_music.py
@@ -26,12 +26,21 @@ def bundled_library() -> Path | None:
     return directory if directory.is_dir() else None
 
 
-def bundled_track_for_mood(mood: str | None, library: Path | None = None) -> Path | None:
+def bundled_track_for_mood(
+    mood: str | None,
+    library: Path | None = None,
+    cadence_seconds: float | None = None,
+) -> Path | None:
     """Pick a bundled track for a mood, at random so repeats differ.
 
     Falls back to any bundled track when the mood has no folder of its own: some
     music beats silence, and the analyser's mood vocabulary is wider than the set
     of moods we ship.
+
+    With a photo cadence, the pick stops being random and becomes the track whose
+    beat divides that cadence -- the bundled counterpart to asking a generator
+    for a beat-aligned tempo (#312). Without photos there is no rhythm to sync
+    to, so variety wins and the choice stays random.
     """
     root = library if library is not None else bundled_library()
     if root is None or not root.is_dir():
@@ -46,10 +55,19 @@ def bundled_track_for_mood(mood: str | None, library: Path | None = None) -> Pat
     if not candidates:
         return None
 
-    chosen = random.choice(candidates)
+    chosen = _fitting_track(candidates, cadence_seconds) or random.choice(candidates)
     logger.info("Using bundled music: %s/%s", chosen.parent.name, chosen.name)
     return chosen
 
 
 def _tracks_in(folder: Path) -> list[Path]:
     return sorted(p for p in folder.iterdir() if p.suffix.lower() in _SUFFIXES)
+
+
+def _fitting_track(candidates: list[Path], cadence_seconds: float | None) -> Path | None:
+    """The candidate whose beat lands on the cadence, when there is one to land on."""
+    if not cadence_seconds:
+        return None
+    from immich_memories.audio.track_tempo import track_for_cadence
+
+    return track_for_cadence(candidates, cadence_seconds)

--- a/src/immich_memories/audio/track_tempo.py
+++ b/src/immich_memories/audio/track_tempo.py
@@ -1,0 +1,113 @@
+"""Measure a bundled track's tempo, and pick the one that fits the cut cadence.
+
+#312's first half asks a generator for a tempo whose beat divides the photo
+cadence. A bundled track cannot be asked — its tempo is already fixed — so the
+choice runs the other way: measure what ships, then pick the track that lands on
+the cadence.
+
+Detection is numpy over an ffmpeg decode on purpose. librosa would be one line,
+but it is not a dependency of this project (it arrives transitively with the
+torch extras), so importing it would fail `make dep-check` and break a plain
+install that has music but no GPU stack.
+
+The method is an onset envelope plus autocorrelation: frame the signal, take the
+positive energy differences between frames, and find the lag whose repetition is
+strongest. That is the beat period.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_RATE = 22050
+_FRAME = 512
+# Outside this range a "tempo" is either a half-time artefact or a drone.
+_MIN_BPM = 60
+_MAX_BPM = 180
+# How near a whole number of beats a cadence must fall to count as aligned.
+_BEAT_TOLERANCE = 0.12
+
+
+def _decode_mono(path: Path) -> np.ndarray | None:
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-ac",
+            "1",
+            "-ar",
+            str(_SAMPLE_RATE),
+            "-f",
+            "f32le",
+            "-",
+        ],
+        capture_output=True,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    return np.frombuffer(proc.stdout, dtype=np.float32)
+
+
+def detect_bpm(path: Path) -> float | None:
+    """Tempo of a track in BPM, or None when it cannot be read or has no pulse."""
+    samples = _decode_mono(path)
+    if samples is None or samples.size < _SAMPLE_RATE:
+        return None
+
+    frames = samples[: samples.size - samples.size % _FRAME].reshape(-1, _FRAME)
+    energy = np.sqrt((frames.astype(np.float64) ** 2).mean(axis=1))
+    # WHY only rises: a beat is where energy arrives, not where it decays.
+    onset = np.diff(energy, prepend=energy[:1]).clip(min=0)
+    onset -= onset.mean()
+    if not onset.any():
+        return None
+
+    correlation = np.correlate(onset, onset, mode="full")[onset.size - 1 :]
+    frames_per_second = _SAMPLE_RATE / _FRAME
+    lo = int(frames_per_second * 60 / _MAX_BPM)
+    hi = min(int(frames_per_second * 60 / _MIN_BPM), correlation.size - 1)
+    if hi <= lo:
+        return None
+
+    lag = lo + int(np.argmax(correlation[lo:hi]))
+    return round(60 * frames_per_second / lag, 1) if lag else None
+
+
+def _beat_misfit(bpm: float, cadence_seconds: float) -> float:
+    """How far the cadence sits from a whole number of beats, in beats."""
+    beats = cadence_seconds * bpm / 60
+    return abs(beats - round(beats))
+
+
+def track_for_cadence(candidates: list[Path], cadence_seconds: float) -> Path | None:
+    """The candidate whose beat divides the cadence most exactly.
+
+    A track that cannot be read costs itself its turn, not the run. With nothing
+    measurable, the caller's own fallback applies.
+    """
+    if not candidates or cadence_seconds <= 0:
+        return None
+
+    best: tuple[float, Path] | None = None
+    for track in candidates:
+        bpm = detect_bpm(track)
+        if bpm is None:
+            logger.debug("No tempo read from %s; skipping it for cadence matching", track.name)
+            continue
+        misfit = _beat_misfit(bpm, cadence_seconds)
+        if best is None or misfit < best[0]:
+            best = (misfit, track)
+
+    if best is None:
+        return None
+    logger.info("Bundled track %s fits a %.1fs cadence", best[1].name, cadence_seconds)
+    return best[1]

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -156,7 +156,11 @@ def resolve_music_file(
     # the Docker/NAS path gets by default.
     from immich_memories.audio.bundled_music import bundled_track_for_mood
 
-    bundled = bundled_track_for_mood(_mood_for_clips(assembly_clips), library=bundled_library)
+    bundled = bundled_track_for_mood(
+        _mood_for_clips(assembly_clips),
+        library=bundled_library,
+        cadence_seconds=photo_cadence_seconds(assembly_clips),
+    )
     return _master(bundled, run_output_dir) if bundled else bundled
 
 

--- a/tests/test_bundled_tempo_choice.py
+++ b/tests/test_bundled_tempo_choice.py
@@ -1,0 +1,53 @@
+"""A bundled track is chosen for its tempo when there is a cadence to fit.
+
+#312's generator half asks for a tempo whose beat divides the photo cadence.
+Bundled tracks cannot be asked, so the fit has to be found by measuring.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from immich_memories.audio.bundled_music import bundled_track_for_mood
+
+
+def _library(tmp_path: Path, bpms: dict[str, int]) -> Path:
+    root = tmp_path / "library" / "happy"
+    root.mkdir(parents=True)
+    for name, bpm in bpms.items():
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-v",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1200:duration=12:sample_rate=22050",
+                "-af",
+                f"volume='if(lt(mod(t*{bpm}/60,1),0.06),1,0)':eval=frame",
+                str(root / name),
+            ],
+            check=True,
+        )
+    return tmp_path / "library"
+
+
+def test_the_fitting_tempo_is_chosen_when_a_cadence_is_given(tmp_path: Path) -> None:
+    """4s is 8 beats at 120 and 6.67 at 100."""
+    library = _library(tmp_path, {"fits.wav": 120, "misses.wav": 100})
+
+    chosen = bundled_track_for_mood("happy", library=library, cadence_seconds=4.0)
+
+    assert chosen is not None and chosen.name == "fits.wav"
+
+
+def test_without_a_cadence_the_choice_stays_random(tmp_path: Path) -> None:
+    """No photos means no rhythm to sync to; variety matters more than tempo."""
+    library = _library(tmp_path, {"a.wav": 120, "b.wav": 100})
+
+    picks = {bundled_track_for_mood("happy", library=library) for _ in range(25)}
+
+    assert len(picks) == 2, "a fixed pick would make every repeat sound the same"

--- a/tests/test_track_tempo.py
+++ b/tests/test_track_tempo.py
@@ -1,0 +1,74 @@
+"""Pick the bundled track whose beat divides the photo cadence.
+
+#312's first half asks a generator for a beat-aligned tempo. A bundled track
+cannot be asked — its tempo is already fixed — so the choice has to run the
+other way: measure what ships, then pick the one that lands on the cadence.
+
+Detection is numpy + ffmpeg on purpose. librosa is present in this venv only as
+a transitive dependency of an extra, so importing it would fail `make dep-check`
+and break a plain install.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from immich_memories.audio.track_tempo import detect_bpm, track_for_cadence
+
+
+def _click_track(path: Path, bpm: int, seconds: int = 12) -> Path:
+    """A metronome at a known tempo — the only fixture with a knowable answer."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=1200:duration={seconds}:sample_rate=22050",
+            "-af",
+            f"atrim=0:{seconds},asetrate=22050,"
+            f"volume='if(lt(mod(t*{bpm}/60,1),0.06),1,0)':eval=frame",
+            str(path),
+        ],
+        check=True,
+    )
+    return path
+
+
+@pytest.mark.parametrize("bpm", [90, 120])
+def test_a_metronome_reads_back_at_its_own_tempo(tmp_path: Path, bpm: int) -> None:
+    track = _click_track(tmp_path / f"click{bpm}.wav", bpm)
+
+    detected = detect_bpm(track)
+
+    assert detected is not None
+    assert abs(detected - bpm) <= 3, f"read {detected}, expected ~{bpm}"
+
+
+def test_the_track_whose_beat_divides_the_cadence_wins(tmp_path: Path) -> None:
+    """A 4s photo is 8 beats at 120bpm and 6.67 at 100 — 120 is the fit."""
+    good = _click_track(tmp_path / "a.wav", 120)
+    poor = _click_track(tmp_path / "b.wav", 100)
+
+    chosen = track_for_cadence([poor, good], cadence_seconds=4.0)
+
+    assert chosen == good
+
+
+def test_no_candidates_is_not_an_error() -> None:
+    assert track_for_cadence([], cadence_seconds=4.0) is None
+
+
+def test_an_unreadable_track_is_skipped_not_fatal(tmp_path: Path) -> None:
+    """A bad file must cost that track its turn, not the run."""
+    broken = tmp_path / "broken.opus"
+    broken.write_bytes(b"not audio")
+    good = _click_track(tmp_path / "good.wav", 120)
+
+    assert track_for_cadence([broken, good], cadence_seconds=4.0) == good


### PR DESCRIPTION
Refs #312 — completes its bundled-music half.

#312's first half asks a generator for a tempo whose beat divides the photo
cadence. A bundled track cannot be asked; its tempo is already fixed. So the fit
runs the other way: measure what ships, then pick the track that lands on the
cadence instead of one at random.

With no photos there is no rhythm to sync to, so the pick stays random and
repeats keep sounding different.

## Why numpy and not librosa

librosa would be one line, and it imports fine in a dev venv — which is the
trap. It is **not a dependency of this project**; it arrives transitively with
the torch extras. Using it would fail `make dep-check` and break a plain install
that has the `music` extra and no GPU stack — exactly the Docker/NAS profile
bundled music exists for.

So detection is an onset envelope plus autocorrelation over an FFmpeg decode,
in numpy: frame the signal, take positive energy differences, find the lag whose
repetition is strongest.

## Validated on the real library, not just fixtures

10/10 bundled tracks measured, with credible values:

```
calm/calm_acoustic_1.opus              68.0
calm/calm_electronic_s522.opus         95.7
energetic/energetic_electronic_2.opus  152.0
```

The unit tests use synthetic metronomes because those are the only fixtures with
a knowable answer — detection lands within 3 bpm at 90 and 120.

A track that cannot be read costs itself its turn rather than the run, and with
nothing measurable the existing random fallback still applies.

## Verification

- `make lint`, `make typecheck` clean; 249 music/bundled/tempo tests pass
- `make docs-build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
