### PR TITLE
fix(ui): stop persisting a session file per anonymous request

### DIFF
--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -236,6 +236,9 @@ In your config YAML, set `trusted_proxies` to Traefik's container IP (prefer a s
 ## Session
 
 - Sessions last 24 hours by default (`session_ttl_hours`). Range: 1--720 hours.
+- The same value expires session state on disk: abandoned session files are
+  swept at startup and every 15 minutes thereafter, so an exposed instance
+  doesn't accumulate one file per drive-by request.
 - Logout via the sidebar button or by navigating to `/logout`.
 - OIDC logout redirects to the IdP's `end_session_endpoint` when available (the IdP terminates the SSO session too). Falls back to a local-only logout if the IdP doesn't advertise that endpoint.
 

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -592,9 +592,13 @@ app.add_api_route("/health/ready", _readiness_handler, methods=["GET"])
 
 
 def _check_login_rate_limit(request: Request) -> JSONResponse | None:
-    """Stash client IP and return 429 if rate-limited."""
+    """Return 429 if the client is rate-limited.
+
+    Deliberately writes nothing: NiceGUI persists any non-empty `storage.user`
+    to a file keyed by a cookie the caller may not send, and expires only tab
+    storage. The login page reads the same IP off `client.ip` instead.
+    """
     client_ip = request.client.host if request.client else "unknown"
-    app.storage.user["_client_ip"] = client_ip
     if is_rate_limited(client_ip):
         return JSONResponse({"detail": "Too many failed login attempts"}, status_code=429)
     return None
@@ -753,6 +757,15 @@ def initialize_app() -> None:
 app.on_startup(initialize_app)
 
 
+def _expire_session_storage() -> None:
+    """Drop the session files NiceGUI persists and never expires."""
+    from nicegui.storage import Storage
+
+    from immich_memories.ui.session_storage import sweep_expired_user_storage
+
+    sweep_expired_user_storage(Storage.path, ttl_hours=get_config().auth.session_ttl_hours)
+
+
 async def _session_cleanup_loop() -> None:
     """Periodically clean up stale sessions."""
     from immich_memories.ui.state import cleanup_stale_sessions
@@ -760,12 +773,14 @@ async def _session_cleanup_loop() -> None:
     while True:
         await asyncio.sleep(900)  # 15 minutes
         cleanup_stale_sessions()
+        _expire_session_storage()
 
 
 def _start_cleanup_task() -> None:
     asyncio.ensure_future(_session_cleanup_loop())
 
 
+app.on_startup(_expire_session_storage)
 app.on_startup(_start_cleanup_task)
 app.on_startup(lambda: asyncio.ensure_future(automation_scheduler.run_forever()))
 

--- a/src/immich_memories/ui/pages/login.py
+++ b/src/immich_memories/ui/pages/login.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from nicegui import app, ui
+from nicegui import app, context, ui
 
 from immich_memories.config_models_auth import AuthConfig
 from immich_memories.ui.auth import (
@@ -52,9 +52,10 @@ def _render_basic_form(auth_config: AuthConfig) -> None:
     error_label = ui.label("").classes("text-xs").style("color: var(--im-error); display: none")
 
     async def attempt_login() -> None:
-        # WHY: the HTTP middleware stashes client IP in storage on /login load
-        # because NiceGUI button callbacks run over websockets, not HTTP.
-        client_ip = app.storage.user.get("_client_ip", "unknown")
+        # WHY: this callback arrives over a websocket, so there is no HTTP
+        # request to read. `client.ip` reads through to the request that loaded
+        # the page, and is defined before the socket connects.
+        client_ip = context.client.ip or "unknown"
 
         if is_rate_limited(client_ip):
             error_label.style("display: block")

--- a/src/immich_memories/ui/session_storage.py
+++ b/src/immich_memories/ui/session_storage.py
@@ -1,0 +1,51 @@
+"""Expire the session files NiceGUI persists but never cleans up.
+
+NiceGUI writes `app.storage.user` to `storage-user-<uuid>.json` keyed by a
+signed cookie, and expires only *tab* storage. A client that sends no cookie
+gets a fresh uuid, so anything that dirties the user dict during an
+unauthenticated request leaves a file behind permanently -- one per scanner hit
+on an internet-exposed instance.
+
+Removing the writes stops new junk accruing; this clears what is already there,
+and the sessions that are simply abandoned. Age is the right axis because
+NiceGUI rewrites a file whenever the session changes, so mtime is last-use, and
+the auth layer already treats a session older than `session_ttl_hours` as
+expired.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# General storage is app-wide state, and tab storage has NiceGUI's own 30-day
+# TTL. Only the per-user files are unmanaged.
+_USER_STORAGE_GLOB = "storage-user-*.json"
+
+
+def sweep_expired_user_storage(directory: Path, *, ttl_hours: int) -> int:
+    """Delete user-storage files untouched for longer than ttl_hours.
+
+    Returns the number of files removed. A ttl of zero or less would expire
+    every session at once, which is a config error rather than an instruction
+    to log everyone out, so it sweeps nothing.
+    """
+    if ttl_hours <= 0 or not directory.is_dir():
+        return 0
+
+    cutoff = time.time() - ttl_hours * 3600
+    removed = 0
+    for path in directory.glob(_USER_STORAGE_GLOB):
+        with contextlib.suppress(OSError):
+            if path.stat().st_mtime >= cutoff:
+                continue
+            path.unlink()
+            removed += 1
+
+    if removed:
+        logger.info("Expired %d abandoned session file(s) from %s", removed, directory)
+    return removed

--- a/tests/test_auth_middleware_helpers.py
+++ b/tests/test_auth_middleware_helpers.py
@@ -51,7 +51,19 @@ class TestCheckLoginRateLimit:
             result = _check_login_rate_limit(request)
 
         assert result is None
-        assert _mock_storage["_client_ip"] == "192.168.1.1"
+
+    def test_an_unauthenticated_hit_leaves_nothing_to_persist(self, _mock_storage):
+        """NiceGUI writes a storage file per cookieless request that dirties the
+        user dict, and expires only tab storage -- so a scanner sweeping /login
+        used to cost one file per hit, forever."""
+        from immich_memories.ui.app import _check_login_rate_limit
+
+        request = _make_request(host="192.168.1.1")
+        # WHY: the rate limiter's process-wide failed-attempt counters.
+        with patch("immich_memories.ui.app.is_rate_limited", return_value=False):
+            _check_login_rate_limit(request)
+
+        assert _mock_storage == {}
 
     def test_limited_returns_429(self, _mock_storage):
         from immich_memories.ui.app import _check_login_rate_limit
@@ -75,11 +87,11 @@ class TestCheckLoginRateLimit:
             "server": ("localhost", 8080),
         }
         request = Request(scope)
-        with patch("immich_memories.ui.app.is_rate_limited", return_value=False):
+        with patch("immich_memories.ui.app.is_rate_limited", return_value=False) as limited:
             result = _check_login_rate_limit(request)
 
         assert result is None
-        assert _mock_storage["_client_ip"] == "unknown"
+        limited.assert_called_once_with("unknown")
 
 
 class TestTryHeaderAuth:

--- a/tests/test_session_storage_sweep.py
+++ b/tests/test_session_storage_sweep.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from immich_memories.ui.session_storage import sweep_expired_user_storage
+
+_HOUR = 3600
+
+
+def _aged(path: Path, *, hours: float) -> Path:
+    path.write_text("{}")
+    stamp = time.time() - hours * _HOUR
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+class TestSweepExpiredUserStorage:
+    def test_it_removes_user_storage_nothing_came_back_for(self, tmp_path):
+        stale = _aged(tmp_path / "storage-user-abandoned.json", hours=30)
+        fresh = _aged(tmp_path / "storage-user-active.json", hours=1)
+
+        removed = sweep_expired_user_storage(tmp_path, ttl_hours=24)
+
+        assert removed == 1
+        assert not stale.exists()
+        assert fresh.exists()
+
+    def test_it_leaves_the_storage_nicegui_manages_itself(self, tmp_path):
+        """General storage is app-wide state; tab storage has its own TTL."""
+        general = _aged(tmp_path / "storage-general.json", hours=500)
+        tab = _aged(tmp_path / "storage-tab-abc.json", hours=500)
+
+        assert sweep_expired_user_storage(tmp_path, ttl_hours=24) == 0
+        assert general.exists()
+        assert tab.exists()
+
+    def test_a_missing_directory_is_not_an_error(self, tmp_path):
+        assert sweep_expired_user_storage(tmp_path / "nope", ttl_hours=24) == 0
+
+    @pytest.mark.parametrize("ttl_hours", [0, -1])
+    def test_a_nonsensical_ttl_sweeps_nothing(self, tmp_path, ttl_hours):
+        """Config bounds ttl to >=1; a bad value must not wipe every session."""
+        kept = _aged(tmp_path / "storage-user-kept.json", hours=500)
+
+        assert sweep_expired_user_storage(tmp_path, ttl_hours=ttl_hours) == 0
+        assert kept.exists()
+
+
+class TestAppWiring:
+    def test_the_app_expires_session_files_using_the_configured_ttl(self, tmp_path):
+        """A wrong TTL here silently either hoards files or logs everyone out."""
+        from unittest.mock import patch
+
+        from immich_memories.config import Config
+        from immich_memories.ui.app import _expire_session_storage
+
+        stale = _aged(tmp_path / "storage-user-old.json", hours=5)
+        kept = _aged(tmp_path / "storage-user-new.json", hours=1)
+
+        # WHY: both replace process-wide state rather than collaborators.
+        with (
+            # WHY: NiceGUI's real on-disk storage directory.
+            patch("nicegui.storage.Storage.path", tmp_path),
+            # WHY: the config file on disk, proving the TTL is read not hardcoded.
+            patch(
+                "immich_memories.ui.app.get_config",
+                return_value=Config(auth={"session_ttl_hours": 3}),
+            ),
+        ):
+            _expire_session_storage()
+
+        assert not stale.exists()
+        assert kept.exists()


### PR DESCRIPTION
Closes #429. From the 2026-08-18 security/perf review (S6).

## The leak

NiceGUI persists `app.storage.user` to `storage-user-<uuid>.json`, keyed by a
signed cookie, and expires only *tab* storage — `Storage.max_tab_storage_age`
has no user-storage counterpart, and NiceGUI's own housekeeping only sweeps
`storage-*.json.tmp`.

`_check_login_rate_limit` wrote the client IP into that dict on every
`GET /login`. A caller that sends no cookie gets a fresh uuid, so every
unauthenticated hit left a file behind permanently. Nothing sensitive is in them
(`session_id`, `theme`, `_client_ip`, `username`, `email`) — this is unbounded
disk growth driven by unauthenticated requests, not a disclosure.

## The fix

**Remove the write.** The login page now reads `context.client.ip`. The old
comment justified the stash because button callbacks arrive over a websocket
with no HTTP request to read — but NiceGUI has guaranteed since 2.0 that
`client.ip` is populated *before* the socket connects, reading through to the
request that loaded the page. The workaround outlived its reason.

Because being wrong here means nobody can log in, this is verified end-to-end
rather than by assertion: `tests/e2e/test_auth_flow.py` drives a real Chromium
through the Sign in click, and all 3 tests pass.

**Then sweep the backlog.** `ui/session_storage.py` expires
`storage-user-*.json` older than `auth.session_ttl_hours`, at startup and in the
existing 15-minute cleanup loop. Age is the right axis: NiceGUI rewrites a file
whenever the session changes, so mtime is last-use, and the auth layer already
treats a session past that TTL as expired.

Deliberate boundaries:
- **General and tab storage are untouched** — the former is app-wide state, the
  latter already has NiceGUI's own 30-day TTL.
- **A ttl of zero or less sweeps nothing.** Config bounds it to ≥1, so that
  value can only arrive as an error, and "expire every session at once" is not a
  reasonable reading of it.

Order matters: the sweep alone would have been a treadmill, since the next scan
recreates what was deleted. Removing the write is the fix.

## Why now rather than in the LOW pile

#446 moves session storage onto the persistent config volume, which turns this
residue from ephemeral into permanent — it starts surviving `--force-recreate`.

For the record, the driver is cookieless `GET /login` (scanners, new browsers),
**not** the probe loop: `/health/live` and `/health/ready` are plain
`add_api_route` handlers, not NiceGUI pages, so they never touch user storage.

## Tests

`tests/test_session_storage_sweep.py` covers the sweep, what it must not delete,
a missing directory, and the zero/negative TTL guard, plus the app wiring using
the configured TTL. `tests/test_auth_middleware_helpers.py` gains a test that an
unauthenticated hit leaves nothing to persist; two assertions there that pinned
the old `_client_ip` mechanism now observe the fallback through the rate limiter
instead. `make check` green (5106 passed); `make docs-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qHRMEg5LDWNf1NjuMhrmX