### PR TITLE
fix(titles): drop slow-mo frames left behind by a failed decode

### DIFF
--- a/src/immich_memories/titles/content_background.py
+++ b/src/immich_memories/titles/content_background.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# WHY (#517): Catmull-Rom only needs two frames, so `is_active` accepted two — but
+# two frames stretched across the 3.5s ease is a still image with a smear on it.
+# The default request is 0.5s of source, ~15 frames at 30fps; five is where the
+# ease still has distinct motion to interpolate. Below that the static background
+# is the better picture. No realistic clip falls short: five frames at 30fps is
+# 0.17s, and the window itself is already floored at 0.1s.
+_MIN_SOURCE_FRAMES = 5
+
 try:
     from PIL import Image, ImageFilter
 
@@ -223,11 +231,25 @@ class SlowmoBackgroundReader:
                 self._source_frames.append(
                     np.frombuffer(chunk, dtype=dtype).reshape((height, width, 3))
                 )
-            proc.wait(timeout=30)
+            returncode = proc.wait(timeout=30)
         except (OSError, subprocess.SubprocessError) as e:
             logger.debug(f"Failed to extract frames from {clip_path}: {e}")
             with contextlib.suppress(Exception):
                 proc.kill()
+            self._source_frames.clear()
+            return
+
+        # WHY (#517): frames are appended as they stream, so a decode that dies
+        # partway still leaves a handful behind. Keeping them let the 3.5s ease
+        # animate a ~0.1s sliver of source — a nearly frozen, smearing title
+        # background. A run that failed, or that never produced enough frames for
+        # the ease to read as motion, has nothing worth animating: drop the lot so
+        # the caller's static-frame fallback engages.
+        if returncode != 0 or len(self._source_frames) < _MIN_SOURCE_FRAMES:
+            logger.warning(
+                f"Slowmo decode of {clip_path.name} exited {returncode} with "
+                f"{len(self._source_frames)} frames; falling back to a static background"
+            )
             self._source_frames.clear()
             return
 

--- a/tests/integration/titles/test_slowmo_decode_failure.py
+++ b/tests/integration/titles/test_slowmo_decode_failure.py
@@ -1,0 +1,117 @@
+"""A slow-mo title background must not animate the debris of a failed decode.
+
+#517: `SlowmoBackgroundReader` streams frames as FFmpeg emits them, so a clip
+whose tail is unreadable still leaves a handful of frames behind. The streaming
+rewrite stopped checking the exit status, so those frames were kept and the 3.5s
+ease spread them over the whole title — a nearly frozen, smearing background
+where the static frame used to take over.
+
+Run: make test-integration-titles
+"""
+
+from __future__ import annotations
+
+import random
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from immich_memories.titles.content_background import SlowmoBackgroundReader
+
+pytestmark = [pytest.mark.integration]
+
+# The reader does not scale — it reshapes the raw pipe to these dimensions,
+# so the source clip has to be authored at exactly this size.
+_W, _H, _FPS = 320, 180, 30
+_FRAME_BYTES = _W * _H * 3
+
+
+def _make_clip(path: Path) -> Path:
+    # WHY faststart: moov lands ahead of mdat, so corrupting the tail damages the
+    # picture data while leaving the file openable — a decode that starts,
+    # delivers frames, and only then fails.
+    cmd = [
+        "ffmpeg", "-v", "error",
+        "-f", "lavfi",
+        "-i", f"testsrc2=size={_W}x{_H}:duration=3:rate={_FPS}",
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-g", "5",
+        "-movflags", "+faststart",
+        "-y", str(path),
+    ]  # fmt: skip
+    subprocess.run(cmd, check=True, capture_output=True, timeout=60)
+    return path
+
+
+def _corrupt_tail(source: Path, dest: Path, fraction: float) -> Path:
+    data = bytearray(source.read_bytes())
+    rng = random.Random(7)
+    for i in range(int(len(data) * (1 - fraction)), len(data)):
+        data[i] = rng.randrange(256)
+    dest.write_bytes(bytes(data))
+    return dest
+
+
+def _decode(clip: Path) -> tuple[int, int]:
+    """Exit status and whole-frame count from the pipe the reader itself uses."""
+    cmd = [
+        "ffmpeg",
+        "-ss", "0",
+        "-t", "0.5",
+        "-i", str(clip),
+        "-f", "rawvideo",
+        "-pix_fmt", "rgb24",
+        "-an",
+        "pipe:1",
+    ]  # fmt: skip
+    proc = subprocess.run(cmd, capture_output=True, timeout=60)
+    return proc.returncode, len(proc.stdout) // _FRAME_BYTES
+
+
+@pytest.fixture(scope="module")
+def intact_clip(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return _make_clip(tmp_path_factory.mktemp("slowmo") / "intact.mp4")
+
+
+@pytest.fixture(scope="module")
+def half_decoded_clip(intact_clip: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A clip whose decode exits nonzero *after* emitting usable frames.
+
+    How much corruption produces that depends on the FFmpeg build, so the
+    fixture searches for a fraction that does and skips when none is found
+    rather than asserting on a number that only holds on one machine.
+    """
+    out = tmp_path_factory.mktemp("slowmo-corrupt") / "corrupt.mp4"
+    for fraction in (0.8, 0.7, 0.6, 0.9):
+        _corrupt_tail(intact_clip, out, fraction)
+        returncode, frames = _decode(out)
+        if returncode != 0 and frames >= 2:
+            return out
+    pytest.skip("this FFmpeg build never exits nonzero with frames already emitted")
+
+
+def test_intact_clip_animates(intact_clip: Path) -> None:
+    """Positive control: the fallback must be about the failure, not the fixture."""
+    reader = SlowmoBackgroundReader(intact_clip, _W, _H, _FPS, title_duration=3.5)
+
+    assert reader.is_active
+    assert reader.read_frame() is not None
+    reader.close()
+
+
+def test_failed_decode_falls_back_instead_of_animating_a_sliver(
+    half_decoded_clip: Path,
+) -> None:
+    returncode, frames = _decode(half_decoded_clip)
+    assert returncode != 0 and frames >= 2, "fixture no longer reproduces the failure"
+
+    reader = SlowmoBackgroundReader(half_decoded_clip, _W, _H, _FPS, title_duration=3.5)
+
+    assert not reader.is_active, (
+        f"kept {frames} frames from a decode that exited {returncode}; "
+        "the 3.5s ease would animate a sliver of source"
+    )
+    assert reader.read_frame() is None
+    reader.close()

--- a/tests/test_content_background.py
+++ b/tests/test_content_background.py
@@ -198,3 +198,60 @@ class TestSourceLoadingStreams:
         assert reader.is_active
         frame = reader.read_frame()
         assert frame is not None and frame.dtype == np.float32
+
+
+class TestFailedDecodeFallsBackToStatic:
+    """#517: the streaming rewrite dropped the ffmpeg returncode check. Frames
+    are appended as they arrive, so a decode that died mid-stream kept its
+    partial output and the 3.5s slow-mo ease stretched over a ~0.1s sliver —
+    a nearly frozen, smearing background instead of the static fallback."""
+
+    @staticmethod
+    def _reader(returncode: int, frame_count: int) -> object:
+        import io
+        from unittest.mock import MagicMock, patch
+
+        from immich_memories.titles.content_background import SlowmoBackgroundReader
+
+        mod = "immich_memories.titles.content_background"
+        duration_probe = MagicMock(stdout="2.0", returncode=0)
+        frame = np.full((2, 2, 3), 200, dtype=np.uint8).tobytes()
+        proc = MagicMock()
+        proc.stdout = io.BytesIO(frame * frame_count)
+        proc.wait.return_value = returncode
+
+        # The fake streams whole frames, then EOFs with a chosen exit status.
+        # WHY: ffprobe and ffmpeg are the boundary the keep-or-drop decision reads.
+        with (
+            patch(f"{mod}.shutil.which", return_value="ffmpeg"),
+            patch(f"{mod}.subprocess.run", side_effect=[duration_probe]),
+            patch(f"{mod}.subprocess.Popen", return_value=proc),
+        ):
+            return SlowmoBackgroundReader(
+                Path("/nonexistent/content.mp4"),
+                width=2,
+                height=2,
+                fps=2,
+                title_duration=1.0,
+            )
+
+    def test_nonzero_exit_drops_the_partial_frames(self):
+        reader = self._reader(returncode=1, frame_count=8)
+
+        assert not reader.is_active, (
+            "frames from a failed decode were kept — the ease will animate a sliver"
+        )
+        assert reader.read_frame() is None
+
+    def test_clean_exit_keeps_its_frames(self):
+        reader = self._reader(returncode=0, frame_count=8)
+
+        assert reader.is_active
+        assert reader.read_frame() is not None
+
+    def test_a_handful_of_frames_is_not_enough_to_animate(self):
+        """A clean exit that yielded almost nothing is the same sliver: the ease
+        would spread three frames over the full title duration."""
+        reader = self._reader(returncode=0, frame_count=3)
+
+        assert not reader.is_active

--- a/tests/test_title_pipeline_integration.py
+++ b/tests/test_title_pipeline_integration.py
@@ -189,7 +189,9 @@ class TestSlowmoColorDomain:
         # WHY a real BytesIO: extraction streams the pipe (#408); the mock
         # process must behave like one — data, then EOF.
         frame_proc = MagicMock()
-        frame_proc.stdout = io.BytesIO(frame * 2)
+        # WHY 5 frames: fewer is treated as a failed decode and falls back to the
+        # static background (#517); this test is about the command, not the count.
+        frame_proc.stdout = io.BytesIO(frame * 5)
         frame_proc.wait.return_value = 0
         # WHY: ffprobe/ffmpeg are the external boundary; the fake streams then EOFs (#408)
         with (


### PR DESCRIPTION
## What

`SlowmoBackgroundReader` streams frames as FFmpeg emits them (#408) and threw away what `proc.wait` returned. A clip whose tail will not decode still delivers a handful of frames before FFmpeg exits nonzero — and those frames sailed past `is_active`'s two-frame floor.

The result: the 3.5s slow-mo ease stretched over a ~0.1s sliver of source. A nearly frozen, smearing title background, where before the rewrite the reader cleanly fell back to the static frame (`rendering_service.py:199-201`).

## Fix

Keep the exit status from `proc.wait` and act on it. Frames are dropped — so the caller's static-frame fallback engages — when either:

- FFmpeg exited nonzero, or
- the decode never produced enough frames for the ease to have real motion to interpolate.

`_MIN_SOURCE_FRAMES = 5`: Catmull-Rom only structurally needs two, but two frames spread across 3.5s is a still image with a smear on it. The default request is 0.5s of source (~15 frames at 30fps), and five frames at 30fps is 0.17s — under the 0.1s floor the window already enforces, so no realistic clip is affected.

## Tests

**Unit** (`tests/test_content_background.py`) — the keep-or-drop decision with the subprocess boundary faked, since neither input is reproducible on demand from a real file:

- nonzero exit with 8 frames streamed → dropped
- clean exit with 8 frames → kept (guards against over-clearing)
- clean exit with 3 frames → dropped

**Integration** (`tests/integration/titles/test_slowmo_decode_failure.py`) — a real clip, corrupted rather than truncated:

- Truncating an mp4 makes FFmpeg exit **0** (measured: it decodes what it can), so it never reproduces this bug. Corrupting the tail of a `+faststart` mp4 does — moov survives, the picture data does not, and the decode exits 69 after emitting 6 frames.
- The fixture searches for a corruption fraction that produces nonzero-exit-with-frames on the local FFmpeg build and skips if none does, rather than pinning a number that only holds on one machine.
- A positive control on the intact clip proves the fallback is about the failure, not the fixture.

Verified RED: with the fix stashed, `test_failed_decode_falls_back_instead_of_animating_a_sliver` fails while the positive control still passes.

One existing test moved with the contract: `TestSlowmoColorDomain`'s fake streamed exactly 2 frames, which is now treated as a failed decode. It streams 5 now — that test is about the FFmpeg command shape, not the frame count.

## Verification

`make ci` passes: 5445 passed, 9 skipped. `make test-integration-titles` passes: 138 passed.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
