### PR TITLE
perf(render): stream title source frames and cap photo prep at 1.5x

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2651,95 +2651,95 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 582,
-        "line_end": 681,
+        "line_start": 586,
+        "line_end": 685,
         "line_complexities": [
-          {
-            "line": 603,
-            "complexity": 0
-          },
-          {
-            "line": 604,
-            "complexity": 1
-          },
-          {
-            "line": 606,
-            "complexity": 1
-          },
           {
             "line": 607,
             "complexity": 0
           },
           {
             "line": 608,
-            "complexity": 2
+            "complexity": 1
           },
           {
-            "line": 609,
+            "line": 610,
+            "complexity": 1
+          },
+          {
+            "line": 611,
             "complexity": 0
           },
           {
-            "line": 616,
-            "complexity": 1
+            "line": 612,
+            "complexity": 2
+          },
+          {
+            "line": 613,
+            "complexity": 0
           },
           {
             "line": 620,
-            "complexity": 0
-          },
-          {
-            "line": 621,
-            "complexity": 0
-          },
-          {
-            "line": 622,
             "complexity": 1
           },
           {
-            "line": 623,
-            "complexity": 0
-          },
-          {
             "line": 624,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 625,
             "complexity": 0
           },
           {
-            "line": 632,
+            "line": 626,
             "complexity": 1
           },
           {
-            "line": 636,
+            "line": 627,
             "complexity": 0
           },
           {
-            "line": 639,
-            "complexity": 0
-          },
-          {
-            "line": 640,
+            "line": 628,
             "complexity": 2
           },
           {
-            "line": 641,
-            "complexity": 3
-          },
-          {
-            "line": 643,
-            "complexity": 1
-          },
-          {
-            "line": 646,
+            "line": 629,
             "complexity": 0
           },
           {
-            "line": 680,
+            "line": 636,
             "complexity": 1
           },
           {
-            "line": 681,
+            "line": 640,
+            "complexity": 0
+          },
+          {
+            "line": 643,
+            "complexity": 0
+          },
+          {
+            "line": 644,
+            "complexity": 2
+          },
+          {
+            "line": 645,
+            "complexity": 3
+          },
+          {
+            "line": 647,
+            "complexity": 1
+          },
+          {
+            "line": 650,
+            "complexity": 0
+          },
+          {
+            "line": 684,
+            "complexity": 1
+          },
+          {
+            "line": 685,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -511,11 +511,15 @@ def _render_single_photo(
             download_fn(asset.id, raw_path)
 
         # Prepare (HEIC decode, gain map extraction for HDR).
-        # WHY: capped at twice the output before any array work. Ken Burns zooms
-        # by at most ~15%, so it never samples beyond this, and the renderer
-        # holds three float32 copies of whatever it is given -- a 24 MP HEIC
-        # peaks near 0.9 GB and a 48 MP one exceeds a 4 GB container.
-        prepared = prepare_photo_source(raw_path, work_dir, max_size=(target_w * 2, target_h * 2))
+        # WHY 1.5x (#423): the renderer samples at most output x 1.12 max zoom
+        # x 1.26 pan margin = 1.41x, and it holds three float32 copies of
+        # whatever it is given. Measured on a 24.5 MP HEIC at 4K: 2.0x paid
+        # 0.63 s and 0.32 GB per photo for pixels its own resize discarded.
+        prepared = prepare_photo_source(
+            raw_path,
+            work_dir,
+            max_size=(round(target_w * 1.5), round(target_h * 1.5)),
+        )
 
         # Load image — 16-bit for gain-mapped HDR, 8-bit for SDR
         img = cv2.imread(str(prepared.path), cv2.IMREAD_UNCHANGED)

--- a/src/immich_memories/titles/content_background.py
+++ b/src/immich_memories/titles/content_background.py
@@ -6,6 +6,7 @@ Supports both static frames and slow-motion video backgrounds.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import shutil
 import subprocess
@@ -175,6 +176,7 @@ class SlowmoBackgroundReader:
         source_transfer: HdrTransfer = HdrTransfer.NONE,
     ):
         self._source_frames: list[np.ndarray] = []
+        self._float_cache: dict[int, np.ndarray] = {}
         self._output_index = 0
         self._total_output_frames = int(title_duration * fps)
 
@@ -204,28 +206,30 @@ class SlowmoBackgroundReader:
             "pipe:1",
         ]  # fmt: skip
 
+        # WHY streaming + native dtype (#408): capture_output=True held every
+        # raw frame (746 MB for 15 frames at 4K 16-bit) while float32 copies
+        # (1.5 GB) accumulated beside it — a 2.2 GB peak. Reading the pipe one
+        # frame at a time and keeping frames in their native dtype caps the
+        # working set at the raw frames plus the small float window read_frame
+        # converts on demand.
         try:
-            result = subprocess.run(cmd, capture_output=True, timeout=30)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            assert proc.stdout is not None
+            while True:
+                chunk = proc.stdout.read(frame_size)
+                if len(chunk) < frame_size:
+                    break
+                dtype = np.uint16 if source_is_hdr else np.uint8
+                self._source_frames.append(
+                    np.frombuffer(chunk, dtype=dtype).reshape((height, width, 3))
+                )
+            proc.wait(timeout=30)
         except (OSError, subprocess.SubprocessError) as e:
             logger.debug(f"Failed to extract frames from {clip_path}: {e}")
+            with contextlib.suppress(Exception):
+                proc.kill()
+            self._source_frames.clear()
             return
-
-        if result.returncode != 0:
-            return
-
-        # Read all source frames into memory (~150MB for 15 frames at 4K 16-bit)
-        data = result.stdout
-        offset = 0
-        while offset + frame_size <= len(data):
-            chunk = data[offset : offset + frame_size]
-            if source_is_hdr:
-                raw = np.frombuffer(chunk, dtype=np.uint16)
-                frame = raw.reshape((height, width, 3)).astype(np.float32) / 65535.0
-            else:
-                raw = np.frombuffer(chunk, dtype=np.uint8)
-                frame = raw.reshape((height, width, 3)).astype(np.float32) / 255.0
-            self._source_frames.append(frame)
-            offset += frame_size
 
         logger.info(
             f"Loaded {len(self._source_frames)} source frames for "
@@ -261,10 +265,10 @@ class SlowmoBackgroundReader:
         # WHY: Catmull-Rom cubic interpolation uses 4 frames instead of 2.
         # This eliminates the "pop" at frame pair boundaries that linear
         # interpolation creates (C1 continuity vs C0).
-        p0 = self._source_frames[max(0, idx - 1)]
-        p1 = self._source_frames[idx]
-        p2 = self._source_frames[min(idx + 1, n_src - 1)]
-        p3 = self._source_frames[min(idx + 2, n_src - 1)]
+        p0 = self._as_float(max(0, idx - 1))
+        p1 = self._as_float(idx)
+        p2 = self._as_float(min(idx + 1, n_src - 1))
+        p3 = self._as_float(min(idx + 2, n_src - 1))
 
         frame = 0.5 * (
             2.0 * p1
@@ -277,8 +281,24 @@ class SlowmoBackgroundReader:
         self._output_index += 1
         return frame
 
+    def _as_float(self, idx: int) -> np.ndarray:
+        """Normalized float32 view of one source frame, cached for the 4-frame
+        Catmull-Rom window. Access is monotonic, so each frame converts once
+        and the float working set never exceeds four frames."""
+        cached = self._float_cache.get(idx)
+        if cached is not None:
+            return cached
+        raw = self._source_frames[idx]
+        scale = 65535.0 if raw.dtype == np.uint16 else 255.0
+        frame = raw.astype(np.float32) / scale
+        self._float_cache[idx] = frame
+        while len(self._float_cache) > 4:
+            del self._float_cache[min(self._float_cache)]
+        return frame
+
     def close(self) -> None:
         self._source_frames.clear()
+        self._float_cache.clear()
 
     def __del__(self) -> None:
         self.close()

--- a/tests/test_content_background.py
+++ b/tests/test_content_background.py
@@ -166,3 +166,35 @@ class TestPerformance:
         frame = np.random.rand(1080, 1920, 3).astype(np.float32)
         result = benchmark(prepare_content_background, frame, 0.45, 40)
         assert result is not None
+
+
+class TestSourceLoadingStreams:
+    """#408: capture_output=True buffered every raw frame (746 MB at 4K HDR)
+    while float32 copies accumulated beside it — a 2.2 GB peak the comment
+    called 150 MB. Loading must stream the pipe, one frame at a time."""
+
+    def test_loading_never_uses_the_buffering_api(self, sample_video: Path):
+        import subprocess as sp
+        from unittest.mock import patch
+
+        from immich_memories.titles.content_background import SlowmoBackgroundReader
+
+        real_run = sp.run  # captured before the patch replaces the module attr
+
+        # WHY: subprocess.run(capture_output=True) IS the leak — holding the
+        # whole raw stream. The tiny ffprobe duration call may buffer; the
+        # frame extraction must go through a streamed pipe.
+        def no_rawvideo_run(cmd, *args, **kwargs):
+            assert "rawvideo" not in cmd, "frame extraction used the buffering API"
+            return real_run(cmd, *args, **kwargs)
+
+        # WHY: run() with capture_output IS the leak under test; the probe may pass
+        with patch(
+            "immich_memories.titles.content_background.subprocess.run",
+            side_effect=no_rawvideo_run,
+        ):
+            reader = SlowmoBackgroundReader(sample_video, width=64, height=64, fps=10.0)
+
+        assert reader.is_active
+        frame = reader.read_frame()
+        assert frame is not None and frame.dtype == np.float32

--- a/tests/test_photo_downscale.py
+++ b/tests/test_photo_downscale.py
@@ -75,3 +75,34 @@ def test_a_gain_mapped_photo_is_capped_and_still_hdr(tmp_path) -> None:
 
     assert max(_dimensions(result.path)) <= max(CAP)
     assert result.has_gain_map
+
+
+def test_the_pipeline_caps_the_source_at_1_5x_output(monkeypatch, tmp_path) -> None:
+    """#423: the renderer samples at most output x 1.12 zoom x 1.26 margin
+    = 1.41x; a 2.0x cap paid 0.63s and 0.32 GB per photo for pixels the
+    internal resize threw away. 1.5x covers the worst case with headroom."""
+    from immich_memories.photos import photo_pipeline
+
+    seen = {}
+
+    def spy_prepare(path, work_dir, max_size=None):  # WHY: capture the cap, skip real HEIC work
+        seen["max_size"] = max_size
+        raise RuntimeError("stop after capture")
+
+    monkeypatch.setattr(photo_pipeline, "prepare_photo_source", spy_prepare)
+    from unittest.mock import MagicMock
+
+    asset = MagicMock(id="a1", original_file_name="p.jpg")
+    import contextlib
+
+    with contextlib.suppress(RuntimeError):
+        photo_pipeline._render_single_photo(  # noqa: SLF001 — the cap lives on this path
+            asset,
+            config=MagicMock(),
+            target_w=3840,
+            target_h=2160,
+            work_dir=tmp_path,
+            download_fn=lambda _id, p: p.write_bytes(b"x"),
+        )
+
+    assert seen["max_size"] == (5760, 3240)  # 1.5x of 4K, not 2.0x

--- a/tests/test_title_pipeline_integration.py
+++ b/tests/test_title_pipeline_integration.py
@@ -180,17 +180,28 @@ class TestSlowmoColorDomain:
 
     @staticmethod
     def _reader_command(source_transfer: HdrTransfer) -> list[str]:
+        import io
+
         from immich_memories.titles.content_background import SlowmoBackgroundReader
 
         duration_probe = MagicMock(stdout="2.0", returncode=0)
         frame = np.full((2, 2, 3), 32768, dtype=np.uint16).tobytes()
-        frame_probe = MagicMock(stdout=frame * 2, returncode=0)
+        # WHY a real BytesIO: extraction streams the pipe (#408); the mock
+        # process must behave like one — data, then EOF.
+        frame_proc = MagicMock()
+        frame_proc.stdout = io.BytesIO(frame * 2)
+        frame_proc.wait.return_value = 0
+        # WHY: ffprobe/ffmpeg are the external boundary; the fake streams then EOFs (#408)
         with (
             patch("immich_memories.titles.content_background.shutil.which", return_value="ffmpeg"),
             patch(
                 "immich_memories.titles.content_background.subprocess.run",
-                side_effect=[duration_probe, frame_probe],
-            ) as run,
+                side_effect=[duration_probe],
+            ),
+            patch(
+                "immich_memories.titles.content_background.subprocess.Popen",
+                return_value=frame_proc,
+            ) as popen,
         ):
             reader = SlowmoBackgroundReader(
                 Path("/tmp/content.mp4"),
@@ -201,7 +212,7 @@ class TestSlowmoColorDomain:
                 source_transfer=source_transfer,
             )
         assert reader.is_active
-        return run.call_args_list[1].args[0]
+        return popen.call_args_list[0].args[0]
 
     def test_hlg_background_is_not_tone_mapped_before_title_composition(self) -> None:
         command = self._reader_command(HdrTransfer.HLG)


### PR DESCRIPTION
Closes #408 and #423 — the two measured render-path memory spikes, grouped per maintainer's direction.

**Title slow-mo background (#408):** `capture_output=True` held every raw source frame (746 MB at 4K 16-bit) while float32 conversions (1.5 GB) accumulated beside it — a 2.2 GB peak documented as 150 MB. Loading now streams the pipe one frame at a time and stores native dtype; `read_frame` converts through a four-frame float window matching the Catmull-Rom stencil (monotonic access → each frame converts once). A guard test pins the streamed path; the real-ffmpeg behavior tests are unchanged and green.

**Photo prep (#423):** cap was `output × 2.0` where the renderer samples at most `output × 1.12 zoom × 1.26 margin = 1.41×`. Per the issue's benchmarks, 2.0× paid 0.63 s and 0.32 GB per photo for pixels the renderer's own resize discarded. Now 1.5×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM