### PR TITLE
fix(cli): stop holiday and then-and-now collapsing to the 30s floor

### DIFF
--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -243,6 +243,11 @@ Mother's and Father's Day land on the correct date in each year, including years
 nobody has thought about yet. The window is the holiday ±2 days by default, so
 Christmas Eve and Boxing Day belong to Christmas.
 
+Without `--duration` this runs 60 seconds. The usual duration scaling reads the
+span between the first and last date, which for five Christmases is five years —
+a length meant for one continuous stretch, not a handful of days repeated. The
+number of years does not change the target; pass `--duration` for a longer cut.
+
 ### Then and now
 
 Two whole years, far apart, in one video:
@@ -253,6 +258,9 @@ immich-memories generate --memory-type then_and_now --year 2025 --years-back 10
 
 That covers 2015 and 2025. Whole years rather than narrow windows, because the
 contrast is the point and a two-day window a decade ago is usually empty.
+
+Without `--duration` this runs 45 seconds — two years side by side, not the ten
+that separate them.
 
 ### Trip closest to a date
 

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -201,6 +201,21 @@ def duration_from_date_range(date_range: DateRange) -> float:
     return float(max(30, min(600, duration)))
 
 
+# WHY these two by name: they span whole years, and duration_from_date_range's
+# curve was fitted on 1-12 months -- it turns negative past ~40 months, so five
+# Christmases clamped to the same 30s floor as an empty weekend (#511). Their
+# presets already state the length they want, so the CLI reads that instead.
+_PRESET_DURATION_TYPES = ("holiday", "then_and_now")
+
+
+def _preset_duration(memory_type: str) -> float | None:
+    """The registered preset's own intended length for a memory type."""
+    from immich_memories.memory_types.factory import create_preset
+    from immich_memories.memory_types.registry import MemoryType
+
+    return create_preset(MemoryType(memory_type)).default_duration_seconds
+
+
 def default_duration_for_type(
     memory_type: str | None, date_range: DateRange | None
 ) -> float | None:
@@ -208,14 +223,17 @@ def default_duration_for_type(
 
     Date-range based types scale with span (1 month = 60s, 1 year = 600s).
     Trip dates provide an editorial estimate; discovered media later applies
-    the capacity cap. Other fixed types: on_this_day (45s), person without
-    range (120s).
+    the capacity cap. Types that span several years take the length their
+    preset asks for, since the span curve does not reach that far. Other fixed
+    types: on_this_day (45s), person without range (120s).
     """
     if not memory_type:
         return None
 
     if memory_type == "on_this_day":
         return 45.0
+    if memory_type in _PRESET_DURATION_TYPES:
+        return _preset_duration(memory_type)
     if memory_type == "trip" and date_range is not None:
         from immich_memories.planning.auto_duration import trip_editorial_duration_seconds
 

--- a/tests/test_date_resolution.py
+++ b/tests/test_date_resolution.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 
 import pytest
 
-from immich_memories.cli._date_resolution import resolve_date_range
+from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
 from immich_memories.cli._trip_display import _closest_trip_to_date, select_trips
 from immich_memories.timeperiod import DateRange
 
@@ -444,3 +444,56 @@ class TestTripSelection:
         """--near-date with no trips returns empty."""
         result = select_trips([], near_date="2024-07-05")
         assert result == []
+
+
+class TestMultiYearDefaultDuration:
+    """Durations for spans no month-based curve was ever fitted for (#511)."""
+
+    @staticmethod
+    def _display_span(ranges: list[DateRange]) -> DateRange:
+        """Collapse preset ranges the way the CLI does before sizing the video."""
+        return DateRange(start=ranges[-1].start, end=ranges[0].end)
+
+    def test_holiday_default_duration_is_the_preset_length_not_the_floor(self):
+        ranges = resolve_date_range(
+            year=None,
+            start=None,
+            end=None,
+            period=None,
+            birthday=None,
+            memory_type="holiday",
+            holiday="christmas",
+        )
+        assert isinstance(ranges, list)
+        span = self._display_span(ranges)
+
+        assert default_duration_for_type("holiday", span) == 60.0
+
+    def test_then_and_now_default_duration_is_the_preset_length_not_the_floor(self):
+        ranges = resolve_date_range(
+            year=2026,
+            start=None,
+            end=None,
+            period=None,
+            birthday=None,
+            memory_type="then_and_now",
+        )
+        assert isinstance(ranges, list)
+        span = self._display_span(ranges)
+
+        assert default_duration_for_type("then_and_now", span) == 45.0
+
+    def test_a_single_month_still_scales_off_its_span(self):
+        """The span curve keeps the range it was fitted for: one month ~= 60s."""
+        span = resolve_date_range(
+            year=2026,
+            start=None,
+            end=None,
+            period=None,
+            birthday=None,
+            memory_type="monthly_highlights",
+            month=7,
+        )
+        assert isinstance(span, DateRange)
+
+        assert default_duration_for_type("monthly_highlights", span) == pytest.approx(62.3, abs=0.1)


### PR DESCRIPTION
## What

`default_duration_for_type` had no case for `holiday` or `then_and_now`, so their
multi-year display span fell through to `duration_from_date_range`. That curve is a
quadratic fitted through (1mo, 60s), (6mo, 360s), (12mo, 600s) — its positive root is
around 40 months, so every longer span comes out negative and clamps to the 30s floor:

```
holiday --years-back 5  → ~49 months → (-20m² + 800m - 120)/11 = -799 → 30.0s
then_and_now (10y span) → 30.0s
```

Five Christmases got the same runtime as an empty weekend.

## Fix

Both presets already declare the length they want (`memory_types/factory.py`:
holiday 60s, then_and_now 45s). The CLI now reads that instead of asking a curve
about a span it was never fitted for. The quadratic is untouched and still handles
every type it was calibrated for.

An explicit `--duration` still wins — `generate.py` only consults this helper when
the user gave none.

## UI path

The UI has its own resolution path — `ui/pages/step1_presets.py::_apply_preset_to_state`
reads `preset.default_duration_seconds` straight off the factory preset, so it already
produced 60s/45s for these types and needed no change. Worth knowing for #461, which
exposes these types in the wizard: the two paths agree on the numbers because they now
share the same source.

## Tests

TDD, one cycle per case. Both new cases were verified RED first (each returned `30.0`):

- `test_holiday_default_duration_is_the_preset_length_not_the_floor` — resolves the
  real ranges, collapses them to the display span the way the CLI does, expects 60s
- `test_then_and_now_default_duration_is_the_preset_length_not_the_floor` — expects 45s
- `test_a_single_month_still_scales_off_its_span` — regression guard, one month stays
  on the curve at ~62.3s

## Docs

`docs-site/docs/create/cli/generate.md` now states the default runtime for both types
in their sections. `make docs-build` passes.

## Verification

`make ci` — 5445 passed, 9 skipped. `make critique` — no findings on the changed files.
Pre-commit diff coverage (≥80% on changed lines) passed.

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
