### PR TITLE
fix(selection): the review prompt was missing the date and place it promised

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -3,7 +3,7 @@
 The mechanical judge sees scores; it cannot see that two clips are the same
 birthday candles twice, or that one clip breaks the set's feel. This pass
 shows the LLM the FULL cut — every clip's raw description, emotion, setting,
-subjects and transcript, in timeline order — and asks which clips are
+subjects and audio, in timeline order — and asks which clips are
 redundant or clash with the whole. Raw data in, not pre-digested stats: the
 model finds the patterns.
 
@@ -51,12 +51,16 @@ def _ask(prompt: str, llm_config: LLMConfig, timeout_seconds: int) -> str:
 
 
 def _clip_line(index: int, member: ClipWithSegment) -> str:
+    from immich_memories.generate_privacy import clip_location_name
+
     clip = member.clip
     parts = [f"Clip {index}:"]
-    when = getattr(clip, "date", None)
-    if when:
-        parts.append(f"date={when}")
-    where = getattr(clip, "location_name", None)
+    # WHY read through asset: date and place live on the Immich asset, not on
+    # VideoClipInfo — reading them off the clip silently sent nothing (#475).
+    taken = getattr(clip.asset, "file_created_at", None)
+    if taken:
+        parts.append(f"date={taken.date().isoformat()}")
+    where = clip_location_name(getattr(clip.asset, "exif_info", None))
     if where:
         parts.append(f"place={where}")
     parts.append(f"score={member.score:.2f}")
@@ -66,7 +70,6 @@ def _clip_line(index: int, member: ClipWithSegment) -> str:
         ("setting", "llm_setting"),
         ("subjects", "llm_subjects"),
         ("heard", "audio_categories"),
-        ("transcript", "transcript"),
     ):
         value = getattr(clip, attr, None)
         if value:

--- a/tests/test_selection_review.py
+++ b/tests/test_selection_review.py
@@ -74,3 +74,38 @@ class TestReviewSelection:
             drops = review_selection(_selection(), LLMConfig())
 
         assert len(drops) <= 1  # 20% of 3, floored, min 1
+
+
+class TestTheClipLineCarriesRealFields:
+    """Found by the #475 investigation: _clip_line read `date`, `location_name`
+    and `transcript` off VideoClipInfo, which has none of them — three of the
+    fields the prompt claims to send were silently absent. Place in particular
+    is the evidence a "does this set hang together" question needs."""
+
+    def test_date_and_place_reach_the_prompt(self):
+        from datetime import UTC, datetime
+
+        from immich_memories.api.models import ExifInfo
+
+        member = _member("a-1", "Kids on the sand")
+        member.clip.asset.file_created_at = datetime(2025, 8, 14, tzinfo=UTC)
+        member.clip.asset.exif_info = ExifInfo(city="Jette", country="Belgium")
+        selection = [member, _member("a-2", "Ferry crossing"), _member("a-3", "Dinner")]
+
+        # WHY: the LLM call is the external boundary; we inspect the prompt
+        with patch(
+            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+        ) as ask:
+            review_selection(selection, LLMConfig())
+
+        prompt = ask.call_args[0][0]
+        assert "2025-08-14" in prompt
+        assert "Jette, Belgium" in prompt
+
+    def test_a_clip_without_exif_still_renders(self):
+        with patch(
+            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+        ) as ask:
+            review_selection(_selection(), LLMConfig())
+
+        assert "Clip 1:" in ask.call_args[0][0]


### PR DESCRIPTION
Found by the #475 investigation, in code merged earlier today (#477).

`selection_review._clip_line` read `date`, `location_name` and `transcript` off `VideoClipInfo` with `getattr` defaults — and `VideoClipInfo` has **none of the three**. Every holistic-review prompt has silently omitted them while the module docstring advertised them.

- **Date and place** now come from the Immich asset (`file_created_at`, and city/country via `clip_location_name`). Place is exactly the evidence a "does this set hang together" question needs — and the signal a future mode detector reads.
- **Transcript** is dropped from the docstring rather than faked: transcripts live on cached segments, not on the clip. Claiming it and sending nothing is worse than not claiming it.

Two tests: one asserts the date and place actually reach the prompt, one that a clip without EXIF still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM