### PR TITLE
fix(music): refuse result URLs that leave the configured API host

### DIFF
--- a/src/immich_memories/audio/music_generator_client.py
+++ b/src/immich_memories/audio/music_generator_client.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -56,6 +57,25 @@ class MusicGenClientConfig:
 # =============================================================================
 # API Client
 # =============================================================================
+
+
+def _origin(parts) -> tuple[str, str | None, int | None]:
+    default_port = {"http": 80, "https": 443}.get(parts.scheme)
+    return parts.scheme, (parts.hostname or "").lower() or None, parts.port or default_port
+
+
+def result_url_within(file_url: str, base_url: str) -> bool:
+    """Whether a job's result URL stays on the configured API host.
+
+    A relative path is fine -- httpx resolves it against `base_url`. An absolute
+    URL overrides `base_url` entirely while still carrying the client's
+    `X-API-Key` header, so anything naming another origin would hand the key to
+    a host the user never configured.
+    """
+    parts = urlsplit(file_url)
+    if not parts.scheme and not parts.netloc:
+        return True
+    return _origin(parts) == _origin(urlsplit(base_url))
 
 
 class MusicGenClient:
@@ -151,7 +171,9 @@ class MusicGenClient:
             await asyncio.sleep(self.config.poll_interval_seconds)
 
     async def _download_file(self, file_url: str, output_path: Path) -> Path:
-        """Download a result file."""
+        """Download a result file, refusing any URL that leaves the API host."""
+        if not result_url_within(file_url, self.config.base_url):
+            raise ValueError(f"Result URL {file_url!r} is outside the configured MusicGen host")
         resp = await self.client.get(file_url)
         resp.raise_for_status()
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_music_result_url_origin.py
+++ b/tests/test_music_result_url_origin.py
@@ -1,0 +1,60 @@
+"""The music API's own job JSON decides which host receives its API key.
+
+httpx honours an absolute URL over `base_url` and still sends client-level
+headers, so a `result_urls` entry naming another host causes a request there
+carrying `X-API-Key`. The configured host has to be malicious or compromised for
+it to matter -- but it is a host the user chose, and the key should not leave it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from immich_memories.audio.music_generator_client import (
+    MusicGenClient,
+    MusicGenClientConfig,
+    result_url_within,
+)
+
+_BASE = "http://music.local:8000"
+
+
+class TestResultUrlWithin:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/files/track.wav",
+            "files/track.wav",
+            "http://music.local:8000/files/track.wav",
+            "http://MUSIC.LOCAL:8000/files/track.wav",
+        ],
+    )
+    def test_it_allows_relative_paths_and_the_configured_origin(self, url):
+        assert result_url_within(url, _BASE) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://evil.example/collect",
+            "https://music.local:8000/files/track.wav",
+            "http://music.local:9999/files/track.wav",
+            "http://music.local.evil.example/files/track.wav",
+            "//evil.example/collect",
+            "file:///etc/passwd",
+        ],
+    )
+    def test_it_rejects_anything_that_leaves_that_origin(self, url):
+        assert result_url_within(url, _BASE) is False
+
+    def test_an_implicit_port_matches_the_explicit_one(self):
+        assert result_url_within("http://music.local:80/f.wav", "http://music.local") is True
+        assert result_url_within("https://m.local/f.wav", "https://m.local:443") is True
+
+
+class TestDownloadRefusesForeignHosts:
+    @pytest.mark.asyncio
+    async def test_it_raises_before_any_request_is_made(self, tmp_path):
+        config = MusicGenClientConfig(base_url=_BASE, api_key="secret")
+        async with MusicGenClient(config) as client:
+            with pytest.raises(ValueError, match="outside the configured"):
+                await client._download_file("http://evil.example/collect", tmp_path / "track.wav")


### PR DESCRIPTION
Closes #433. S15 in `docs/reviews/2026-08-18-security-perf-review.md`.

## The leak

The music API's job JSON names the files to fetch, and `_download_file` used
those names as-is. httpx honours an absolute URL over `base_url` while still
sending client-level headers, so a `result_urls` entry naming another host
produced a request to that host carrying `X-API-Key`.

Reaching this requires the configured MusicGen host to be malicious or
compromised — a host the user chose — which is why the review rated it INFO
rather than an SSRF finding. The key still should not leave it.

## The fix

The guard goes in `_download_file`, the one place all seven call sites funnel
through, so generation and stem separation are both covered and any future
caller inherits it rather than having to remember.

`result_url_within` allows relative paths, since httpx resolves those against
`base_url`, and requires an absolute URL to match scheme, host and port.
Implicit ports are resolved, so `http://h` and `http://h:80` agree. Rejected
cases include a different host, a different scheme, a different port, a
suffix-confusion host (`music.local.evil.example`), a scheme-relative
`//evil.example/...`, and `file:///etc/passwd`.

## Not changed

`audio/generators/ace_step_backend.py:844` builds the same kind of URL by
concatenation (`f"{api_url}{file_url}"`), which turns an absolute URL into a
malformed host rather than a request to it. Safe — though by accident rather
than intent, so it is worth knowing if that line is ever refactored to pass the
URL to httpx directly.

## Tests

`tests/test_music_result_url_origin.py` — the allowed and rejected forms above,
implicit-vs-explicit ports, and that `_download_file` raises before issuing a
request. `make check` green (5111 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qHRMEg5LDWNf1NjuMhrmX