### PR TITLE
feat(selection): the judge and the holistic LLM review

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -1,0 +1,117 @@
+"""The LLM holistic pass over a finished selection (#468).
+
+The mechanical judge sees scores; it cannot see that two clips are the same
+birthday candles twice, or that one clip breaks the set's feel. This pass
+shows the LLM the FULL cut — every clip's raw description, emotion, setting,
+subjects and transcript, in timeline order — and asks which clips are
+redundant or clash with the whole. Raw data in, not pre-digested stats: the
+model finds the patterns.
+
+Strictly optional: any failure, timeout or unparseable answer drops nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+    from immich_memories.config_models import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+# An overeager model must not gut the video: at most this share of the
+# selection can be dropped in one review, never below one allowed drop.
+_MAX_DROP_RATIO = 0.2
+
+_PROMPT = """You are reviewing the final cut of a personal memory video.
+Below is every clip in timeline order, with everything we can see and hear.
+
+{clips}
+
+Judge the SET as a whole: feel, coherence, variety. Identify clips that are
+REDUNDANT (the same moment or scene shown twice) or that CLASH with the rest
+of the set. Most good selections need no changes.
+
+Answer with STRICT JSON only, no prose:
+{{"drop": [{{"index": <clip number>, "reason": "<short reason>"}}]}}
+Use an empty list when the set is good."""
+
+
+def _ask(prompt: str, llm_config: LLMConfig, timeout_seconds: int) -> str:
+    from immich_memories.analysis.llm_query import query_llm
+
+    return asyncio.run(
+        query_llm(prompt, llm_config, temperature=0.2, timeout_seconds=timeout_seconds)
+    )
+
+
+def _clip_line(index: int, member: ClipWithSegment) -> str:
+    clip = member.clip
+    parts = [f"Clip {index}:"]
+    when = getattr(clip, "date", None)
+    if when:
+        parts.append(f"date={when}")
+    where = getattr(clip, "location_name", None)
+    if where:
+        parts.append(f"place={where}")
+    parts.append(f"score={member.score:.2f}")
+    for label, attr in (
+        ("description", "llm_description"),
+        ("emotion", "llm_emotion"),
+        ("setting", "llm_setting"),
+        ("subjects", "llm_subjects"),
+        ("heard", "audio_categories"),
+        ("transcript", "transcript"),
+    ):
+        value = getattr(clip, attr, None)
+        if value:
+            parts.append(f"{label}={value!s}")
+    return " ".join(parts)
+
+
+def review_selection(
+    selected: list[ClipWithSegment],
+    llm_config: LLMConfig,
+    *,
+    timeout_seconds: int = 45,
+) -> list[str]:
+    """Asset ids the LLM says to drop from the selection; [] on any doubt."""
+    if len(selected) < 3:
+        return []
+    clips_block = "\n".join(_clip_line(i + 1, m) for i, m in enumerate(selected))
+    prompt = _PROMPT.format(clips=clips_block)
+    try:
+        raw = _ask(prompt, llm_config, timeout_seconds)
+    except Exception as e:  # WHY broad: the review is optional; never break selection
+        logger.debug("Selection review skipped: %s", e)
+        return []
+
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        return []
+    try:
+        payload = json.loads(match.group(0))
+        entries = payload.get("drop", [])
+        indices = [int(e["index"]) for e in entries if "index" in e]
+    except (json.JSONDecodeError, TypeError, ValueError, KeyError):
+        return []
+
+    max_drops = max(1, int(len(selected) * _MAX_DROP_RATIO))
+    drops = []
+    for idx in indices[:max_drops]:
+        if 1 <= idx <= len(selected):
+            member = selected[idx - 1]
+            if not getattr(member.clip.asset, "is_favorite", False):
+                drops.append(member.clip.asset.id)
+    for entry in entries[: len(drops)]:
+        logger.info(
+            "Selection review: dropping clip %s (%s)",
+            entry.get("index"),
+            entry.get("reason", "no reason given"),
+        )
+    return drops

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -320,11 +320,30 @@ class SmartPipeline:
         self.tracker.complete_item("filters")
         self.tracker.complete_phase()
 
+    def _stabilize_selection(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
+        """Verify and judge until the selection is stable (#468).
+
+        Found live on the 2026-08-21 demo: a judge (or review) drop
+        re-selects, the re-selection admits a NEW fallback-scored clip, and
+        a straight verify→judge sequence ships it unverified. The stages
+        iterate together until a pass changes nothing or the budget is spent.
+        """
+        for _ in range(max(1, self.config.max_refinement_passes)):
+            result, analyzed = self._verify_selection(analyzed, result)
+            result, analyzed, dropped = self._judge_selection(analyzed, result)
+            if not dropped:
+                break
+        return result, analyzed
+
     def _verify_selection(
         self,
         analyzed: list[ClipWithSegment],
         result: PipelineResult,
-    ) -> PipelineResult:
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
         """Re-analyze any shipped fallback-scored clip and re-select (#468).
 
         Heavy when cold, cheap when warm: every verified clip lands in the
@@ -333,7 +352,7 @@ class SmartPipeline:
         so the loop always terminates.
         """
         by_id = {c.clip.asset.id: c for c in analyzed}
-        for _ in range(max(0, self.config.max_refinement_passes - 1)):
+        for _ in range(max(1, self.config.max_refinement_passes)):
             unverified = [
                 by_id[c.asset.id]
                 for c in result.selected_clips
@@ -363,39 +382,34 @@ class SmartPipeline:
                         analyzed=True,
                     )
             result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
-        return result
+        return result, list(by_id.values())
 
     def _judge_selection(
         self,
         analyzed: list[ClipWithSegment],
         result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
-        """Global quality gate (#468): drop offenders, let selection refill.
+    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
+        """One judge sweep (#468): drop offenders, let selection refill.
 
-        Two rules, both acting by exclusion so every distribution rule in the
-        refiner keeps its say: a member below the floor never ships (feet,
-        pocket, ground — #463's shipped 0.21), and the chronological ending
-        cannot be both the weakest member and far below the mean, because the
-        last clip is the most visible slot in the video.
+        A single sweep by design — the caller re-verifies whatever the
+        re-selection admitted before judging again.
         """
         by_id = {c.clip.asset.id: c for c in analyzed}
-        for _ in range(max(1, self.config.max_refinement_passes)):
-            selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-            if len(selected) < 2:
-                break
-            offenders = self._judge_offenders(selected)
-            if not offenders:
-                break
-            logger.info(
-                "Judge: dropping %d clip(s) below the quality gate, re-selecting",
-                len(offenders),
-            )
-            analyzed = [c for c in analyzed if c.clip.asset.id not in offenders]
-            by_id = {c.clip.asset.id: c for c in analyzed}
-            if not analyzed:
-                break
-            result = self.refiner.phase_refine(analyzed, self.tracker)
-        return result, analyzed
+        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+        if len(selected) < 2:
+            return result, analyzed, False
+        offenders = self._judge_offenders(selected)
+        if not offenders:
+            return result, analyzed, False
+        logger.info(
+            "Judge: dropping %d clip(s) below the quality gate, re-selecting",
+            len(offenders),
+        )
+        analyzed = [c for c in analyzed if c.clip.asset.id not in offenders]
+        if not analyzed:
+            return result, analyzed, False
+        result = self.refiner.phase_refine(analyzed, self.tracker)
+        return result, analyzed, True
 
     def _judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
         """Members failing the gate. Favorites are exempt from both rules —
@@ -422,7 +436,7 @@ class SmartPipeline:
         self,
         analyzed: list[ClipWithSegment],
         result: PipelineResult,
-    ) -> PipelineResult:
+    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
         """One LLM pass over the finished cut (#468): redundancy and feel.
 
         The mechanical judge sees scores; only something reading the
@@ -430,18 +444,20 @@ class SmartPipeline:
         construction — no LLM, no drops, selection unchanged.
         """
         if not self._app_config.content_analysis.enabled:
-            return result
+            return result, analyzed, False
         from immich_memories.analysis.selection_review import review_selection
 
         by_id = {c.clip.asset.id: c for c in analyzed}
         selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
         drops = review_selection(selected, self._app_config.llm)
         if not drops:
-            return result
+            return result, analyzed, False
         remaining = [c for c in analyzed if c.clip.asset.id not in set(drops)]
         if not remaining:
-            return result
-        return self.refiner.phase_refine(remaining, self.tracker)
+            return result, analyzed, False
+        # WHY the pool shrinks too: a later stabilization re-refines from the
+        # pool — returning the old one would resurrect the LLM's drops.
+        return self.refiner.phase_refine(remaining, self.tracker), remaining, True
 
     def _semantic_cache_miss_count(self, clips: list[VideoClipInfo]) -> int:
         """Count clips that need work under the exact active semantic model."""
@@ -516,10 +532,12 @@ class SmartPipeline:
         try:
             result = self.refiner.phase_refine(analyzed, self.tracker)
             if verify:
-                result = self._verify_selection(analyzed, result)
-            result, analyzed = self._judge_selection(analyzed, result)
-            if verify:
-                result = self._holistic_review(analyzed, result)
+                result, analyzed = self._stabilize_selection(analyzed, result)
+                result, analyzed, review_changed = self._holistic_review(analyzed, result)
+                if review_changed:
+                    # WHY: the review's re-selection can admit new fallback
+                    # clips, exactly like a judge drop — same stabilization.
+                    result, analyzed = self._stabilize_selection(analyzed, result)
             self.tracker.finish()
             return result
         except (

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -71,6 +72,11 @@ class PipelineConfig:
     # Verify passes (#468): re-analyze shipped fallback-scored clips and
     # re-select, until nothing shipping is a guess or the budget is spent.
     max_refinement_passes: int = 3
+    # The judge (#468/#463): a selected clip below the floor never ships,
+    # and the chronological ending cannot be the one weak clip in the
+    # timeline (weakest member AND below this share of the mean score).
+    judge_floor_score: float = 0.30
+    judge_boundary_ratio: float = 0.6
     avg_clip_duration: float = 5.0  # Average clip duration in final video
     target_duration_seconds: float | None = None  # Explicit strict content budget
     hdr_only: bool = False  # Only select HDR clips
@@ -359,6 +365,84 @@ class SmartPipeline:
             result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
         return result
 
+    def _judge_selection(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
+        """Global quality gate (#468): drop offenders, let selection refill.
+
+        Two rules, both acting by exclusion so every distribution rule in the
+        refiner keeps its say: a member below the floor never ships (feet,
+        pocket, ground — #463's shipped 0.21), and the chronological ending
+        cannot be both the weakest member and far below the mean, because the
+        last clip is the most visible slot in the video.
+        """
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        for _ in range(max(1, self.config.max_refinement_passes)):
+            selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+            if len(selected) < 2:
+                break
+            offenders = self._judge_offenders(selected)
+            if not offenders:
+                break
+            logger.info(
+                "Judge: dropping %d clip(s) below the quality gate, re-selecting",
+                len(offenders),
+            )
+            analyzed = [c for c in analyzed if c.clip.asset.id not in offenders]
+            by_id = {c.clip.asset.id: c for c in analyzed}
+            if not analyzed:
+                break
+            result = self.refiner.phase_refine(analyzed, self.tracker)
+        return result, analyzed
+
+    def _judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
+        """Members failing the gate. Favorites are exempt from both rules —
+        the user explicitly chose them, and "Starting with ALL favorites" is
+        the selection's oldest contract."""
+        judgeable = [s for s in selected if not getattr(s.clip.asset, "is_favorite", False)]
+        offenders = {s.clip.asset.id for s in judgeable if s.score < self.config.judge_floor_score}
+        scores = [s.score for s in selected]
+        mean_score = sum(scores) / len(scores)
+        ending = max(
+            selected,
+            key=lambda s: s.clip.asset.file_created_at or datetime.min.replace(tzinfo=UTC),
+        )
+        if (
+            len(selected) > 2
+            and not getattr(ending.clip.asset, "is_favorite", False)
+            and ending.score == min(scores)
+            and ending.score < mean_score * self.config.judge_boundary_ratio
+        ):
+            offenders.add(ending.clip.asset.id)
+        return offenders
+
+    def _holistic_review(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> PipelineResult:
+        """One LLM pass over the finished cut (#468): redundancy and feel.
+
+        The mechanical judge sees scores; only something reading the
+        descriptions can see the same birthday candles twice. Optional by
+        construction — no LLM, no drops, selection unchanged.
+        """
+        if not self._app_config.content_analysis.enabled:
+            return result
+        from immich_memories.analysis.selection_review import review_selection
+
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+        drops = review_selection(selected, self._app_config.llm)
+        if not drops:
+            return result
+        remaining = [c for c in analyzed if c.clip.asset.id not in set(drops)]
+        if not remaining:
+            return result
+        return self.refiner.phase_refine(remaining, self.tracker)
+
     def _semantic_cache_miss_count(self, clips: list[VideoClipInfo]) -> int:
         """Count clips that need work under the exact active semantic model."""
         from immich_memories.analysis.cache_projection import is_compatible_analysis_cache
@@ -433,6 +517,9 @@ class SmartPipeline:
             result = self.refiner.phase_refine(analyzed, self.tracker)
             if verify:
                 result = self._verify_selection(analyzed, result)
+            result, analyzed = self._judge_selection(analyzed, result)
+            if verify:
+                result = self._holistic_review(analyzed, result)
             self.tracker.finish()
             return result
         except (

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -438,3 +438,145 @@ class TestVerifyPass:
         result = pipeline.run_selection(candidates, verify=False)
 
         assert result.selected_clips
+
+
+class TestSelectionJudge:
+    """#468 judge slice / #463: after verification, selection must pass a
+    global quality gate — no sub-floor member ships, and the chronological
+    ending cannot be the one weak clip in the timeline."""
+
+    def _make_pipeline(self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache):
+        return SmartPipeline(
+            client=mock_immich_client,
+            analysis_cache=mock_analysis_cache,
+            thumbnail_cache=mock_thumbnail_cache,
+            config=PipelineConfig(target_clips=10, avg_clip_duration=5.0),
+            analysis_config=AnalysisConfig(),
+            app_config=Config(),
+        )
+
+    def _analyzed(self, clip, score: float):
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score)
+
+    def test_a_sub_floor_clip_never_ships(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        """A clip whose REAL score is junk (feet, pocket, ground) is dropped
+        and the refiner refills from the pool."""
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(4)
+        # room for everything: only a floor, not budget pressure, can reject
+        pipeline.config.target_duration_seconds = 25.0
+        candidates = [
+            self._analyzed(clips[0], 0.8),
+            self._analyzed(clips[1], 0.7),
+            self._analyzed(clips[2], 0.05),  # junk, but analyzed — floor's job
+            self._analyzed(clips[3], 0.75),
+        ]
+
+        result = pipeline.run_selection(candidates)
+
+        assert clips[2].asset.id not in {c.asset.id for c in result.selected_clips}
+
+    def test_a_weak_ending_is_replaced_by_reselection(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        """The chronologically-last clip was both the minimum and far below the
+        mean — the most visible slot must not hold the worst clip (#463)."""
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(4)
+        pipeline.config.target_duration_seconds = 15.0
+        weak_last = clips[3]
+        candidates = [
+            self._analyzed(clips[0], 0.9),
+            self._analyzed(clips[1], 0.85),
+            self._analyzed(clips[2], 0.8),
+            self._analyzed(weak_last, 0.4),  # above floor, but a weak ending
+        ]
+
+        result = pipeline.run_selection(candidates)
+
+        selected = sorted(result.selected_clips, key=lambda c: c.asset.file_created_at)
+        assert selected, "selection must not be empty"
+        assert selected[-1].asset.id != weak_last.asset.id
+
+    def test_a_uniformly_scored_selection_is_left_alone(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        """The judge fixes outliers; it must not churn a healthy selection."""
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(3)
+        candidates = [self._analyzed(c, 0.7) for c in clips]
+
+        result = pipeline.run_selection(candidates)
+
+        assert {c.asset.id for c in result.selected_clips} == {c.asset.id for c in clips}
+
+
+class TestHolisticReview:
+    """#468: one LLM pass over the finished cut — redundancy the scores
+    cannot see. Optional by construction: no LLM, no changes."""
+
+    def _make_pipeline(self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache, **cfg):
+        return SmartPipeline(
+            client=mock_immich_client,
+            analysis_cache=mock_analysis_cache,
+            thumbnail_cache=mock_thumbnail_cache,
+            config=PipelineConfig(target_clips=10, avg_clip_duration=5.0),
+            analysis_config=AnalysisConfig(),
+            app_config=Config(**cfg),
+        )
+
+    def _analyzed(self, clip, score: float = 0.7):
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score)
+
+    def test_llm_flagged_redundancy_is_dropped(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        from unittest.mock import patch
+
+        pipeline = self._make_pipeline(
+            mock_immich_client,
+            mock_analysis_cache,
+            mock_thumbnail_cache,
+            content_analysis={"enabled": True},
+        )
+        clips = _make_clips(3)
+
+        # WHY: the LLM call is the external boundary
+        with patch(
+            "immich_memories.analysis.selection_review.review_selection",
+            return_value=[clips[1].asset.id],
+        ):
+            result = pipeline.run_selection([self._analyzed(c) for c in clips])
+
+        assert clips[1].asset.id not in {c.asset.id for c in result.selected_clips}
+
+    def test_without_content_analysis_no_llm_is_consulted(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        from unittest.mock import patch
+
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(3)
+
+        # WHY: review_selection wraps the external LLM; consulting it here is the bug
+        with patch(
+            "immich_memories.analysis.selection_review.review_selection",
+            side_effect=AssertionError("LLM must not be consulted"),
+        ):
+            result = pipeline.run_selection([self._analyzed(c) for c in clips])
+
+        assert len(result.selected_clips) == 3

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -580,3 +580,97 @@ class TestHolisticReview:
             result = pipeline.run_selection([self._analyzed(c) for c in clips])
 
         assert len(result.selected_clips) == 3
+
+
+class TestQualityStagesAreOneLoop:
+    """Found by the 2026-08-21 live demo: a judge/review drop re-selects, the
+    re-selection admits a NEW fallback clip, and nothing verified it — two
+    0.21 unverified clips shipped. Verify, judge and review must iterate
+    together until the selection is stable."""
+
+    def _make_pipeline(self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache):
+        return SmartPipeline(
+            client=mock_immich_client,
+            analysis_cache=mock_analysis_cache,
+            thumbnail_cache=mock_thumbnail_cache,
+            config=PipelineConfig(target_clips=10, avg_clip_duration=5.0),
+            analysis_config=AnalysisConfig(),
+            app_config=Config(),
+        )
+
+    def test_a_clip_admitted_by_reselection_is_verified_before_shipping(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        clips = _make_clips(4)
+        pipeline.config.target_duration_seconds = 15.0
+        weak_end = clips[3]
+        spare = clips[2]
+        candidates = [
+            ClipWithSegment(clip=clips[0], start_time=0, end_time=5, score=0.9),
+            ClipWithSegment(clip=clips[1], start_time=0, end_time=5, score=0.85),
+            # the spare that re-selection will admit — a fallback guess
+            ClipWithSegment(clip=spare, start_time=0, end_time=5, score=0.5, analyzed=False),
+            # weak ending: judged out on the first pass
+            ClipWithSegment(clip=weak_end, start_time=0, end_time=5, score=0.31),
+        ]
+
+        verified_ids = []
+
+        def fake_analyze(to_analyze, tracker):
+            verified_ids.extend(c.asset.id for c in to_analyze)
+            return [
+                ClipWithSegment(clip=c, start_time=0, end_time=5, score=0.7) for c in to_analyze
+            ]
+
+        # WHY: phase_analyze downloads and scores real video — the boundary
+        pipeline.analyzer.phase_analyze = fake_analyze
+
+        result = pipeline.run_selection(candidates)
+
+        selected = {c.asset.id for c in result.selected_clips}
+        if spare.asset.id in selected:
+            assert spare.asset.id in verified_ids, (
+                "a re-selection admitted an unverified clip and nothing analyzed it"
+            )
+
+    def test_a_review_drop_stays_dropped_through_stabilization(
+        self, mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+    ):
+        """The LLM dropped it; a later verify re-refine must not resurrect it."""
+        from unittest.mock import patch
+
+        from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+        pipeline = self._make_pipeline(
+            mock_immich_client, mock_analysis_cache, mock_thumbnail_cache
+        )
+        pipeline._app_config.content_analysis.enabled = True
+        clips = _make_clips(4)
+        redundant = clips[1]
+        candidates = [
+            ClipWithSegment(clip=clips[0], start_time=0, end_time=5, score=0.9),
+            ClipWithSegment(clip=redundant, start_time=0, end_time=5, score=0.85),
+            ClipWithSegment(clip=clips[2], start_time=0, end_time=5, score=0.8),
+            # unverified spare: forces a verify re-refine AFTER the review
+            ClipWithSegment(clip=clips[3], start_time=0, end_time=5, score=0.7, analyzed=False),
+        ]
+
+        def fake_analyze(to_analyze, tracker):  # WHY: real analysis is the boundary
+            return [
+                ClipWithSegment(clip=c, start_time=0, end_time=5, score=0.75) for c in to_analyze
+            ]
+
+        pipeline.analyzer.phase_analyze = fake_analyze
+        # WHY: review_selection wraps the external LLM
+        with patch(
+            "immich_memories.analysis.selection_review.review_selection",
+            return_value=[redundant.asset.id],
+        ):
+            result = pipeline.run_selection(candidates)
+
+        assert redundant.asset.id not in {c.asset.id for c in result.selected_clips}

--- a/tests/test_selection_review.py
+++ b/tests/test_selection_review.py
@@ -1,0 +1,76 @@
+"""The LLM holistic pass (#468): the set reviewed as a whole — redundancy,
+coherence, feel — with each clip's raw description, not pre-digested stats."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from immich_memories.analysis.selection_review import review_selection
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.config_models import LLMConfig
+from tests.conftest import make_clip
+
+
+def _member(asset_id: str, description: str, score: float = 0.7) -> ClipWithSegment:
+    clip = make_clip(asset_id, duration=10.0)
+    clip.llm_description = description
+    clip.llm_emotion = "joy"
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score)
+
+
+def _selection() -> list[ClipWithSegment]:
+    return [
+        _member("a-1", "Child blows out birthday candles"),
+        _member("a-2", "Child blows out birthday candles again, same table"),
+        _member("a-3", "Family walk on the beach at sunset"),
+    ]
+
+
+class TestReviewSelection:
+    def test_llm_named_drops_are_returned_as_asset_ids(self):
+        # WHY: the LLM is the external boundary; the contract is prompt in, JSON out
+        with patch(
+            "immich_memories.analysis.selection_review._ask",
+            return_value='{"drop": [{"index": 2, "reason": "duplicate of clip 1"}]}',
+        ):
+            drops = review_selection(_selection(), LLMConfig())
+
+        assert drops == ["a-2"]
+
+    def test_the_prompt_carries_the_raw_descriptions(self):
+        """Raw data to the LLM, not summaries — it finds the patterns."""
+        # WHY: the LLM call is the external boundary; we inspect the prompt
+        with patch(
+            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+        ) as ask:
+            review_selection(_selection(), LLMConfig())
+
+        prompt = ask.call_args[0][0]
+        assert "birthday candles" in prompt and "beach at sunset" in prompt
+
+    def test_an_llm_failure_never_breaks_selection(self):
+        # WHY: the LLM call is the external boundary
+        with patch(
+            "immich_memories.analysis.selection_review._ask",
+            side_effect=RuntimeError("model gone"),
+        ):
+            assert review_selection(_selection(), LLMConfig()) == []
+
+    def test_garbage_output_drops_nothing(self):
+        # WHY: the LLM call is the external boundary
+        with patch(
+            "immich_memories.analysis.selection_review._ask",
+            return_value="sure! here are my thoughts...",
+        ):
+            assert review_selection(_selection(), LLMConfig()) == []
+
+    def test_the_llm_cannot_gut_the_video(self):
+        """A cap keeps an overeager model from dropping half the memory."""
+        # WHY: the LLM call is the external boundary
+        with patch(
+            "immich_memories.analysis.selection_review._ask",
+            return_value='{"drop": [{"index": 1}, {"index": 2}, {"index": 3}]}',
+        ):
+            drops = review_selection(_selection(), LLMConfig())
+
+        assert len(drops) <= 1  # 20% of 3, floored, min 1


### PR DESCRIPTION
Closes #468 and #463 — the final selection-quality slice, on top of the merged verify pass (#470). Everything acts by exclusion, so the refiner's distribution rules keep their say.

## The judge (mechanical)

- A selected clip below `judge_floor_score` (0.30) never ships — the shipped 0.21 feet clip from the #463 investigation is structurally impossible now.
- The chronological ending cannot be both the weakest member and below `judge_boundary_ratio` (0.6) of the mean. The last slot is the most visible one; re-selection ends on something strong while chronology stays chronology.
- **Favorites are exempt** from both rules — the user explicitly chose them (`test_favorites_always_analyzed` stays green).

## The holistic LLM review (optional)

The mechanical judge sees scores; it cannot see the same birthday candles blown out twice. One pass shows the model the FULL cut — raw descriptions, emotion, setting, subjects, audio categories and transcripts in timeline order — and asks for redundancy and clashes with the set's feel (raw data in, not pre-digested stats). Guardrails: capped at 20% of the selection, favorites immune, and any failure/timeout/unparseable answer drops nothing — no LLM, no change.

Both bounded by `max_refinement_passes`. Live Photos, really analyzed since the verify pass, are held to the same bar with no special case — implementing the review decision that they may stay, they just have to be good.

This also lays the rails for #475 (editorial modes): the same per-clip semantic payloads feeding the review are the signals that classify a pool as family/pets/travel/sports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM