### PR TITLE
fix(analysis): keep objective scores when the LLM model changes

### DIFF
--- a/src/immich_memories/analysis/cache_projection.py
+++ b/src/immich_memories/analysis/cache_projection.py
@@ -12,6 +12,20 @@ if TYPE_CHECKING:
     from immich_memories.config_loader import Config
 
 
+def has_reusable_objective_analysis(cached: CachedVideoAnalysis | None) -> bool:
+    """Return whether a cache row's objective analysis (segments, vision/audio
+    scores) is reusable, regardless of which LLM produced any semantics.
+
+    Base scores are visual+audio+duration; the LLM only ever adds a bonus. A
+    model switch therefore stales the semantic payload, not the analysis —
+    treating it as a full miss degrades the whole library to metadata-fallback
+    scoring (#467).
+    """
+    if not (cached and cached.segments):
+        return False
+    return cached.analysis_version == ANALYSIS_VERSION
+
+
 def is_compatible_analysis_cache(cached: CachedVideoAnalysis | None, config: Config) -> bool:
     """Return whether a cache row is safe to reuse under the active configuration.
 

--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, cast
 from immich_memories.analysis.cache_projection import (
     apply_cached_segment,
     apply_semantic_payload,
+    has_reusable_objective_analysis,
     is_compatible_analysis_cache,
 )
 from immich_memories.processing.downscaler import cleanup_downscaled
@@ -229,19 +230,22 @@ class ClipAnalyzer:
         if not (cached and cached.segments and len(cached.segments) > 0):
             return None
 
-        if not is_compatible_analysis_cache(cached, self._app_config):
-            logger.info(
-                "Ignoring semantic cache for %s: cached model=%s, configured model=%s",
-                clip.asset.id,
-                cached.model_version or "none",
-                self._app_config.llm.model,
-            )
+        if not has_reusable_objective_analysis(cached):
             return None
 
         best = max(cached.segments, key=lambda s: s.total_score or 0.0)
         start, end, score = best.start_time, best.end_time, best.total_score or 0.0
 
-        cached_llm_analysis = apply_cached_segment(clip, best)
+        semantics_fresh = is_compatible_analysis_cache(cached, self._app_config)
+        if not semantics_fresh:
+            logger.info(
+                "Semantic cache stale for %s (cached model=%s, configured model=%s): "
+                "reusing objective scores, dropping semantics",
+                clip.asset.id,
+                cached.model_version or "none",
+                self._app_config.llm.model,
+            )
+        cached_llm_analysis = apply_cached_segment(clip, best) if semantics_fresh else None
 
         preview_path = self.preview_builder.find_cached_preview(clip.asset.id, start, end)
 

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -154,19 +154,29 @@ class TestCheckAnalysisCache:
 
         assert result is None
 
-    def test_semantic_cache_from_different_model_is_a_miss(self) -> None:
+    def test_model_switch_keeps_objective_scores_and_drops_semantics(self) -> None:
+        """A model change stales the SEMANTICS, not the vision analysis.
+
+        Base scores are visual+audio+duration; the LLM only adds a bonus. #467:
+        discarding the whole cache on a model switch degraded entire libraries
+        to metadata-fallback scoring (5 of 6 shipped clips content-blind).
+        """
         app_config = Config(
             llm={"model": "qwen-3.6"},
             content_analysis={"enabled": True},
         )
         analyzer, _, mock_cache, _ = _make_analyzer(app_config=app_config)
-        cached = _make_cached_analysis(_make_cached_segment(score=0.95))
+        cached = _make_cached_analysis(
+            _make_cached_segment(score=0.95, llm_description="old-model text", llm_emotion="joy")
+        )
         cached.model_version = "qwen-3.5"
         mock_cache.get_analysis.return_value = cached
 
         result = analyzer._check_analysis_cache(make_clip("asset-stale", duration=10.0))
 
-        assert result is None
+        assert result is not None
+        assert result[2] == 0.95  # objective score reused
+        assert result[4] is None  # stale semantics not applied
 
     def test_semantic_cache_from_configured_model_is_reused(self) -> None:
         app_config = Config(


### PR DESCRIPTION
Closes #467. Root cause 2 from the #463 selection investigation.

## What

`is_compatible_analysis_cache` answered two questions with one bool — "is this analysis reusable" and "are its semantics from the active model" — so a model switch voided the entire cached analysis and the clip fell back to a metadata-only score. Measured impact in #463: 5 of 6 shipped clips selected content-blind.

The score architecture makes the discard needless: base score is visual+audio+duration, the LLM only adds a bonus. An analysis from a different model is at worst missing a bonus, never wrong.

Split the question:
- `has_reusable_objective_analysis` — structural gate (segments exist, `ANALYSIS_VERSION` matches). Version bumps remain intentional epochs.
- model comparison — now decides only whether the cached semantic payload is applied, with a log naming semantics stale instead of pretending a full miss.

`smart_pipeline._semantic_cache_miss_count` and step2's cache surfacing intentionally keep full-freshness semantics — they answer "needs re-analysis under the active model?", which is a different question.

## Found while verifying, not fixed here

The library cache holds 1037 analyzed assets, 88% orphaned by `ANALYSIS_VERSION` bumps (706×v9, 204×v12, 127 current — 738 with paid-for LLM descriptions). The old "Ignoring semantic cache … model=…" message conflated version- and model-staleness. Version-stale recovery is #468's multi-pass loop or a bulk re-analyze — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM