### PR TITLE
test(conftest): mark integration tests by path so a marker cannot be forgotten

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,3 +218,15 @@ def _no_leaked_drain_threads():
         f"stderr drain thread(s) outlived this test: {leaked} — a mocked pipe "
         'never reached EOF; use stderr.read.side_effect = [data, b""]'
     )
+
+
+def pytest_collection_modifyitems(items) -> None:
+    """Mark everything under tests/integration/ as integration, by path.
+
+    WHY: `pytestmark` in a conftest does nothing, so a forgotten decorator
+    silently runs an integration test in every unit job (#450). Path-based
+    marking cannot be forgotten.
+    """
+    for item in items:
+        if "tests/integration" in item.path.as_posix():
+            item.add_marker("integration")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,7 +77,8 @@ def _has_ffmpeg() -> bool:
 
 # WHY: integration tests spawn FFmpeg subprocesses (CPU + memory heavy).
 # xdist_group serializes them on one worker while unit tests fly in parallel.
-pytestmark = [pytest.mark.integration, pytest.mark.xdist_group("ffmpeg")]
+# (markers are applied by path in tests/conftest.py — pytestmark in a
+# conftest has never worked; see #450)
 requires_ffmpeg = pytest.mark.skipif(not _has_ffmpeg(), reason="FFmpeg not available")
 
 

--- a/tests/test_integration_marker_guard.py
+++ b/tests/test_integration_marker_guard.py
@@ -1,0 +1,33 @@
+"""No test under tests/integration/ may leak into the unit suite (#450).
+
+`pytestmark` in a conftest does nothing — markers only work in test modules —
+so a forgotten `@pytest.mark.integration` silently ran a mega-flow test in
+every unit CI job (+450 MB, real pipeline work). The root conftest now marks
+by path, so the marker cannot be forgotten.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests.conftest import pytest_collection_modifyitems
+
+
+def _item(path: str):
+    markers: list = []
+    return SimpleNamespace(
+        path=Path(path),
+        add_marker=markers.append,
+        markers=markers,
+    )
+
+
+def test_integration_tests_are_marked_by_path():
+    inside = _item("/repo/tests/integration/pipeline/test_mega_flows.py")
+    outside = _item("/repo/tests/test_models.py")
+
+    pytest_collection_modifyitems([inside, outside])
+
+    assert inside.markers == ["integration"]
+    assert outside.markers == []


### PR DESCRIPTION
Closes #450. Found while profiling the exit-137 kills: `test_twelve_day_auto_trip_deeply_analyzes_the_manageable_pool` (#277) had no `@pytest.mark.integration`, so it ran real pipeline work in every unit CI job (+450 MB). The `pytestmark` line in `tests/integration/conftest.py` never guarded anything — pytestmark only works in test modules.

The root conftest now marks everything under `tests/integration/` by path, so a forgotten decorator cannot leak a test into the unit suite again.

Verified: `pytest tests/integration -m "not integration"` collected **1/632 before, 0/632 after**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM