### PR TITLE
feat(audio): the soundtrack steps aside when a clip's own audio is music

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2115,55 +2115,47 @@
       {
         "name": "_generate_memory_inner",
         "complexity": 19,
-        "line_start": 607,
-        "line_end": 852,
+        "line_start": 609,
+        "line_end": 855,
         "line_complexities": [
           {
-            "line": 618,
+            "line": 620,
             "complexity": 1
           },
           {
-            "line": 625,
+            "line": 627,
             "complexity": 1
           },
           {
-            "line": 626,
+            "line": 628,
             "complexity": 0
           },
           {
-            "line": 629,
+            "line": 631,
             "complexity": 0
           },
           {
-            "line": 630,
+            "line": 632,
             "complexity": 0
           },
           {
-            "line": 635,
+            "line": 637,
             "complexity": 0
           },
           {
-            "line": 650,
+            "line": 652,
             "complexity": 0
           },
           {
-            "line": 653,
+            "line": 655,
             "complexity": 0
           },
           {
-            "line": 654,
+            "line": 656,
             "complexity": 0
           },
           {
-            "line": 657,
-            "complexity": 0
-          },
-          {
-            "line": 661,
-            "complexity": 0
-          },
-          {
-            "line": 662,
+            "line": 659,
             "complexity": 0
           },
           {
@@ -2171,35 +2163,39 @@
             "complexity": 0
           },
           {
-            "line": 676,
+            "line": 664,
+            "complexity": 0
+          },
+          {
+            "line": 665,
+            "complexity": 0
+          },
+          {
+            "line": 678,
             "complexity": 2
           },
           {
-            "line": 677,
+            "line": 679,
             "complexity": 0
           },
           {
-            "line": 684,
+            "line": 686,
             "complexity": 0
           },
           {
-            "line": 685,
+            "line": 687,
             "complexity": 0
           },
           {
-            "line": 691,
+            "line": 693,
             "complexity": 1
           },
           {
-            "line": 694,
+            "line": 696,
             "complexity": 0
           },
           {
-            "line": 710,
-            "complexity": 0
-          },
-          {
-            "line": 714,
+            "line": 712,
             "complexity": 0
           },
           {
@@ -2207,107 +2203,103 @@
             "complexity": 0
           },
           {
-            "line": 717,
+            "line": 718,
             "complexity": 0
           },
           {
-            "line": 721,
+            "line": 719,
             "complexity": 0
           },
           {
             "line": 723,
-            "complexity": 2
-          },
-          {
-            "line": 724,
             "complexity": 0
           },
           {
-            "line": 727,
+            "line": 725,
             "complexity": 2
           },
           {
-            "line": 728,
+            "line": 726,
             "complexity": 0
           },
           {
             "line": 729,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 730,
             "complexity": 0
           },
           {
-            "line": 736,
+            "line": 731,
             "complexity": 0
           },
           {
-            "line": 739,
+            "line": 732,
             "complexity": 0
           },
           {
-            "line": 740,
+            "line": 738,
             "complexity": 0
           },
           {
-            "line": 743,
+            "line": 741,
             "complexity": 0
           },
           {
-            "line": 748,
+            "line": 742,
             "complexity": 0
           },
           {
-            "line": 752,
+            "line": 745,
             "complexity": 0
           },
           {
-            "line": 757,
+            "line": 750,
             "complexity": 0
           },
           {
-            "line": 760,
+            "line": 754,
             "complexity": 0
           },
           {
-            "line": 766,
+            "line": 759,
             "complexity": 0
           },
           {
-            "line": 767,
+            "line": 762,
             "complexity": 0
           },
           {
-            "line": 770,
+            "line": 768,
             "complexity": 0
           },
           {
-            "line": 778,
+            "line": 769,
+            "complexity": 0
+          },
+          {
+            "line": 772,
             "complexity": 0
           },
           {
             "line": 780,
+            "complexity": 0
+          },
+          {
+            "line": 782,
             "complexity": 2
           },
           {
-            "line": 781,
+            "line": 783,
             "complexity": 0
           },
           {
-            "line": 790,
+            "line": 792,
             "complexity": 0
           },
           {
-            "line": 791,
-            "complexity": 0
-          },
-          {
-            "line": 801,
-            "complexity": 0
-          },
-          {
-            "line": 803,
+            "line": 793,
             "complexity": 0
           },
           {
@@ -2315,63 +2307,71 @@
             "complexity": 0
           },
           {
-            "line": 818,
+            "line": 806,
             "complexity": 0
           },
           {
-            "line": 824,
+            "line": 807,
             "complexity": 0
           },
           {
-            "line": 826,
-            "complexity": 1
+            "line": 821,
+            "complexity": 0
           },
           {
             "line": 827,
             "complexity": 0
           },
           {
-            "line": 828,
+            "line": 829,
             "complexity": 1
           },
           {
-            "line": 829,
+            "line": 830,
             "complexity": 0
           },
           {
             "line": 831,
-            "complexity": 0
-          },
-          {
-            "line": 832,
             "complexity": 1
           },
           {
-            "line": 835,
+            "line": 832,
             "complexity": 0
+          },
+          {
+            "line": 834,
+            "complexity": 0
+          },
+          {
+            "line": 835,
+            "complexity": 1
           },
           {
             "line": 838,
             "complexity": 0
           },
           {
-            "line": 842,
-            "complexity": 1
-          },
-          {
-            "line": 845,
-            "complexity": 3
-          },
-          {
-            "line": 847,
-            "complexity": 1
-          },
-          {
-            "line": 851,
+            "line": 841,
             "complexity": 0
           },
           {
-            "line": 852,
+            "line": 845,
+            "complexity": 1
+          },
+          {
+            "line": 848,
+            "complexity": 3
+          },
+          {
+            "line": 850,
+            "complexity": 1
+          },
+          {
+            "line": 854,
+            "complexity": 0
+          },
+          {
+            "line": 855,
             "complexity": 0
           }
         ]
@@ -2387,7 +2387,7 @@
         "name": "_extract_clips",
         "complexity": 25,
         "line_start": 95,
-        "line_end": 180,
+        "line_end": 181,
         "line_complexities": [
           {
             "line": 109,
@@ -2470,11 +2470,11 @@
             "complexity": 0
           },
           {
-            "line": 176,
+            "line": 177,
             "complexity": 1
           },
           {
-            "line": 180,
+            "line": 181,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -10,6 +10,7 @@ The music pipeline has three stages:
 1. **Mood detection**: A vision LLM looks at keyframes from your video and outputs a structured mood analysis (happy, calm, energetic, etc. plus genre and tempo suggestions).
 2. **Music generation**: The pipeline takes that mood and sends it to the configured music backend. ACE-Step can run directly in the app or through its REST API. MusicGen is the alternative generator when ACE-Step is disabled.
 3. **Audio ducking**: When background music plays over your clips, it automatically gets quieter when someone's talking or when there's an interesting sound in the original audio.
+4. **Music steps aside for music**: when a clip's own audio *is* music — a concert, someone playing piano, a party — the added soundtrack drops to near-silence for that clip instead of playing two songs at once. Detection uses the audio-content analysis (PANNs) `music`/`singing` labels, so it needs the `audio-ml` extra.
 
 ## No GPU? Start here
 

--- a/src/immich_memories/audio/mixer.py
+++ b/src/immich_memories/audio/mixer.py
@@ -70,6 +70,9 @@ class MixConfig:
     fade_out_seconds: float = 3.0
     music_starts_at: float = 0.0  # Seconds into video
     normalize_audio: bool = True
+    # Timeline windows [start, end) where the source audio IS music and the
+    # soundtrack must step aside (#466) — near-mute, not sidechain-lowered.
+    mute_windows: list[tuple[float, float]] | None = None
 
 
 def get_audio_duration(audio_path: Path) -> float:
@@ -317,6 +320,10 @@ def _build_ducking_filter(
     # Prepare music: trim to video length, apply volume, add fades
     music_filter = f"[1:a]atrim=0:{video_duration}"
     music_filter += f",volume={ducking.music_volume_db}dB"
+    # WHY 0.05 not 0: dead silence reads as an error; -26 dB reads as stepping
+    # aside. The step lands on a clip boundary, where the cut masks it.
+    for start, end in config.mute_windows or []:
+        music_filter += f",volume=enable='between(t,{start},{end})':volume=0.05"
 
     if config.fade_in_seconds > 0:
         music_filter += f",afade=t=in:st={config.music_starts_at}:d={config.fade_in_seconds}"
@@ -364,3 +371,29 @@ def _build_ducking_filter(
     )
 
     return filter_parts
+
+
+def music_mute_windows(
+    clips: list,
+    transitions: list[str],
+    fade_duration: float,
+) -> list[tuple[float, float]]:
+    """Timeline windows of clips whose own audio is music (#466).
+
+    Follows the assembler's clock: a crossfade overlaps the next clip into
+    the previous one by ``fade_duration``. Adjacent music windows merge so
+    the soundtrack does not pump between back-to-back concert clips.
+    """
+    windows: list[tuple[float, float]] = []
+    start = 0.0
+    for idx, clip in enumerate(clips):
+        if idx > 0 and idx - 1 < len(transitions) and transitions[idx - 1] == "fade":
+            start -= fade_duration
+        end = start + clip.duration
+        if getattr(clip, "has_music", False):
+            if windows and start <= windows[-1][1]:
+                windows[-1] = (windows[-1][0], end)
+            else:
+                windows.append((start, end))
+        start = end
+    return windows

--- a/src/immich_memories/generate.py
+++ b/src/immich_memories/generate.py
@@ -440,6 +440,7 @@ def _complete_music_phase(
     encoding_plan: EncodingPlan,
     operational: _OperationalProgress,
     progress: _PipelineProgress,
+    mute_windows: list[tuple[float, float]] | None = None,
 ):
     """Run or explicitly skip music while emitting the shared outer phase."""
     if params.no_music:
@@ -457,6 +458,7 @@ def _complete_music_phase(
         run_output_dir,
         run_tracker,
         encoding_plan=encoding_plan,
+        mute_windows=mute_windows,
     )
     progress.report("music", 1.0, result.warning or "Music ready")
     operational.emit(OperationalPhase.MUSIC, 1, 1, result.warning or "Music ready")
@@ -797,6 +799,7 @@ def _generate_memory_inner(
             settings.encoding_plan,
             operational,
             pp,
+            mute_windows=settings.music_mute_windows,
         )
         _phase_times["music"] = _time.monotonic() - _t
 

--- a/src/immich_memories/generate_clips.py
+++ b/src/immich_memories/generate_clips.py
@@ -171,6 +171,7 @@ def _extract_clips(
                     latitude=exif.latitude if exif else None,
                     longitude=exif.longitude if exif else None,
                     location_name=clip_location_name(exif),
+                    has_music=bool(set(clip.audio_categories or []) & {"music", "singing"}),
                 )
             )
         except (OSError, subprocess.SubprocessError, ValueError) as e:

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -367,6 +367,7 @@ def apply_music_file(
     music_path: Path,
     volume: float,
     encoding_plan: EncodingPlan,
+    mute_windows: list[tuple[float, float]] | None = None,
 ) -> OutputProbe:
     """Mix a music file and publish it only when it matches the encoding plan."""
     from immich_memories.audio.mixer import DuckingConfig, MixConfig, mix_audio_with_ducking
@@ -375,6 +376,7 @@ def apply_music_file(
         ducking=DuckingConfig(
             music_volume_db=-20 + (volume * 20),
         ),
+        mute_windows=mute_windows,
     )
     with staged_music_output(video_path, encoding_plan) as staged_path:
         mix_audio_with_ducking(

--- a/src/immich_memories/generate_settings.py
+++ b/src/immich_memories/generate_settings.py
@@ -247,6 +247,7 @@ def _run_music_phase(
     run_tracker: RunTracker,
     *,
     encoding_plan: EncodingPlan,
+    mute_windows: list[tuple[float, float]] | None = None,
 ) -> MusicPhaseResult:
     """Resolve and apply music to the assembled video."""
     from immich_memories.generate_music import (
@@ -284,7 +285,13 @@ def _run_music_phase(
             # without an explicit path or configured generation backend.
             run_tracker.start_phase("music", 1)
             phase_started = True
-        apply_music_file(result_path, music_file, params.music_volume, encoding_plan)
+        apply_music_file(
+            result_path,
+            music_file,
+            params.music_volume,
+            encoding_plan,
+            mute_windows=mute_windows,
+        )
     except Exception as exc:  # WHY: optional music must not invalidate the base artifact
         return _complete_music_failure(
             exc,

--- a/src/immich_memories/processing/assembly_config.py
+++ b/src/immich_memories/processing/assembly_config.py
@@ -129,6 +129,10 @@ class AssemblySettings:
     target_resolution: tuple[int, int] | None = None  # Override resolution (width, height)
     # Title screens
     title_screens: TitleScreenSettings | None = None
+    # Recorded by the assembly engine from the FINAL clip sequence (titles
+    # included): timeline windows where a clip's own audio is music, so the
+    # music phase can step the soundtrack aside (#466).
+    music_mute_windows: list[tuple[float, float]] | None = None
     # Pre-decided transitions (from clips.plan_transitions)
     # If provided, these override the automatic transition decisions
     # Format: list of "fade" or "cut" for each transition between clips
@@ -176,6 +180,9 @@ class AssemblyClip:
     is_photo: bool = False
     # Seek offset: skip this many seconds from the start (used for title trim)
     input_seek: float = 0.0
+    # Source audio contains music (PANNs 'music'/'singing'); the added
+    # soundtrack steps aside over this clip's window (#466).
+    has_music: bool = False
 
 
 def _get_rotation_filter(rotation: int) -> str:

--- a/src/immich_memories/processing/assembly_engine.py
+++ b/src/immich_memories/processing/assembly_engine.py
@@ -233,6 +233,11 @@ class AssemblyEngine:
 
         ctx = create_assembly_context(self.settings, self.prober, clips, target_w, target_h)
         fade_duration = self.settings.transition_duration or 0.5
+        from immich_memories.audio.mixer import music_mute_windows
+
+        # The engine is the only place the FINAL sequence (titles included)
+        # and its transitions coexist — the music phase runs later (#466).
+        self.settings.music_mute_windows = music_mute_windows(clips, transitions, fade_duration)
         plan = self.settings.encoding_plan
         if plan.hdr:
             logger.info("Streaming %s HDR assembly with %s", ctx.hdr_type.upper(), plan.encoder)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -579,3 +579,99 @@ class TestBundledMoodFolders:
         from immich_memories.audio.music_sources import LocalMusicSource
 
         assert ".opus" in LocalMusicSource.SUPPORTED_EXTENSIONS
+
+
+class TestMusicStepsAsideForSourceMusic:
+    """#466: when a clip's own audio IS music, the soundtrack must step
+    aside for that clip's window — sidechain compression only lowers it,
+    and two songs at once is what the matrix review heard."""
+
+    def test_mute_windows_reach_the_music_filter(self):
+        from immich_memories.audio.mixer import _build_ducking_filter
+
+        config = MixConfig(ducking=DuckingConfig(), mute_windows=[(10.0, 14.5)])
+
+        parts = _build_ducking_filter(config, config.ducking, video_duration=30.0)
+        music_chain = next(p for p in parts if p.startswith("[1:a]"))
+
+        assert "between(t,10.0,14.5)" in music_chain
+        assert "volume=" in music_chain
+
+    def test_no_windows_means_the_chain_is_unchanged(self):
+        from immich_memories.audio.mixer import _build_ducking_filter
+
+        config = MixConfig(ducking=DuckingConfig())
+
+        parts = _build_ducking_filter(config, config.ducking, video_duration=30.0)
+        music_chain = next(p for p in parts if p.startswith("[1:a]"))
+
+        assert "between(" not in music_chain
+
+
+class TestMusicMuteWindows:
+    """Timeline windows of clips whose source audio is music."""
+
+    def _clip(self, duration: float, has_music: bool = False):
+        from pathlib import Path
+
+        from immich_memories.processing.assembly_config import AssemblyClip
+
+        return AssemblyClip(
+            path=Path("/x.mp4"), duration=duration, asset_id="x", has_music=has_music
+        )
+
+    def test_windows_follow_the_timeline_with_crossfade_overlap(self):
+        from immich_memories.audio.mixer import music_mute_windows
+
+        clips = [self._clip(10.0), self._clip(8.0, has_music=True), self._clip(6.0)]
+
+        windows = music_mute_windows(clips, ["fade", "cut"], fade_duration=1.0)
+
+        # clip B starts at 10 - 1 (crossfade overlap) = 9.0, runs 8s
+        assert windows == [(9.0, 17.0)]
+
+    def test_adjacent_music_clips_merge_into_one_window(self):
+        from immich_memories.audio.mixer import music_mute_windows
+
+        clips = [self._clip(10.0, has_music=True), self._clip(8.0, has_music=True)]
+
+        windows = music_mute_windows(clips, ["cut"], fade_duration=1.0)
+
+        assert windows == [(0.0, 18.0)]
+
+    def test_no_music_no_windows(self):
+        from immich_memories.audio.mixer import music_mute_windows
+
+        assert music_mute_windows([self._clip(10.0)], [], fade_duration=1.0) == []
+
+
+class TestMuteWindowWiring:
+    def test_apply_music_file_hands_windows_to_the_mixer(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from immich_memories.generate_music import apply_music_file
+
+        captured = {}
+
+        # WHY: mixing runs real ffmpeg; the contract here is config plumbing
+        def spy(video_path, music_path, output_path, config):
+            captured["windows"] = config.mute_windows
+            raise RuntimeError("stop after capture")
+
+        # WHY: mixing runs real ffmpeg and staging touches the filesystem
+        with (
+            patch("immich_memories.audio.mixer.mix_audio_with_ducking", side_effect=spy),
+            patch("immich_memories.generate_music.staged_music_output"),
+        ):
+            try:
+                apply_music_file(
+                    tmp_path / "v.mp4",
+                    tmp_path / "m.mp3",
+                    0.5,
+                    MagicMock(),
+                    mute_windows=[(3.0, 9.0)],
+                )
+            except Exception:
+                pass
+
+        assert captured["windows"] == [(3.0, 9.0)]

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -1597,7 +1597,9 @@ class TestRunMusicPhase:
                 encoding_plan=encoding_plan,
             )
 
-        mock_apply.assert_called_once_with(result_path, music_file, 0.7, encoding_plan)
+        mock_apply.assert_called_once_with(
+            result_path, music_file, 0.7, encoding_plan, mute_windows=None
+        )
         mock_tracker.start_phase.assert_called_once_with("music", 1)
         mock_tracker.complete_phase.assert_called_once_with(items_processed=1)
 

--- a/tests/test_music_output_paths.py
+++ b/tests/test_music_output_paths.py
@@ -1567,7 +1567,9 @@ def test_music_phase_passes_exact_encoding_plan_to_publication(tmp_path: Path) -
         )
 
     assert result == generate_music.MusicPhaseResult(applied=True)
-    apply_music.assert_called_once_with(base_video, music_file, params.music_volume, plan)
+    apply_music.assert_called_once_with(
+        base_video, music_file, params.music_volume, plan, mute_windows=None
+    )
     tracker.complete_phase.assert_called_once_with(items_processed=1)
 
 


### PR DESCRIPTION
Closes #466 — row 11 of the matrix review played the bundled track over a clip whose background audio was already music. Sidechain compression only lowers the soundtrack; a concert clip needs it to *step aside*.

Detection already existed (PANNs `music`/`singing` labels). This PR wires the consumers:

- `AssemblyClip.has_music`, populated from the clip's audio categories at conversion.
- The assembly engine — the only place the FINAL sequence (titles included) and its transitions coexist — records the timeline windows on `AssemblySettings`; adjacent music clips merge so the soundtrack doesn't pump.
- The music phase hands the windows to the mixer, which drops the music chain to **-26 dB** over each window: near-mute reads as stepping aside, dead silence reads as an error. Steps land on clip boundaries, masked by the cut.
- Same behavior for bundled and generated music — they share the mixer.

Docs updated in `create/pipeline/audio-and-music.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM