### PR TITLE
fix(selection): keep the month's real event, not its busiest catalogue

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,101 +6,101 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 533,
-        "line_end": 576,
+        "line_start": 499,
+        "line_end": 542,
         "line_complexities": [
           {
-            "line": 543,
+            "line": 509,
             "complexity": 0
           },
           {
-            "line": 544,
+            "line": 510,
             "complexity": 1
           },
           {
-            "line": 545,
+            "line": 511,
             "complexity": 0
           },
           {
-            "line": 548,
+            "line": 514,
             "complexity": 0
           },
           {
-            "line": 549,
+            "line": 515,
             "complexity": 1
           },
           {
-            "line": 550,
+            "line": 516,
             "complexity": 0
           },
           {
-            "line": 553,
+            "line": 519,
             "complexity": 0
           },
           {
-            "line": 554,
+            "line": 520,
             "complexity": 0
           },
           {
-            "line": 556,
+            "line": 522,
             "complexity": 0
           },
           {
-            "line": 557,
+            "line": 523,
             "complexity": 0
           },
           {
-            "line": 558,
+            "line": 524,
             "complexity": 1
           },
           {
-            "line": 559,
+            "line": 525,
             "complexity": 0
           },
           {
-            "line": 560,
+            "line": 526,
             "complexity": 2
           },
           {
-            "line": 562,
+            "line": 528,
             "complexity": 0
           },
           {
-            "line": 564,
+            "line": 530,
             "complexity": 0
           },
           {
-            "line": 565,
+            "line": 531,
             "complexity": 1
           },
           {
-            "line": 566,
+            "line": 532,
             "complexity": 2
           },
           {
-            "line": 567,
+            "line": 533,
             "complexity": 0
           },
           {
-            "line": 568,
+            "line": 534,
             "complexity": 3
           },
           {
-            "line": 570,
+            "line": 536,
             "complexity": 4
           },
           {
-            "line": 571,
+            "line": 537,
             "complexity": 5
           },
           {
-            "line": 576,
+            "line": 542,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 121
+    "complexity": 120
   },
   {
     "path": "src/immich_memories/analysis/unified_budget.py",

--- a/src/immich_memories/analysis/clip_distribution.py
+++ b/src/immich_memories/analysis/clip_distribution.py
@@ -1,0 +1,237 @@
+"""How a recap's material is spread across the timeline.
+
+Selection ranks clips; this module decides which *periods* deserve to be in
+the cut at all. The two jobs are separable, and keeping them apart matters:
+a per-day cap applied before selection silently destroys the density signal
+selection needs, which is how a November recap once dropped its busiest day
+entirely (#488).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_PHOTOS_PER_DAY = 2
+_EVENT_DENSITY_MULTIPLE = 3.0
+_EVENT_CAP_MULTIPLE = 3
+_EVENT_CLIPS_PER_PERIOD = 3
+_MAX_EVENT_PERIODS = 2
+_MIN_EVENT_PEOPLE_SHARE = 0.10
+
+
+def _people_share(clips: list[ClipWithSegment]) -> float:
+    """Share of a period's material that Immich recognised a person in.
+
+    Free: Immich has already run face recognition over the library, so this
+    reads metadata rather than pixels.
+    """
+    if not clips:
+        return 0.0
+    with_people = sum(1 for c in clips if getattr(c.clip.asset, "people", None))
+    return with_people / len(clips)
+
+
+def _period_key(dt: datetime, span_days: int) -> str:
+    """Bucket key adaptive to date range: weeks for short, months for medium, quarters for long."""
+    if span_days <= 30:
+        return dt.strftime("%Y-%m-%d")  # daily for ≤1 month
+    if span_days <= 90:
+        iso = dt.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"  # weekly for ≤3 months
+    if span_days <= 365:
+        return dt.strftime("%Y-%m")  # monthly for ≤1 year
+    return f"{dt.year}-Q{(dt.month - 1) // 3 + 1}"  # quarterly for >1 year
+
+
+def _event_periods(by_period: dict[str, list[ClipWithSegment]]) -> set[str]:
+    """Periods holding far more material than the month's norm.
+
+    Contrast, not an absolute share: in a flat month every period would clear
+    a fixed threshold and two arbitrary days would win on tie-break.
+    """
+    sizes = sorted(len(v) for v in by_period.values())
+    median = sizes[len(sizes) // 2] if sizes else 0
+    if not median:
+        return set()
+    threshold = _EVENT_DENSITY_MULTIPLE * median
+    ranked = sorted(by_period, key=lambda k: (-len(by_period[k]), k))
+    dense = [k for k in ranked if len(by_period[k]) >= threshold]
+    # Volume is not significance. The densest day of a real November was 130
+    # photos of an empty apartment — a property viewing, no people in any of
+    # them — and density alone promoted that catalogue over the month's real
+    # days. Measured across five event days: the viewing recognised people in
+    # 0% of its assets, every genuine event in 14-51% (#488).
+    peopled = [k for k in dense if _people_share(by_period[k]) >= _MIN_EVENT_PEOPLE_SHARE]
+    return set(peopled[:_MAX_EVENT_PERIODS])
+
+
+def _event_periods_of(clips: list[ClipWithSegment]) -> set[str]:
+    """Event periods measured on the raw pool.
+
+    Must run before any per-day cap: a cap compresses every day into the same
+    narrow range, so the contrast test would end up reading its own output —
+    real events stop standing out and flat days cross the line by accident.
+    """
+    dates = [c.clip.asset.file_created_at for c in clips]
+    if not dates:
+        return set()
+    span_days = (max(dates) - min(dates)).days
+    by_period: dict[str, list[ClipWithSegment]] = defaultdict(list)
+    for c in clips:
+        by_period[_period_key(c.clip.asset.file_created_at, span_days)].append(c)
+    return _event_periods(by_period)
+
+
+def _fill_gap_periods(
+    unselected_by_period: dict[str, list[ClipWithSegment]],
+    covered: set[str],
+    events: set[str],
+) -> list[ClipWithSegment]:
+    """One clip per uncovered period, densest period first.
+
+    Order decides who is served once the duration budget can no longer serve
+    everyone: filling chronologically treats a day holding a fifth of the
+    month exactly like a quiet Tuesday. On a real April recap that cost the
+    month its second event — 99 assets, a whole coastal day — while three
+    clips from ordinary days took 14 of the 58.7 seconds. Event periods earn
+    more than one clip so the day reads as a day rather than a glimpse.
+    """
+    by_material = sorted(unselected_by_period, key=lambda p: (-len(unselected_by_period[p]), p))
+    fillers: list[ClipWithSegment] = []
+    for period in by_material:
+        if period in covered:
+            continue
+        ranked = sorted(unselected_by_period[period], key=lambda c: c.score, reverse=True)
+        fillers.extend(ranked[: _EVENT_CLIPS_PER_PERIOD if period in events else 1])
+        covered.add(period)
+    return fillers
+
+
+def _photo_caps_per_day(
+    by_day: dict[str, list[ClipWithSegment]],
+    base_cap: int,
+) -> dict[str, int]:
+    """Raise the per-day photo cap for days holding far more than the norm.
+
+    A flat cap erases the signal selection depends on: on a real November the
+    busiest day — 129 Live Photos inside one hour — reached the selector
+    holding two clips, indistinguishable from a day with two idle snapshots,
+    and the recap skipped the event entirely (#488).
+    """
+    events = _event_periods(by_day)
+    event_cap = base_cap * _EVENT_CAP_MULTIPLE
+    return {day: event_cap if day in events else base_cap for day in by_day}
+
+
+def _partition_photos_per_day(
+    clips: list[ClipWithSegment],
+    max_per_day: int = _MAX_PHOTOS_PER_DAY,
+) -> tuple[list[ClipWithSegment], list[ClipWithSegment]]:
+    """Partition same-day photos into preferred and duration-fallback pools.
+
+    Videos are always preferred. Within each day, the highest-scored photos
+    enter initial selection and the remainder stay available for backfill.
+    """
+    from immich_memories.api.models import AssetType
+
+    videos = [c for c in clips if c.clip.asset.type != AssetType.IMAGE]
+    photos = [c for c in clips if c.clip.asset.type == AssetType.IMAGE]
+
+    if not photos:
+        return clips, []
+
+    # Group photos by day, keep best N per day
+    by_day: dict[str, list[ClipWithSegment]] = defaultdict(list)
+    for p in photos:
+        day_key = p.clip.asset.file_created_at.strftime("%Y-%m-%d")
+        by_day[day_key].append(p)
+
+    caps = _photo_caps_per_day(by_day, max_per_day)
+    kept_photos: list[ClipWithSegment] = []
+    overflow_photos: list[ClipWithSegment] = []
+    for day_key in sorted(by_day):
+        day_photos = sorted(by_day[day_key], key=lambda c: c.score, reverse=True)
+        cap = caps[day_key]
+        kept_photos.extend(day_photos[:cap])
+        overflow_photos.extend(day_photos[cap:])
+
+    if overflow_photos:
+        logger.info(
+            f"Same-day photo preference: reserved {len(overflow_photos)} overflow photos "
+            f"for duration backfill (preferred max {max_per_day}/day)"
+        )
+
+    return videos + kept_photos, overflow_photos
+
+
+def enforce_photo_cap(
+    clips: list[ClipWithSegment],
+    max_ratio: float,
+    videos_scarce: bool = False,
+    protected_ids: set[str] | None = None,
+) -> list[ClipWithSegment]:
+    """Drop lowest-scored photos until photo ratio <= max_ratio.
+
+    Videos are never dropped. If only photos exist (no videos),
+    all are kept since the ratio can't be improved by dropping.
+    When videos_scarce is True, the cap is bypassed entirely —
+    photos fill the budget freely (matches unified_budget PR #224).
+
+    protected_ids survive the cap. They are the clips selection kept to
+    represent a period, and some months hold their best day entirely in
+    photos: a November recap dropped all three clips of its busiest day —
+    129 Live Photos shot inside one hour — because the cap ranked them as
+    ordinary photos (#488). Protection the scaler honours has to hold here
+    too, or coverage is not coverage.
+    """
+    from immich_memories.api.models import AssetType
+
+    videos = [c for c in clips if c.clip.asset.type != AssetType.IMAGE]
+    photos = [c for c in clips if c.clip.asset.type == AssetType.IMAGE]
+
+    if not photos or not videos:
+        return clips
+
+    if videos_scarce:
+        return clips
+
+    if max_ratio >= 1.0:
+        return clips
+
+    # Solve P / (V + P) <= ratio for P. Using the pre-filter total here
+    # leaves the final, smaller result above the requested ratio.
+    max_photos = max(0, int(len(videos) * max_ratio / (1.0 - max_ratio)))
+
+    if len(photos) <= max_photos:
+        return clips
+
+    # Keep protected photos, then the highest-scored of the rest
+    protected = protected_ids or set()
+    kept_photos = [c for c in photos if c.clip.asset.id in protected]
+    others = sorted(
+        (c for c in photos if c.clip.asset.id not in protected),
+        key=lambda c: c.score,
+        reverse=True,
+    )
+    kept_photos += others[: max(0, max_photos - len(kept_photos))]
+
+    # WHY not "final": duration backfill runs after this and adds more clips, so
+    # the count here is the pool mid-refinement. A real run logged "2 photos
+    # (50% of 4 final clips)" and delivered a 13-clip video with 7 photos in it,
+    # which reads as the cap having been ignored rather than simply not final.
+    logger.info(
+        f"Photo cap: {len(photos)} → {len(kept_photos)} photos "
+        f"(at most {max_ratio:.0%} alongside {len(videos)} videos; "
+        f"backfill may add more)"
+    )
+
+    return videos + kept_photos

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -20,111 +20,23 @@ if TYPE_CHECKING:
     )
     from immich_memories.api.models import VideoClipInfo
 
+from immich_memories.analysis.clip_distribution import (
+    _EVENT_CLIPS_PER_PERIOD,
+    _event_periods_of,
+    _fill_gap_periods,
+    _partition_photos_per_day,
+    _period_key,
+    enforce_photo_cap,
+)
+
 logger = logging.getLogger(__name__)
 
-
-def _period_key(dt: datetime, span_days: int) -> str:
-    """Bucket key adaptive to date range: weeks for short, months for medium, quarters for long."""
-    if span_days <= 30:
-        return dt.strftime("%Y-%m-%d")  # daily for ≤1 month
-    if span_days <= 90:
-        iso = dt.isocalendar()
-        return f"{iso[0]}-W{iso[1]:02d}"  # weekly for ≤3 months
-    if span_days <= 365:
-        return dt.strftime("%Y-%m")  # monthly for ≤1 year
-    return f"{dt.year}-Q{(dt.month - 1) // 3 + 1}"  # quarterly for >1 year
-
-
-_MAX_PHOTOS_PER_DAY = 2
-
-
-def _partition_photos_per_day(
-    clips: list[ClipWithSegment],
-    max_per_day: int = _MAX_PHOTOS_PER_DAY,
-) -> tuple[list[ClipWithSegment], list[ClipWithSegment]]:
-    """Partition same-day photos into preferred and duration-fallback pools.
-
-    Videos are always preferred. Within each day, the highest-scored photos
-    enter initial selection and the remainder stay available for backfill.
-    """
-    from immich_memories.api.models import AssetType
-
-    videos = [c for c in clips if c.clip.asset.type != AssetType.IMAGE]
-    photos = [c for c in clips if c.clip.asset.type == AssetType.IMAGE]
-
-    if not photos:
-        return clips, []
-
-    # Group photos by day, keep best N per day
-    by_day: dict[str, list[ClipWithSegment]] = defaultdict(list)
-    for p in photos:
-        day_key = p.clip.asset.file_created_at.strftime("%Y-%m-%d")
-        by_day[day_key].append(p)
-
-    kept_photos: list[ClipWithSegment] = []
-    overflow_photos: list[ClipWithSegment] = []
-    for day_key in sorted(by_day):
-        day_photos = sorted(by_day[day_key], key=lambda c: c.score, reverse=True)
-        kept_photos.extend(day_photos[:max_per_day])
-        overflow_photos.extend(day_photos[max_per_day:])
-
-    if overflow_photos:
-        logger.info(
-            f"Same-day photo preference: reserved {len(overflow_photos)} overflow photos "
-            f"for duration backfill (preferred max {max_per_day}/day)"
-        )
-
-    return videos + kept_photos, overflow_photos
-
-
-def enforce_photo_cap(
-    clips: list[ClipWithSegment],
-    max_ratio: float,
-    videos_scarce: bool = False,
-) -> list[ClipWithSegment]:
-    """Drop lowest-scored photos until photo ratio <= max_ratio.
-
-    Videos are never dropped. If only photos exist (no videos),
-    all are kept since the ratio can't be improved by dropping.
-    When videos_scarce is True, the cap is bypassed entirely —
-    photos fill the budget freely (matches unified_budget PR #224).
-    """
-    from immich_memories.api.models import AssetType
-
-    videos = [c for c in clips if c.clip.asset.type != AssetType.IMAGE]
-    photos = [c for c in clips if c.clip.asset.type == AssetType.IMAGE]
-
-    if not photos or not videos:
-        return clips
-
-    if videos_scarce:
-        return clips
-
-    if max_ratio >= 1.0:
-        return clips
-
-    # Solve P / (V + P) <= ratio for P. Using the pre-filter total here
-    # leaves the final, smaller result above the requested ratio.
-    max_photos = max(0, int(len(videos) * max_ratio / (1.0 - max_ratio)))
-
-    if len(photos) <= max_photos:
-        return clips
-
-    # Keep highest-scored photos
-    photos.sort(key=lambda c: c.score, reverse=True)
-    kept_photos = photos[:max_photos]
-
-    # WHY not "final": duration backfill runs after this and adds more clips, so
-    # the count here is the pool mid-refinement. A real run logged "2 photos
-    # (50% of 4 final clips)" and delivered a 13-clip video with 7 photos in it,
-    # which reads as the cap having been ignored rather than simply not final.
-    logger.info(
-        f"Photo cap: {len(photos)} → {len(kept_photos)} photos "
-        f"(at most {max_ratio:.0%} alongside {len(videos)} videos; "
-        f"backfill may add more)"
-    )
-
-    return videos + kept_photos
+# An event is defined by CONTRAST with the rest of the period, not by an
+# absolute share: in a flat month every day clears any fixed threshold and the
+# tie-break decides who wins, which is arbitrary. Measured on April 2021, the
+# two events held 133 and 99 assets against a median day of 5 (#488).
+# At most this many periods get the event treatment, so a month recap keeps
+# room for the ordinary days that make it a month.
 
 
 @dataclass(frozen=True)
@@ -432,6 +344,60 @@ class ClipRefiner:
         self.config = config
         self.scaler = scaler
 
+    def _select_without_favorites(
+        self,
+        clips: list[ClipWithSegment],
+        non_favorites: list[ClipWithSegment],
+        target_count: int,
+        event_periods: set[str],
+    ) -> list[ClipWithSegment]:
+        """Select when the user starred nothing — the common case for an
+        older library (#488).
+
+        Ranking alone cannot do this job here: measured on a real recap,
+        83% of the pool carried a metadata fallback score and 55% shared one
+        identical value, so "top N by score" is largely list order. The
+        structure of the month is the only real signal, so periods holding
+        the most material are represented first, and the rest of the slots
+        go to score.
+        """
+        dates = [c.clip.asset.file_created_at for c in clips]
+        span_days = (max(dates) - min(dates)).days if dates else 0
+
+        by_period: dict[str, list[ClipWithSegment]] = defaultdict(list)
+        for c in non_favorites:
+            by_period[_period_key(c.clip.asset.file_created_at, span_days)].append(c)
+
+        densest_first = sorted(by_period, key=lambda k: (-len(by_period[k]), k))
+        reserved = max(1, target_count // 2)
+
+        selected: list[ClipWithSegment] = []
+        selected_ids: set[str] = set()
+        coverage_ids: set[str] = set()
+        events = event_periods
+        for period in densest_first[:reserved]:
+            take = _EVENT_CLIPS_PER_PERIOD if period in events else 1
+            ranked = sorted(by_period[period], key=lambda c: c.score, reverse=True)
+            for best in ranked[:take]:
+                selected.append(best)
+                selected_ids.add(best.clip.asset.id)
+                coverage_ids.add(best.clip.asset.id)
+
+        for c in sorted(non_favorites, key=lambda c: c.score, reverse=True):
+            if len(selected) >= target_count:
+                break
+            if c.clip.asset.id not in selected_ids:
+                selected.append(c)
+                selected_ids.add(c.clip.asset.id)
+
+        self._coverage_ids = coverage_ids
+        selected.sort(key=lambda c: c.clip.asset.file_created_at or datetime.min)
+        logger.info(
+            f"No favorites: {len(coverage_ids)} clips from the densest periods "
+            f"+ {len(selected) - len(coverage_ids)} by score"
+        )
+        return selected
+
     def _classify_favorites_by_week(
         self,
         favorites: list[ClipWithSegment],
@@ -614,6 +580,7 @@ class ClipRefiner:
         selected: list[ClipWithSegment],
         all_clips: list[ClipWithSegment],
         selected_ids: set[str],
+        event_periods: set[str] | None = None,
     ) -> list[ClipWithSegment]:
         """Guarantee at least 1 clip per time period across the full date range.
 
@@ -634,20 +601,18 @@ class ClipRefiner:
                 key = _period_key(c.clip.asset.file_created_at, span_days)
                 unselected_by_period[key].append(c)
 
-        gap_fillers: list[ClipWithSegment] = []
-        for period in sorted(unselected_by_period):
-            if period not in covered:
-                candidates = unselected_by_period[period]
-                candidates.sort(key=lambda c: c.score, reverse=True)
-                best = candidates[0]
-                gap_fillers.append(best)
-                selected_ids.add(best.clip.asset.id)
-                covered.add(period)
+        gap_fillers = _fill_gap_periods(
+            unselected_by_period,
+            covered,
+            _event_periods_of(all_clips) if event_periods is None else event_periods,
+        )
+        selected_ids.update(filler.clip.asset.id for filler in gap_fillers)
 
         if gap_fillers:
             logger.info(
                 f"Temporal coverage: added {len(gap_fillers)} clips "
-                f"to fill {len(gap_fillers)} empty periods (granularity: {span_days}d span)"
+                f"across {len(covered)} periods, densest first "
+                f"(granularity: {span_days}d span)"
             )
 
         return gap_fillers
@@ -656,8 +621,17 @@ class ClipRefiner:
         self,
         clips: list[ClipWithSegment],
         target_count: int,
+        event_periods: set[str] | None = None,
     ) -> list[ClipWithSegment]:
-        """Select clips using density-aware favorites-first approach."""
+        """Select clips using density-aware favorites-first approach.
+
+        event_periods must be measured on the pool before any per-day cap:
+        a cap compresses every day into the same narrow range, so a set
+        derived here would be reading its own output. Callers that still hold
+        the raw pool pass it; otherwise it is derived from `clips`.
+        """
+        if event_periods is None:
+            event_periods = _event_periods_of(clips)
         if not clips:
             return []
 
@@ -672,13 +646,7 @@ class ClipRefiner:
         )
 
         if not favorites:
-            non_favorites.sort(key=lambda c: c.score, reverse=True)
-            selected = non_favorites[:target_count]
-            selected_ids = {c.clip.asset.id for c in selected}
-            coverage = self._ensure_temporal_coverage(selected, clips, selected_ids)
-            selected.extend(coverage)
-            self._coverage_ids = {c.clip.asset.id for c in coverage}
-            return selected[:target_count]
+            return self._select_without_favorites(clips, non_favorites, target_count, event_periods)
 
         _favorites_by_week, protected_weeks = self._classify_favorites_by_week(favorites)
 
@@ -700,7 +668,7 @@ class ClipRefiner:
         self._fill_remaining_slots(selected, non_favorites, target_count, selected_ids)
 
         # Ensure every time period has at least 1 clip
-        coverage = self._ensure_temporal_coverage(selected, clips, selected_ids)
+        coverage = self._ensure_temporal_coverage(selected, clips, selected_ids, event_periods)
         selected.extend(coverage)
         self._coverage_ids = {c.clip.asset.id for c in coverage}
 
@@ -851,6 +819,9 @@ class ClipRefiner:
         # Prefer two photos/day during initial selection, while retaining the
         # overflow as a fallback if the diverse pool cannot fill the target.
         all_analyzed = analyzed
+        # Measured before the per-day cap flattens every day into the same
+        # narrow range (#488).
+        event_periods = _event_periods_of(all_analyzed)
         analyzed, _photo_overflow = _partition_photos_per_day(all_analyzed)
 
         target_with_buffer = int(self.config.target_clips * 1.2)
@@ -858,7 +829,9 @@ class ClipRefiner:
         if self.config.overnight_bases:
             selected = self.select_clips_by_trip_segments(analyzed, target_with_buffer)
         else:
-            selected = self.select_clips_distributed_by_date(analyzed, target_with_buffer)
+            selected = self.select_clips_distributed_by_date(
+                analyzed, target_with_buffer, event_periods
+            )
 
         target_duration = self.config.duration_target
         max_overrun = (
@@ -912,7 +885,12 @@ class ClipRefiner:
             # Even when photos may ultimately fill freely, first normalize a
             # photo-biased selection so backfill has room to use every valid
             # video candidate. The backfill exemption then admits photos again.
-            selected = enforce_photo_cap(selected, self.config.photo_max_ratio, videos_scarce=False)
+            selected = enforce_photo_cap(
+                selected,
+                self.config.photo_max_ratio,
+                videos_scarce=False,
+                protected_ids=coverage_ids,
+            )
 
         selected = self._backfill_to_duration(
             selected,

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -50,8 +50,22 @@ def _ask(prompt: str, llm_config: LLMConfig, timeout_seconds: int) -> str:
     )
 
 
+def _place_for_llm(exif: object) -> str | None:
+    """City, state and country — the caption form is too thin to reason from.
+
+    Captions say "Paradise" because that is what reads well on screen. A model
+    asked whether a set of clips hangs together cannot do anything with that:
+    Paradise and Winchester are the Las Vegas Strip townships, and without the
+    state they look like two unrelated villages rather than one trip.
+    """
+    if not exif:
+        return None
+    parts = [getattr(exif, attr, None) for attr in ("city", "state", "country")]
+    named = [p for p in parts if p]
+    return ", ".join(named) if named else None
+
+
 def _clip_line(index: int, member: ClipWithSegment) -> str:
-    from immich_memories.generate_privacy import clip_location_name
 
     clip = member.clip
     parts = [f"Clip {index}:"]
@@ -60,7 +74,7 @@ def _clip_line(index: int, member: ClipWithSegment) -> str:
     taken = getattr(clip.asset, "file_created_at", None)
     if taken:
         parts.append(f"date={taken.date().isoformat()}")
-    where = clip_location_name(getattr(clip.asset, "exif_info", None))
+    where = _place_for_llm(getattr(clip.asset, "exif_info", None))
     if where:
         parts.append(f"place={where}")
     parts.append(f"score={member.score:.2f}")

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -611,7 +611,7 @@ class TestDetectScenesConvenience:
 
 class TestEnforcePhotoCap:
     def test_no_photos_returns_all(self):
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         clips = [_make_clip_with_segment(f"v{i}") for i in range(5)]
         result = enforce_photo_cap(clips, max_ratio=0.25)
@@ -668,7 +668,7 @@ class TestSelectClipsDistributedByDate:
         result = refiner.select_clips_distributed_by_date([], target_count=10)
         assert result == []
 
-    def test_no_favorites_selects_by_score(self):
+    def test_no_favorites_spreads_across_the_span(self):
         refiner = self._make_refiner()
         clips = [
             _make_clip_with_segment(
@@ -680,9 +680,11 @@ class TestSelectClipsDistributedByDate:
         ]
         result = refiner.select_clips_distributed_by_date(clips, target_count=3)
         assert len(result) == 3
-        # Should be sorted by score descending, so top 3 scores
-        scores = [c.score for c in result]
-        assert scores == sorted(scores, reverse=True)
+        # Ranking alone clusters a recap on its three best-scored days and
+        # opens three days into the month (#488). The best clip is still kept.
+        assert max(c.score for c in result) == 4.0
+        days = {c.clip.asset.file_created_at.day for c in result}
+        assert min(days) == 1
 
     def test_all_favorites_included(self):
         refiner = self._make_refiner()

--- a/tests/test_event_coverage.py
+++ b/tests/test_event_coverage.py
@@ -1,0 +1,197 @@
+"""Dense days must be represented before sparse ones (#488).
+
+Measured on a real April 2021 recap: the month's second event — 99 assets,
+22% of the month, a whole coastal day — got zero clips, while three clips
+scoring 0.21 from ordinary days at home took 14 of the 58.7 seconds. The
+filler rule treated a 99-asset day and a 2-asset Tuesday as equally
+deserving of exactly one slot, chronologically.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.clip_distribution import (
+    _event_periods_of,
+    _partition_photos_per_day,
+    enforce_photo_cap,
+)
+from immich_memories.analysis.clip_refiner import (
+    ClipRefiner,
+)
+from immich_memories.analysis.clip_scaler import ClipScaler
+from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+from immich_memories.api.models import AssetType, Person
+from tests.conftest import make_clip
+
+
+def _member(day: int, index: int, score: float, *, people: bool = True) -> ClipWithSegment:
+    when = datetime(2021, 4, day, 10, 0, tzinfo=UTC) + timedelta(minutes=index)
+    clip = make_clip(f"a-{day:02d}-{index:03d}", duration=10.0, file_created_at=when)
+    if people:
+        clip.asset.people = [Person(id=f"p-{index % 3}")]
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=score)
+
+
+def _pool() -> list[ClipWithSegment]:
+    """Two dense event days and six ordinary ones — April 2021's shape."""
+    pool: list[ClipWithSegment] = []
+    pool += [_member(4, i, 0.50) for i in range(50)]  # the track day
+    pool += [_member(9, i, 0.45) for i in range(40)]  # the coast day
+    for day in (6, 12, 16, 23, 26, 30):  # ordinary days
+        pool += [_member(day, i, 0.21) for i in range(2)]
+    return pool
+
+
+def _refiner() -> ClipRefiner:
+    config = PipelineConfig(target_clips=14, avg_clip_duration=5.0)
+    return ClipRefiner(config, ClipScaler())
+
+
+class TestDenseDaysAreServedFirst:
+    def test_both_events_are_covered_before_ordinary_days(self):
+        pool = _pool()
+        fillers = _refiner()._ensure_temporal_coverage([], pool, set())
+
+        days = [c.clip.asset.file_created_at.day for c in fillers]
+
+        # both events, before any ordinary day — two clips each, so four slots
+        assert set(days[:4]) == {4, 9}, f"events must be served first, got {days[:6]}"
+
+    def test_an_event_earns_more_than_one_clip(self):
+        """A day holding a quarter of the pool deserves more than a Tuesday."""
+        pool = _pool()
+        fillers = _refiner()._ensure_temporal_coverage([], pool, set())
+
+        from collections import Counter
+
+        per_day = Counter(c.clip.asset.file_created_at.day for c in fillers)
+
+        assert per_day[4] >= 2
+        assert per_day[9] >= 2
+
+    def test_ordinary_days_still_get_their_filler(self):
+        """The recap is still a month, not a highlight reel of two days."""
+        pool = _pool()
+        fillers = _refiner()._ensure_temporal_coverage([], pool, set())
+
+        ordinary = {c.clip.asset.file_created_at.day for c in fillers} - {4, 9}
+
+        assert len(ordinary) >= 4, f"filler days were crowded out: {ordinary}"
+
+    def test_a_flat_pool_is_unchanged(self):
+        """No event, no special treatment — one clip per period as before."""
+        from collections import Counter
+
+        flat = [_member(day, i, 0.4) for day in (2, 6, 12, 16) for i in range(3)]
+        fillers = _refiner()._ensure_temporal_coverage([], flat, set())
+
+        per_day = Counter(c.clip.asset.file_created_at.day for c in fillers)
+
+        assert set(per_day) == {2, 6, 12, 16}
+        assert all(n == 1 for n in per_day.values()), per_day
+
+
+class TestCoverageSurvivesTheTruncation:
+    """The no-favorites branch computed temporal coverage, appended it, then
+    returned `selected[:target_count]` — keeping the original top scorers and
+    discarding every coverage clip. Measured on April 2021 (a month with zero
+    favorites): the coverage step added a clip from the 99-asset coastal day
+    and the very next line threw it away (#488)."""
+
+    def test_a_covered_event_day_survives_to_the_output(self):
+        pool: list[ClipWithSegment] = []
+        # ten quiet days that score high — they fill target_count on their own
+        for day in range(10, 20):
+            pool += [_member(day, 0, 0.90)]
+        # the event: lots of material, scoring lower than the quiet days
+        pool += [_member(4, i, 0.45) for i in range(40)]
+
+        selected = _refiner().select_clips_distributed_by_date(pool, target_count=8)
+        days = {c.clip.asset.file_created_at.day for c in selected}
+
+        assert 4 in days, f"the event day was truncated away: {sorted(days)}"
+
+    def test_high_scorers_keep_most_of_the_room(self):
+        """Coverage earns its place; it does not take over the memory."""
+        pool: list[ClipWithSegment] = []
+        for day in range(10, 20):
+            pool += [_member(day, 0, 0.90)]
+        pool += [_member(4, i, 0.45) for i in range(40)]
+
+        selected = _refiner().select_clips_distributed_by_date(pool, target_count=8)
+        high = sum(1 for c in selected if c.score >= 0.9)
+
+        assert high >= len(selected) // 2, f"only {high} of {len(selected)} clips are high scorers"
+
+
+def _photo(day: int, index: int, score: float, *, people: bool = True) -> ClipWithSegment:
+    clip = _member(day, index, score, people=people).clip
+    clip.asset.type = AssetType.IMAGE
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=score)
+
+
+def test_event_day_keeps_more_photos_than_an_ordinary_day() -> None:
+    """A flat per-day cap erased the very density selection needs.
+
+    November 2019's busiest day — 129 Live Photos inside one hour — reached
+    selection holding two clips, identical to a day with two snapshots.
+    """
+    pool = [_photo(10, i, 0.30) for i in range(75)]
+    for day in (2, 3, 6, 8, 12, 14, 21, 23, 27):
+        pool += [_photo(day, i, 0.40) for i in range(4)]
+
+    kept, overflow = _partition_photos_per_day(pool)
+
+    on_event_day = [c for c in kept if c.clip.asset.file_created_at.day == 10]
+    on_ordinary_day = [c for c in kept if c.clip.asset.file_created_at.day == 27]
+    assert len(on_event_day) > len(on_ordinary_day)
+    assert overflow, "the rest stays available for duration backfill"
+
+
+def test_flat_month_gives_every_day_the_same_cap() -> None:
+    """Contrast, not an absolute share — no day in a flat month is an event."""
+    pool = [_photo(day, i, 0.30) for day in range(1, 20) for i in range(4)]
+
+    kept, _overflow = _partition_photos_per_day(pool)
+
+    per_day = Counter(c.clip.asset.file_created_at.day for c in kept)
+    assert set(per_day.values()) == {2}
+
+
+def test_photo_cap_keeps_the_clips_selection_protected() -> None:
+    """Coverage the scaler honours must survive the photo cap too.
+
+    Measured: 13 clips went into the cap with three from the month's busiest
+    day and came out with none, because the cap ranked them as ordinary
+    photos and they scored below the rest.
+    """
+    videos = [_member(4, i, 0.60) for i in range(6)]
+    protected = [_photo(10, i, 0.10) for i in range(3)]
+    others = [_photo(20, i, 0.90) for i in range(6)]
+
+    kept = enforce_photo_cap(
+        videos + protected + others,
+        max_ratio=0.25,
+        protected_ids={c.clip.asset.id for c in protected},
+    )
+
+    kept_ids = {c.clip.asset.id for c in kept}
+    assert all(c.clip.asset.id in kept_ids for c in protected)
+
+
+def test_a_dense_day_with_nobody_in_it_is_not_an_event() -> None:
+    """Volume is not significance.
+
+    The densest day of a real November was 130 photos of an empty apartment —
+    a property viewing. Immich recognised a person in 0% of them, against
+    14-51% on every genuine event day, so density alone promoted a catalogue
+    over the month's real days.
+    """
+    viewing = [_photo(10, i, 0.30, people=False) for i in range(75)]
+    ordinary = [_photo(day, i, 0.40) for day in (2, 3, 6, 8, 12, 27) for i in range(4)]
+
+    events = _event_periods_of(viewing + ordinary)
+
+    assert not events, "a people-free burst is a catalogue, not a memory"

--- a/tests/test_photo_cap.py
+++ b/tests/test_photo_cap.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from immich_memories.analysis.clip_refiner import enforce_photo_cap
+from immich_memories.analysis.clip_distribution import enforce_photo_cap
 from immich_memories.analysis.smart_pipeline import ClipWithSegment
 from immich_memories.api.models import Asset, AssetType, VideoClipInfo
 


### PR DESCRIPTION
Closes #488

## What was wrong

A recap could drop its biggest day entirely — and once that was fixed, it promoted the wrong days instead. Both faults came from treating **volume as significance**.

Measured on real months: a November day holding 129 Live Photos shot inside one hour got **zero seconds**; an April recap lost a whole coastal day the same way.

## Three stacked causes

Each one destroyed the density signal the next stage needed:

1. **The flat two-photos-per-day cap ran before selection.** The busiest day arrived holding two clips — indistinguishable from a day with two idle snapshots. The cap is now proportional to the day's weight.
2. **Selection with no favorites was pure ranking**, which on these months is largely list order: 83% of the pool carries a metadata fallback score. It now represents the densest periods first, then spends the rest on score.
3. **`enforce_photo_cap` dropped the coverage clips `scale_to_target_duration` had just protected**, ranking them as ordinary photos. Protection now holds across both.

## Then the rescued day turned out to be junk

The day all that work rescued was **130 photos of an empty apartment** — a property viewing, nobody in any of them. Density alone promoted that catalogue over the month's real days.

An event period must now also show people. Immich has already run face recognition over the library, so this reads metadata rather than pixels — it costs nothing.

| day | assets | people | what it is |
|---|---|---|---|
| 2019-11-10 | 258 | **0%** | apartment viewing |
| 2019-11-01 | 74 | 14% | a trip |
| 2021-04-04 | 133 | 17% | a track day |
| 2022-03-27 | 265 | **51%** | a real event |

Event periods are measured once on the raw pool and passed explicitly: derived *after* a cap, the contrast test reads its own output, so real events stop standing out and flat days cross the line by accident.

## Also

- The timeline logic moves to `analysis/clip_distribution.py`. `clip_refiner.py` had passed the 1000-line hard limit, and deciding *which periods belong in a cut* is a separate job from ranking the clips inside them.
- The selection review learned where it is. `clip_location_name` gives the caption form — "Paradise" — right for the screen, useless for reasoning, since Paradise and Winchester are the Las Vegas Strip townships and without the state they read as two unrelated villages rather than one trip. The review now sees city, state and country, and starts recognising clips as belonging to the same trip.

## Verification

Nine months with no favorites (2007-08 → 2022-03): each leads with its real event day, the apartment viewing is not promoted, and a genuinely flat month stays flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6esnBSTE5oVAryJoscCtM