### PR TITLE
fix(ui): drop the phantom smart-crop mode and follow the config default

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1081,279 +1081,275 @@
         "name": "register_generate_commands",
         "complexity": 179,
         "line_start": 169,
-        "line_end": 936,
+        "line_end": 937,
         "line_complexities": [
-          {
-            "line": 486,
-            "complexity": 0
-          },
           {
             "line": 487,
             "complexity": 0
           },
           {
-            "line": 494,
-            "complexity": 2
+            "line": 488,
+            "complexity": 0
           },
           {
             "line": 495,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 496,
             "complexity": 0
           },
           {
-            "line": 498,
+            "line": 497,
+            "complexity": 0
+          },
+          {
+            "line": 499,
             "complexity": 2
           },
           {
-            "line": 500,
-            "complexity": 3
-          },
-          {
-            "line": 504,
+            "line": 501,
             "complexity": 3
           },
           {
             "line": 505,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 507,
+            "line": 506,
             "complexity": 0
           },
           {
             "line": 508,
-            "complexity": 2
-          },
-          {
-            "line": 509,
-            "complexity": 1
-          },
-          {
-            "line": 514,
-            "complexity": 3
-          },
-          {
-            "line": 515,
             "complexity": 0
           },
           {
-            "line": 519,
+            "line": 509,
+            "complexity": 2
+          },
+          {
+            "line": 510,
+            "complexity": 1
+          },
+          {
+            "line": 515,
+            "complexity": 3
+          },
+          {
+            "line": 516,
             "complexity": 0
           },
           {
             "line": 520,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 521,
+            "complexity": 1
+          },
+          {
+            "line": 522,
             "complexity": 0
           },
           {
-            "line": 523,
+            "line": 524,
             "complexity": 2
           },
           {
-            "line": 539,
+            "line": 540,
             "complexity": 0
           },
           {
-            "line": 550,
+            "line": 551,
             "complexity": 3
           },
           {
-            "line": 554,
+            "line": 555,
             "complexity": 3
           },
           {
-            "line": 558,
+            "line": 559,
             "complexity": 4
           },
           {
-            "line": 562,
+            "line": 563,
             "complexity": 3
           },
           {
-            "line": 566,
+            "line": 567,
             "complexity": 3
           },
           {
-            "line": 574,
+            "line": 575,
             "complexity": 0
-          },
-          {
-            "line": 591,
-            "complexity": 2
           },
           {
             "line": 592,
-            "complexity": 0
-          },
-          {
-            "line": 593,
-            "complexity": 1
-          },
-          {
-            "line": 595,
-            "complexity": 0
-          },
-          {
-            "line": 596,
-            "complexity": 1
-          },
-          {
-            "line": 597,
-            "complexity": 0
-          },
-          {
-            "line": 598,
-            "complexity": 3
-          },
-          {
-            "line": 603,
-            "complexity": 1
-          },
-          {
-            "line": 604,
-            "complexity": 3
-          },
-          {
-            "line": 605,
-            "complexity": 0
-          },
-          {
-            "line": 606,
-            "complexity": 1
-          },
-          {
-            "line": 607,
-            "complexity": 0
-          },
-          {
-            "line": 610,
-            "complexity": 0
-          },
-          {
-            "line": 614,
             "complexity": 2
           },
           {
-            "line": 619,
+            "line": 593,
             "complexity": 0
           },
           {
-            "line": 622,
+            "line": 594,
+            "complexity": 1
+          },
+          {
+            "line": 596,
+            "complexity": 0
+          },
+          {
+            "line": 597,
+            "complexity": 1
+          },
+          {
+            "line": 598,
+            "complexity": 0
+          },
+          {
+            "line": 599,
+            "complexity": 3
+          },
+          {
+            "line": 604,
+            "complexity": 1
+          },
+          {
+            "line": 605,
+            "complexity": 3
+          },
+          {
+            "line": 606,
+            "complexity": 0
+          },
+          {
+            "line": 607,
+            "complexity": 1
+          },
+          {
+            "line": 608,
+            "complexity": 0
+          },
+          {
+            "line": 611,
+            "complexity": 0
+          },
+          {
+            "line": 615,
+            "complexity": 2
+          },
+          {
+            "line": 620,
             "complexity": 0
           },
           {
             "line": 623,
-            "complexity": 2
-          },
-          {
-            "line": 624,
             "complexity": 0
           },
           {
-            "line": 627,
-            "complexity": 1
+            "line": 624,
+            "complexity": 2
           },
           {
-            "line": 630,
-            "complexity": 3
+            "line": 625,
+            "complexity": 0
+          },
+          {
+            "line": 628,
+            "complexity": 1
           },
           {
             "line": 631,
             "complexity": 3
           },
           {
-            "line": 633,
-            "complexity": 0
-          },
-          {
-            "line": 640,
-            "complexity": 0
-          },
-          {
-            "line": 644,
+            "line": 632,
             "complexity": 3
+          },
+          {
+            "line": 634,
+            "complexity": 0
+          },
+          {
+            "line": 641,
+            "complexity": 0
           },
           {
             "line": 645,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 646,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 647,
-            "complexity": 0
-          },
-          {
-            "line": 649,
-            "complexity": 0
-          },
-          {
-            "line": 673,
-            "complexity": 1
-          },
-          {
-            "line": 674,
-            "complexity": 2
-          },
-          {
-            "line": 678,
-            "complexity": 1
-          },
-          {
-            "line": 689,
             "complexity": 3
           },
           {
-            "line": 690,
+            "line": 648,
             "complexity": 0
+          },
+          {
+            "line": 650,
+            "complexity": 0
+          },
+          {
+            "line": 674,
+            "complexity": 1
+          },
+          {
+            "line": 675,
+            "complexity": 2
+          },
+          {
+            "line": 679,
+            "complexity": 1
+          },
+          {
+            "line": 690,
+            "complexity": 3
           },
           {
             "line": 691,
             "complexity": 0
           },
           {
-            "line": 693,
+            "line": 692,
             "complexity": 0
           },
           {
-            "line": 695,
+            "line": 694,
             "complexity": 0
           },
           {
-            "line": 697,
+            "line": 696,
             "complexity": 0
           },
           {
-            "line": 704,
+            "line": 698,
+            "complexity": 0
+          },
+          {
+            "line": 705,
             "complexity": 5
           },
           {
-            "line": 745,
+            "line": 746,
             "complexity": 6
-          },
-          {
-            "line": 788,
-            "complexity": 0
           },
           {
             "line": 789,
-            "complexity": 5
+            "complexity": 0
           },
           {
             "line": 790,
-            "complexity": 6
+            "complexity": 5
           },
           {
             "line": 791,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 792,
@@ -1361,134 +1357,138 @@
           },
           {
             "line": 793,
-            "complexity": 7
+            "complexity": 0
           },
           {
-            "line": 801,
-            "complexity": 6
+            "line": 794,
+            "complexity": 7
           },
           {
             "line": 802,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 803,
-            "complexity": 7
+            "complexity": 0
           },
           {
             "line": 804,
+            "complexity": 7
+          },
+          {
+            "line": 805,
             "complexity": 0
           },
           {
-            "line": 806,
+            "line": 807,
             "complexity": 1
           },
           {
-            "line": 811,
-            "complexity": 7
-          },
-          {
             "line": 812,
-            "complexity": 0
+            "complexity": 7
           },
           {
-            "line": 825,
-            "complexity": 7
+            "line": 813,
+            "complexity": 0
           },
           {
             "line": 826,
-            "complexity": 0
+            "complexity": 7
           },
           {
             "line": 827,
             "complexity": 0
           },
           {
-            "line": 830,
-            "complexity": 1
+            "line": 828,
+            "complexity": 0
           },
           {
             "line": 831,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 832,
             "complexity": 0
           },
           {
-            "line": 835,
+            "line": 833,
             "complexity": 0
           },
           {
-            "line": 845,
+            "line": 836,
             "complexity": 0
           },
           {
             "line": 846,
-            "complexity": 5
+            "complexity": 0
           },
           {
             "line": 847,
-            "complexity": 6
+            "complexity": 5
           },
           {
             "line": 848,
+            "complexity": 6
+          },
+          {
+            "line": 849,
             "complexity": 7
           },
           {
-            "line": 852,
+            "line": 853,
             "complexity": 6
           },
           {
-            "line": 855,
+            "line": 856,
             "complexity": 6
           },
           {
-            "line": 860,
+            "line": 861,
             "complexity": 0
           },
           {
-            "line": 862,
+            "line": 863,
             "complexity": 5
           },
           {
-            "line": 864,
+            "line": 865,
             "complexity": 5
           },
           {
-            "line": 868,
+            "line": 869,
             "complexity": 5
           },
           {
-            "line": 871,
+            "line": 872,
             "complexity": 1
           },
           {
-            "line": 873,
+            "line": 874,
             "complexity": 0
           },
           {
-            "line": 875,
+            "line": 876,
             "complexity": 0
           },
           {
-            "line": 919,
+            "line": 920,
             "complexity": 1
           },
           {
-            "line": 922,
-            "complexity": 1
-          },
-          {
-            "line": 925,
+            "line": 923,
             "complexity": 1
           },
           {
             "line": 926,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 927,
+            "complexity": 0
+          },
+          {
+            "line": 928,
             "complexity": 1
           }
         ]
@@ -3198,44 +3198,32 @@
       {
         "name": "streaming_assemble_full",
         "complexity": 16,
-        "line_start": 892,
-        "line_end": 995,
+        "line_start": 895,
+        "line_end": 998,
         "line_complexities": [
           {
-            "line": 914,
+            "line": 917,
             "complexity": 1
-          },
-          {
-            "line": 915,
-            "complexity": 0
           },
           {
             "line": 918,
             "complexity": 0
           },
           {
-            "line": 919,
+            "line": 921,
             "complexity": 0
           },
           {
-            "line": 920,
+            "line": 922,
             "complexity": 0
           },
           {
-            "line": 924,
+            "line": 923,
+            "complexity": 0
+          },
+          {
+            "line": 927,
             "complexity": 2
-          },
-          {
-            "line": 930,
-            "complexity": 3
-          },
-          {
-            "line": 931,
-            "complexity": 0
-          },
-          {
-            "line": 932,
-            "complexity": 0
           },
           {
             "line": 933,
@@ -3243,7 +3231,7 @@
           },
           {
             "line": 934,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 935,
@@ -3251,26 +3239,38 @@
           },
           {
             "line": 936,
+            "complexity": 3
+          },
+          {
+            "line": 937,
+            "complexity": 3
+          },
+          {
+            "line": 938,
             "complexity": 0
           },
           {
-            "line": 945,
+            "line": 939,
             "complexity": 0
           },
           {
-            "line": 966,
+            "line": 948,
+            "complexity": 0
+          },
+          {
+            "line": 969,
             "complexity": 2
           },
           {
-            "line": 972,
+            "line": 975,
             "complexity": 0
           },
           {
-            "line": 987,
+            "line": 990,
             "complexity": 2
           },
           {
-            "line": 993,
+            "line": 996,
             "complexity": 0
           }
         ]
@@ -3278,20 +3278,12 @@
       {
         "name": "assemble_streaming",
         "complexity": 24,
-        "line_start": 639,
-        "line_end": 773,
+        "line_start": 642,
+        "line_end": 776,
         "line_complexities": [
           {
-            "line": 664,
-            "complexity": 1
-          },
-          {
-            "line": 665,
-            "complexity": 0
-          },
-          {
             "line": 667,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 668,
@@ -3303,11 +3295,7 @@
           },
           {
             "line": 671,
-            "complexity": 1
-          },
-          {
-            "line": 672,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 673,
@@ -3315,66 +3303,66 @@
           },
           {
             "line": 674,
-            "complexity": 0
+            "complexity": 1
+          },
+          {
+            "line": 675,
+            "complexity": 1
           },
           {
             "line": 676,
             "complexity": 0
           },
           {
+            "line": 677,
+            "complexity": 0
+          },
+          {
             "line": 679,
+            "complexity": 0
+          },
+          {
+            "line": 682,
             "complexity": 3
           },
           {
-            "line": 680,
+            "line": 683,
             "complexity": 0
           },
           {
-            "line": 681,
+            "line": 684,
             "complexity": 0
           },
           {
-            "line": 687,
+            "line": 690,
             "complexity": 0
-          },
-          {
-            "line": 711,
-            "complexity": 1
-          },
-          {
-            "line": 712,
-            "complexity": 0
-          },
-          {
-            "line": 713,
-            "complexity": 2
           },
           {
             "line": 714,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 715,
             "complexity": 0
           },
           {
-            "line": 739,
-            "complexity": 1
+            "line": 716,
+            "complexity": 2
           },
           {
-            "line": 740,
+            "line": 717,
+            "complexity": 0
+          },
+          {
+            "line": 718,
             "complexity": 0
           },
           {
             "line": 742,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 743,
-            "complexity": 2
-          },
-          {
-            "line": 744,
             "complexity": 0
           },
           {
@@ -3383,51 +3371,51 @@
           },
           {
             "line": 746,
-            "complexity": 1
+            "complexity": 2
           },
           {
             "line": 747,
             "complexity": 0
           },
           {
-            "line": 749,
+            "line": 748,
             "complexity": 0
           },
           {
-            "line": 753,
+            "line": 749,
             "complexity": 1
           },
           {
-            "line": 754,
+            "line": 750,
             "complexity": 0
           },
           {
-            "line": 755,
-            "complexity": 2
+            "line": 752,
+            "complexity": 0
           },
           {
             "line": 756,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 757,
             "complexity": 0
           },
           {
-            "line": 759,
-            "complexity": 1
+            "line": 758,
+            "complexity": 2
           },
           {
-            "line": 765,
+            "line": 759,
             "complexity": 0
           },
           {
-            "line": 766,
-            "complexity": 1
+            "line": 760,
+            "complexity": 0
           },
           {
-            "line": 767,
-            "complexity": 2
+            "line": 762,
+            "complexity": 1
           },
           {
             "line": 768,
@@ -3435,14 +3423,26 @@
           },
           {
             "line": 769,
-            "complexity": 3
-          },
-          {
-            "line": 771,
             "complexity": 1
           },
           {
-            "line": 773,
+            "line": 770,
+            "complexity": 2
+          },
+          {
+            "line": 771,
+            "complexity": 0
+          },
+          {
+            "line": 772,
+            "complexity": 3
+          },
+          {
+            "line": 774,
+            "complexity": 1
+          },
+          {
+            "line": 776,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -46,7 +46,7 @@ immich-memories generate [OPTIONS]
 | `--short-form` | — | choice | — | `15`, `30`, `60`, or `90` — sets the duration and goes vertical |
 | `--orientation` | `-o` | choice | `landscape` | `landscape`, `portrait`, or `square` |
 | `--resolution` | `-r` | choice | config value; `auto` matches source clips | `auto`, `4k`, `1080p`, or `720p` |
-| `--scale-mode` | `-s` | choice | config/`blur` | `fit`, `fill`, `smart_crop`, or `blur` |
+| `--scale-mode` | `-s` | choice | config/`blur` | `blur` (blurred background) or `fit` (black bars) |
 | `--transition` | `-t` | choice | `smart` | `smart`, `cut`, `crossfade`, or `none` |
 | `--quality` | `-q` | choice | config value | `high`, `medium`, or `low` |
 | `--format` | — | choice | config value | `mp4`, `h265`, or `prores` |

--- a/docs-site/docs/create/pipeline/face-aware-cropping.md
+++ b/docs-site/docs/create/pipeline/face-aware-cropping.md
@@ -1,24 +1,21 @@
 ---
 sidebar_position: 2
-title: Face-Aware Cropping
+title: Face-Aware Framing
 ---
 
-# Face-Aware Cropping
+# Face-Aware Framing
 
-When your source videos are landscape (16:9) but the output is portrait (9:16), or any other aspect ratio conversion, you lose a lot of the frame. Dumb center-cropping will cut people's heads off. Face-aware cropping detects faces first, then positions the crop window to keep them in frame.
+Faces steer two things: which clips get picked, and where a photo's Ken Burns move ends up. They do **not** crop your video clips — see [What happens to video clips](#what-happens-to-video-clips) below.
 
-## How it works
+## Photos pan toward the face
 
-1. Detect faces in the frame
-2. Calculate the bounding box that contains all detected faces
-3. Position the crop window to center that bounding box
-4. Clamp to frame boundaries (faces near the edge stay visible, the crop just shifts as far as it can)
+Immich already knows where the faces are in a photo. The photo animator reads those boxes, picks the largest face, and makes it the end point of the Ken Burns pan. So the move drifts toward the person instead of drifting off into a wall.
 
-If no faces are detected, it falls back to center crop: which is fine for landscapes, food shots, etc.
+With no faces on the asset, the pan ends at the centre — fine for landscapes, food shots, and the dog.
 
-## Detection backends
+## Faces feed clip scoring
 
-The pipeline picks the face detection backend automatically based on your hardware:
+Clip scoring counts faces per frame: a segment with people in it outscores an equally sharp segment of scenery. The pipeline picks the detection backend automatically:
 
 | Platform | Backend | Speed |
 |----------|---------|-------|
@@ -29,8 +26,11 @@ There is no CUDA face-detection path; on Linux, GPUs are used for encoding, scal
 
 On a Mac with an M-series chip, the Vision Framework runs face detection on the Neural Engine, which is purpose-built for this kind of work. It's not just faster: it's more accurate too, especially with small or partially occluded faces.
 
-## When it matters
+## What happens to video clips
 
-Face-aware cropping kicks in during the assembly phase, whenever the source and target aspect ratios differ. If you're outputting at the same aspect ratio as your source, no cropping happens and this is a no-op.
+Nothing gets cropped. When a landscape clip lands in a portrait video, the whole frame is kept and the leftover space is filled, using [`scale_mode`](../../reference/config-reference.md#generation-defaults):
 
-The most common case: you shot everything in landscape on your phone, but want a vertical video for sharing. Without face-aware cropping, you'd lose whoever was standing on the left or right side of frame.
+- `blur` (default) — a blurred, zoomed copy of the frame sits behind the sharp one
+- `fit` — black bars
+
+Face-aware cropping of video is **not implemented**. Cropping a moving subject needs per-frame tracking and a smoothed crop path, not a single face position, so the frame is kept whole instead of guessing. The face-centre helpers in `processing/scaling_utilities.py` are parked there for whoever builds it.

--- a/docs-site/docs/create/web-ui/step3-generation-options.mdx
+++ b/docs-site/docs/create/web-ui/step3-generation-options.mdx
@@ -22,8 +22,8 @@ Two selects are always visible:
 
 A collapsed expansion under the two selects:
 
-- **Orientation**: **Auto (detect from clips)** (default), Landscape (16:9), Portrait (9:16), Square (1:1). When the source and target aspect ratios differ, [face-aware cropping](../pipeline/face-aware-cropping.md) keeps faces in frame.
-- **Scaling Mode**: Smart Crop (keep faces), Fill (crop), Fit (letterbox), Blur (blurred background). The UI defaults to Smart Crop; the CLI and config default to `blur`.
+- **Orientation**: **Auto (detect from clips)** (default), Landscape (16:9), Portrait (9:16), Square (1:1). When the source and target aspect ratios differ, the whole frame is kept and the leftover space is filled — clips are never cropped, see [face-aware framing](../pipeline/face-aware-cropping.md).
+- **Scaling Mode**: **Blur background** (default), Letterbox (black bars). Starts on whatever `defaults.scale_mode` says, so the wizard and `--scale-mode` produce the same video.
 - **Transition Style**: **Smart (mix of fades & cuts)** (default), Crossfade, Cut, None. Smart picks per cut point: crossfade for slow scenes, hard cut for fast action.
 - **Add date overlay** and **Keep intermediate files** checkboxes.
 - When photos are enabled: "Photos enabled (N found)" and a **Photo duration (seconds)** field (1–10).

--- a/docs-site/docs/deploy/configuration/config-file.md
+++ b/docs-site/docs/deploy/configuration/config-file.md
@@ -31,7 +31,7 @@ output:
   hdr_mode: auto                  # Preserve HLG/PQ when present; otherwise output SDR
 
 defaults:
-  scale_mode: "blur"             # fit, fill, smart_crop, blur
+  scale_mode: "blur"             # blur background, or fit for black bars
   transition: "smart"            # cut, crossfade, smart, none
 
 # ── AI analysis (any OpenAI-compatible vision model) ──────

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -270,7 +270,7 @@ immich-memories generate [OPTIONS]
 | `--duration`, `-d` | integer | - | Target duration in seconds (default: from memory type preset) |
 | `--short-form` | choice: `15` \| `30` \| `60` \| `90` | - | Short-form preset: sets the duration and makes the video vertical |
 | `--orientation`, `-o` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |
-| `--scale-mode`, `-s` | choice: `fit` \| `fill` \| `smart_crop` \| `blur` | - | Scale mode (default: from config or smart_crop) |
+| `--scale-mode`, `-s` | choice: `fit` \| `blur` | - | How to fill an aspect mismatch: blurred background or black bars (default: from config, else blur) |
 | `--transition`, `-t` | choice: `smart` \| `cut` \| `crossfade` \| `none` | smart | Transition style (default: smart — mix of fades & cuts) |
 | `--resolution`, `-r` | choice: `auto` \| `4k` \| `1080p` \| `720p` | - | Output resolution (default: config value, 'auto' to match source clips) |
 | `--music-volume` | float | 0.5 | Music volume 0.0-1.0 (default: 0.5) |

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -133,7 +133,7 @@ or more within the merge window is treated as a burst — the count is not confi
 
 ```yaml
 defaults:
-  scale_mode: "blur"             # fit, fill, smart_crop, blur (used when --scale-mode is not given)
+  scale_mode: "blur"             # blur | fit (black bars) — used when --scale-mode is not given
   transition: "smart"            # cut, crossfade, smart, none (used when --transition is left on smart)
   transition_duration: 0.5       # 0-2 seconds
 ```

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -257,9 +257,10 @@ def register_generate_commands(main: click.Group) -> None:
     @click.option(
         "--scale-mode",
         "-s",
-        type=click.Choice(["fit", "fill", "smart_crop", "blur"]),
+        type=click.Choice(["fit", "blur"]),
         default=None,
-        help="Scale mode (default: from config or smart_crop)",
+        help="How to fill an aspect mismatch: blurred background or black bars "
+        "(default: from config, else blur)",
     )
     @click.option(
         "--transition",

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -82,12 +82,43 @@ class ImmichConfig(BaseModel):
         return v
 
 
+# The assembler fills an aspect mismatch two ways and no more: a blurred, zoomed
+# copy of the frame behind the sharp one, or black bars. `smart_crop` and `fill`
+# both silently rendered as black bars because no crop path exists for video.
+# `fill` keeps that rendering under its real name; `smart_crop` moves to blur,
+# which is what someone asking to keep faces in frame was actually after.
+_LEGACY_SCALE_MODES = {"smart_crop": "blur", "fill": "fit"}
+
+
+def normalize_scale_mode(value: str) -> str:
+    """Map a retired scale mode onto an implemented one, saying so."""
+    replacement = _LEGACY_SCALE_MODES.get(value)
+    if replacement is None:
+        return value
+    logger.warning(
+        "scale_mode '%s' no longer exists — no crop path was ever implemented for "
+        "video, so it rendered as black bars. Using '%s'.",
+        value,
+        replacement,
+    )
+    return replacement
+
+
 class DefaultsConfig(BaseModel):
     """Default settings for video generation."""
 
-    scale_mode: Literal["fit", "fill", "smart_crop", "blur"] = "blur"
+    scale_mode: Literal["fit", "blur"] = Field(
+        default="blur",
+        description="How to fill an aspect mismatch: 'blur' background or 'fit' (black bars)",
+    )
     transition: Literal["cut", "crossfade", "smart", "none"] = "smart"
     transition_duration: float = Field(default=0.5, ge=0, le=2.0)
+
+    @field_validator("scale_mode", mode="before")
+    @classmethod
+    def map_legacy_scale_mode(cls, v: str) -> str:
+        """Keep configs written against the retired modes loading."""
+        return normalize_scale_mode(v) if isinstance(v, str) else v
 
 
 _CLIP_STYLE_PRESETS: dict[str, dict[str, float]] = {

--- a/src/immich_memories/generate_settings.py
+++ b/src/immich_memories/generate_settings.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.config_models import normalize_scale_mode
 from immich_memories.generate_privacy import (
     extract_trip_locations,
     generate_trip_title_text,
@@ -68,7 +69,7 @@ def _build_assembly_settings(
     title_screen_settings = _build_title_settings(params, config, assembly_clips)
 
     # Scale mode: CLI/param > config > default
-    effective_scale_mode = params.scale_mode or config.defaults.scale_mode
+    effective_scale_mode = normalize_scale_mode(params.scale_mode or config.defaults.scale_mode)
 
     # A CLI format override selects both a compatible codec and container.
     # With no override, the explicit output config remains authoritative.

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -164,6 +164,9 @@ class FrameDecoder:
             )
             self._use_filter_complex = True
         else:
+            # "fit": scale down inside the frame and pad the rest black. There is
+            # no face-aware crop on the video path, so anything that is not
+            # "blur" lands here — which is why no such mode is offered.
             parts.extend(
                 (
                     f"scale={self._width}:{self._height}:force_original_aspect_ratio=decrease:flags=lanczos",

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -22,6 +22,7 @@ from immich_memories.ui.components import (
     im_separator,
 )
 from immich_memories.ui.nicegui_compat import io_bound_result, run_ui_observer
+from immich_memories.ui.pages.step3_options import SCALE_MODE_OPTIONS, resolve_scale_mode_label
 
 if TYPE_CHECKING:
     from immich_memories.processing.encoding_plan import EncodingPlan
@@ -161,13 +162,6 @@ _RESOLUTION_MAP = {
     "Auto (match clips)": "auto",
 }
 
-_SCALE_MODE_MAP = {
-    "Smart Crop (keep faces)": "smart_crop",
-    "Fill (crop)": "fill",
-    "Fit (letterbox)": "fit",
-    "Blur (blurred background)": "blur",
-}
-
 _FORMAT_MAP = {
     "MP4 (H.264)": "mp4",
     "MP4 (H.265)": "h265",
@@ -233,9 +227,9 @@ def _build_generation_params(state, selected_clips, output_path):
             gen_options.get("transition", "Smart (mix of fades & cuts)"), "crossfade"
         ),
         output_resolution=_RESOLUTION_MAP.get(gen_options.get("resolution", "Auto (match clips)")),
-        scale_mode=_SCALE_MODE_MAP.get(
-            gen_options.get("scale_mode", "Smart Crop (keep faces)"), "smart_crop"
-        ),
+        scale_mode=SCALE_MODE_OPTIONS[
+            resolve_scale_mode_label(state.config, gen_options.get("scale_mode"))
+        ],
         output_format=_FORMAT_MAP.get(gen_options.get("format_override")),
         add_date_overlay=gen_options.get("add_date", False),
         debug_preserve_intermediates=gen_options.get("keep_intermediates", False),

--- a/src/immich_memories/ui/pages/step3_options.py
+++ b/src/immich_memories/ui/pages/step3_options.py
@@ -6,6 +6,7 @@ import logging
 
 from nicegui import ui
 
+from immich_memories.config_models import DefaultsConfig, normalize_scale_mode
 from immich_memories.ui.components import (
     im_button,
     im_card,
@@ -39,12 +40,35 @@ def configured_output_format_label(config) -> str:
 
 _RESOLUTION_LABELS = {"4k": "4K", "1080p": "1080p", "720p": "720p"}
 
+# WHY: the assembler fills an aspect mismatch two ways and no more — a blurred,
+# zoomed copy of the frame behind the sharp one, or black bars. Offering a third
+# choice here would just relabel the black bars (see streaming_assembler._build_vf).
+SCALE_MODE_OPTIONS = {
+    "Blur background": "blur",
+    "Letterbox (black bars)": "fit",
+}
+_SCALE_MODE_LABELS = {mode: label for label, mode in SCALE_MODE_OPTIONS.items()}
+_DEFAULT_SCALE_MODE_LABEL = _SCALE_MODE_LABELS[DefaultsConfig().scale_mode]
+
 
 def default_resolution_label(config) -> str:
     """Match clips unless a preset pins the resolution (fast → 1080p on a NAS, not 4K)."""
     if config is None or config.preset is None:
         return "Auto (match clips)"
     return _RESOLUTION_LABELS.get(config.output.resolution, "Auto (match clips)")
+
+
+def resolve_scale_mode_label(config, stored: str | None = None) -> str:
+    """Pick the label to show, starting the wizard wherever the CLI would start.
+
+    A `stored` label saved before the retired modes were dropped is discarded
+    rather than shown as a mode that no longer exists, and so is a configured
+    mode this wizard has no widget for.
+    """
+    if stored is not None and stored in SCALE_MODE_OPTIONS:
+        return stored
+    configured = normalize_scale_mode(config.defaults.scale_mode) if config is not None else ""
+    return _SCALE_MODE_LABELS.get(configured, _DEFAULT_SCALE_MODE_LABEL)
 
 
 def _render_preset_banner(config) -> None:
@@ -184,7 +208,7 @@ def render_step3() -> None:
     if not state.generation_options:
         state.generation_options = {
             "orientation": "Auto (detect from clips)",
-            "scale_mode": "Smart Crop (keep faces)",
+            "scale_mode": resolve_scale_mode_label(config),
             "transition": "Smart (mix of fades & cuts)",
             "resolution": default_resolution_label(config),
             "format": configured_format,
@@ -255,14 +279,9 @@ def render_step3() -> None:
                 orientation_select.on_value_change(on_orientation_change)
 
                 scale_select = ui.select(
-                    options=[
-                        "Smart Crop (keep faces)",
-                        "Fill (crop)",
-                        "Fit (letterbox)",
-                        "Blur (blurred background)",
-                    ],
+                    options=list(SCALE_MODE_OPTIONS),
                     label="Scaling Mode",
-                    value=options.get("scale_mode", "Smart Crop (keep faces)"),
+                    value=resolve_scale_mode_label(config, options.get("scale_mode")),
                 ).classes("w-full")
 
                 def on_scale_change(e):

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -92,6 +92,14 @@ class TestCLIHelp:
         assert "--start" in result.output
         assert "--end" in result.output
 
+    def test_generate_help_offers_only_implemented_scale_modes(self):
+        """--help must not advertise a crop the assembler cannot do, nor a wrong default."""
+        result = _invoke(["generate", "--help"])
+
+        assert result.exit_code == 0
+        assert "smart_crop" not in result.output
+        assert "fit|blur" in result.output.replace("\n", "").replace(" ", "")
+
     def test_config_help(self):
         """config --help lists subcommands."""
         result = _invoke(["config", "--help"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -122,6 +123,27 @@ class TestDefaultsConfig:
 
         config = DefaultsConfig(transition_duration=2.0)
         assert config.transition_duration == 2.0
+
+    def test_legacy_smart_crop_loads_as_blur(self, caplog):
+        """An existing config saying smart_crop keeps loading, and says what it became."""
+        with caplog.at_level(logging.WARNING):
+            config = DefaultsConfig(scale_mode="smart_crop")
+
+        assert config.scale_mode == "blur"
+        assert "smart_crop" in caplog.text
+
+    def test_legacy_fill_loads_as_fit(self, caplog):
+        """fill never cropped to fill the frame — it letterboxed, which is fit."""
+        with caplog.at_level(logging.WARNING):
+            config = DefaultsConfig(scale_mode="fill")
+
+        assert config.scale_mode == "fit"
+        assert "fill" in caplog.text
+
+    def test_unknown_scale_mode_is_rejected(self):
+        """A typo still fails loudly rather than silently letterboxing."""
+        with pytest.raises(ValidationError):
+            DefaultsConfig(scale_mode="smart_zoom")
 
 
 class TestAnalysisConfig:

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -905,19 +905,30 @@ class TestBuildAssemblySettingsExtraBranches:
             clips=[],
             output_path=Path("/out/o.mp4"),
             config=Config(),
+            scale_mode="fit",
+        )
+        settings = _build_assembly_settings(params, [])
+        assert settings.scale_mode == "fit"
+
+    def test_legacy_scale_mode_from_params_is_mapped(self):
+        """A caller still passing smart_crop gets blur, not a silent letterbox."""
+        params = GenerationParams(
+            clips=[],
+            output_path=Path("/out/o.mp4"),
+            config=Config(),
             scale_mode="smart_crop",
         )
         settings = _build_assembly_settings(params, [])
-        assert settings.scale_mode == "smart_crop"
+        assert settings.scale_mode == "blur"
 
     def test_scale_mode_from_config_when_param_none(self):
         config = Config()
-        config.defaults.scale_mode = "fill"
+        config.defaults.scale_mode = "fit"
         params = GenerationParams(
             clips=[], output_path=Path("/out/o.mp4"), config=config, scale_mode=None
         )
         settings = _build_assembly_settings(params, [])
-        assert settings.scale_mode == "fill"
+        assert settings.scale_mode == "fit"
 
     def test_4k_resolution(self):
         params = GenerationParams(

--- a/tests/test_storage_cli_coverage.py
+++ b/tests/test_storage_cli_coverage.py
@@ -1149,7 +1149,7 @@ class TestGenerateBuildParamsTable:
             person_names=["Alice"],
             duration=600.0,
             orientation="landscape",
-            scale_mode="smart_crop",
+            scale_mode="blur",
             transition="smart",
             resolution="auto",
             output_format="mp4",

--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -408,6 +408,37 @@ def test_frame_decoder_applies_hdr_to_sdr_color_chain() -> None:
     assert vf.endswith("setsar=1")
 
 
+def _vf_for_scale_mode(mode: str) -> str:
+    from immich_memories.processing.streaming_assembler import FrameDecoder
+
+    return FrameDecoder(
+        Path("clip.mp4"), width=1920, height=1080, fps=30, scale_mode=mode
+    )._build_vf()
+
+
+def test_the_configurable_scale_modes_render_differently() -> None:
+    """Two accepted modes that build the same chain would mean one is a phantom."""
+    from immich_memories.config_models import DefaultsConfig
+
+    modes = [mode for mode in ("blur", "fit") if DefaultsConfig(scale_mode=mode).scale_mode == mode]
+    chains = {_vf_for_scale_mode(mode) for mode in modes}
+
+    assert len(chains) == len(modes) == 2
+
+
+def test_blur_scale_mode_renders_a_blurred_background() -> None:
+    vf = _vf_for_scale_mode("blur")
+
+    assert "gblur=sigma=30" in vf
+    assert "overlay=(W-w)/2:(H-h)/2" in vf
+
+
+def test_fit_scale_mode_renders_black_bars() -> None:
+    vf = _vf_for_scale_mode("fit")
+
+    assert "pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black" in vf
+
+
 def test_streaming_decoder_builds_plan_targeted_hlg_to_sdr_chain() -> None:
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -234,19 +234,49 @@ class TestAppStateSingleton:
         assert s1 is not s2
 
 
-class TestScaleModeMap:
-    """Test the scale mode map includes blur."""
+class TestScaleModeOptions:
+    """The wizard must offer the same scale modes, and the same default, as the CLI."""
 
-    def test_blur_mode_mapped(self):
-        from immich_memories.ui.pages._step4_generate import _SCALE_MODE_MAP
+    def test_default_label_is_the_configured_mode(self):
+        from immich_memories.ui.pages.step3_options import (
+            SCALE_MODE_OPTIONS,
+            resolve_scale_mode_label,
+        )
 
-        assert "Blur (blurred background)" in _SCALE_MODE_MAP
-        assert _SCALE_MODE_MAP["Blur (blurred background)"] == "blur"
+        assert SCALE_MODE_OPTIONS[resolve_scale_mode_label(None)] == Config().defaults.scale_mode
 
-    def test_all_four_modes_present(self):
-        from immich_memories.ui.pages._step4_generate import _SCALE_MODE_MAP
+    def test_default_label_follows_a_configured_override(self):
+        from immich_memories.ui.pages.step3_options import (
+            SCALE_MODE_OPTIONS,
+            resolve_scale_mode_label,
+        )
 
-        assert len(_SCALE_MODE_MAP) == 4
+        config = Config()
+        config.defaults.scale_mode = "fit"
+
+        assert SCALE_MODE_OPTIONS[resolve_scale_mode_label(config)] == "fit"
+
+    def test_offered_labels_cover_exactly_the_configurable_modes(self):
+        """No option the config rejects, and no configurable mode the wizard cannot show."""
+        from typing import get_args
+
+        from immich_memories.config_models import DefaultsConfig
+        from immich_memories.ui.pages.step3_options import SCALE_MODE_OPTIONS
+
+        configurable = set(get_args(DefaultsConfig.model_fields["scale_mode"].annotation))
+
+        assert set(SCALE_MODE_OPTIONS.values()) == configurable
+
+    def test_retired_stored_label_falls_back_to_the_configured_mode(self):
+        """A wizard state saved when 'Smart Crop (keep faces)' existed must still render."""
+        from immich_memories.ui.pages.step3_options import (
+            SCALE_MODE_OPTIONS,
+            resolve_scale_mode_label,
+        )
+
+        label = resolve_scale_mode_label(None, "Smart Crop (keep faces)")
+
+        assert SCALE_MODE_OPTIONS[label] == Config().defaults.scale_mode
 
 
 def test_ui_output_options_include_h265() -> None:

--- a/vulture-whitelist.py
+++ b/vulture-whitelist.py
@@ -155,6 +155,7 @@ _.serialize_api_version  # unused method (src/immich_memories/config_models.py:3
 _.expand_env  # unused method (src/immich_memories/config_models.py:43)
 clip_style  # unused variable (src/immich_memories/config_models.py:100)
 use_scene_detection  # unused variable (src/immich_memories/config_models.py:107)
+_.map_legacy_scale_mode  # unused method (src/immich_memories/config_models.py:117)
 _.apply_clip_style  # unused method (src/immich_memories/config_models.py:147)
 _.validate_duration_constraints  # unused method (src/immich_memories/config_models.py:178)
 _.serialize_hdr_mode  # unused method (src/immich_memories/config_models.py:299)


### PR DESCRIPTION
## The bug

Step 3 of the wizard defaulted to a scaling mode labelled **"Smart Crop (keep faces)"** and sent `scale_mode="smart_crop"` into generation. `streaming_assembler._build_vf` implements exactly two fills: `blur` (a blurred, zoomed copy of the frame behind the sharp one) and everything-else → `scale ... + pad ... :black`. So `smart_crop` fell into the black-bar branch.

Every UI user on defaults with an aspect mismatch got letterboxed video sold to them as face-aware cropping — and a different render than the CLI, which defaults to `blur`. `--scale-mode`'s help text claimed a `smart_crop` default that never existed either.

## The decision

No face-aware crop for video is implemented here. The product stops claiming one.

`fill` turns out to be phantom in the same way — it also landed in the black-bar branch — so it goes too.

## What changed

- **Wizard**: offers **Blur background** and **Letterbox (black bars)**, the only two branches that exist, and starts on `defaults.scale_mode` via a shared `resolve_scale_mode_label()`. The wizard and `--scale-mode` now render the same video for the same config. A wizard state saved with a retired label resolves to the configured mode instead of showing a mode that no longer exists.
- **Config**: `defaults.scale_mode` narrows to `fit | blur`, with a field description. Existing configs still load — a `field_validator` maps `smart_crop → blur` (what someone asking to keep faces was actually after) and `fill → fit` (its real rendering, under its real name), each with one warning line naming the substitution. A typo is still rejected outright.
- **Programmatic callers**: `_build_assembly_settings` runs the same `normalize_scale_mode()`, so a `GenerationParams(scale_mode="smart_crop")` from any surface gets blur rather than a silent letterbox.
- **CLI**: `--scale-mode` offers `fit|blur` and the help text says what each does and where the default comes from. `cli-reference.md` regenerated via `make docs-cli`.
- **Docs**: `config-file.md`, `config-reference.md`, `generate.md`, `step3-generation-options.mdx` updated. `face-aware-cropping.md` claimed cropping "kicks in during the assembly phase" — it never did. That page is now **Face-Aware Framing** and describes only what is real: photo Ken Burns pans steer toward the largest face from Immich's face data (`photos/photo_pipeline.py:788`), and face coverage/count feed clip scoring (`analysis/scoring.py`). It states plainly that video clips are never cropped.
- `streaming_assembler._build_vf`'s `else` branch now says in a comment that it is `fit`, and why nothing else is offered.

## Heads-up for existing users

- A config saying `scale_mode: smart_crop` keeps loading but now renders **blur instead of black bars** — a deliberate change, with a warning in the log.
- `--scale-mode smart_crop` and `--scale-mode fill` are now rejected by Click (`is not one of 'fit', 'blur'`). That is a loud, one-line fix for a scripted caller, chosen over silently rendering something else. Nothing in this repo's own scripts or workflows passes those values.

## Tests

- `DefaultsConfig(scale_mode="smart_crop")` → `blur` with a warning; `"fill"` → `fit`; `"smart_zoom"` still raises.
- `_build_assembly_settings` maps a legacy param value.
- The wizard's default label equals the configured mode; it follows a configured override; a retired stored label falls back; the offered labels cover exactly the modes the config accepts (`get_args` on the Literal).
- `generate --help` advertises no `smart_crop` and no wrong default.
- `blur` builds the blurred-background chain, `fit` builds `pad=...:black`, and the two configurable modes build different chains — a pin against a future mode quietly sharing the fallback.

`make ci` passes. `make docs-build` passes.

## Future work

Real face-aware video cropping is still possible: `_detect_face_center_in_video` / `_get_smart_crop_filter` in `processing/scaling_utilities.py` are parked there for whoever builds it. It needs per-frame tracking and a smoothed crop path, not a single face position — which is why this PR does not fake it.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
