### PR TITLE
feat(analysis): capture the signals period classification needs

### DIFF
--- a/docs-site/docs/create/pipeline/llm-content-analysis.md
+++ b/docs-site/docs/create/pipeline/llm-content-analysis.md
@@ -32,12 +32,15 @@ This works with anything that speaks the OpenAI chat completions API:
 | `category` | exactly one of `people`, `animal`, `landscape`, `object`, `screen` — drives the subject policy |
 | `subjects` | short lowercase nouns in frame (`["child", "dog", "beach"]`) |
 | `setting` | exactly one of `indoor_home`, `indoor_public`, `outdoor_nature`, `outdoor_urban`, `vehicle`, `water` |
+| `activities` | recognisable pastimes or sports (`["cycling"]`), empty when none — most clips have none |
 | `emotion` | one word mood, used for music selection |
 | `interestingness`, `quality` | 0.0–1.0 |
 
 `setting` is a closed vocabulary on purpose: it describes *what kind of period* a memory covers,
 which free text cannot answer reliably. A value outside the list is dropped rather than stored, so
-a model that ignores the vocabulary cannot reintroduce free text.
+a model that ignores the vocabulary cannot reintroduce free text. `activities` is deliberately
+sparse — it fires on a recognisable pastime and stays empty otherwise, which is the correct answer
+for most clips.
 
 Analysis is per-period and on demand: when the fields change, `ANALYSIS_VERSION` is bumped and each
 pool re-analyzes itself the next time a memory covers it. Nothing sweeps the whole library.

--- a/docs-site/docs/create/pipeline/llm-content-analysis.md
+++ b/docs-site/docs/create/pipeline/llm-content-analysis.md
@@ -32,13 +32,12 @@ This works with anything that speaks the OpenAI chat completions API:
 | `category` | exactly one of `people`, `animal`, `landscape`, `object`, `screen` — drives the subject policy |
 | `subjects` | short lowercase nouns in frame (`["child", "dog", "beach"]`) |
 | `setting` | exactly one of `indoor_home`, `indoor_public`, `outdoor_nature`, `outdoor_urban`, `vehicle`, `water` |
-| `activities` | short lowercase verbs (`["cycling", "riding"]`), empty when nothing specific is happening |
 | `emotion` | one word mood, used for music selection |
 | `interestingness`, `quality` | 0.0–1.0 |
 
-`setting` and `activities` are closed/structured on purpose: they describe *what kind of period* a
-memory covers, which free text cannot answer reliably. A value outside the `setting` list is
-dropped rather than stored, so a model that ignores the vocabulary cannot reintroduce free text.
+`setting` is a closed vocabulary on purpose: it describes *what kind of period* a memory covers,
+which free text cannot answer reliably. A value outside the list is dropped rather than stored, so
+a model that ignores the vocabulary cannot reintroduce free text.
 
 Analysis is per-period and on demand: when the fields change, `ANALYSIS_VERSION` is bumped and each
 pool re-analyzes itself the next time a memory covers it. Nothing sweeps the whole library.

--- a/docs-site/docs/create/pipeline/llm-content-analysis.md
+++ b/docs-site/docs/create/pipeline/llm-content-analysis.md
@@ -24,6 +24,25 @@ This works with anything that speaks the OpenAI chat completions API:
 3. The LLM response is parsed into a score
 4. That score is weighted and added to the overall [interest score](./clip-selection-scoring.md)
 
+### What the model returns per segment
+
+| field | what it is |
+|---|---|
+| `description` | what is happening in the scene |
+| `category` | exactly one of `people`, `animal`, `landscape`, `object`, `screen` — drives the subject policy |
+| `subjects` | short lowercase nouns in frame (`["child", "dog", "beach"]`) |
+| `setting` | exactly one of `indoor_home`, `indoor_public`, `outdoor_nature`, `outdoor_urban`, `vehicle`, `water` |
+| `activities` | short lowercase verbs (`["cycling", "riding"]`), empty when nothing specific is happening |
+| `emotion` | one word mood, used for music selection |
+| `interestingness`, `quality` | 0.0–1.0 |
+
+`setting` and `activities` are closed/structured on purpose: they describe *what kind of period* a
+memory covers, which free text cannot answer reliably. A value outside the `setting` list is
+dropped rather than stored, so a model that ignores the vocabulary cannot reintroduce free text.
+
+Analysis is per-period and on demand: when the fields change, `ANALYSIS_VERSION` is bumped and each
+pool re-analyzes itself the next time a memory covers it. Nothing sweeps the whole library.
+
 ## LLM Title Generation
 
 Instead of generic "TWO WEEKS IN SPAIN, SUMMER 2025" template titles, the app feeds your trip's raw GPS data to a local LLM and gets back something like "Sous les falaises de grès" or "Odyssée le long de la côte". It works in any language and classifies your trip pattern too.

--- a/src/immich_memories/analysis/analyzer_models.py
+++ b/src/immich_memories/analysis/analyzer_models.py
@@ -71,7 +71,6 @@ class ScoredSegment:
     llm_emotion: str | None = None
     llm_setting: str | None = None
     llm_subjects: list[str] | None = None
-    llm_activities: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None
     llm_confidence: float | None = None

--- a/src/immich_memories/analysis/analyzer_models.py
+++ b/src/immich_memories/analysis/analyzer_models.py
@@ -71,6 +71,7 @@ class ScoredSegment:
     llm_emotion: str | None = None
     llm_setting: str | None = None
     llm_subjects: list[str] | None = None
+    llm_activities: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None
     llm_confidence: float | None = None

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -49,13 +49,11 @@ _PROMPT_TAIL = """Return JSON with these fields:
   outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
   "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
   "outdoor_nature" for anything outdoors that is not built up.
-- activities: What are they doing? (short lowercase verbs, e.g. ["cycling", "riding"];
-  empty list when nothing specific is happening)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "activities": ["digging"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 
@@ -110,7 +108,6 @@ class ContentAnalysis:
     category: str = ""
     subjects: list[str] = field(default_factory=list)
     setting: str = ""
-    activities: list[str] = field(default_factory=list)
     emotion: str = ""
     interestingness: float = 0.5
     quality: float = 0.5
@@ -407,9 +404,6 @@ class ContentAnalyzer:
         # the enum must not quietly reintroduce free text (#483).
         raw_setting = str(data.get("setting", "")).strip().lower()
         setting = raw_setting if raw_setting in SETTING_VALUES else ""
-        activities = [
-            str(a).strip().lower()[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]
-        ]
         emotion = emotion[:MAX_STR]
 
         raw_interest = float(data.get("interestingness", 0.5))
@@ -422,7 +416,6 @@ class ContentAnalyzer:
             subjects=subjects,
             category=category,
             setting=setting,
-            activities=activities,
             emotion=emotion,
             interestingness=interestingness,
             quality=quality,

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -22,6 +22,20 @@ logger = logging.getLogger(__name__)
 # Prompt for content analysis - optimized for small vision models like Moondream
 _PROMPT_HEAD = """Describe what you see in this image."""
 
+# WHY a closed vocabulary (#483): free text gave 39+ values including both
+# "indoor" and "indoors", plus "computer screen" and "restaurant patio". The
+# indoor/outdoor split is the one signal that survived every control in the
+# #475 period-classification study, so it has to be exact rather than
+# reconstructed from description keywords.
+SETTING_VALUES = (
+    "indoor_home",
+    "indoor_public",
+    "outdoor_nature",
+    "outdoor_urban",
+    "vehicle",
+    "water",
+)
+
 _PROMPT_TAIL = """Return JSON with these fields:
 - description: What is happening in this scene?
 - category: What is this mainly of? Exactly one of: people, animal, landscape, object, screen.
@@ -31,12 +45,17 @@ _PROMPT_TAIL = """Return JSON with these fields:
   toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
   never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
-- setting: Where is it? (one or two words: beach, kitchen, park, car)
+- setting: Where is it? Exactly one of: indoor_home, indoor_public, outdoor_nature,
+  outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
+  "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
+  "outdoor_nature" for anything outdoors that is not built up.
+- activities: What are they doing? (short lowercase verbs, e.g. ["cycling", "riding"];
+  empty list when nothing specific is happening)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "beach", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "activities": ["digging"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 
@@ -91,6 +110,7 @@ class ContentAnalysis:
     category: str = ""
     subjects: list[str] = field(default_factory=list)
     setting: str = ""
+    activities: list[str] = field(default_factory=list)
     emotion: str = ""
     interestingness: float = 0.5
     quality: float = 0.5
@@ -383,7 +403,13 @@ class ContentAnalyzer:
         description = str(data.get("description", ""))[:MAX_STR]
         subjects = [str(s)[:MAX_STR] for s in data.get("subjects", [])[:MAX_LIST]]
         category = str(data.get("category", ""))[:MAX_STR]
-        setting = str(data.get("setting", ""))[:MAX_STR]
+        # An unlisted value is dropped rather than stored: a model that ignores
+        # the enum must not quietly reintroduce free text (#483).
+        raw_setting = str(data.get("setting", "")).strip().lower()
+        setting = raw_setting if raw_setting in SETTING_VALUES else ""
+        activities = [
+            str(a).strip().lower()[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]
+        ]
         emotion = emotion[:MAX_STR]
 
         raw_interest = float(data.get("interestingness", 0.5))
@@ -396,6 +422,7 @@ class ContentAnalyzer:
             subjects=subjects,
             category=category,
             setting=setting,
+            activities=activities,
             emotion=emotion,
             interestingness=interestingness,
             quality=quality,

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -49,6 +49,9 @@ _PROMPT_TAIL = """Return JSON with these fields:
   outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
   "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
   "outdoor_nature" for anything outdoors that is not built up.
+- activities: If the scene shows a recognisable pastime or sport, name it:
+  ["cycling"], ["swimming"], ["skiing"], ["hiking"], ["running"], ["cooking"].
+  Empty list when no pastime or sport is recognisable.
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
@@ -108,6 +111,7 @@ class ContentAnalysis:
     category: str = ""
     subjects: list[str] = field(default_factory=list)
     setting: str = ""
+    activities: list[str] = field(default_factory=list)
     emotion: str = ""
     interestingness: float = 0.5
     quality: float = 0.5
@@ -402,6 +406,9 @@ class ContentAnalyzer:
         category = str(data.get("category", ""))[:MAX_STR]
         # An unlisted value is dropped rather than stored: a model that ignores
         # the enum must not quietly reintroduce free text (#483).
+        activities = [
+            str(a).strip().lower()[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]
+        ]
         raw_setting = str(data.get("setting", "")).strip().lower()
         setting = raw_setting if raw_setting in SETTING_VALUES else ""
         emotion = emotion[:MAX_STR]
@@ -416,6 +423,7 @@ class ContentAnalyzer:
             subjects=subjects,
             category=category,
             setting=setting,
+            activities=activities,
             emotion=emotion,
             interestingness=interestingness,
             quality=quality,

--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -62,6 +63,17 @@ def log_top_segments(segments: list[ScoredSegment], top_n: int = 5) -> None:
             f"duration={seg.duration_score:.2f} visual={seg.visual_score:.2f} "
             f"cut_q={seg.cut_quality:.2f}"
         )
+
+
+@dataclass(frozen=True)
+class _VisualScores:
+    """One segment's visual scores plus the face geometry behind them."""
+
+    face: float
+    motion: float
+    stability: float
+    total: float
+    face_positions: list[tuple[float, float]] | None = None
 
 
 class UnifiedSegmentAnalyzer:
@@ -491,9 +503,7 @@ class UnifiedSegmentAnalyzer:
 
         return score
 
-    def _score_visual(
-        self, video_path: Path, start_time: float, end_time: float
-    ) -> dict[str, float]:
+    def _score_visual(self, video_path: Path, start_time: float, end_time: float) -> _VisualScores:
         """Score a segment using visual analysis (faces, motion, stability).
 
         Args:
@@ -528,12 +538,16 @@ class UnifiedSegmentAnalyzer:
         else:
             total = 0.0
 
-        return {
-            "face": moment.face_score,
-            "motion": moment.motion_score,
-            "stability": moment.stability_score,
-            "total": total,
-        }
+        return _VisualScores(
+            face=moment.face_score,
+            motion=moment.motion_score,
+            stability=moment.stability_score,
+            total=total,
+            # WHY carried through: score_scene computes face geometry and this
+            # returned only the floats, so processing/transforms.py — which
+            # takes face_positions for framing — was fed nothing (#483).
+            face_positions=moment.face_positions,
+        )
 
     def _score_content(
         self,
@@ -697,11 +711,12 @@ class UnifiedSegmentAnalyzer:
 
             # Score using visual analysis only
             try:
-                visual_scores = self._score_visual(video_path, segment.start_time, segment.end_time)
-                segment.face_score = visual_scores.get("face", 0.0)
-                segment.motion_score = visual_scores.get("motion", 0.0)
-                segment.stability_score = visual_scores.get("stability", 0.0)
-                segment.visual_score = visual_scores.get("total", 0.0)
+                visual = self._score_visual(video_path, segment.start_time, segment.end_time)
+                segment.face_score = visual.face
+                segment.motion_score = visual.motion
+                segment.stability_score = visual.stability
+                segment.visual_score = visual.total
+                segment.face_positions = visual.face_positions
             except (OSError, subprocess.SubprocessError, RuntimeError, ValueError, TypeError) as e:
                 logger.warning(f"Visual scoring failed: {e}")
                 # Not 0.5: the ceiling for a segment with no faces is exactly

--- a/src/immich_memories/cache/database.py
+++ b/src/immich_memories/cache/database.py
@@ -633,7 +633,6 @@ class VideoAnalysisCache:
         for i, segment in enumerate(segments):
             # Serialize list fields to JSON
             subjects = getattr(segment, "llm_subjects", None)
-            activities = getattr(segment, "llm_activities", None)
             audio_cats = getattr(segment, "audio_categories", None)
 
             conn.execute(
@@ -643,11 +642,11 @@ class VideoAnalysisCache:
                     face_score, motion_score, stability_score,
                     audio_score, total_score, face_positions,
                     llm_description, llm_category, llm_emotion, llm_setting,
-                    llm_subjects, llm_activities,
+                    llm_subjects,
                     llm_interestingness, llm_quality,
                     audio_categories,
                     transcript, transcript_language, transcript_confidence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     asset_id,
@@ -665,7 +664,6 @@ class VideoAnalysisCache:
                     getattr(segment, "llm_emotion", None),
                     getattr(segment, "llm_setting", None),
                     json.dumps(list(subjects)) if subjects else None,
-                    json.dumps(list(activities)) if activities else None,
                     getattr(segment, "llm_interestingness", None),
                     getattr(segment, "llm_quality", None),
                     json.dumps(sorted(audio_cats)) if audio_cats else None,

--- a/src/immich_memories/cache/database.py
+++ b/src/immich_memories/cache/database.py
@@ -633,6 +633,7 @@ class VideoAnalysisCache:
         for i, segment in enumerate(segments):
             # Serialize list fields to JSON
             subjects = getattr(segment, "llm_subjects", None)
+            activities = getattr(segment, "llm_activities", None)
             audio_cats = getattr(segment, "audio_categories", None)
 
             conn.execute(
@@ -642,11 +643,11 @@ class VideoAnalysisCache:
                     face_score, motion_score, stability_score,
                     audio_score, total_score, face_positions,
                     llm_description, llm_category, llm_emotion, llm_setting,
-                    llm_subjects,
+                    llm_subjects, llm_activities,
                     llm_interestingness, llm_quality,
                     audio_categories,
                     transcript, transcript_language, transcript_confidence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     asset_id,
@@ -664,6 +665,7 @@ class VideoAnalysisCache:
                     getattr(segment, "llm_emotion", None),
                     getattr(segment, "llm_setting", None),
                     json.dumps(list(subjects)) if subjects else None,
+                    json.dumps(list(activities)) if activities else None,
                     getattr(segment, "llm_interestingness", None),
                     getattr(segment, "llm_quality", None),
                     json.dumps(sorted(audio_cats)) if audio_cats else None,

--- a/src/immich_memories/cache/database_models.py
+++ b/src/immich_memories/cache/database_models.py
@@ -37,6 +37,7 @@ class CachedSegment:
     llm_emotion: str | None = None
     llm_setting: str | None = None
     llm_subjects: list[str] | None = None
+    llm_activities: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None
 

--- a/src/immich_memories/cache/database_models.py
+++ b/src/immich_memories/cache/database_models.py
@@ -37,7 +37,6 @@ class CachedSegment:
     llm_emotion: str | None = None
     llm_setting: str | None = None
     llm_subjects: list[str] | None = None
-    llm_activities: list[str] | None = None
     llm_interestingness: float | None = None
     llm_quality: float | None = None
 

--- a/src/immich_memories/cache/database_rows.py
+++ b/src/immich_memories/cache/database_rows.py
@@ -72,6 +72,7 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         return float(value) if value is not None else None
 
     subjects_raw = optional_str("llm_subjects")
+    activities_raw = optional_str("llm_activities")
     audio_categories_raw = optional_str("audio_categories")
 
     return CachedSegment(
@@ -93,6 +94,7 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         llm_emotion=optional_str("llm_emotion"),
         llm_setting=optional_str("llm_setting"),
         llm_subjects=(json.loads(subjects_raw) if subjects_raw else None),
+        llm_activities=(json.loads(activities_raw) if activities_raw else None),
         llm_interestingness=optional_float("llm_interestingness"),
         llm_quality=optional_float("llm_quality"),
         audio_categories=(json.loads(audio_categories_raw) if audio_categories_raw else None),

--- a/src/immich_memories/cache/database_rows.py
+++ b/src/immich_memories/cache/database_rows.py
@@ -72,7 +72,6 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         return float(value) if value is not None else None
 
     subjects_raw = optional_str("llm_subjects")
-    activities_raw = optional_str("llm_activities")
     audio_categories_raw = optional_str("audio_categories")
 
     return CachedSegment(
@@ -94,7 +93,6 @@ def row_to_segment(row: sqlite3.Row) -> CachedSegment:
         llm_emotion=optional_str("llm_emotion"),
         llm_setting=optional_str("llm_setting"),
         llm_subjects=(json.loads(subjects_raw) if subjects_raw else None),
-        llm_activities=(json.loads(activities_raw) if activities_raw else None),
         llm_interestingness=optional_float("llm_interestingness"),
         llm_quality=optional_float("llm_quality"),
         audio_categories=(json.loads(audio_categories_raw) if audio_categories_raw else None),

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
 SCHEMA_VERSION = 19
-ANALYSIS_VERSION = 14
+ANALYSIS_VERSION = 15
 SCORING_VERSION = 3

--- a/tests/test_analysis_mode_signals.py
+++ b/tests/test_analysis_mode_signals.py
@@ -1,0 +1,123 @@
+"""Signals the analyzer must capture for period classification (#483).
+
+Per-period analysis means every pool generated from now on either carries
+these fields or doesn't — a later regeneration is the only recovery, so the
+schema goes in before the periods people care about.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from immich_memories.analysis.llm_response_parser import (
+    SETTING_VALUES,
+    ContentAnalysis,
+    ContentAnalyzer,
+    build_content_analysis_prompt,
+)
+
+
+def parse_content_response(text: str) -> ContentAnalysis:
+    """Parse a model response the way the analyzer does."""
+    return ContentAnalyzer()._parse_content_response(text)  # noqa: SLF001
+
+
+class TestSettingIsAClosedVocabulary:
+    """Free text gave 39+ values including both "indoor" and "indoors".
+    outdoor_share is the one signal that survived every control in the #475
+    era-split study, so it has to be exact rather than reconstructed."""
+
+    def test_the_prompt_lists_the_allowed_values(self):
+        prompt = build_content_analysis_prompt()
+
+        for value in SETTING_VALUES:
+            assert value in prompt
+
+    def test_a_listed_value_is_kept(self):
+        result = parse_content_response('{"setting": "outdoor_nature"}')
+
+        assert result.setting == "outdoor_nature"
+
+    def test_an_unlisted_value_is_dropped_rather_than_stored(self):
+        """A model that ignores the enum must not reintroduce free text."""
+        result = parse_content_response('{"setting": "restaurant patio"}')
+
+        assert result.setting == ""
+
+    def test_a_near_miss_is_normalised(self):
+        assert parse_content_response('{"setting": "Outdoor_Nature "}').setting == (
+            "outdoor_nature"
+        )
+
+    def test_the_vocabulary_distinguishes_indoor_from_outdoor(self):
+        """The indoor/outdoor split is what period classification reads; the
+        derived helper belongs with its first consumer, not here."""
+        assert {"outdoor_nature", "outdoor_urban", "water"} <= set(SETTING_VALUES)
+        assert {"indoor_home", "indoor_public"} <= set(SETTING_VALUES)
+
+
+class TestActivitiesAreCaptured:
+    """llm_activities exists as a column with 0 of 10378 rows populated: the
+    field is not in the prompt and nothing writes it. It is the only path to
+    detecting an activity period — a cycling month is identical to a family
+    month on every other measured axis."""
+
+    def test_the_prompt_asks_for_activities(self):
+        assert "activities" in build_content_analysis_prompt()
+
+    def test_activities_are_parsed(self):
+        result = parse_content_response('{"activities": ["Cycling", "riding"]}')
+
+        assert result.activities == ["cycling", "riding"]
+
+    def test_missing_activities_are_empty_not_none(self):
+        assert parse_content_response('{"description": "x"}').activities == []
+
+
+@pytest.fixture
+def mock_asset():
+    """WHY a mock: the cache takes an Asset only for identity and timestamps."""
+    asset = MagicMock()
+    asset.id = "asset-act"
+    asset.checksum = "abc123"
+    asset.file_modified_at = datetime(2024, 1, 15, 12, 0, 0)
+    asset.file_created_at = datetime(2024, 1, 15, 10, 0, 0)
+    asset.duration_seconds = 30.0
+    return asset
+
+
+class TestActivitiesReachTheDatabase:
+    """The column exists with 0 of 10378 rows populated — the INSERT omits it,
+    so even a populated field would be dropped on the way to disk."""
+
+    def test_a_segment_activities_survive_the_round_trip(self, tmp_path, mock_asset):
+        from immich_memories.analysis.analyzer_models import ScoredSegment
+        from immich_memories.cache.database import VideoAnalysisCache
+
+        cache = VideoAnalysisCache(tmp_path / "cache.db")
+        segment = ScoredSegment(start_time=0.0, end_time=5.0)
+        segment.total_score = 0.7
+        segment.llm_activities = ["cycling", "riding"]
+
+        cache.save_analysis(asset=mock_asset, segments=[segment])
+        loaded = cache.get_analysis(mock_asset.id)
+
+        assert loaded is not None
+        assert loaded.segments[0].llm_activities == ["cycling", "riding"]
+
+
+class TestFacePositionsSurviveScoring:
+    """score_scene computes face positions and _score_visual threw them away —
+    processing/transforms.py takes them for framing and was fed nothing."""
+
+    def test_the_visual_scorer_keeps_the_geometry(self):
+        import inspect
+
+        from immich_memories.analysis import unified_analyzer
+
+        source = inspect.getsource(unified_analyzer.UnifiedSegmentAnalyzer._score_visual)
+
+        assert "face_positions" in source

--- a/tests/test_analysis_mode_signals.py
+++ b/tests/test_analysis_mode_signals.py
@@ -7,6 +7,8 @@ schema goes in before the periods people care about.
 
 from __future__ import annotations
 
+import pytest
+
 from immich_memories.analysis.llm_response_parser import (
     SETTING_VALUES,
     ContentAnalysis,
@@ -52,3 +54,57 @@ class TestSettingIsAClosedVocabulary:
         derived helper belongs with its first consumer, not here."""
         assert {"outdoor_nature", "outdoor_urban", "water"} <= set(SETTING_VALUES)
         assert {"indoor_home", "indoor_public"} <= set(SETTING_VALUES)
+
+
+class TestActivitiesAreCaptured:
+    """Measured on clips Immich CLIP search says ARE cycling: the model
+    returns ["cycling"] for 10 of 12. An earlier attempt read 1/12 because
+    it sampled a race day by API order and got a lanyard, a cardboard box
+    and spectators — bad sampling, not a dead field."""
+
+    def test_the_prompt_asks_for_activities(self):
+        assert "activities" in build_content_analysis_prompt()
+
+    def test_activities_are_parsed_and_normalised(self):
+        assert parse_content_response('{"activities": ["Cycling", "riding"]}').activities == [
+            "cycling",
+            "riding",
+        ]
+
+    def test_missing_activities_are_empty_not_none(self):
+        assert parse_content_response('{"description": "x"}').activities == []
+
+
+class TestActivitiesReachTheDatabase:
+    """The column existed with 0 of 10378 rows populated: the field was
+    absent from the prompt AND from the segment INSERT."""
+
+    def test_a_segment_activities_survive_the_round_trip(self, tmp_path, mock_asset):
+        from immich_memories.analysis.analyzer_models import ScoredSegment
+        from immich_memories.cache.database import VideoAnalysisCache
+
+        cache = VideoAnalysisCache(tmp_path / "cache.db")
+        segment = ScoredSegment(start_time=0.0, end_time=5.0)
+        segment.total_score = 0.7
+        segment.llm_activities = ["cycling"]
+
+        cache.save_analysis(asset=mock_asset, segments=[segment])
+        loaded = cache.get_analysis(mock_asset.id)
+
+        assert loaded is not None
+        assert loaded.segments[0].llm_activities == ["cycling"]
+
+
+@pytest.fixture
+def mock_asset():
+    """WHY a mock: the cache takes an Asset only for identity and timestamps."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    asset = MagicMock()
+    asset.id = "asset-act"
+    asset.checksum = "abc123"
+    asset.file_modified_at = datetime(2024, 1, 15, 12, 0, 0)
+    asset.file_created_at = datetime(2024, 1, 15, 10, 0, 0)
+    asset.duration_seconds = 30.0
+    return asset

--- a/tests/test_analysis_mode_signals.py
+++ b/tests/test_analysis_mode_signals.py
@@ -7,11 +7,6 @@ schema goes in before the periods people care about.
 
 from __future__ import annotations
 
-from datetime import datetime
-from unittest.mock import MagicMock
-
-import pytest
-
 from immich_memories.analysis.llm_response_parser import (
     SETTING_VALUES,
     ContentAnalysis,
@@ -57,67 +52,3 @@ class TestSettingIsAClosedVocabulary:
         derived helper belongs with its first consumer, not here."""
         assert {"outdoor_nature", "outdoor_urban", "water"} <= set(SETTING_VALUES)
         assert {"indoor_home", "indoor_public"} <= set(SETTING_VALUES)
-
-
-class TestActivitiesAreCaptured:
-    """llm_activities exists as a column with 0 of 10378 rows populated: the
-    field is not in the prompt and nothing writes it. It is the only path to
-    detecting an activity period — a cycling month is identical to a family
-    month on every other measured axis."""
-
-    def test_the_prompt_asks_for_activities(self):
-        assert "activities" in build_content_analysis_prompt()
-
-    def test_activities_are_parsed(self):
-        result = parse_content_response('{"activities": ["Cycling", "riding"]}')
-
-        assert result.activities == ["cycling", "riding"]
-
-    def test_missing_activities_are_empty_not_none(self):
-        assert parse_content_response('{"description": "x"}').activities == []
-
-
-@pytest.fixture
-def mock_asset():
-    """WHY a mock: the cache takes an Asset only for identity and timestamps."""
-    asset = MagicMock()
-    asset.id = "asset-act"
-    asset.checksum = "abc123"
-    asset.file_modified_at = datetime(2024, 1, 15, 12, 0, 0)
-    asset.file_created_at = datetime(2024, 1, 15, 10, 0, 0)
-    asset.duration_seconds = 30.0
-    return asset
-
-
-class TestActivitiesReachTheDatabase:
-    """The column exists with 0 of 10378 rows populated — the INSERT omits it,
-    so even a populated field would be dropped on the way to disk."""
-
-    def test_a_segment_activities_survive_the_round_trip(self, tmp_path, mock_asset):
-        from immich_memories.analysis.analyzer_models import ScoredSegment
-        from immich_memories.cache.database import VideoAnalysisCache
-
-        cache = VideoAnalysisCache(tmp_path / "cache.db")
-        segment = ScoredSegment(start_time=0.0, end_time=5.0)
-        segment.total_score = 0.7
-        segment.llm_activities = ["cycling", "riding"]
-
-        cache.save_analysis(asset=mock_asset, segments=[segment])
-        loaded = cache.get_analysis(mock_asset.id)
-
-        assert loaded is not None
-        assert loaded.segments[0].llm_activities == ["cycling", "riding"]
-
-
-class TestFacePositionsSurviveScoring:
-    """score_scene computes face positions and _score_visual threw them away —
-    processing/transforms.py takes them for framing and was fed nothing."""
-
-    def test_the_visual_scorer_keeps_the_geometry(self):
-        import inspect
-
-        from immich_memories.analysis import unified_analyzer
-
-        source = inspect.getsource(unified_analyzer.UnifiedSegmentAnalyzer._score_visual)
-
-        assert "face_positions" in source

--- a/tests/test_audio_context_prompt.py
+++ b/tests/test_audio_context_prompt.py
@@ -20,7 +20,8 @@ from immich_memories.config_models import AnalysisConfig, AudioContentConfig
 
 # Hard-coded rather than compared against the constant: comparing against the
 # constant would pass even if both changed together, which is the regression this
-# guards.
+# guards. Updating this literal is therefore a deliberate act — it means the
+# prompt genuinely changed and every analysis from here on differs (#483).
 TODAYS_PROMPT = """Describe what you see in this image.
 
 Return JSON with these fields:
@@ -32,12 +33,17 @@ Return JSON with these fields:
   toy, figurine, drawing or photo of one. Use "landscape" only for a wide outdoor view,
   never for a close-up of a thing. Use "object" for anything else.
 - subjects: What is in frame? (short lowercase nouns, e.g. ["child", "dog", "beach"])
-- setting: Where is it? (one or two words: beach, kitchen, park, car)
+- setting: Where is it? Exactly one of: indoor_home, indoor_public, outdoor_nature,
+  outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
+  "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
+  "outdoor_nature" for anything outdoors that is not built up.
+- activities: What are they doing? (short lowercase verbs, e.g. ["cycling", "riding"];
+  empty list when nothing specific is happening)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "beach", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "activities": ["digging"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 

--- a/tests/test_audio_context_prompt.py
+++ b/tests/test_audio_context_prompt.py
@@ -37,6 +37,9 @@ Return JSON with these fields:
   outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
   "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
   "outdoor_nature" for anything outdoors that is not built up.
+- activities: If the scene shows a recognisable pastime or sport, name it:
+  ["cycling"], ["swimming"], ["skiing"], ["hiking"], ["running"], ["cooking"].
+  Empty list when no pastime or sport is recognisable.
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)

--- a/tests/test_audio_context_prompt.py
+++ b/tests/test_audio_context_prompt.py
@@ -37,13 +37,11 @@ Return JSON with these fields:
   outdoor_urban, vehicle, water. Use "water" for in or on water (pool, sea, boat),
   "vehicle" for inside a car, train or plane, "outdoor_urban" for streets and towns,
   "outdoor_nature" for anything outdoors that is not built up.
-- activities: What are they doing? (short lowercase verbs, e.g. ["cycling", "riding"];
-  empty list when nothing specific is happening)
 - emotion: What is the mood? (one word: happy, calm, excited, playful, joyful, peaceful)
 - interestingness: How memorable is this moment? (0.0 to 1.0)
 - quality: How good is the image quality? (0.0 to 1.0)
 
-Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "activities": ["digging"], "emotion": "...", "interestingness": 0.7, "quality": 0.8}
+Example format: {"description": "...", "category": "people", "subjects": ["child", "sand"], "setting": "outdoor_nature", "emotion": "...", "interestingness": 0.7, "quality": 0.8}
 
 JSON:"""
 

--- a/tests/test_llm_response_parser.py
+++ b/tests/test_llm_response_parser.py
@@ -278,14 +278,18 @@ class TestBuildContentAnalysis:
         assert result.quality == pytest.approx(0.5)
 
     def test_setting_field(self):
-        data = {"setting": "indoor kitchen"}
+        """setting is a closed vocabulary since #483 — free text is dropped."""
+        data = {"setting": "outdoor_nature"}
         result = ContentAnalyzer._build_content_analysis(data, "happy")
-        assert result.setting == "indoor kitchen"
+        assert result.setting == "outdoor_nature"
 
-    def test_truncates_long_setting(self):
-        data = {"setting": "s" * 600}
-        result = ContentAnalyzer._build_content_analysis(data, "")
-        assert len(result.setting) == 500
+    def test_free_text_setting_is_dropped_not_truncated(self):
+        """Truncation was the right answer for free text; for an enum, a value
+        outside the list is simply not a value."""
+        assert (
+            ContentAnalyzer._build_content_analysis({"setting": "indoor kitchen"}, "").setting == ""
+        )
+        assert ContentAnalyzer._build_content_analysis({"setting": "s" * 600}, "").setting == ""
 
 
 class TestParseContentResponse:

--- a/tests/test_pipeline_orchestration_coverage.py
+++ b/tests/test_pipeline_orchestration_coverage.py
@@ -454,7 +454,7 @@ class TestScoreVisualZeroWeights:
 
         analyzer = _make_analyzer(scorer=scorer)
         result = analyzer._score_visual(Path("/fake.mp4"), 0.0, 5.0)
-        assert result["total"] == 0.0
+        assert result.total == 0.0
 
 
 class TestScoreContentBranches:

--- a/tests/test_unified_analyzer.py
+++ b/tests/test_unified_analyzer.py
@@ -563,14 +563,12 @@ class TestUnifiedAnalyzerIntegration:
             call_count = [0]
 
             def score_side_effect(*args, **kwargs):
+                from immich_memories.analysis.unified_analyzer import _VisualScores
+
                 call_count[0] += 1
                 scores = [0.5, 0.9, 0.7]  # Middle segment is best
-                return {
-                    "face": scores[call_count[0] % 3],
-                    "motion": scores[call_count[0] % 3],
-                    "stability": scores[call_count[0] % 3],
-                    "total": scores[call_count[0] % 3],
-                }
+                score = scores[call_count[0] % 3]
+                return _VisualScores(face=score, motion=score, stability=score, total=score)
 
             mock_score.side_effect = score_side_effect
 
@@ -679,7 +677,7 @@ class TestScoreVisualExcludesAudio:
 
         # Visual score = weighted average of face, motion, stability ONLY
         expected = (0.9 * 0.35 + 0.6 * 0.20 + 0.3 * 0.15) / (0.35 + 0.20 + 0.15)
-        assert abs(result["total"] - expected) < 0.001
+        assert abs(result.total - expected) < 0.001
 
 
 class TestBestSegmentOverlapHandling:


### PR DESCRIPTION
Closes #483, blocks #475. Analysis is **per-period on demand** — `needs_reanalysis` fires whenever a pool's `analysis_version` differs from `ANALYSIS_VERSION`, so every pool generated from now on either carries these fields or doesn't, and a later regeneration is the only recovery. Hence: schema first, then periods.

Every field here was **validated against the real model on real clips** before landing — one was removed and then restored on that evidence.

## 1. `setting` becomes a closed vocabulary

`indoor_home | indoor_public | outdoor_nature | outdoor_urban | vehicle | water`

Free text produced **39+ distinct values** including both `indoor` and `indoors`, plus `computer screen` and `restaurant patio` — and the indoor/outdoor split is the **one signal that survived every control** in the #475 era-split study (AUC 0.296 videos / 0.294 images).

**Measured on 24 real clips across four periods: 24/24 came back inside the vocabulary**, distinctions holding — a street race reads `outdoor_urban`, an alpine valley `outdoor_nature`, home `indoor_home`. A value outside the list is **dropped rather than truncated**: for an enum, a value not in the list is not a value.

## 2. `activities` — removed, then restored on better evidence

The first measurement said 1/12 on a real bike-race day, and I removed the field. That test took the first six assets in metadata-API order and got a cardboard box at home, spectators behind barriers, a lanyard and posed medal photos — for which `activities: []` is *correct*.

Re-run against clips Immich CLIP search says **are** cycling, the same model on the same prompt returns `["cycling"]` for **10 of 12**:

```
55fc744f  acts=['cycling']  subj=['cyclist','bicycle','road']   "A group of cyclists are racing on a paved road"
9726d7df  acts=['cycling']  subj=['cyclist','finish line']      "cyclists racing on a wet road"
3ac29d7d  acts=['cycling']  subj=['person','bicycle','mud']     "person wearing a helmet and an orange shirt"
```

The field was fine; the measurement wasn't. The column existed with **0 of 10,378 rows populated** — absent from the prompt *and* from the segment INSERT. Both fixed, round trip pinned by a test.

## 3. `face_positions` stop being discarded

`score_scene` computes them; `_score_visual` returned four floats and threw the geometry away, so `processing/transforms.py` — which takes `face_positions` for framing — was fed nothing. The return becomes a small typed result instead of a loose dict, and its three consumers move with it.

**For framing, not classification.** The face-geometry hypothesis for mode detection was tested and failed: saturation AUC 0.518 / 0.496 (chance) — the childless era is a selfie era, so a selfie couple and a toddler close-up have identical geometry.

## Deliberately NOT added

a child flag (`llm_subjects` already carries it) · face count/area columns (`face_score` is already area-derived) · motion/stability variance columns (AUC 0.492 / 0.515) · a wind audio category (0.00 in both cycling months) · an `is_outdoor` helper (no consumer until detection lands — vulture was right).

---

`ANALYSIS_VERSION` 14 → 15. The pinned prompt literal in `test_audio_context_prompt` is updated **deliberately** — the prompt genuinely changed and every analysis from here differs. Docs gain a per-segment field table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM