### PR TITLE
fix(tracking): store the run's target duration in seconds, not floored minutes

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -5375,28 +5375,20 @@
       {
         "name": "RunDatabase::update_run_status",
         "complexity": 18,
-        "line_start": 331,
-        "line_end": 392,
+        "line_start": 339,
+        "line_end": 400,
         "line_complexities": [
           {
-            "line": 346,
-            "complexity": 0
-          },
-          {
-            "line": 347,
-            "complexity": 0
-          },
-          {
-            "line": 348,
-            "complexity": 0
-          },
-          {
-            "line": 350,
-            "complexity": 2
-          },
-          {
             "line": 354,
-            "complexity": 2
+            "complexity": 0
+          },
+          {
+            "line": 355,
+            "complexity": 0
+          },
+          {
+            "line": 356,
+            "complexity": 0
           },
           {
             "line": 358,
@@ -5425,42 +5417,34 @@
           {
             "line": 382,
             "complexity": 2
+          },
+          {
+            "line": 386,
+            "complexity": 2
+          },
+          {
+            "line": 390,
+            "complexity": 2
           }
         ]
       },
       {
         "name": "RunDatabase::update_operational_phase",
         "complexity": 21,
-        "line_start": 241,
-        "line_end": 274,
+        "line_start": 249,
+        "line_end": 282,
         "line_complexities": [
           {
-            "line": 243,
-            "complexity": 0
-          },
-          {
-            "line": 244,
-            "complexity": 0
-          },
-          {
-            "line": 248,
-            "complexity": 2
-          },
-          {
-            "line": 249,
-            "complexity": 0
-          },
-          {
-            "line": 250,
-            "complexity": 2
-          },
-          {
             "line": 251,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 252,
             "complexity": 0
+          },
+          {
+            "line": 256,
+            "complexity": 2
           },
           {
             "line": 257,
@@ -5472,22 +5456,38 @@
           },
           {
             "line": 259,
-            "complexity": 0
-          },
-          {
-            "line": 262,
             "complexity": 3
           },
           {
-            "line": 263,
+            "line": 260,
+            "complexity": 0
+          },
+          {
+            "line": 265,
+            "complexity": 0
+          },
+          {
+            "line": 266,
+            "complexity": 2
+          },
+          {
+            "line": 267,
+            "complexity": 0
+          },
+          {
+            "line": 270,
+            "complexity": 3
+          },
+          {
+            "line": 271,
             "complexity": 4
           },
           {
-            "line": 268,
+            "line": 276,
             "complexity": 5
           },
           {
-            "line": 274,
+            "line": 282,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/cache/database.py
+++ b/src/immich_memories/cache/database.py
@@ -26,6 +26,7 @@ from immich_memories.cache.migration_v14 import migrate_operational_phases
 from immich_memories.cache.migration_v15 import migrate_notification_health
 from immich_memories.cache.migration_v16 import migrate_video_analysis_model_version
 from immich_memories.cache.migration_v17 import migrate_segment_transcripts
+from immich_memories.cache.migration_v19 import migrate_target_duration_seconds
 from immich_memories.cache.versions import ANALYSIS_VERSION, SCHEMA_VERSION, SCORING_VERSION
 
 if TYPE_CHECKING:
@@ -108,6 +109,7 @@ class VideoAnalysisCache:
             16: migrate_video_analysis_model_version,
             17: migrate_segment_transcripts,
             18: self._migration_v18_llm_category,
+            19: migrate_target_duration_seconds,
         }
 
         for version in range(from_version + 1, SCHEMA_VERSION + 1):

--- a/src/immich_memories/cache/migration_v19.py
+++ b/src/immich_memories/cache/migration_v19.py
@@ -1,0 +1,34 @@
+"""v19: store the run's target duration in seconds, not minutes (#411).
+
+`target_duration_minutes` floors a 25 s target to 0, and the read path's
+`(0 or 10) * 60` turned that into the 600 s preset default — run_metadata
+claimed 10 minutes for every sub-minute run. Seconds are the unit every
+producer already uses; old rows backfill from minutes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate_target_duration_seconds(conn: sqlite3.Connection) -> None:
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'pipeline_runs'"
+    ).fetchone()
+    if table_exists is None:
+        return
+
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(pipeline_runs)")}
+    if "target_duration_seconds" in existing:
+        return
+
+    conn.execute("ALTER TABLE pipeline_runs ADD COLUMN target_duration_seconds INTEGER")
+    # WHY the column check: minimal fixture databases (and any schema old
+    # enough) may lack the minutes column entirely; they get the old default.
+    if "target_duration_minutes" in existing:
+        conn.execute(
+            "UPDATE pipeline_runs SET target_duration_seconds ="
+            " COALESCE(target_duration_minutes, 10) * 60"
+        )
+    else:
+        conn.execute("UPDATE pipeline_runs SET target_duration_seconds = 600")

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 ANALYSIS_VERSION = 14
 SCORING_VERSION = 3

--- a/src/immich_memories/tracking/run_database.py
+++ b/src/immich_memories/tracking/run_database.py
@@ -104,7 +104,15 @@ def row_to_run(row: sqlite3.Row) -> RunMetadata:
         date_range_end=(
             date.fromisoformat(row["date_range_end"]) if row["date_range_end"] else None
         ),
-        target_duration_seconds=(row["target_duration_minutes"] or 10) * 60,
+        # WHY the keys() check: a reader can hold a connection while another
+        # process is mid-migration (the concurrent-upgrade tests pin that
+        # window), and sqlite3.Row raises on a column that does not exist yet.
+        target_duration_seconds=(
+            row["target_duration_seconds"]
+            if "target_duration_seconds" in row.keys()  # noqa: SIM118 — sqlite3.Row `in` checks values, not keys
+            and row["target_duration_seconds"] is not None
+            else (row["target_duration_minutes"] or 10) * 60
+        ),
         output_path=row["output_path"],
         output_size_bytes=row["output_size_bytes"] or 0,
         output_duration_seconds=row["output_duration_seconds"] or 0.0,
@@ -195,7 +203,7 @@ class RunDatabase:
                     automation_attempt_id,
                     last_phase,
                     person_name, person_id, date_range_start, date_range_end,
-                    target_duration_minutes, output_path, output_size_bytes,
+                    target_duration_seconds, output_path, output_size_bytes,
                     output_duration_seconds, clips_analyzed, clips_selected,
                     errors_count, system_info, delivery_status, delivery_attempts,
                     delivery_error, immich_asset_id, delivery_album, warnings_json
@@ -218,7 +226,7 @@ class RunDatabase:
                     run.person_id,
                     run.date_range_start.isoformat() if run.date_range_start else None,
                     run.date_range_end.isoformat() if run.date_range_end else None,
-                    run.target_duration_seconds // 60,
+                    run.target_duration_seconds,
                     run.output_path,
                     run.output_size_bytes,
                     run.output_duration_seconds,

--- a/tests/test_run_database_fk.py
+++ b/tests/test_run_database_fk.py
@@ -89,6 +89,8 @@ class TestSavePhaseStatsFKConstraint:
 
     def test_valid_run_id_saves_normally(self, db):
         """Phase stats with a valid run_id are saved successfully."""
+        from datetime import datetime
+
         from immich_memories.tracking.models import RunMetadata
 
         run = RunMetadata(
@@ -506,3 +508,68 @@ def test_completed_automation_attempt_identity_rejects_ambiguity(db: RunDatabase
             "attempt-duplicate",
             memory_key="trip:key",
         )
+
+
+class TestTargetDurationSurvivesTheRoundTrip:
+    """#411: a 25s target was stored as 25//60 = 0 minutes and read back as
+    (0 or 10)*60 = 600 — run_metadata claimed the preset default for every
+    sub-minute or non-round-minute run."""
+
+    def test_a_sub_minute_target_is_preserved(self, tmp_path: Path) -> None:
+        from datetime import UTC, datetime
+
+        from immich_memories.tracking.models import RunMetadata
+
+        db = RunDatabase(db_path=tmp_path / "t.db")
+        run = RunMetadata(
+            run_id="r-25s",
+            created_at=datetime(2026, 8, 21, tzinfo=UTC),
+            target_duration_seconds=25,
+        )
+        db.save_run(run)
+
+        loaded = db.get_run("r-25s")
+
+        assert loaded is not None
+        assert loaded.target_duration_seconds == 25
+
+    def test_a_pre_migration_row_backfills_from_minutes(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        from immich_memories.cache import database as cache_database
+
+        db_path = tmp_path / "old.db"
+        current = cache_database.SCHEMA_VERSION
+        try:
+            cache_database.SCHEMA_VERSION = 18
+            RunDatabase(db_path)
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "INSERT INTO pipeline_runs (run_id, created_at, status, target_duration_minutes)"
+                    " VALUES ('r-old', '2026-08-01', 'completed', 10)"
+                )
+        finally:
+            cache_database.SCHEMA_VERSION = current
+
+        db = RunDatabase(db_path)  # migrates
+        loaded = db.get_run("r-old")
+
+        assert loaded is not None
+        assert loaded.target_duration_seconds == 600
+
+    def test_v19_tolerates_a_missing_table_and_reruns(self, tmp_path: Path) -> None:
+        """A migration must be a no-op on a db without the table, and re-entrant
+        when the column already exists (interrupted upgrade, restarted)."""
+        import sqlite3
+
+        from immich_memories.cache.migration_v19 import migrate_target_duration_seconds
+
+        with sqlite3.connect(tmp_path / "no-table.db") as conn:
+            migrate_target_duration_seconds(conn)  # no pipeline_runs — no-op
+
+        RunDatabase(db_path=tmp_path / "t.db")  # fully migrated
+        with sqlite3.connect(tmp_path / "t.db") as conn:
+            migrate_target_duration_seconds(conn)  # column exists — no-op
+            cols = [r[1] for r in conn.execute("PRAGMA table_info(pipeline_runs)")]
+
+        assert cols.count("target_duration_seconds") == 1


### PR DESCRIPTION
Closes #411. Noticed while using run metadata as evidence in the #463 investigation: a `--duration 25` run recorded `target_duration_seconds: 600`.

## Root cause

The DB column held **minutes**: `25 s // 60 = 0` on write, and the read path's `(0 or 10) * 60` resurrected the 10-minute preset default. Every sub-minute or non-round-minute target was misreported.

## Fix

- Migration **v19** adds `target_duration_seconds`, backfilled `minutes * 60` (600 when even the minutes column is absent — minimal fixture schemas lack it; caught by the full-suite hook run).
- `save_run`/`get_run` move to the seconds column.
- The read keeps a guarded fallback for a connection observing a mid-migration schema — the concurrent-upgrade window the v9/v10 tests pin. (`in row.keys()` is deliberate: `in` on `sqlite3.Row` checks values, not keys.)
- Migration is re-entrant and a no-op without the table, both tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM