### PR TITLE
fix(security): close the remaining findings from the 2026-08-18 review

### DIFF
--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -325,6 +325,11 @@ the app has to keep seeing the proxy's own address to trust `Remote-User`, and t
 limiter and OIDC redirect don't apply to that provider anyway. Leave `FORWARDED_ALLOW_IPS` unset
 in that case.
 
+The login rate limiter reads `X-Forwarded-For` the same way — only when the immediate peer
+is in `auth.trusted_proxies`. Without that, every login behind a proxy shares one bucket and
+five wrong passwords from anyone lock out everyone for ten minutes; with it, an untrusted
+caller still cannot pick its own bucket by setting the header itself.
+
 When running without a reverse proxy (direct access on localhost), none of this applies.
 :::
 

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -33,6 +33,7 @@ from immich_memories.security import (
 )
 from immich_memories.ui.auth import (
     clear_session,
+    client_ip_for_rate_limit,
     is_auth_enabled,
     is_bypass_path,
     is_health_probe_path,
@@ -599,7 +600,12 @@ def _check_login_rate_limit(request: Request) -> JSONResponse | None:
     to a file keyed by a cookie the caller may not send, and expires only tab
     storage. The login page reads the same IP off `client.ip` instead.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    peer_ip = request.client.host if request.client else "unknown"
+    client_ip = client_ip_for_rate_limit(
+        peer_ip=peer_ip,
+        forwarded_for=request.headers.get("x-forwarded-for"),
+        auth_config=get_config().auth,
+    )
     if is_rate_limited(client_ip):
         return JSONResponse({"detail": "Too many failed login attempts"}, status_code=429)
     return None

--- a/src/immich_memories/ui/auth.py
+++ b/src/immich_memories/ui/auth.py
@@ -165,3 +165,25 @@ def clear_session(session: MutableMapping[str, object]) -> None:
 def is_auth_enabled(auth_config: AuthConfig) -> bool:
     """Check whether authentication is enabled in config."""
     return auth_config.enabled
+
+
+def client_ip_for_rate_limit(
+    *,
+    peer_ip: str,
+    forwarded_for: str | None,
+    auth_config: AuthConfig,
+) -> str:
+    """The IP the login limiter should bucket on (S3).
+
+    Behind Traefik/nginx every request carries the proxy's address, so one
+    bad actor locks out everyone (5 failures = a 10-minute global lockout).
+    X-Forwarded-For fixes that, but only from a peer we trust: an untrusted
+    caller reaching the port directly could otherwise pick its own bucket —
+    or evade the limiter entirely — by setting the header itself.
+    """
+    if not forwarded_for or not is_trusted_proxy(peer_ip, auth_config.trusted_proxies):
+        return peer_ip
+    # Leftmost is the originating client as recorded by the first proxy; the
+    # chain is only as trustworthy as the peer that handed it to us.
+    candidate = forwarded_for.split(",")[0].strip()
+    return candidate or peer_ip

--- a/src/immich_memories/ui/pages/settings_config.py
+++ b/src/immich_memories/ui/pages/settings_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import logging
 from typing import Any
 
@@ -25,14 +26,16 @@ _SENSITIVE_KEYS = {
 }
 
 
-def _redact(data: Any, _key: str = "") -> Any:
+def redact_config(data: Any, _key: str = "") -> Any:
     """Recursively redact sensitive values in a config dict."""
     if isinstance(data, dict):
-        return {k: _redact(v, k) for k, v in data.items()}
+        return {k: redact_config(v, k) for k, v in data.items()}
     if isinstance(data, list):
-        return [_redact(v, _key) for v in data]
+        return [redact_config(v, _key) for v in data]
     if _key in _SENSITIVE_KEYS and isinstance(data, str) and data:
-        return data[:3] + "***" + data[-2:] if len(data) > 5 else "***"
+        # WHY a full mask (S16): the old abc***yz showed five characters of
+        # every secret, auth.password included.
+        return "***"
     return data
 
 
@@ -69,43 +72,48 @@ def _section_icon(section: str) -> str:
     }.get(section, "settings")
 
 
-def _render_section_table(section_data: dict) -> None:
-    """Render a config section as a compact HTML table."""
-    rows_html: list[str] = []
+def build_config_table_html(section_data: dict) -> str:
+    """The section table's HTML, with every key and value escaped.
+
+    WHY (S5): `immich.url` is editable from the browser and persisted, and this
+    table is rendered with `ui.html`, so an unescaped f-string is stored XSS
+    against the next admin who opens Settings.
+    """
+    rows_html = []
     for key, value in section_data.items():
         if isinstance(value, dict):
-            # Nested — render as sub-header + rows
             rows_html.append(
                 f'<tr><td colspan="2" style="color:var(--im-text);font-weight:600;'
-                f'padding:4px 0 2px 0;font-size:12px">{key}</td></tr>'
+                f'padding:4px 0 2px 0;font-size:12px">{html.escape(str(key))}</td></tr>'
             )
             for sk, sv in value.items():
-                display = _format_value(sv)
+                display = html.escape(_format_value(sv))
                 rows_html.append(
                     f'<tr><td style="color:var(--im-text-secondary);padding:1px 12px 1px 16px;'
-                    f'font-size:12px;white-space:nowrap">{sk}</td>'
+                    f'font-size:12px;white-space:nowrap">{html.escape(str(sk))}</td>'
                     f'<td style="color:var(--im-text);font-family:monospace;font-size:12px;'
                     f'padding:1px 0;word-break:break-all">{display}</td></tr>'
                 )
         else:
-            display = _format_value(value)
+            display = html.escape(_format_value(value))
             rows_html.append(
                 f'<tr><td style="color:var(--im-text-secondary);padding:1px 12px 1px 0;'
-                f'font-size:12px;white-space:nowrap">{key}</td>'
+                f'font-size:12px;white-space:nowrap">{html.escape(str(key))}</td>'
                 f'<td style="color:var(--im-text);font-family:monospace;font-size:12px;'
                 f'padding:1px 0;word-break:break-all">{display}</td></tr>'
             )
+    return '<table style="width:100%;border-collapse:collapse">' + "".join(rows_html) + "</table>"
 
-    table_html = (
-        '<table style="width:100%;border-collapse:collapse">' + "".join(rows_html) + "</table>"
-    )
-    ui.html(table_html)
+
+def _render_section_table(section_data: dict) -> None:
+    """Render a config section as a compact table."""
+    ui.html(build_config_table_html(section_data))
 
 
 def render_config_viewer() -> None:
     """Render the configuration viewer panel."""
     config = get_config(reload=True)
-    redacted = _redact(config.model_dump())
+    redacted = redact_config(config.model_dump())
 
     im_info_card(
         "Active config from ~/.immich-memories/config.yaml with env overrides. "

--- a/src/immich_memories/ui/pages/step3_options.py
+++ b/src/immich_memories/ui/pages/step3_options.py
@@ -59,6 +59,36 @@ def _render_preset_banner(config) -> None:
     )
 
 
+# A soundtrack is minutes of compressed audio; 64 MiB is generous for MP3/M4A
+# and still bounds what one click can pin in session memory (S10).
+MAX_MUSIC_UPLOAD_BYTES = 64 * 1024 * 1024
+
+_AUDIO_SUFFIXES = {".mp3", ".m4a", ".wav"}
+_AUDIO_MAGIC = (
+    b"ID3",  # MP3 with an ID3 tag
+    b"RIFF",  # WAV
+    b"\xff\xfb",  # MP3 frame sync
+    b"\xff\xf3",
+    b"\xff\xf2",
+)
+
+
+def is_supported_audio(filename: str, payload: bytes) -> bool:
+    """Whether an upload really is one of the audio formats we accept.
+
+    Suffix AND content: the browser's `accept=` filter is advisory, and a
+    renamed executable must not reach the mixer or session state.
+    """
+    from pathlib import Path as _Path
+
+    if _Path(filename).suffix.lower() not in _AUDIO_SUFFIXES:
+        return False
+    if payload.startswith(_AUDIO_MAGIC):
+        return True
+    # M4A/MP4: 'ftyp' box at offset 4
+    return len(payload) >= 12 and payload[4:8] == b"ftyp"
+
+
 def _render_volume_slider(options: dict, width: str = "w-64") -> None:
     """Render a music volume slider."""
     with ui.row().classes("items-center gap-4 mt-2"):
@@ -81,13 +111,20 @@ def _render_upload_music_options(options: dict) -> None:
     )
 
     async def handle_upload(e):
-        options["music_file"] = e.content.read()
+        payload = e.content.read()
+        # WHY (S10): `accept=` is browser-side only, so the server must check
+        # what actually arrived before holding it in session state.
+        if not is_supported_audio(e.name, payload):
+            ui.notify("That file is not an MP3, M4A or WAV", type="negative")
+            return
+        options["music_file"] = payload
         options["music_filename"] = e.name
         ui.notify(f"Uploaded: {e.name}", type="positive")
 
     ui.upload(
         label="Select music file",
         auto_upload=True,
+        max_file_size=MAX_MUSIC_UPLOAD_BYTES,
         on_upload=handle_upload,
     ).props("accept='.mp3,.m4a,.wav'").classes("w-full max-w-md")
 

--- a/tests/test_security_review_remainder.py
+++ b/tests/test_security_review_remainder.py
@@ -1,0 +1,109 @@
+"""The security findings left open from docs/reviews/2026-08-18-security-perf-review.md.
+
+S3 (rate limiter behind a proxy), S5 (stored XSS in the config viewer),
+S10 (unbounded music upload), S16 (secrets partly shown).
+"""
+
+from __future__ import annotations
+
+from immich_memories.config_models_auth import AuthConfig
+
+
+class TestS5ConfigViewerEscapesValues:
+    """immich.url is editable from the browser and persisted; rendering it into
+    ui.html with an f-string makes it stored XSS for the next admin visit."""
+
+    def test_a_script_in_a_value_is_escaped(self):
+        from immich_memories.ui.pages.settings_config import build_config_table_html
+
+        html = build_config_table_html({"immich": {"url": "<script>alert(1)</script>"}})
+
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_a_script_in_a_key_is_escaped(self):
+        from immich_memories.ui.pages.settings_config import build_config_table_html
+
+        html = build_config_table_html({"<img src=x onerror=alert(1)>": "v"})
+
+        assert "<img" not in html
+
+    def test_ordinary_values_still_render(self):
+        from immich_memories.ui.pages.settings_config import build_config_table_html
+
+        html = build_config_table_html({"immich": {"url": "http://immich:2283"}})
+
+        assert "http://immich:2283" in html
+
+
+class TestS16SecretsAreFullyMasked:
+    """abc***yz leaks five characters of every secret, auth.password included."""
+
+    def test_no_characters_of_the_secret_survive(self):
+        from immich_memories.ui.pages.settings_config import redact_config
+
+        redacted = redact_config({"immich": {"api_key": "abcdefghijklmnop"}})
+
+        assert redacted["immich"]["api_key"] == "***"
+        assert "abc" not in redacted["immich"]["api_key"]
+
+    def test_an_empty_secret_stays_empty(self):
+        from immich_memories.ui.pages.settings_config import redact_config
+
+        assert redact_config({"immich": {"api_key": ""}})["immich"]["api_key"] == ""
+
+
+class TestS3RateLimiterSeesTheRealClient:
+    """Behind Traefik/nginx every request carries the proxy's IP, so one bad
+    actor locks out everyone. Trust X-Forwarded-For only from a trusted peer."""
+
+    def test_the_forwarded_client_is_used_when_the_peer_is_trusted(self):
+        from immich_memories.ui.auth import client_ip_for_rate_limit
+
+        ip = client_ip_for_rate_limit(
+            peer_ip="10.0.0.5",
+            forwarded_for="203.0.113.9, 10.0.0.5",
+            auth_config=AuthConfig(trusted_proxies=["10.0.0.0/8"]),
+        )
+
+        assert ip == "203.0.113.9"
+
+    def test_an_untrusted_peer_cannot_spoof_its_bucket(self):
+        from immich_memories.ui.auth import client_ip_for_rate_limit
+
+        ip = client_ip_for_rate_limit(
+            peer_ip="198.51.100.7",
+            forwarded_for="1.2.3.4",
+            auth_config=AuthConfig(trusted_proxies=["10.0.0.0/8"]),
+        )
+
+        assert ip == "198.51.100.7"
+
+    def test_no_header_means_the_peer(self):
+        from immich_memories.ui.auth import client_ip_for_rate_limit
+
+        ip = client_ip_for_rate_limit(
+            peer_ip="10.0.0.5",
+            forwarded_for=None,
+            auth_config=AuthConfig(trusted_proxies=["10.0.0.0/8"]),
+        )
+
+        assert ip == "10.0.0.5"
+
+
+class TestS10MusicUploadIsBounded:
+    def test_the_upload_declares_a_size_cap(self):
+        import inspect
+
+        from immich_memories.ui.pages import step3_options
+
+        source = inspect.getsource(step3_options)
+
+        assert "max_file_size" in source
+
+    def test_a_non_audio_payload_is_rejected(self):
+        from immich_memories.ui.pages.step3_options import is_supported_audio
+
+        assert is_supported_audio("track.mp3", b"ID3\x04\x00\x00\x00")
+        assert not is_supported_audio("evil.mp3", b"MZ\x90\x00\x03\x00\x00\x00")
+        assert not is_supported_audio("evil.exe", b"ID3\x04\x00\x00\x00")


### PR DESCRIPTION
Re-audited all 17 security findings from `docs/reviews/2026-08-18-security-perf-review.md` against current main before writing anything. S1, S2, S4, S6, S7, S8, S11–S15 and S17 are already fixed and stayed fixed; R1–R4 likewise. These four were still open:

| # | Sev | Fix |
|---|---|---|
| **S5** | MED | **Stored XSS** — the config viewer f-stringed keys and values into `ui.html`, and `immich.url` is editable from the browser and persisted, so a payload survived to the next admin who opened Settings. Table building extracted to `build_config_table_html` with `html.escape` on every key and value. |
| **S3** | MED | **Rate limiter bucketed on the proxy** — `request.client.host` is Traefik/nginx, so five wrong passwords from anyone locked out everyone for 10 minutes. `client_ip_for_rate_limit` reads `X-Forwarded-For` **only** when the immediate peer is in `auth.trusted_proxies`, so an untrusted caller can't pick its own bucket or evade the limiter. |
| **S10** | LOW | **Unbounded music upload** — no `max_file_size`, and `accept=` is browser-side only, so any renamed file was read whole into session state. 64 MiB cap + server-side suffix **and** magic check (ID3 / RIFF / MP3 frame sync / `ftyp`). |
| **S16** | INFO | **Partial secret mask** — `abc***yz` showed five characters of every secret, `auth.password` included. Full mask. |

10 new tests, one per behavior. Proxy-aware limiting documented in `authentication.mdx`.

**Not in this PR:** #459 (header-provider allow-list) is a separate concern with its own issue, and R5 (SIGTERM leaves the run row `running`, orphaned grandchild ffmpeg) is reliability, not security — flagged to the maintainer for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM