### PR TITLE
fix(test): render the caption test with a software encoder

### DIFF
--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -859,9 +859,13 @@ class TestPhotoPlaceCaption:
     `--add-place` renders "City, Country" for a video, via clip_location_name.
     The photo path attached the bare city, so one memory containing both showed
     "Ghent, Belgium" under a video and "Ghent" under the photo beside it.
+
+    This has never passed on a macOS runner -- not since #434 shortened it, since
+    #421 introduced it. #421's macOS job failed too, and #434 merged with all
+    three macOS jobs cancelled, so nothing ever reported it.
     """
 
-    def test_a_photo_captions_a_place_like_a_video_does(self, tmp_path):
+    def test_a_photo_captions_a_place_like_a_video_does(self, tmp_path, monkeypatch):
         import cv2
         import numpy as np
 
@@ -870,23 +874,28 @@ class TestPhotoPlaceCaption:
         from immich_memories.generate_privacy import clip_location_name
         from immich_memories.photos.photo_pipeline import _render_single_photo
 
+        # WHY: the encoder is what this fails on, not the caption.
+        # _render_single_photo picks hevc_videotoolbox when zscale is present, and
+        # VideoToolbox writes no file inside CI's macOS VM -- the render returns
+        # None and the assertion below blames the caption instead. This test has
+        # never passed on a macOS runner for that reason, at any duration.
+        # Forcing the SDR path (rgb24 + libx264, always available) keeps it about
+        # the thing it names.
+        monkeypatch.setattr(
+            "immich_memories.processing.hdr_utilities.check_zscale_available", lambda: False
+        )
+
         exif = ExifInfo(city="Ghent", country="Belgium")
         # WHY .jpg: the download path takes its suffix from the filename, and
         # the fixture default (.HEIC) is not something cv2 can write.
         asset = _make_asset(id="place-001", exifInfo=exif, originalFileName="IMG_1.jpg")
 
         def download(asset_id, path):
-            cv2.imwrite(str(path), np.full((120, 160, 3), 128, dtype=np.uint8))
+            cv2.imwrite(str(path), np.full((240, 320, 3), 128, dtype=np.uint8))
 
-        # WHY the tiny frame and the shortest legal duration: this asserts
-        # which function supplies location_name, but reaches it through a real
-        # Ken Burns render so the test survives a refactor of the call site. At
-        # the 4s default that is 120 encoded frames to check one string -- 5.8s
-        # on CI, heavy enough that this test was the one in flight when a runner
-        # was OOM-killed. 30 frames at 320x180 prove the same thing.
         config = PhotoConfig(duration=1.0)
 
-        clip = _render_single_photo(asset, config, 320, 180, tmp_path, download)
+        clip = _render_single_photo(asset, config, 640, 360, tmp_path, download)
 
         assert clip is not None
         assert clip.location_name == clip_location_name(exif) == "Ghent, Belgium"


### PR DESCRIPTION
**main is red on all three macOS jobs.** Every PR cut from main inherits it, so
this should merge before anything else.

```
FAILED tests/test_processing_coverage.py::TestPhotoPlaceCaption::
       test_a_photo_captions_a_place_like_a_video_does - assert None is not None
```

## It has never passed on macOS

Not since #434 shortened it — since **#421 introduced it**:

| PR | macOS job | merged |
|---|---|---|
| #421 (introduced the test) | **failure** | yes |
| #434 (shortened it) | **all three cancelled — never ran** | yes |
| #436 | — | surfaced on main |

Two merges, zero macOS runs that actually verified this test.

## The cause is the encoder, not the test's size

I guessed wrong twice — first the frame size, then the duration. Both were
wrong, and both survived because the test passes on a real Mac.

`_render_single_photo` picks its encoder from `check_zscale_available()`: with
zscale, `hevc_videotoolbox`; without, `libx264`. VideoToolbox writes no file
inside CI's macOS VM, the function returns `None` when encoding produces
nothing, and the assertion then blames the caption.

Verified rather than assumed:

```
normal path        -> hevc
zscale forced off  -> h264
```

## The fix

Force the SDR path in this one test, so it stops depending on hardware CI does
not have. The caption is what the test is about; the encoder never was.

Keeps #434's 1.0s duration — 30 frames rather than 120 — because that part was
sound, it simply was never the problem. Runs in 0.16s.

**Generally:** any unit test reaching `_render_single_photo` or the photo
encoder will fail on a macOS runner unless it does the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM
