### PR TITLE
fix(analysis): keep the activities the model was asked for

### DIFF
--- a/src/immich_memories/analysis/cache_projection.py
+++ b/src/immich_memories/analysis/cache_projection.py
@@ -51,6 +51,7 @@ def semantic_payload_from_segment(segment: CachedSegment) -> dict[str, object] |
         "emotion": segment.llm_emotion,
         "setting": segment.llm_setting,
         "subjects": segment.llm_subjects,
+        "activities": segment.llm_activities,
         "interestingness": segment.llm_interestingness,
         "quality": segment.llm_quality,
     }
@@ -69,6 +70,7 @@ def apply_semantic_payload(
     clip.llm_emotion = cast(str | None, payload.get("emotion"))
     clip.llm_setting = cast(str | None, payload.get("setting"))
     clip.llm_subjects = cast(list[str] | None, payload.get("subjects"))
+    clip.llm_activities = cast(list[str] | None, payload.get("activities"))
     clip.llm_interestingness = cast(float | None, payload.get("interestingness"))
     clip.llm_quality = cast(float | None, payload.get("quality"))
 

--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -445,6 +445,7 @@ class ClipAnalyzer:
                     "emotion": best_segment.llm_emotion,
                     "setting": best_segment.llm_setting,
                     "subjects": best_segment.llm_subjects,
+                    "activities": best_segment.llm_activities,
                     "interestingness": best_segment.llm_interestingness,
                     "quality": best_segment.llm_quality,
                 }

--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -614,6 +614,7 @@ class UnifiedSegmentAnalyzer:
                 segment.llm_emotion = analysis.emotion
                 segment.llm_setting = analysis.setting
                 segment.llm_subjects = analysis.subjects
+                segment.llm_activities = analysis.activities
                 segment.llm_interestingness = analysis.interestingness
                 segment.llm_quality = analysis.quality
 

--- a/src/immich_memories/api/models.py
+++ b/src/immich_memories/api/models.py
@@ -406,6 +406,7 @@ class VideoClipInfo(BaseModel):
     llm_emotion: str | None = None  # Detected emotional tone (happy, calm, excited, etc.)
     llm_setting: str | None = None  # Where it takes place (indoor, outdoor, beach, etc.)
     llm_subjects: list[str] | None = None  # Who/what is in the video
+    llm_activities: list[str] | None = None  # Pastimes/sports named, e.g. ["cycling"]
     llm_interestingness: float | None = None  # Score 0-1 for how interesting
     llm_quality: float | None = None  # Score 0-1 for visual quality
 

--- a/src/immich_memories/cache/database.py
+++ b/src/immich_memories/cache/database.py
@@ -323,7 +323,7 @@ class VideoAnalysisCache:
             ("llm_description", "TEXT"),
             ("llm_emotion", "TEXT"),
             ("llm_setting", "TEXT"),
-            ("llm_activities", "TEXT"),  # JSON array; no longer written, never read
+            ("llm_activities", "TEXT"),  # JSON array
             ("llm_subjects", "TEXT"),  # JSON array
             ("llm_interestingness", "REAL"),
             ("llm_quality", "REAL"),

--- a/tests/test_analysis_mode_signals.py
+++ b/tests/test_analysis_mode_signals.py
@@ -7,6 +7,9 @@ schema goes in before the periods people care about.
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 
 from immich_memories.analysis.llm_response_parser import (
@@ -79,6 +82,32 @@ class TestActivitiesReachTheDatabase:
     """The column existed with 0 of 10378 rows populated: the field was
     absent from the prompt AND from the segment INSERT."""
 
+    def test_the_analyzer_puts_the_parsed_activities_on_the_segment(self):
+        """#485 pays prompt tokens for the answer; nothing copied it onto the
+        segment, so the INSERT read None and every row was NULL again (#518)."""
+        from immich_memories.analysis.analyzer_models import ScoredSegment
+        from immich_memories.analysis.unified_analyzer import UnifiedSegmentAnalyzer
+        from immich_memories.config_models import AnalysisConfig, AudioContentConfig
+
+        # WHY: replaces the vision LLM, an external network service.
+        content = MagicMock()
+        content.analyze_segment.return_value = ContentAnalysis(
+            description="a rider on a climb",
+            activities=["cycling"],
+            confidence=0.9,
+        )
+        analyzer = UnifiedSegmentAnalyzer(
+            scorer=MagicMock(content_min_confidence=0.5),
+            content_analyzer=content,
+            audio_content_config=AudioContentConfig(),
+            analysis_config=AnalysisConfig(),
+        )
+        segment = ScoredSegment(start_time=0.0, end_time=3.0)
+
+        analyzer._score_content(Path("/fake.mov"), 0.0, 3.0, segment=segment)  # noqa: SLF001
+
+        assert segment.llm_activities == ["cycling"]
+
     def test_a_segment_activities_survive_the_round_trip(self, tmp_path, mock_asset):
         from immich_memories.analysis.analyzer_models import ScoredSegment
         from immich_memories.cache.database import VideoAnalysisCache
@@ -93,6 +122,28 @@ class TestActivitiesReachTheDatabase:
 
         assert loaded is not None
         assert loaded.segments[0].llm_activities == ["cycling"]
+
+    def test_activities_come_back_out_of_the_cache_onto_the_clip(self, tmp_path):
+        """The projection is what hands cached semantics to review and selection.
+        It copied every other semantic field and skipped this one, so a cached
+        rerun saw nothing even once the column was populated (#518)."""
+        from immich_memories.analysis.analyzer_models import ScoredSegment
+        from immich_memories.analysis.cache_projection import apply_cached_segment
+        from immich_memories.cache.database import VideoAnalysisCache
+        from tests.conftest import make_asset, make_clip
+
+        cache = VideoAnalysisCache(tmp_path / "cache.db")
+        segment = ScoredSegment(start_time=0.0, end_time=5.0)
+        segment.llm_description = "a rider on a climb"
+        segment.llm_activities = ["cycling"]
+        cache.save_analysis(make_asset("act-projected"), segments=[segment])
+
+        restored = cache.get_analysis("act-projected")
+        assert restored is not None
+        clip = make_clip("act-projected")
+        apply_cached_segment(clip, restored.segments[0])
+
+        assert clip.llm_activities == ["cycling"]
 
 
 @pytest.fixture

--- a/tests/test_clip_analyzer.py
+++ b/tests/test_clip_analyzer.py
@@ -63,6 +63,7 @@ def _make_cached_segment(
     llm_emotion: str | None = None,
     llm_setting: str | None = None,
     llm_subjects: list[str] | None = None,
+    llm_activities: list[str] | None = None,
     llm_interestingness: float | None = None,
     llm_quality: float | None = None,
     audio_categories: list[str] | None = None,
@@ -77,6 +78,7 @@ def _make_cached_segment(
     seg.llm_emotion = llm_emotion
     seg.llm_setting = llm_setting
     seg.llm_subjects = llm_subjects
+    seg.llm_activities = llm_activities
     seg.llm_interestingness = llm_interestingness
     seg.llm_quality = llm_quality
     seg.audio_categories = audio_categories
@@ -689,6 +691,42 @@ class TestRunAnalysisWithFallback:
 
 
 class TestReusableAnalysisServices:
+    def test_a_fresh_analysis_hands_the_activities_to_the_clip(self, tmp_path) -> None:
+        """The cached path and the fresh path build the same payload by hand,
+        and only the cached one listed activities — so a clip analysed this run
+        knew nothing the same clip knew on the next run (#518)."""
+        from immich_memories.analysis.analyzer_models import ScoredSegment
+        from immich_memories.analysis.cache_projection import apply_semantic_payload
+        from immich_memories.cache.database import VideoAnalysisCache
+
+        cache = VideoAnalysisCache(tmp_path / "cache.db")
+        analyzer = ClipAnalyzer(
+            PipelineConfig(),
+            MagicMock(),
+            cache,
+            MagicMock(),
+            app_config=Config(),
+        )
+        # WHY: replaces the unified analyzer, which shells out to FFmpeg and
+        # calls the vision LLM over the network.
+        unified = MagicMock()
+        unified.analyze.return_value = [
+            ScoredSegment(
+                start_time=1.0,
+                end_time=5.0,
+                total_score=0.8,
+                llm_description="a rider on a climb",
+                llm_activities=["cycling"],
+            )
+        ]
+        analyzer._cached_unified_analyzer = unified
+        clip = make_clip("fresh-activities", duration=10.0)
+
+        *_, payload = analyzer._run_unified_analysis(clip, MagicMock(), MagicMock(), 10.0)
+        apply_semantic_payload(clip, payload)
+
+        assert clip.llm_activities == ["cycling"]
+
     def test_successful_semantic_analysis_records_the_exact_model(self, tmp_path) -> None:
         from immich_memories.analysis.analyzer_models import ScoredSegment
         from immich_memories.cache.database import VideoAnalysisCache


### PR DESCRIPTION
## What

`#485` added `activities` to the content-analysis prompt and parsed them into `ContentAnalysis`. Nothing then copied the answer onto the segment: `_score_content` assigns description, category, emotion, setting, subjects, interestingness and quality, and stops. The INSERT in `cache/database.py` reads `getattr(segment, "llm_activities", None)`, so every row went in NULL — the exact 0-rows-populated state #485 set out to fix, and a re-analysis could not backfill it because the fresh path was the broken one.

The cache projection had the same hole: `semantic_payload_from_segment` / `apply_semantic_payload` carried every other semantic field and skipped this one, and `clip_analyzer` builds the fresh-analysis payload by hand with the same list.

## Changes

- `unified_analyzer._score_content` assigns `segment.llm_activities = analysis.activities`.
- `cache_projection` carries `activities` in both directions of the payload round-trip; `VideoClipInfo` gains the field it lands on.
- `clip_analyzer._run_unified_analysis` lists it in the fresh-analysis payload, so a clip analysed this run knows what the same clip knows on the next run.
- Dropped a stale comment on the migration that called the column "no longer written, never read".

## Tests

Three, all TDD RED first:

- the analyzer puts the parsed activities on the segment (one mock — the vision LLM)
- activities come back out of a real sqlite cache in `tmp_path` onto the clip
- a fresh analysis hands the activities to the clip through the payload it returns

`_make_cached_segment` in `test_clip_analyzer.py` now sets `llm_activities` explicitly — it builds a `MagicMock`, so an unset attribute is a truthy auto-mock rather than `None`, which made two unrelated payload assertions flip once the projection started reading the field.

## Not in scope

`selection_review` still does not send activities to the review LLM, and nothing reads the signal yet — that is the #475 consumer's call, and adding it here would change prompts and token cost under a storage fix.

`make ci` passes.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
