### PR TITLE
test(processing): give mocked stderr pipes real EOF semantics

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import threading
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -199,3 +200,21 @@ def tmp_output_dir(tmp_path: Path) -> Path:
 def sample_config() -> Config:
     """Provide a Config with safe defaults for testing."""
     return Config()
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_drain_threads():
+    """Fail any test that leaves a stderr drain thread spinning.
+
+    A mocked pipe whose read() never returns b"" (constant return_value, or a
+    bare MagicMock — its __iter__ yields nothing and __bool__ is True) traps
+    drain_stderr_tail in an infinite loop. The thread outlives the test at
+    ~250k read()/s, MagicMock records every call, and the suite bloats by
+    gigabytes until the 7 GB macOS CI runner kills pytest (exit 137).
+    """
+    yield
+    leaked = [t for t in threading.enumerate() if "drain_stderr_tail" in t.name and t.is_alive()]
+    assert not leaked, (
+        f"stderr drain thread(s) outlived this test: {leaked} — a mocked pipe "
+        'never reached EOF; use stderr.read.side_effect = [data, b""]'
+    )

--- a/tests/test_photo_stderr.py
+++ b/tests/test_photo_stderr.py
@@ -6,6 +6,7 @@ there's no diagnostic info — just a non-zero return code.
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,7 +31,11 @@ class TestStreamRenderStderrCapture:
         mock_proc.wait.return_value = None
         mock_proc.returncode = 1
         mock_proc.stderr = MagicMock()
-        mock_proc.stderr.read.return_value = b"Error: codec not found"
+        # WHY: a real pipe reaches EOF; a constant return_value never does and
+        # the drain thread spins on it for the rest of the suite.
+        mock_proc.stderr.read.side_effect = [b"Error: codec not found", b""]
+
+        threads_before = set(threading.enumerate())
 
         # WHY: mock Popen and render_ken_burns_streaming to avoid real FFmpeg
         with (
@@ -45,6 +50,12 @@ class TestStreamRenderStderrCapture:
             pytest.raises(RuntimeError, match="codec not found"),
         ):
             _stream_render_to_mp4(img, params, output, 100, 100)
+
+        # WHY: a drain thread that outlives the call spins on the mock for the
+        # rest of the suite (~250k read()/s, each recorded by MagicMock) — the
+        # +2.8 GB / 10 s regression behind the macOS CI exit-137 kills.
+        leaked = [t for t in threading.enumerate() if t not in threads_before and t.is_alive()]
+        assert not leaked, f"stderr drain thread outlived _stream_render_to_mp4: {leaked}"
 
     def test_ffmpeg_success_does_not_raise(self, tmp_path):
         """When FFmpeg succeeds, no error raised."""

--- a/tests/test_photo_stderr.py
+++ b/tests/test_photo_stderr.py
@@ -6,7 +6,6 @@ there's no diagnostic info — just a non-zero return code.
 
 from __future__ import annotations
 
-import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -35,8 +34,6 @@ class TestStreamRenderStderrCapture:
         # the drain thread spins on it for the rest of the suite.
         mock_proc.stderr.read.side_effect = [b"Error: codec not found", b""]
 
-        threads_before = set(threading.enumerate())
-
         # WHY: mock Popen and render_ken_burns_streaming to avoid real FFmpeg
         with (
             patch(
@@ -50,12 +47,6 @@ class TestStreamRenderStderrCapture:
             pytest.raises(RuntimeError, match="codec not found"),
         ):
             _stream_render_to_mp4(img, params, output, 100, 100)
-
-        # WHY: a drain thread that outlives the call spins on the mock for the
-        # rest of the suite (~250k read()/s, each recorded by MagicMock) — the
-        # +2.8 GB / 10 s regression behind the macOS CI exit-137 kills.
-        leaked = [t for t in threading.enumerate() if t not in threads_before and t.is_alive()]
-        assert not leaked, f"stderr drain thread outlived _stream_render_to_mp4: {leaked}"
 
     def test_ffmpeg_success_does_not_raise(self, tmp_path):
         """When FFmpeg succeeds, no error raised."""

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -409,7 +409,8 @@ class TestRunWithProgress:
         mock_process.stdout.readline.side_effect = ["", ""]
         mock_process.poll.return_value = 1
         mock_process.returncode = 1
-        mock_process.stderr.read.return_value = "encode failed"
+        # WHY: EOF after one chunk — a constant return_value spins the drain.
+        mock_process.stderr.read.side_effect = ["encode failed", ""]
         mock_process.__enter__ = MagicMock(return_value=mock_process)
         mock_process.__exit__ = MagicMock(return_value=False)
 
@@ -917,6 +918,7 @@ class TestStreamRenderToMp4:
         mock_proc.wait.return_value = None
         mock_proc.returncode = 0
         mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read.side_effect = [b""]
 
         # WHY: subprocess.Popen starts ffmpeg process for encoding
         with (
@@ -958,6 +960,7 @@ class TestStreamRenderToMp4:
         mock_proc.wait.return_value = None
         mock_proc.returncode = 0
         mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read.side_effect = [b""]
 
         with (
             patch(
@@ -1003,7 +1006,9 @@ class TestStreamRenderToMp4:
         mock_proc.stdin = MagicMock()
         mock_proc.wait.return_value = None
         mock_proc.returncode = 1
-        mock_proc.stderr.read.return_value = b"encode error"
+        # WHY: a real pipe reaches EOF; a constant return_value spins the
+        # stderr drain thread for the rest of the suite.
+        mock_proc.stderr.read.side_effect = [b"encode error", b""]
 
         with (
             patch("immich_memories.photos.photo_pipeline.subprocess.Popen", return_value=mock_proc),

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -1485,6 +1485,7 @@ class TestZscaleFallbackBehavior:
             mock_proc = MagicMock()
             mock_proc.returncode = 0
             mock_proc.stdin = MagicMock()
+            mock_proc.stderr.read.side_effect = [b""]
             mock_popen.return_value = mock_proc
 
             import numpy as np
@@ -1518,6 +1519,7 @@ class TestZscaleFallbackBehavior:
             mock_proc = MagicMock()
             mock_proc.returncode = 0
             mock_proc.stdin = MagicMock()
+            mock_proc.stderr.read.side_effect = [b""]
             mock_popen.return_value = mock_proc
 
             import numpy as np


### PR DESCRIPTION
Closes #451. Second of the two fixes for the exit-137 macOS CI kills (the other is #452) — and this one is the Aug 19 trigger: #353 merged 11:19, first CI collapse 12:38.

## What

#353's `write_frames_to_ffmpeg` starts a `drain_stderr_tail` thread that reads stderr to EOF (`while chunk := stream.read(65536)`). Several March-era tests mock Popen with `stderr.read.return_value = b"..."` — a constant is returned forever; a mock pipe never EOFs. The drain thread spins, `reader.join(timeout=10)` gives up (the mysterious 10 s per test), and the thread outlives the test — measured **~250k `read()` calls/s** for the rest of the suite, each appending a `_Call` record to the mock: +2.8 GB from `test_photo_stderr` alone, +3.3 GB from `test_processing_coverage`, on every platform.

The spinning threads also starve the GIL, which explains the macOS job pathology beyond memory: 24m–64m wall-time spread on identical work, one `test_thumbnail_prefetch` test at 616 s, and long post-summary silence while coverage XML crawls.

Mock pipes now yield their data once and then `b""` — the pattern `test_ffmpeg_pipe.py` already used, with a comment saying why. The two bare `MagicMock()` stderr sites get explicit EOF too (their drain thread previously died instantly on `TypeError`, silently unexercised). The photo-stderr test now asserts no drain thread outlives the call, so a reintroduced never-EOF mock fails in milliseconds with a clear message instead of eating gigabytes.

## Evidence

- `test_photo_stderr.py` file runtime: **107 s → 0.28 s**.
- Surviving thread proven pre-fix: `read()` call count still climbing a full second after `_stream_render_to_mp4` returned.
- Suite-wide numbers in #451 and the combined verification comment to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM