### PR TITLE
fix(ui): stop sending the Immich API key to the browser

### DIFF
--- a/docs-site/docs/create/web-ui/step1-configuration.mdx
+++ b/docs-site/docs/create/web-ui/step1-configuration.mdx
@@ -13,7 +13,7 @@ This is where you tell the tool what to work with. The sidebar calls this step *
 
 ## Immich Connection
 
-A collapsible panel with two fields, **Immich Server URL** and **API Key**, and two buttons: **Test Connection** and **Save Config**. If the URL and key are already in your `config.yaml` or environment variables, they are pre-filled and the page connects on its own when it loads. Once connected, the panel collapses to a one-line header, "Immich Connection — *your name*"; expand it again to change the credentials.
+A collapsible panel with two fields, **Immich Server URL** and **API Key**, and two buttons: **Test Connection** and **Save Config**. If the URL and key are already in your `config.yaml` or environment variables, the URL is pre-filled and the page connects on its own when it loads. The **API Key** field stays empty and reads *"Saved — type a new key to replace it"*: the stored key is never sent to the browser, so leaving the field alone keeps it, and typing in it replaces it. Once connected, the panel collapses to a one-line header, "Immich Connection — *your name*"; expand it again to change the credentials.
 
 The rest of the page (Memory Type, Options, Next) only appears after a successful connection.
 

--- a/src/immich_memories/ui/pages/step1_config.py
+++ b/src/immich_memories/ui/pages/step1_config.py
@@ -33,7 +33,7 @@ from immich_memories.ui.pages.step1_tabs import (
     _render_duration_tab,
     _render_year_tab,
 )
-from immich_memories.ui.state import get_app_state
+from immich_memories.ui.state import apply_api_key_entry, get_app_state
 
 if TYPE_CHECKING:
     from nicegui.elements.number import Number
@@ -69,11 +69,15 @@ def _render_immich_config_section(state) -> None:
                 placeholder="https://photos.example.com",
             ).classes("flex-1").bind_value(state, "immich_url")
 
+            # WHY the entry field: a binding is two-way, so binding the stored
+            # key would send it to every browser that loads this page --
+            # `password=True` masks it on screen, it does not withhold it.
             ui.input(
                 "API Key",
                 password=True,
                 password_toggle_button=True,
-            ).classes("flex-1").bind_value(state, "immich_api_key")
+                placeholder="Saved - type a new key to replace it" if state.immich_api_key else "",
+            ).classes("flex-1").bind_value(state, "api_key_entry")
 
         # Connection buttons
         status_label = ui.label("").classes("text-sm")
@@ -81,6 +85,7 @@ def _render_immich_config_section(state) -> None:
         with ui.row().classes("gap-2 mt-1"):
 
             async def test_connection() -> None:
+                apply_api_key_entry(state)
                 if not state.immich_url or not state.immich_api_key:
                     status_label.set_text("Please enter both URL and API key")
                     status_label.style("color: var(--im-error)")
@@ -130,6 +135,7 @@ def _render_immich_config_section(state) -> None:
                     status_label.style("color: var(--im-error)")
 
             def save_config() -> None:
+                apply_api_key_entry(state)
                 config = state.config
                 config.immich.url = state.immich_url
                 config.immich.api_key = state.immich_api_key

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -36,6 +36,10 @@ class AppState:
     config_saved: bool = False
     immich_url: str = ""
     immich_api_key: str = ""
+    # What the user typed into the API key field. Separate from the stored
+    # key because this one is bound to a widget, and a binding is two-way:
+    # whatever it holds is sent to the browser.
+    api_key_entry: str = ""
     immich_api_version: ApiVersionPolicy = ApiVersionPolicy.AUTO
 
     # Time period selection
@@ -200,6 +204,19 @@ class AppState:
     def target_duration_seconds(self) -> float:
         """Return the exact total runtime requested by Auto or Manual mode."""
         return self.target_duration * 60.0
+
+
+def apply_api_key_entry(state: AppState) -> None:
+    """Move a newly typed API key into the stored one, then forget the entry.
+
+    An empty field means "unchanged" rather than "clear it": the field always
+    loads empty, because filling it would mean sending the stored key to the
+    browser.
+    """
+    typed = state.api_key_entry.strip()
+    if typed:
+        state.immich_api_key = typed
+    state.api_key_entry = ""
 
 
 # Session store: maps session_id → AppState

--- a/tests/test_api_key_stays_server_side.py
+++ b/tests/test_api_key_stays_server_side.py
@@ -1,0 +1,69 @@
+"""The stored Immich API key must not reach the browser.
+
+`ui.input(password=True, password_toggle_button=True)` masks the value on
+screen; it does not withhold it. A two-way binding sends the real key to every
+client that loads Step 1, and the eye icon reveals it in one click. Auth is off
+by default and the UI binds 0.0.0.0, so on a default deployment that is anyone
+on the LAN.
+
+Every other reader of `state.immich_api_key` runs server-side -- NiceGUI event
+handlers execute on the server -- so the binding is the whole exposure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.ui.state import AppState, apply_api_key_entry
+
+_STEP1 = Path(__file__).resolve().parent.parent / "src/immich_memories/ui/pages/step1_config.py"
+
+
+class TestNoWidgetBindsTheStoredKey:
+    def test_step1_never_binds_the_stored_key(self):
+        """The one line that would send it to every browser."""
+        source = _STEP1.read_text()
+
+        assert 'bind_value(state, "immich_api_key")' not in source
+
+    def test_step1_binds_the_entry_field_instead(self):
+        source = _STEP1.read_text()
+
+        assert 'bind_value(state, "api_key_entry")' in source
+
+
+class TestApplyApiKeyEntry:
+    def test_a_typed_key_replaces_the_stored_one(self):
+        state = AppState()
+        state.immich_api_key = "old-key"
+        state.api_key_entry = "new-key"
+
+        apply_api_key_entry(state)
+
+        assert state.immich_api_key == "new-key"
+
+    def test_an_untouched_field_keeps_the_stored_key(self):
+        """The form loads empty, so empty means "unchanged", not "clear it"."""
+        state = AppState()
+        state.immich_api_key = "stored-key"
+        state.api_key_entry = ""
+
+        apply_api_key_entry(state)
+
+        assert state.immich_api_key == "stored-key"
+
+    def test_the_entry_is_cleared_so_it_is_not_re_sent(self):
+        state = AppState()
+        state.api_key_entry = "new-key"
+
+        apply_api_key_entry(state)
+
+        assert state.api_key_entry == ""
+
+    def test_surrounding_whitespace_is_dropped(self):
+        state = AppState()
+        state.api_key_entry = "  pasted-key\n"
+
+        apply_api_key_entry(state)
+
+        assert state.immich_api_key == "pasted-key"


### PR DESCRIPTION
Closes #456. S1 in `docs/reviews/2026-08-18-security-perf-review.md`.

## The leak

`ui/state.py` copied the stored key into per-session state, and
`ui/pages/step1_config.py` two-way-bound it into the form:

```python
ui.input("API Key", password=True, password_toggle_button=True)
   .bind_value(state, "immich_api_key")
```

`password=True` masks the value on screen. It does not withhold it — the real key
is in the DOM of every client that loads Step 1, and the eye icon reveals it in
one click.

Auth is off by default and the UI binds `0.0.0.0`, so on a default deployment
that is anyone on the LAN. With OIDC and no allow-list (#457, fixed separately)
it is any account on the tenant. The settings page redacts the same key, so the
two pages disagreed about whether it was a secret.

## Why this is one widget and not a refactor

There are two dozen other readers of `state.immich_api_key` — `step2_loading`,
`clip_pipeline`, `_step4_generate`, `step1_presets`, `step2_helpers`. Every one
of them runs **server-side**: NiceGUI event handlers execute on the server, and
only a binding crosses to the browser. So the binding was the entire exposure,
and the rest of the app needs no change.

## The fix

`AppState` gains `api_key_entry`, and that is what the widget binds. The stored
key never goes near a binding.

The field loads empty with the placeholder *"Saved — type a new key to replace
it"*, so empty means **unchanged**, not "clear it" — it has to, because filling
it would mean sending the key to the browser. `apply_api_key_entry()` promotes a
typed value into the stored key and clears the entry so it is not sent back;
both **Test Connection** and **Save Config** call it first.

Swept the rest of the UI for the same shape: the only other `password=True`
input is the login form, which is user-entered and binds nothing.

## Tests

`tests/test_api_key_stays_server_side.py` — that no widget binds the stored key
(the assertion that would have caught this originally), and the entry semantics:
a typed key replaces, an untouched field keeps, the entry is cleared, whitespace
is stripped.

## Docs

`step1-configuration.mdx` said both credentials "are pre-filled", which is no
longer true of the key.

`make check` green (5105 passed); `make docs-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qHRMEg5LDWNf1NjuMhrmX
