### PR TITLE
fix(security): keep scratch files out of shared /tmp

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3768,77 +3768,77 @@
       {
         "name": "configured_secret_values",
         "complexity": 23,
-        "line_start": 45,
-        "line_end": 68,
+        "line_start": 76,
+        "line_end": 99,
         "line_complexities": [
           {
-            "line": 47,
+            "line": 78,
             "complexity": 0
           },
           {
-            "line": 48,
+            "line": 79,
             "complexity": 0
           },
           {
-            "line": 49,
+            "line": 80,
             "complexity": 1
           },
           {
-            "line": 50,
+            "line": 81,
             "complexity": 0
           },
           {
-            "line": 51,
+            "line": 82,
             "complexity": 2
           },
           {
-            "line": 52,
+            "line": 83,
             "complexity": 3
           },
           {
-            "line": 53,
+            "line": 84,
             "complexity": 0
           },
           {
-            "line": 54,
+            "line": 85,
             "complexity": 4
           },
           {
-            "line": 55,
+            "line": 86,
             "complexity": 6
           },
           {
-            "line": 57,
+            "line": 88,
             "complexity": 1
           },
           {
-            "line": 59,
+            "line": 90,
             "complexity": 1
           },
           {
-            "line": 61,
+            "line": 92,
             "complexity": 1
           },
           {
-            "line": 64,
+            "line": 95,
             "complexity": 0
           },
           {
-            "line": 65,
+            "line": 96,
             "complexity": 1
           },
           {
-            "line": 66,
+            "line": 97,
             "complexity": 3
           },
           {
-            "line": 68,
+            "line": 99,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 36
+    "complexity": 39
   },
   {
     "path": "src/immich_memories/titles/sdf_font.py",

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -10,11 +10,12 @@ import contextlib
 import json
 import logging
 import re
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import cv2
+
+from immich_memories.security import private_temp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -226,8 +227,7 @@ class ContentAnalyzer:
         ]
 
         frames: list[Path] = []
-        temp_dir = Path(tempfile.gettempdir()) / "immich_memories" / "content_frames"
-        temp_dir.mkdir(parents=True, exist_ok=True)
+        temp_dir = private_temp_dir("content_frames")
 
         for i, time_pos in enumerate(frame_times):
             frame_num = int(time_pos * fps)

--- a/src/immich_memories/analysis/scenes.py
+++ b/src/immich_memories/analysis/scenes.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
+
+from immich_memories.security import private_temp_dir
 
 if TYPE_CHECKING:
     from immich_memories.config_models import AnalysisConfig, HardwareAccelConfig
@@ -377,10 +378,7 @@ class SceneDetector:
             scenes: List of scenes to extract keyframes for.
             output_dir: Directory to save keyframes.
         """
-        if output_dir is None:
-            output_dir = Path(tempfile.gettempdir()) / "immich_memories" / "keyframes"
-        else:
-            output_dir = Path(output_dir)
+        output_dir = private_temp_dir("keyframes") if output_dir is None else Path(output_dir)
 
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/immich_memories/audio/generators/base.py
+++ b/src/immich_memories/audio/generators/base.py
@@ -7,13 +7,13 @@ plus a Protocol for stem separation (Demucs local or MusicGen API).
 from __future__ import annotations
 
 import logging
-import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from immich_memories.audio.music_generator_models import MusicStems
+from immich_memories.security import private_temp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class GenerationRequest:
     photo_cadence_seconds: float | None = None
 
     # Output
-    output_dir: Path = field(default_factory=lambda: Path(tempfile.gettempdir()) / "musicgen")
+    output_dir: Path = field(default_factory=lambda: private_temp_dir("musicgen"))
 
     @property
     def is_multi_scene(self) -> bool:

--- a/src/immich_memories/automation/notifications.py
+++ b/src/immich_memories/automation/notifications.py
@@ -157,15 +157,25 @@ def _classify_failure(exc: Exception) -> NotificationFailureCategory:
 
 def _extract_thumbnail(output_path: str) -> str | None:
     """Extract a thumbnail frame from the output video for notification attachment."""
+    import os
     import subprocess
     import tempfile
     from pathlib import Path
+
+    from immich_memories.security import private_temp_dir
 
     video = Path(output_path)
     if not video.exists():
         return None
 
-    thumb = Path(tempfile.gettempdir()) / f"immich_notif_{video.stem}.jpg"
+    # WHY mkstemp, not a name built from the video: `ffmpeg -y` overwrites
+    # whatever is at the path, following a symlink placed there first. A
+    # predictable name in a shared directory is what makes that reachable.
+    handle, thumb_name = tempfile.mkstemp(
+        suffix=".jpg", prefix="notif_", dir=private_temp_dir("notifications")
+    )
+    os.close(handle)
+    thumb = Path(thumb_name)
     try:
         # WHY: seek to 25% of video for a representative frame (skips title screen)
         subprocess.run(

--- a/src/immich_memories/processing/clips.py
+++ b/src/immich_memories/processing/clips.py
@@ -6,7 +6,6 @@ import contextlib
 import hashlib
 import logging
 import subprocess
-import tempfile
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -26,7 +25,7 @@ from immich_memories.processing.hardware import (
     get_ffmpeg_encoder,
     get_ffmpeg_hwaccel_args,
 )
-from immich_memories.security import validate_video_path
+from immich_memories.security import private_temp_dir, validate_video_path
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +77,7 @@ class ClipExtractor:
         self._config = config
 
         if output_dir is None:
-            output_dir = Path(tempfile.gettempdir()) / "immich_memories" / "clips"
+            output_dir = private_temp_dir("clips")
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -553,8 +552,7 @@ def _build_clip_output_path(
     buffer_end: bool,
     reencode: bool,
 ) -> Path:
-    output_dir = Path(tempfile.gettempdir()) / "immich_memories" / "clips"
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = private_temp_dir("clips")
     source_hash = hashlib.md5(str(source_path).encode(), usedforsecurity=False).hexdigest()[:8]  # noqa: S324
     buffer_suffix = (
         f"_b{int(buffer_start)}{int(buffer_end)}" if (buffer_start or buffer_end) else ""

--- a/src/immich_memories/processing/transforms.py
+++ b/src/immich_memories/processing/transforms.py
@@ -8,7 +8,6 @@ Public API surface — delegates heavy lifting to helper modules:
 from __future__ import annotations
 
 import logging
-import tempfile
 from enum import StrEnum
 from pathlib import Path
 from typing import Literal
@@ -30,7 +29,7 @@ from immich_memories.processing.transforms_smart_crop import (
     init_face_detectors,
     transform_smart_crop,
 )
-from immich_memories.security import validate_video_path
+from immich_memories.security import private_temp_dir, validate_video_path
 
 # Re-export helpers so existing ``from transforms import …`` keeps working.
 __all__ = [
@@ -156,8 +155,7 @@ class AspectRatioTransformer:
         input_path = validate_video_path(input_path, must_exist=True)
 
         if output_path is None:
-            output_dir = Path(tempfile.gettempdir()) / "immich_memories" / "transformed"
-            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir = private_temp_dir("transformed")
             output_path = output_dir / f"transformed_{input_path.stem}.mp4"
 
         if self.scale_mode == ScaleMode.FIT:

--- a/src/immich_memories/security.py
+++ b/src/immich_memories/security.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import stat
+import tempfile
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -40,6 +41,36 @@ def write_secret_file(path: Path, text: str) -> None:
         with contextlib.suppress(OSError):
             tmp.unlink(missing_ok=True)
         raise
+
+
+def _assert_private(path: Path) -> None:
+    """Refuse a path someone else could have prepared for us."""
+    info = path.lstat()
+    owned = info.st_uid == os.getuid()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode) or not owned:
+        raise RuntimeError(f"{path} is not a private directory")
+    if stat.S_IMODE(info.st_mode) & (stat.S_IRWXG | stat.S_IRWXO):
+        raise RuntimeError(f"{path} is not a private directory (group/other access)")
+
+
+def private_temp_dir(name: str) -> Path:
+    """A scratch directory under the system temp dir that only this user can enter.
+
+    `tempfile.gettempdir()` is shared and world-writable, so a fixed path under
+    it is a name another user can claim first -- as a symlink we then write
+    through, since `ffmpeg -y` follows one, or as a directory they can read.
+    Scoping by uid and refusing anything we do not own closes both.
+
+    `lstat` rather than `stat`: the question is what the path itself is, and a
+    symlink to a directory we own would answer "directory" through `stat`.
+    """
+    root = Path(tempfile.gettempdir()) / f"immich-memories-{os.getuid()}"
+    target = root / name
+    root.mkdir(mode=0o700, exist_ok=True)
+    _assert_private(root)
+    target.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _assert_private(target)
+    return target
 
 
 def configured_secret_values(config: BaseModel) -> tuple[str, ...]:

--- a/tests/test_clip_extractor.py
+++ b/tests/test_clip_extractor.py
@@ -65,10 +65,17 @@ class TestClipExtractorInit:
         assert out.exists()
         assert extractor.output_dir == out
 
-    def test_default_output_dir(self):
-        """Default output dir uses tempdir."""
+    def test_default_output_dir_is_private_to_this_user(self):
+        """Clips are extracted to a scratch dir; shared /tmp would let another
+        user on the host read them, or pre-place a symlink we write through."""
+        import os
+        import stat
+
         extractor = ClipExtractor(config=_MOCK_CONFIG)
-        assert "immich_memories" in str(extractor.output_dir)
+        info = extractor.output_dir.stat()
+
+        assert info.st_uid == os.getuid()
+        assert stat.S_IMODE(info.st_mode) == 0o700
 
 
 class TestClipExtractorCleanup:

--- a/tests/test_private_temp_dir.py
+++ b/tests/test_private_temp_dir.py
@@ -1,0 +1,74 @@
+"""Scratch files belong somewhere only this user can reach.
+
+`tempfile.gettempdir()` is shared and world-writable. A fixed name under it --
+`immich_notif_<stem>.jpg`, `immich_memories/clips/` -- is fully predictable, so
+another user on the same host can pre-place a symlink there and have ffmpeg
+`-y` write through it, or read what lands there. Only matters on a multi-user
+box, which is why the review rated it low rather than none.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+
+import pytest
+
+from immich_memories.security import private_temp_dir
+
+
+def _use(tmp_path, monkeypatch) -> None:
+    """WHY: gettempdir() caches its answer on first call, so setting TMPDIR
+    after the fact changes nothing -- the tests would silently run against the
+    real temp dir. `tempfile.tempdir` is the documented override."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+
+class TestPrivateTempDir:
+    def test_it_creates_the_directory_owner_only(self, tmp_path, monkeypatch):
+        _use(tmp_path, monkeypatch)
+
+        created = private_temp_dir("clips")
+
+        assert created.is_dir()
+        assert stat.S_IMODE(created.stat().st_mode) == 0o700
+
+    def test_the_parent_it_creates_is_also_owner_only(self, tmp_path, monkeypatch):
+        """A 0700 leaf under a 0777 parent still lets others rename the leaf."""
+        _use(tmp_path, monkeypatch)
+
+        created = private_temp_dir("clips")
+
+        assert stat.S_IMODE(created.parent.stat().st_mode) == 0o700
+
+    def test_it_is_scoped_so_two_users_cannot_collide(self, tmp_path, monkeypatch):
+        _use(tmp_path, monkeypatch)
+
+        assert str(os.getuid()) in str(private_temp_dir("clips"))
+
+    def test_calling_it_twice_returns_the_same_usable_directory(self, tmp_path, monkeypatch):
+        _use(tmp_path, monkeypatch)
+
+        assert private_temp_dir("clips") == private_temp_dir("clips")
+
+    def test_it_refuses_a_pre_placed_symlink(self, tmp_path, monkeypatch):
+        """The attack: plant the path first and have us write through it."""
+        _use(tmp_path, monkeypatch)
+        root = tmp_path / f"immich-memories-{os.getuid()}"
+        root.mkdir(mode=0o700)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (root / "clips").symlink_to(elsewhere)
+
+        with pytest.raises(RuntimeError, match="not a private directory"):
+            private_temp_dir("clips")
+
+    def test_it_refuses_a_directory_others_can_write(self, tmp_path, monkeypatch):
+        _use(tmp_path, monkeypatch)
+        root = tmp_path / f"immich-memories-{os.getuid()}"
+        (root / "clips").mkdir(parents=True)
+        (root / "clips").chmod(0o777)
+
+        with pytest.raises(RuntimeError, match="not a private directory"):
+            private_temp_dir("clips")


### PR DESCRIPTION
Closes #431. S13 in `docs/reviews/2026-08-18-security-perf-review.md`.

## The exposure

`tempfile.gettempdir()` is shared and world-writable, and every scratch path
under it was fixed and predictable:

| Site | Path |
|---|---|
| `automation/notifications.py` | `immich_notif_<video-stem>.jpg` |
| `processing/clips.py` (×2) | `immich_memories/clips/` |
| `processing/transforms.py` | `immich_memories/transformed/` |
| `analysis/scenes.py` | `immich_memories/keyframes/` |
| `analysis/llm_response_parser.py` | `immich_memories/content_frames/` |
| `audio/generators/base.py` | `musicgen/` |

A fixed name in a shared directory is a name another user on the host can claim
first — as a symlink we then write through, since the thumbnail is produced by
`ffmpeg -y`, or as a directory they can read our intermediates out of. The
thumbnail is the sharp one: its name is fully derivable from the output filename.

Only reachable on a multi-user host, which is not the common deployment. Low
severity, not none.

## The fix

`private_temp_dir(name)` puts all seven under `<tempdir>/immich-memories-<uid>/`
at `0700`, and refuses any component we do not own or that carries group/other
bits.

It uses `lstat`, not `stat`. The question is what the path *itself* is, and a
symlink pointing at a directory we own answers "directory, owned by you" through
`stat` — which is exactly the case the check exists to catch.

The notification thumbnail additionally moves to `mkstemp`, so its name is no
longer derivable from the video. The other six only needed the private root:
their contents are already keyed by content hash, so the names were never the
weak part.

## A test that was checking the wrong thing

`test_default_output_dir` asserted `"immich_memories" in str(extractor.output_dir)`
— the literal old path, not the property it existed to protect. It now asserts
owner and mode, which survives a rename and actually checks what matters.

## Note on the snapshot file

`complexipy-snapshot.json` is included. The per-file total for `security.py`
moves 36 → 39 because this adds two new functions, both under the threshold;
`configured_secret_values` holds at 23 and no per-function watermark changes.
Verified by diffing the JSON structurally rather than textually — see #453,
where the tooling makes this harder than it should be.

## Tests

`tests/test_private_temp_dir.py` — mode and ownership on the directory and its
parent, uid scoping, idempotence, and the two attack cases (a pre-placed symlink
and a world-writable directory).

Worth knowing: the first version of these tests was worthless in a way that
looked fine. `tempfile.gettempdir()` memoises into `tempfile.tempdir` on first
call and pytest touches the temp dir long before the test runs, so
`monkeypatch.setenv("TMPDIR", ...)` did nothing — the four passing tests were
silently exercising the real `/var/folders/…`. They now override
`tempfile.tempdir`, which is the documented seam.

`make check` green (5103 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qHRMEg5LDWNf1NjuMhrmX
