### PR TITLE
feat(selection): verify pass — what ships must be analyzed

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,43 +6,31 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 529,
-        "line_end": 572,
+        "line_start": 533,
+        "line_end": 576,
         "line_complexities": [
           {
-            "line": 539,
-            "complexity": 0
-          },
-          {
-            "line": 540,
-            "complexity": 1
-          },
-          {
-            "line": 541,
+            "line": 543,
             "complexity": 0
           },
           {
             "line": 544,
-            "complexity": 0
-          },
-          {
-            "line": 545,
             "complexity": 1
           },
           {
-            "line": 546,
+            "line": 545,
+            "complexity": 0
+          },
+          {
+            "line": 548,
             "complexity": 0
           },
           {
             "line": 549,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 550,
-            "complexity": 0
-          },
-          {
-            "line": 552,
             "complexity": 0
           },
           {
@@ -51,50 +39,62 @@
           },
           {
             "line": 554,
-            "complexity": 1
-          },
-          {
-            "line": 555,
             "complexity": 0
           },
           {
             "line": 556,
-            "complexity": 2
+            "complexity": 0
+          },
+          {
+            "line": 557,
+            "complexity": 0
           },
           {
             "line": 558,
+            "complexity": 1
+          },
+          {
+            "line": 559,
             "complexity": 0
           },
           {
             "line": 560,
-            "complexity": 0
-          },
-          {
-            "line": 561,
-            "complexity": 1
-          },
-          {
-            "line": 562,
             "complexity": 2
           },
           {
-            "line": 563,
+            "line": 562,
             "complexity": 0
           },
           {
             "line": 564,
-            "complexity": 3
+            "complexity": 0
+          },
+          {
+            "line": 565,
+            "complexity": 1
           },
           {
             "line": 566,
-            "complexity": 4
+            "complexity": 2
           },
           {
             "line": 567,
+            "complexity": 0
+          },
+          {
+            "line": 568,
+            "complexity": 3
+          },
+          {
+            "line": 570,
+            "complexity": 4
+          },
+          {
+            "line": 571,
             "complexity": 5
           },
           {
-            "line": 572,
+            "line": 576,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -218,7 +218,13 @@ class ClipAnalyzer:
         else:
             start, end, score, _preview_path, llm_analysis = cached
             apply_semantic_payload(clip, llm_analysis)
-        return ClipWithSegment(clip=clip, start_time=start, end_time=end, score=score)
+        return ClipWithSegment(
+            clip=clip,
+            start_time=start,
+            end_time=end,
+            score=score,
+            analyzed=cached is not None,
+        )
 
     def _check_analysis_cache(
         self,

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from immich_memories.analysis.clip_scaler import ClipScaler
-    from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+    from immich_memories.analysis.smart_pipeline import (
+        ClipWithSegment,
+        PipelineConfig,
+        PipelineResult,
+    )
     from immich_memories.api.models import VideoClipInfo
 
 logger = logging.getLogger(__name__)
@@ -836,7 +840,7 @@ class ClipRefiner:
         self,
         analyzed: list[ClipWithSegment],
         tracker: object,
-    ) -> object:
+    ) -> PipelineResult:
         """Phase 4: Refine final selection."""
         from immich_memories.analysis.progress import PipelinePhase
         from immich_memories.analysis.smart_pipeline import PipelineResult

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -68,6 +68,9 @@ class PipelineConfig:
 
     # Selection settings
     target_clips: int = 120  # Target number of clips to select
+    # Verify passes (#468): re-analyze shipped fallback-scored clips and
+    # re-select, until nothing shipping is a guess or the budget is spent.
+    max_refinement_passes: int = 3
     avg_clip_duration: float = 5.0  # Average clip duration in final video
     target_duration_seconds: float | None = None  # Explicit strict content budget
     hdr_only: bool = False  # Only select HDR clips
@@ -133,6 +136,9 @@ class ClipWithSegment:
     start_time: float
     end_time: float
     score: float
+    # WHY: the verify pass (#468) must tell real analysis from a metadata
+    # guess — a fallback score is a placeholder, not a rank.
+    analyzed: bool = True
 
 
 class SmartPipeline:
@@ -308,6 +314,51 @@ class SmartPipeline:
         self.tracker.complete_item("filters")
         self.tracker.complete_phase()
 
+    def _verify_selection(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> PipelineResult:
+        """Re-analyze any shipped fallback-scored clip and re-select (#468).
+
+        Heavy when cold, cheap when warm: every verified clip lands in the
+        analysis cache, so later runs start from real scores. A clip whose
+        analysis fails keeps its fallback score but stops being re-queued,
+        so the loop always terminates.
+        """
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        for _ in range(max(0, self.config.max_refinement_passes - 1)):
+            unverified = [
+                by_id[c.asset.id]
+                for c in result.selected_clips
+                if c.asset.id in by_id and not by_id[c.asset.id].analyzed
+            ]
+            if not unverified:
+                break
+            logger.info(
+                "Verify pass: analyzing %d selected clip(s) shipping on fallback scores",
+                len(unverified),
+            )
+            try:
+                verified = self.analyzer.phase_analyze([u.clip for u in unverified], self.tracker)
+            finally:
+                with contextlib.suppress(Exception):
+                    self.analyzer.close()
+            verified_ids = {v.clip.asset.id for v in verified}
+            for v in verified:
+                by_id[v.clip.asset.id] = v
+            for u in unverified:
+                if u.clip.asset.id not in verified_ids:
+                    by_id[u.clip.asset.id] = ClipWithSegment(
+                        clip=u.clip,
+                        start_time=u.start_time,
+                        end_time=u.end_time,
+                        score=u.score,
+                        analyzed=True,
+                    )
+            result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
+        return result
+
     def _semantic_cache_miss_count(self, clips: list[VideoClipInfo]) -> int:
         """Count clips that need work under the exact active semantic model."""
         from immich_memories.analysis.cache_projection import is_compatible_analysis_cache
@@ -363,8 +414,16 @@ class SmartPipeline:
         self,
         analyzed: list[ClipWithSegment],
         progress_callback: Callable[[dict], None] | None = None,
+        *,
+        verify: bool = True,
     ) -> PipelineResult:
-        """Run phase 4 (refine) on pre-analyzed clips. Finishes the tracker."""
+        """Run phase 4 (refine) on pre-analyzed clips. Finishes the tracker.
+
+        With ``verify`` (the default), selection runs the #468 verify loop:
+        any selected clip whose score is a metadata guess is analyzed for
+        real and selection re-runs, so nothing ships unseen. ``verify=False``
+        is for planning/dry-run paths that must stay local.
+        """
         if progress_callback:
             self.tracker.add_callback(
                 lambda _: progress_callback(self.tracker.get_status_summary())
@@ -372,6 +431,8 @@ class SmartPipeline:
 
         try:
             result = self.refiner.phase_refine(analyzed, self.tracker)
+            if verify:
+                result = self._verify_selection(analyzed, result)
             self.tracker.finish()
             return result
         except (

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -413,7 +413,7 @@ def run_pipeline_and_generate(
 
     # Phase 4: Unified selection (videos + photos compete together)
     phases.emit(OperationalPhase.SELECTION, 0, len(all_candidates), "Selecting clips")
-    pipeline_result = pipeline.run_selection(all_candidates)
+    pipeline_result = pipeline.run_selection(all_candidates, verify=not dry_run)
     _analysis_time = _time.monotonic() - _pipeline_start
     selected_clips = pipeline_result.selected_clips
     clip_segments = pipeline_result.clip_segments

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -1047,3 +1047,25 @@ class TestPhaseAnalyzeOrchestration:
 
         assert analyzer._cached_content_analyzer is None
         assert analyzer._cached_audio_analyzer is None
+
+
+class TestFallbackProvenance:
+    """#468: the verify pass must know which shipped clips were guesses."""
+
+    def test_a_metadata_fallback_is_marked_unanalyzed(self) -> None:
+        analyzer, _, mock_cache, _ = _make_analyzer(avg_clip_duration=5.0)
+        mock_cache.get_analysis.return_value = None
+
+        (planned,) = analyzer.plan_cached_or_metadata([make_clip("asset-x", duration=12.0)])
+
+        assert planned.analyzed is False
+
+    def test_a_cached_analysis_is_marked_analyzed(self) -> None:
+        analyzer, _, mock_cache, _ = _make_analyzer()
+        mock_cache.get_analysis.return_value = _make_cached_analysis(
+            _make_cached_segment(score=0.9)
+        )
+
+        (planned,) = analyzer.plan_cached_or_metadata([make_clip("asset-y", duration=10.0)])
+
+        assert planned.analyzed is True

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -347,3 +347,94 @@ class TestSmartPipelineIntegration:
         result2 = pipeline.run(clips)
 
         assert len(result1.selected_clips) == len(result2.selected_clips)
+
+
+class TestVerifyPass:
+    """#468: what ships must be analyzed — a fallback score is a placeholder,
+    not a rank, and the verify pass replaces it with the real thing."""
+
+    def _make_pipeline(self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache):
+        return SmartPipeline(
+            client=mock_immich_client,
+            analysis_cache=mock_analysis_cache,
+            thumbnail_cache=mock_thumbnail_cache,
+            config=PipelineConfig(target_clips=10, avg_clip_duration=5.0),
+            analysis_config=AnalysisConfig(),
+            app_config=Config(),
+        )
+
+    def _fallback(self, pipeline, clip, score: float):
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score, analyzed=False)
+
+    def _analyzed(self, clip, score: float):
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score)
+
+    def test_a_shipped_fallback_clip_is_analyzed_before_assembly(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(3)
+        candidates = [
+            self._analyzed(clips[0], 0.8),
+            self._analyzed(clips[1], 0.7),
+            self._fallback(pipeline, clips[2], 0.4),
+        ]
+
+        # WHY: phase_analyze downloads and scores real video — the external boundary
+        verified = self._analyzed(clips[2], 0.75)
+        pipeline.analyzer.phase_analyze = MagicMock(return_value=[verified])
+
+        result = pipeline.run_selection(candidates)
+
+        analyzed_ids = [c.asset.id for c in pipeline.analyzer.phase_analyze.call_args[0][0]]
+        assert analyzed_ids == [clips[2].asset.id]
+        assert clips[2].asset.id in {c.asset.id for c in result.selected_clips}
+
+    def test_a_verified_clip_whose_score_collapses_is_replaced(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(3)
+        # tight budget: only 2 of 3 fit; the fallback's optimistic 0.9 wins pass 1
+        pipeline.config.target_duration_seconds = 10.0
+        candidates = [
+            self._analyzed(clips[0], 0.8),
+            self._analyzed(clips[1], 0.7),
+            self._fallback(pipeline, clips[2], 0.9),
+        ]
+
+        # WHY: real analysis is the boundary; it reveals the clip is bad (feet)
+        collapsed = self._analyzed(clips[2], 0.05)
+        pipeline.analyzer.phase_analyze = MagicMock(return_value=[collapsed])
+
+        result = pipeline.run_selection(candidates)
+
+        selected = {c.asset.id for c in result.selected_clips}
+        assert clips[2].asset.id not in selected
+
+    def test_dry_run_planning_never_analyzes(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(2)
+        candidates = [
+            self._analyzed(clips[0], 0.8),
+            self._fallback(pipeline, clips[1], 0.4),
+        ]
+        pipeline.analyzer.phase_analyze = MagicMock(
+            side_effect=AssertionError("dry-run must stay local")
+        )
+
+        result = pipeline.run_selection(candidates, verify=False)
+
+        assert result.selected_clips


### PR DESCRIPTION
First slice of #468, closing the mechanism measured in #463: 5 of 6 shipped clips were selected on metadata-fallback scores, so the subject policy never saw what actually went into the video — a feet clip closed a memory carrying the lowest score in the timeline.

## What

- `ClipWithSegment.analyzed` records whether a score came from real analysis or a metadata guess (`plan_cached_or_metadata` marks its guesses).
- `run_selection` now runs the verify loop: any **selected** clip shipping on a guess is analyzed for real (`phase_analyze` on just those clips), then selection re-runs — up to `max_refinement_passes` (default 3), so a displaced selection surfacing new guesses converges. A clip whose analysis fails keeps its fallback score but stops being re-queued: the loop always terminates.
- Heavy when cold, cheap when warm: every verified clip lands in the analysis cache for the next run. Combined with #469, a warm library converges in one pass.
- Dry-run planning passes `verify=False` and stays fully local (tested: analysis in dry-run raises).

## Not in this PR

The #468 global-quality judge (boundary strength, min/mean gate, holding Live Photos to the video bar) is the next slice; #468 stays open to track it.

Refs #468, #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM