### PR TITLE
fix(docker): keep web UI sessions on the config volume

### DIFF
--- a/deploy/kubernetes/base/deployment.yaml
+++ b/deploy/kubernetes/base/deployment.yaml
@@ -36,7 +36,9 @@ spec:
 
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false  # NiceGUI writes under /app/.nicegui
+            # Sessions now live on the `data` volume, but ~/.cache still
+            # needs a writable mount before this can flip to true (#445).
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - ALL

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -178,7 +178,9 @@ resource "kubernetes_deployment_v1" "this" {
 
           security_context {
             allow_privilege_escalation = false
-            read_only_root_filesystem  = false # NiceGUI writes under /app/.nicegui
+            # Sessions now live on the data volume, but ~/.cache still needs
+            # a writable mount before this can flip to true (#445).
+            read_only_root_filesystem = false
 
             capabilities {
               drop = ["ALL"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,8 +76,9 @@ RUN pip install --no-cache-dir /wheels/*.whl && \
 RUN groupadd -g 1000 immich && useradd -u 1000 -g immich -d /home/immich -m immich
 
 # Create config, cache, and NiceGUI state directories with correct ownership
-RUN mkdir -p /home/immich/.immich-memories/cache /app/output /app/.nicegui && \
-    chown -R immich:immich /home/immich/.immich-memories /app/output /app/.nicegui
+RUN mkdir -p /home/immich/.immich-memories/cache /home/immich/.immich-memories/.nicegui \
+      /app/output && \
+    chown -R immich:immich /home/immich/.immich-memories /app/output
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
@@ -85,6 +86,12 @@ ENV HOME=/home/immich
 # Generated videos must land on the volume the compose quickstart mounts;
 # the app default (~/Videos/Memories) would resolve inside the container.
 ENV IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output
+# NiceGUI writes session storage to `.nicegui` beside the working directory,
+# which is /app -- part of the root filesystem the hardening recipe makes
+# read-only. The write fails silently and logins evaporate about ten seconds
+# after the last tab closes. The config volume is writable and persists, so
+# sessions survive a restart rather than merely surviving the container.
+ENV NICEGUI_STORAGE_PATH=/home/immich/.immich-memories/.nicegui
 
 # Switch to non-root user
 USER immich

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -137,7 +137,7 @@ Inside Immich's own compose stack, `immich-server` listens on **2283** (every Im
 | `IMMICH_API_KEY` | Yes | Immich API key |
 | `IMMICH_MEMORIES_PRESET` | No | `fast` = CPU-only/NAS profile (1080p h264, fast encoder, static titles, no speech pass, favorites-first analysis). Explicit settings win. See the [NAS guide](../common-setups/nas-only.md#one-switch-preset-fast). |
 | `IMMICH_MEMORIES_OUTPUT__DIRECTORY` | Recommended | Set to `/app/output` so videos land in the mounted output directory (default is `~/Videos/Memories` inside the container). |
-| `IMMICH_MEMORIES_STORAGE_SECRET` | No | Session secret for the web UI. Auto-generated if not set. Set this explicitly to keep sessions across restarts. It does not make multiple replicas supported. |
+| `IMMICH_MEMORIES_STORAGE_SECRET` | No | Session secret for the web UI. Auto-generated into the config volume if not set, so sessions already survive a restart. Set it explicitly to share one secret across hosts. It does not make multiple replicas supported. |
 | `IMMICH_MEMORIES_LLM__BASE_URL` | No | LLM endpoint (any OpenAI-compatible API). On its own it does nothing for scoring — see the next row. |
 | `IMMICH_MEMORIES_LLM__MODEL` | No | LLM model name (e.g., `qwen2.5-vl`) |
 | `IMMICH_MEMORIES_CONTENT_ANALYSIS__ENABLED` | No | `true` to actually use the LLM for clip scoring. Off by default. |
@@ -179,6 +179,12 @@ services:
 ```
 
 The root `docker-compose.yml` has these options as a commented section: uncomment to enable.
+
+Nothing else needs a writable root. The web UI keeps its session storage under
+`/home/immich/.immich-memories/.nicegui` on the config volume (the image sets
+`NICEGUI_STORAGE_PATH`), so logins survive both a read-only root and a restart.
+Don't repoint that variable at `/tmp` or another tmpfs — sessions would work
+until the next restart and then quietly log everyone out.
 
 :::caution tmpfs size for 4K
 The default tmpfs is 2 GB. If you're generating 4K videos, FFmpeg intermediates can exceed that. Either increase to 8 GB (`/tmp:size=8G`) or remove the tmpfs entry and let the container write to disk.

--- a/tests/test_nicegui_storage_location_contract.py
+++ b/tests/test_nicegui_storage_location_contract.py
@@ -1,0 +1,61 @@
+"""Sessions must live on the persisted volume, not the container's root.
+
+NiceGUI writes session storage to `.nicegui` relative to the working directory,
+which in the image is `/app` -- part of the read-only root under the documented
+hardening recipe. The write fails silently, `prune_user_storage` drops the
+in-memory dict about 10s after the last tab closes, and the user experiences
+"it keeps logging me out" with nothing in the logs.
+
+tmpfs would fix the crash and still log everyone out on restart. The config
+volume is already mounted, already writable, and already the place durable state
+belongs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG_VOLUME = "/home/immich/.immich-memories"
+
+
+def _dockerfile() -> str:
+    return (REPO_ROOT / "docker" / "Dockerfile").read_text()
+
+
+def _compose() -> dict:
+    return yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text())
+
+
+def test_the_image_points_nicegui_storage_at_the_persisted_volume():
+    """Set in the image, so it holds however the container is started."""
+    match = re.search(r"ENV\s+NICEGUI_STORAGE_PATH=(\S+)", _dockerfile())
+
+    assert match, "the image does not set NICEGUI_STORAGE_PATH"
+    assert match.group(1).startswith(_CONFIG_VOLUME), (
+        f"sessions would be written to {match.group(1)}, which is not on the config volume"
+    )
+
+
+def test_that_path_is_a_mounted_volume_in_compose():
+    """A path the image writes to must be one compose actually persists."""
+    service = _compose()["services"]["immich-memories"]
+    mounted = [v.split(":")[1] for v in service["volumes"] if ":" in v]
+
+    assert _CONFIG_VOLUME in mounted
+
+
+def test_the_recipe_does_not_park_sessions_on_a_tmpfs():
+    """tmpfs is the tempting fix; it trades a silent failure for a restart wipe.
+
+    The hardening block is commented guidance rather than active YAML, so it is
+    checked as text.
+    """
+    compose_text = (REPO_ROOT / "docker-compose.yml").read_text()
+    hardening = compose_text[compose_text.index("Security hardening") :]
+
+    assert "read_only: true" in hardening
+    assert ".nicegui" not in hardening, "session storage belongs on a volume, not tmpfs"


### PR DESCRIPTION
Closes #432.

## The bug

NiceGUI resolves its session store relative to the working directory:

```python
# nicegui/storage.py:84
path = Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui')).resolve()
```

In the image that is `/app/.nicegui` — on the root filesystem, which the
hardening recipe we ship in `docs-site/docs/deploy/installation/docker.md`
mounts read-only. The write fails without surfacing anything, `prune_user_storage`
drops the in-memory dict about ten seconds after the last tab closes, and the
user experiences "it keeps logging me out" against a clean log.

## The fix

Point `NICEGUI_STORAGE_PATH` at the config volume, in the image.

Two choices worth spelling out:

- **Volume, not tmpfs.** A tmpfs mount for `/app/.nicegui` stops the failure and
  still logs everyone out on every restart. The config volume is already mounted,
  already writable under `read_only: true`, and already where durable state
  lives. Sessions now survive a restart, not merely a read-only root.
- **Dockerfile `ENV`, not compose `environment:`.** Compose is one of several
  ways this image gets started; `docker run`, Kubernetes, Unraid and Portainer
  hit the same bug. Setting it in the image fixes all of them.

The signing secret needed no change — `_get_storage_secret` already persists it
to `~/.immich-memories/.storage_secret`, which is on the same volume. The env
var row in the docs claimed otherwise and is now corrected.

## Manifests

`deploy/kubernetes/base/deployment.yaml` and `deploy/terraform/main.tf` both
disable `readOnlyRootFilesystem` citing this exact path. That justification is
gone, but `~/.cache` still needs a writable mount before they can flip, so the
comments now say that and point at #445. Not flipped here: the failure mode is a
crashloop on first write and no unit test in this repo can catch it.

## Known interaction

This makes #429 (one `storage-user-*.json` per cookieless request, never expired)
persistent rather than ephemeral — those files now land on the volume and survive
`--force-recreate`. Health probes are plain FastAPI routes and don't touch user
storage, so the driver is cookieless `GET /login` (scanners, new browsers), not
the probe loop. #429 is next in my queue.

## Upgrade note

Existing containers will ask for one more login. The signing secret persists;
the session store starts empty at the new location.

## Tests

`tests/test_nicegui_storage_location_contract.py` — asserts the image sets the
variable, that it points at a path compose actually mounts, and that the recipe
doesn't try to solve this with a tmpfs. `make check` green (5102 passed);
`make docs-build` green; `terraform fmt -check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qHRMEg5LDWNf1NjuMhrmX