### PR TITLE
fix(config): stop pinning the wildcard bind into every saved config

### DIFF
--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -9,10 +9,17 @@ import ThemedScreenshot from '@site/src/components/ThemedScreenshot';
 
 By default, the web UI has no authentication — and because of that, it binds to
 `127.0.0.1` unless you decide otherwise. To listen beyond localhost you either enable
-authentication, set `server.host` explicitly, or set
+authentication, name the address yourself (`--host`, `IMMICH_MEMORIES_SERVER__HOST`, or a
+`server.host` in the config file that is not the `0.0.0.0` wildcard), or set
 `server.allow_unauthenticated_lan: true` — a name that spells out what it allows.
 (The Docker image passes `--host 0.0.0.0` explicitly; publishing its port is the
 compose file's deliberate decision, so enable auth there before exposing it.)
+
+One line in a config file does not count: a bare `server.host: 0.0.0.0`. Older versions
+wrote it into every config they saved, chosen or not, so it says nothing about intent and
+the loader now ignores it with a warning. If your LAN bind came from that line, set
+`server.allow_unauthenticated_lan: true` (or pass `--host`) — after reading the next
+paragraph.
 
 When authentication is disabled and the server listens beyond localhost, anyone who can reach the
 port can use the app — and, through it, your Immich library. The UI is single-user, single-replica because active workflow state lives in the

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -49,7 +49,8 @@ Env: `IMMICH_MEMORIES_PRESET=fast`. One-off on the CLI: `immich-memories --prese
 its resolution to the preset's and says so.
 
 Caveat: the settings page's "save" writes every value to `config.yaml`, after which they all count
-as "set by you" — remove the keys you want the preset to own again.
+as "set by you" — remove the keys you want the preset to own again. (`server.host` is the single
+exception; see [Server (UI)](#server-ui).)
 
 ## Immich connection
 
@@ -546,6 +547,14 @@ server:
 ```
 
 These can also be set via CLI flags: `immich-memories ui --host 127.0.0.1 --port 9090`.
+
+`host` is the one value "save" leaves out of `config.yaml` when you never set it. Writing the
+`0.0.0.0` default would make the next load treat it as your decision and quietly retire the
+localhost bind — which is exactly what older versions did, so a `server.host: 0.0.0.0` already
+sitting in your file is ignored with a warning and disappears the next time the file is saved.
+Any other address is yours and is kept; so are `--host` and `IMMICH_MEMORIES_SERVER__HOST`, which
+nothing but a human ever wrote. To keep a LAN bind with authentication off, use
+`allow_unauthenticated_lan: true`.
 
 ## Upload to Immich
 

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -40,7 +40,7 @@ from immich_memories.config_models import (
 )
 from immich_memories.config_models_auth import AuthConfig
 from immich_memories.config_models_llm import LLMConfig  # noqa: F401
-from immich_memories.config_models_server import ServerConfig
+from immich_memories.config_models_server import WILDCARD_HOST, ServerConfig
 from immich_memories.config_presets import PresetName, apply_preset
 from immich_memories.scheduling.models import SchedulerConfig
 from immich_memories.security import CREDENTIAL_FIELD_NAMES, write_secret_file
@@ -72,6 +72,29 @@ _REMOVED_TOP_LEVEL_SECTIONS = {
 }
 
 
+def _drop_app_written_wildcard_host(data: dict, path: Path) -> None:
+    """Ignore a `server.host: 0.0.0.0` that the app itself wrote (#507).
+
+    Versions before this one dumped the wildcard default into every saved config, so
+    a file carrying that exact value says nothing about what the operator wanted --
+    and reading it as a decision is what disabled the localhost default. A --host
+    flag, an env var, and any other address in the file are untouched; the file
+    heals itself the next time it is saved.
+    """
+    server = data.get("server")
+    if not isinstance(server, dict) or server.get("host") != WILDCARD_HOST:
+        return
+    del server["host"]
+    logging.getLogger(__name__).warning(
+        "Ignoring 'server.host: %s' in %s — older versions wrote that line "
+        "automatically, so it does not count as a choice. With authentication "
+        "disabled the UI binds 127.0.0.1 unless you pass --host or set "
+        "server.allow_unauthenticated_lan: true.",
+        WILDCARD_HOST,
+        path,
+    )
+
+
 def _load_yaml_data(path: Path) -> dict:
     """Load and flatten YAML config data (advanced: → top-level)."""
     if not path.exists():
@@ -83,6 +106,7 @@ def _load_yaml_data(path: Path) -> dict:
         for key, value in advanced.items():
             if key not in data:
                 data[key] = value
+    _drop_app_written_wildcard_host(data, path)
     for key, reason in _REMOVED_TOP_LEVEL_SECTIONS.items():
         if key in data:
             data.pop(key)
@@ -262,9 +286,17 @@ class Config(BaseSettings):
         return (init_settings, env_settings, yaml_source, dotenv_settings, file_secret_settings)
 
     def save_yaml(self, path: Path) -> None:
-        """Save configuration to a YAML file (tiered format)."""
+        """Save configuration to a YAML file (tiered format).
+
+        Every value is written, so what you see in the file is what runs -- with
+        one exception. `server.host` is left out unless the operator set it:
+        writing the wildcard default would make the next load read it as a
+        deliberate LAN bind and silently retire the localhost default (#507).
+        """
         path.parent.mkdir(parents=True, exist_ok=True)
         data = self.model_dump()
+        if "host" not in self.server.model_fields_set:
+            data["server"].pop("host", None)
         _keep_env_secrets_out(data, self._credential_templates)
 
         # Group tier 2 sections under advanced:

--- a/src/immich_memories/config_models_server.py
+++ b/src/immich_memories/config_models_server.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# Bind-everything address: the field default, and -- until #507 -- the value every
+# saved config carried whether or not anyone chose it. The loader ignores it when it
+# comes from a config file, since it cannot be told apart from that automatic write.
+WILDCARD_HOST = "0.0.0.0"  # noqa: S104
+
 
 class ServerConfig(BaseModel):
     """UI server settings (host, port)."""
 
-    host: str = Field(default="0.0.0.0", description="Listen address (IPv4, IPv6, or hostname)")  # noqa: S104
+    host: str = Field(default=WILDCARD_HOST, description="Listen address (IPv4, IPv6, or hostname)")
     port: int = Field(default=8080, ge=1, le=65535, description="Listen port")
     enable_demo_mode: bool = Field(
         default=False, description="Show demo/privacy toggle in sidebar (for screenshots/E2E)"

--- a/tests/test_server_bind.py
+++ b/tests/test_server_bind.py
@@ -3,6 +3,12 @@ operator says otherwise — in config or on the command line."""
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from immich_memories.cli import main
 from immich_memories.config_loader import Config
 
 
@@ -33,3 +39,68 @@ class TestEffectiveHost:
         config = _config(server={"allow_unauthenticated_lan": True})
 
         assert config.server.effective_host(auth_enabled=False) == "0.0.0.0"  # noqa: S104 — the assertion IS about the broad bind
+
+
+class TestSavingDoesNotDecideForTheOperator:
+    """#507: a config the app wrote must not read back as a deliberate LAN bind."""
+
+    def test_a_config_written_by_the_cli_still_binds_localhost(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+
+        # WHY: init_config_dir writes to the real ~/.immich-memories
+        with patch("immich_memories.cli.init_config_dir"):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "--config",
+                    str(config_path),
+                    "config",
+                    "--url",
+                    "http://immich.test",
+                    "--api-key",
+                    "test-key",
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+
+        reloaded = Config.from_yaml(config_path)
+
+        assert reloaded.server.effective_host(auth_enabled=False) == "127.0.0.1"
+
+    def test_a_host_the_operator_chose_survives_the_round_trip(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        _config(server={"host": "192.168.1.10"}).save_yaml(config_path)
+
+        reloaded = Config.from_yaml(config_path)
+
+        assert reloaded.server.effective_host(auth_enabled=False) == "192.168.1.10"
+
+    def test_the_rest_of_the_server_section_is_still_written(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        _config(server={"port": 9090}).save_yaml(config_path)
+
+        assert Config.from_yaml(config_path).server.port == 9090
+
+
+class TestConfigsAlreadyCarryingTheWildcard:
+    """#507 migration: the wildcard the app used to write is not a decision."""
+
+    def test_a_file_written_by_an_older_version_binds_localhost(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("advanced:\n  server:\n    host: 0.0.0.0\n    port: 9090\n")
+
+        reloaded = Config.from_yaml(config_path)
+
+        assert reloaded.server.port == 9090
+        assert reloaded.server.effective_host(auth_enabled=False) == "127.0.0.1"
+
+    def test_the_env_var_is_still_a_decision(self, tmp_path: Path, monkeypatch) -> None:
+        """Only the file is ambiguous — nothing ever wrote the env var but a human."""
+        monkeypatch.setenv("IMMICH_MEMORIES_SERVER__HOST", "0.0.0.0")  # noqa: S104 — the operator's choice under test
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("advanced:\n  server:\n    host: 0.0.0.0\n")
+
+        reloaded = Config.from_yaml(config_path)
+
+        assert reloaded.server.effective_host(auth_enabled=False) == "0.0.0.0"  # noqa: S104 — the assertion IS about the broad bind


### PR DESCRIPTION
Closes #507

## The bug

`save_yaml` dumped the whole model, so `immich-memories config` and the UI's **Save Config** button wrote `server.host: 0.0.0.0` into `config.yaml`. On the next load that key landed in `model_fields_set`, `effective_host` read it as an operator decision, and the secure-by-default localhost bind (#476/#480) never engaged — on virtually every non-Docker install whose config the app had written. Reproduced first as a failing test that drives the real CLI flow: init a config, reload it, ask for the bind. It came back `0.0.0.0`.

## The fix

**Save side** — `save_yaml` leaves `server.host` out unless the operator actually set it. Everything else the settings page saves is still written, so the documented "save writes every value" behaviour holds for every other field (the config reference now names the one exception).

**Load side (migration)** — a config already carrying `server.host: 0.0.0.0` would stay broken forever, so the loader drops that key with a warning. The guard is deliberately narrow: it fires only on the exact wildcard value the app itself used to write, in the config file only.

- `--host` on the CLI (including the Docker image's `CMD ["immich-memories", "ui", "--host", "0.0.0.0"]`) — untouched, it bypasses `effective_host` entirely.
- `IMMICH_MEMORIES_SERVER__HOST=0.0.0.0` — untouched and still a decision; nothing but a human ever wrote an env var. There is a test pinning this.
- Any other address in the file (`192.168.1.10`, `::`) — untouched; the app never wrote those.
- Files heal themselves: once the key is ignored it is no longer "set", so the next save drops it.

`effective_host` itself is unchanged.

## Blast radius

Someone who hand-wrote `server.host: 0.0.0.0` with auth disabled and no escape hatch now binds localhost after upgrading. That is the fail-closed direction, it is logged with the exact line to add (`server.allow_unauthenticated_lan: true`), and both docs pages spell it out. The alternative — keep honouring a value indistinguishable from the app's own write — is the vulnerability.

## Deliberately not done

- **No `model_dump(exclude_unset=True)`.** It would fix the bind but silently change what the settings page persists for every other field, which the config reference documents on purpose (presets rely on the distinction). The narrow exclusion was the option the issue offered, and it is the one taken.
- **No guard on the `host` *value* at bind time** (e.g. "0.0.0.0 with auth off is never a decision"). That would also override `--host` and env vars, breaking Docker and reverse-proxy deployments. Keeping the guard at the file boundary is what makes it safe.
- **No IPv6 `::` handling.** The app never wrote it, so a config containing it is a genuine choice.

## Tests

`tests/test_server_bind.py`:

- `TestSavingDoesNotDecideForTheOperator::test_a_config_written_by_the_cli_still_binds_localhost` — the required test: real CLI init through `CliRunner`, reload, assert `127.0.0.1`. Fails on `main`.
- `::test_a_host_the_operator_chose_survives_the_round_trip` — the fix is not over-broad.
- `::test_the_rest_of_the_server_section_is_still_written`
- `TestConfigsAlreadyCarryingTheWildcard::test_a_file_written_by_an_older_version_binds_localhost` — the migration.
- `::test_the_env_var_is_still_a_decision` — the guard is file-only.

## Verification

`make ci` passed locally (lint, format, mypy, file-length, xenon, complexipy, vulture, bandit, semgrep, refurb, deptry, import-linter, jscpd, critique, docs-cli-check, 5447 tests). `make docs-build` passes with no warnings.

## Docs

- `docs-site/docs/reference/config-reference.md` — Server (UI) section explains the save exception and the migration; the preset caveat names it as the single exception.
- `docs-site/docs/deploy/configuration/authentication.mdx` — "set `server.host` explicitly" was the advice this bug made unsafe; it now lists the three ways to choose a bind and says why a bare `0.0.0.0` in the file is not one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
