### PR TITLE
fix(ci): make release smoke fixtures camera-plausible

### DIFF
--- a/tests/e2e/fake_immich.py
+++ b/tests/e2e/fake_immich.py
@@ -16,19 +16,49 @@ from urllib.parse import parse_qs, urlsplit
 
 _MONTH_BUCKET = "2024-06-01T00:00:00.000Z"
 
+# WHY these three facts together (#525): selection drops a clip whose short
+# side is under 1080 unless EXIF names a camera, drops a still that names no
+# camera at all, and collapses assets whose thumbnails hash alike. A fixture
+# that is small, EXIF-less and identical fails all three, and the release smoke
+# test spent every run since #491 reporting "Pipeline selected no clips".
+_CAMERA_EXIF = {"make": "FakeCam", "model": "Hermetic One"}
+_VIDEO_SIZE = (1920, 1080)
+_PHOTO_SIZE = (2016, 1512)
+_VIDEO_DURATION = 4.0
 
-def _asset_payload(
-    asset_id: str,
-    asset_type: str,
-    filename: str,
-    *,
-    is_favorite: bool = False,
-) -> dict[str, Any]:
-    created_at = f"2024-06-{1 + int(asset_id[-1]):02d}T12:00:00.000Z"
+
+@dataclass(frozen=True, slots=True)
+class _Moment:
+    """One synthetic capture: its own scene, its own day of the month."""
+
+    asset_id: str
+    lavfi: str
+    taken_at: str
+    is_favorite: bool = False
+
+
+# Scenes chosen by measurement: every pair of these sources is at least 20 bits
+# apart under the average hash the pipeline dedups with, against a duplicate
+# threshold of 8 and a moment-suppression threshold of 10.
+_VIDEO_MOMENTS = (
+    _Moment("video-1", "testsrc2", "2024-06-08T10:15:00.000Z", is_favorite=True),
+    _Moment("video-2", "mandelbrot", "2024-06-14T16:20:00.000Z"),
+    _Moment("video-3", "testsrc", "2024-06-21T18:40:00.000Z"),
+)
+_PHOTO_MOMENTS = (
+    _Moment("photo-1", "smptehdbars", "2024-06-09T11:30:00.000Z"),
+    _Moment("photo-2", "rgbtestsrc", "2024-06-15T09:05:00.000Z", is_favorite=True),
+    _Moment("photo-3", "colorspectrum", "2024-06-22T14:10:00.000Z"),
+)
+
+
+def _asset_payload(moment: _Moment, asset_type: str) -> dict[str, Any]:
     is_video = asset_type == "VIDEO"
+    filename = f"{moment.asset_id}.{'mp4' if is_video else 'jpg'}"
+    width, height = _VIDEO_SIZE if is_video else _PHOTO_SIZE
     return {
-        "id": asset_id,
-        "deviceAssetId": f"fake-device-{asset_id}",
+        "id": moment.asset_id,
+        "deviceAssetId": f"fake-device-{moment.asset_id}",
         "ownerId": "fake-user",
         "deviceId": "fake-device",
         "type": asset_type,
@@ -36,39 +66,41 @@ def _asset_payload(
         "originalFileName": filename,
         "originalMimeType": "video/mp4" if is_video else "image/jpeg",
         "thumbhash": None,
-        "fileCreatedAt": created_at,
-        "fileModifiedAt": created_at,
-        "localDateTime": created_at,
-        "updatedAt": created_at,
-        "isFavorite": is_favorite,
+        "fileCreatedAt": moment.taken_at,
+        "fileModifiedAt": moment.taken_at,
+        "localDateTime": moment.taken_at,
+        "updatedAt": moment.taken_at,
+        "isFavorite": moment.is_favorite,
         "isArchived": False,
         "isTrashed": False,
-        "duration": 2000 if is_video else None,
-        "width": 640 if is_video else 320,
-        "height": 360 if is_video else 240,
+        "duration": int(_VIDEO_DURATION * 1000) if is_video else None,
+        "width": width,
+        "height": height,
         "exifInfo": {
-            "dateTimeOriginal": created_at,
-            "fileSizeInByte": 100_000 if is_video else 2_000,
+            **_CAMERA_EXIF,
+            "dateTimeOriginal": moment.taken_at,
+            "fileSizeInByte": 400_000 if is_video else 20_000,
         },
         "people": [],
         "faces": [],
-        "checksum": f"fake-checksum-{asset_id}",
+        "checksum": f"fake-checksum-{moment.asset_id}",
         "livePhotoVideoId": None,
         "smartInfo": {"objects": ["test-pattern"]},
     }
 
 
-_ASSETS = (
-    _asset_payload("video-1", "VIDEO", "video-1.mp4", is_favorite=True),
-    _asset_payload("video-2", "VIDEO", "video-2.mp4"),
-    _asset_payload("photo-1", "IMAGE", "photo-1.jpg"),
-    _asset_payload("photo-2", "IMAGE", "photo-2.jpg"),
+TIMELINE_ASSETS = tuple(_asset_payload(moment, "VIDEO") for moment in _VIDEO_MOMENTS) + tuple(
+    _asset_payload(moment, "IMAGE") for moment in _PHOTO_MOMENTS
 )
 
 
 def _assets_for_query(query: dict[str, list[str]]) -> list[dict[str, Any]]:
     requested_type = query.get("type", [None])[0]
-    return [asset for asset in _ASSETS if requested_type is None or asset["type"] == requested_type]
+    return [
+        asset
+        for asset in TIMELINE_ASSETS
+        if requested_type is None or asset["type"] == requested_type
+    ]
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,17 +142,27 @@ class FakeImmichServer:
     def start(cls, root: Path, *, upload_commit_delay: float = 0.0) -> Self:
         """Start the service on an operating-system-selected localhost port."""
         root.mkdir(parents=True, exist_ok=True)
-        source_video = _generate_video(root)
-        photo_paths = _generate_photos(root)
-        media = {"video-1": source_video, "video-2": source_video} | photo_paths
+        media_dir = root / "media"
+        media_dir.mkdir()
+        video_paths = _generate_videos(media_dir)
+        photo_paths = _generate_photos(media_dir)
+        media = video_paths | photo_paths
+        thumbnail_paths = _generate_thumbnails(media_dir, media)
         uploads: list[RecordedUpload] = []
         httpd = ThreadingHTTPServer(
             ("127.0.0.1", 0),
-            _handler_type(media, uploads, upload_commit_delay),
+            _handler_type(media, thumbnail_paths, uploads, upload_commit_delay),
         )
         thread = threading.Thread(target=httpd.serve_forever, daemon=True)
         thread.start()
-        return cls(root, httpd, thread, source_video, photo_paths, uploads)
+        return cls(
+            root,
+            httpd,
+            thread,
+            video_paths[_VIDEO_MOMENTS[0].asset_id],
+            photo_paths,
+            uploads,
+        )
 
     def close(self) -> None:
         """Stop the service and release its listening socket."""
@@ -129,29 +171,37 @@ class FakeImmichServer:
         self._thread.join(timeout=5)
 
 
-def _generate_video(root: Path) -> Path:
-    media_dir = root / "media"
-    media_dir.mkdir()
-    video_path = media_dir / "source.mp4"
+def _ffmpeg(*args: str) -> None:
     subprocess.run(  # noqa: S603
-        [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-y",
+        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _generate_videos(media_dir: Path) -> dict[str, Path]:
+    width, height = _VIDEO_SIZE
+    videos: dict[str, Path] = {}
+    for index, moment in enumerate(_VIDEO_MOMENTS):
+        video_path = media_dir / f"{moment.asset_id}.mp4"
+        _ffmpeg(
             "-f",
             "lavfi",
+            # WHY -t below rather than a duration= option: mandelbrot has none.
             "-i",
-            "testsrc2=size=640x360:rate=30:duration=2.0",
+            f"{moment.lavfi}=size={width}x{height}:rate=30",
             "-f",
             "lavfi",
+            # A tone per clip: silence detection reads the audio track too.
             "-i",
-            "sine=frequency=440:sample_rate=48000:duration=2.0",
+            f"sine=frequency={440 + index * 110}:sample_rate=48000:duration={_VIDEO_DURATION}",
             "-map",
             "0:v:0",
             "-map",
             "1:a:0",
+            "-t",
+            str(_VIDEO_DURATION),
             "-c:v",
             "libx264",
             "-preset",
@@ -172,48 +222,66 @@ def _generate_video(root: Path) -> Path:
             "-movflags",
             "+faststart",
             str(video_path),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return video_path
-
-
-def _generate_photos(root: Path) -> dict[str, Path]:
-    media_dir = root / "media"
-    photos: dict[str, Path] = {}
-    for asset_id, color in (("photo-1", "red"), ("photo-2", "blue")):
-        photo_path = media_dir / f"{asset_id}.jpg"
-        subprocess.run(  # noqa: S603
-            [
-                "ffmpeg",
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-y",
-                "-f",
-                "lavfi",
-                "-i",
-                f"color=c={color}:size=320x240",
-                "-frames:v",
-                "1",
-                "-q:v",
-                "2",
-                "-update",
-                "1",
-                str(photo_path),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
         )
-        photos[asset_id] = photo_path
+        videos[moment.asset_id] = video_path
+    return videos
+
+
+def _generate_photos(media_dir: Path) -> dict[str, Path]:
+    width, height = _PHOTO_SIZE
+    photos: dict[str, Path] = {}
+    for moment in _PHOTO_MOMENTS:
+        photo_path = media_dir / f"{moment.asset_id}.jpg"
+        _ffmpeg(
+            "-f",
+            "lavfi",
+            "-i",
+            f"{moment.lavfi}=size={width}x{height}",
+            "-frames:v",
+            "1",
+            "-q:v",
+            "2",
+            "-update",
+            "1",
+            str(photo_path),
+        )
+        photos[moment.asset_id] = photo_path
     return photos
+
+
+def _generate_thumbnails(media_dir: Path, media: dict[str, Path]) -> dict[str, Path]:
+    """Render each asset its own preview, the way Immich serves one per asset.
+
+    One shared thumbnail made every asset a perceptual duplicate of every
+    other, and Phase 1 clustering collapsed the whole pool into one clip.
+    """
+    thumbnail_dir = media_dir / "thumbnails"
+    thumbnail_dir.mkdir()
+    thumbnails: dict[str, Path] = {}
+    for asset_id, source in media.items():
+        thumbnail_path = thumbnail_dir / f"{asset_id}.jpg"
+        seek = ["-ss", str(_VIDEO_DURATION / 2)] if source.suffix == ".mp4" else []
+        _ffmpeg(
+            *seek,
+            "-i",
+            str(source),
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=1440:-2",
+            "-q:v",
+            "3",
+            "-update",
+            "1",
+            str(thumbnail_path),
+        )
+        thumbnails[asset_id] = thumbnail_path
+    return thumbnails
 
 
 def _handler_type(
     media: dict[str, Path],
+    thumbnails: dict[str, Path],
     uploads: list[RecordedUpload],
     upload_commit_delay: float,
 ) -> type[BaseHTTPRequestHandler]:
@@ -276,8 +344,8 @@ def _handler_type(
                 content_type = "video/mp4" if media[parts[0]].suffix == ".mp4" else "image/jpeg"
                 self._send_file(media[parts[0]], content_type)
                 return
-            if len(parts) == 2 and parts[0] in media and parts[1] == "thumbnail":
-                self._send_file(media["photo-1"], "image/jpeg")
+            if len(parts) == 2 and parts[0] in thumbnails and parts[1] == "thumbnail":
+                self._send_file(thumbnails[parts[0]], "image/jpeg")
                 return
             if (
                 len(parts) == 3
@@ -299,7 +367,7 @@ def _handler_type(
                 requested_type = payload.get("type")
                 items = [
                     asset
-                    for asset in _ASSETS
+                    for asset in TIMELINE_ASSETS
                     if requested_type is None or asset["type"] == requested_type
                 ]
                 self._send_json(

--- a/tests/e2e/test_fake_immich.py
+++ b/tests/e2e/test_fake_immich.py
@@ -5,21 +5,27 @@ from __future__ import annotations
 import json
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from itertools import combinations
 from pathlib import Path
 
 import httpx
 import pytest
 
 from immich_memories.analysis.density_budget import AssetEntry
+from immich_memories.analysis.duplicate_hashing import compute_thumbnail_hash, hamming_distance
 from immich_memories.analysis.smart_pipeline import PipelineConfig, SmartPipeline
 from immich_memories.api.compatibility import ResolvedApiVersion
 from immich_memories.api.immich import ImmichAuthError, SyncImmichClient
-from immich_memories.api.models import AssetType
+from immich_memories.api.models import AssetType, VideoClipInfo
+from immich_memories.config_models import AnalysisConfig
 from immich_memories.timeperiod import calendar_year
 from immich_memories.ui.pages.step2_loading import MIN_CLIP_DURATION, _build_clips
 from tests.e2e.fake_immich import FakeImmichServer
 
 pytestmark = pytest.mark.e2e
+
+_VIDEO_IDS = ["video-1", "video-2", "video-3"]
+_PHOTO_IDS = ["photo-1", "photo-2", "photo-3"]
 
 
 def _probe_video(path: Path) -> dict:
@@ -132,7 +138,7 @@ def test_wrong_api_key_is_rejected(fake_immich_server) -> None:
         client.get_current_user()
 
 
-def test_monthly_timeline_contains_two_videos_and_two_photos(fake_immich_server) -> None:
+def test_monthly_timeline_contains_every_synthetic_moment(fake_immich_server) -> None:
     """Timeline discovery exposes the fake's complete deterministic inventory."""
     with SyncImmichClient(
         fake_immich_server.base_url,
@@ -143,16 +149,10 @@ def test_monthly_timeline_contains_two_videos_and_two_photos(fake_immich_server)
         assets = client.get_bucket_assets("2024-06-01T00:00:00.000Z", size="MONTH")
 
     assert [(bucket.time_bucket, bucket.count) for bucket in buckets] == [
-        ("2024-06-01T00:00:00.000Z", 4)
+        ("2024-06-01T00:00:00.000Z", 6)
     ]
-    assert [asset.id for asset in assets if asset.type is AssetType.VIDEO] == [
-        "video-1",
-        "video-2",
-    ]
-    assert [asset.id for asset in assets if asset.type is AssetType.IMAGE] == [
-        "photo-1",
-        "photo-2",
-    ]
+    assert [asset.id for asset in assets if asset.type is AssetType.VIDEO] == _VIDEO_IDS
+    assert [asset.id for asset in assets if asset.type is AssetType.IMAGE] == _PHOTO_IDS
 
 
 def test_monthly_timeline_honors_requested_asset_type_and_count(fake_immich_server) -> None:
@@ -175,10 +175,10 @@ def test_monthly_timeline_honors_requested_asset_type_and_count(fake_immich_serv
             asset_type=AssetType.IMAGE,
         )
 
-    assert [bucket.count for bucket in video_buckets] == [2]
-    assert [bucket.count for bucket in photo_buckets] == [2]
-    assert [asset.id for asset in videos] == ["video-1", "video-2"]
-    assert [asset.id for asset in photos] == ["photo-1", "photo-2"]
+    assert [bucket.count for bucket in video_buckets] == [3]
+    assert [bucket.count for bucket in photo_buckets] == [3]
+    assert [asset.id for asset in videos] == _VIDEO_IDS
+    assert [asset.id for asset in photos] == _PHOTO_IDS
 
 
 def test_metadata_search_filters_the_video_and_photo_inventories(fake_immich_server) -> None:
@@ -191,10 +191,10 @@ def test_metadata_search_filters_the_video_and_photo_inventories(fake_immich_ser
         videos = client.search_metadata(asset_type=AssetType.VIDEO).all_assets
         photos = client.search_metadata(asset_type=AssetType.IMAGE).all_assets
 
-    assert [asset.id for asset in videos] == ["video-1", "video-2"]
-    assert [asset.duration_seconds for asset in videos] == [2.0, 2.0]
-    assert [asset.id for asset in photos] == ["photo-1", "photo-2"]
-    assert [asset.duration_seconds for asset in photos] == [None, None]
+    assert [asset.id for asset in videos] == _VIDEO_IDS
+    assert [asset.duration_seconds for asset in videos] == [4.0, 4.0, 4.0]
+    assert [asset.id for asset in photos] == _PHOTO_IDS
+    assert [asset.duration_seconds for asset in photos] == [None, None, None]
 
 
 def test_search_uses_v3_millisecond_duration_on_the_wire(fake_immich_server) -> None:
@@ -207,7 +207,7 @@ def test_search_uses_v3_millisecond_duration_on_the_wire(fake_immich_server) -> 
 
     response.raise_for_status()
     durations = [asset["duration"] for asset in response.json()["assets"]["items"]]
-    assert durations == [2000, 2000]
+    assert durations == [4000, 4000, 4000]
     assert all(type(duration) is int for duration in durations)
 
 
@@ -223,12 +223,16 @@ def test_real_step2_duration_filter_keeps_selectable_fake_clips(fake_immich_serv
     clips, skipped = _build_clips(assets)
 
     assert skipped == 0
-    assert [clip.asset.id for clip in clips] == ["video-1", "video-2"]
+    assert [clip.asset.id for clip in clips] == _VIDEO_IDS
     assert all(clip.duration_seconds >= MIN_CLIP_DURATION for clip in clips)
 
 
-def test_default_2160p_budget_gate_keeps_a_fake_favorite(fake_immich_server) -> None:
-    """A favorite fake video survives the real default low-resolution gate."""
+def test_default_2160p_budget_gate_keeps_every_fake_video(fake_immich_server) -> None:
+    """No fake video may depend on a star to reach analysis (#525).
+
+    The gate reads camera EXIF and resolution off the asset, so the fixture
+    only survives it by carrying both — which is exactly what it stopped doing.
+    """
     with SyncImmichClient(
         fake_immich_server.base_url,
         fake_immich_server.api_key,
@@ -246,7 +250,7 @@ def test_default_2160p_budget_gate_keeps_a_fake_favorite(fake_immich_server) -> 
             score=0.0,
             width=asset.width,
             height=asset.height,
-            is_camera_original=True,
+            is_camera_original=VideoClipInfo(asset=asset).is_camera_original,
         )
         for asset in assets
     ]
@@ -256,7 +260,8 @@ def test_default_2160p_budget_gate_keeps_a_fake_favorite(fake_immich_server) -> 
     survivors = pipeline._apply_budget_quality_gate(entries)
 
     assert pipeline.config.output_resolution == 2160
-    assert [(entry.asset_id, entry.is_favorite) for entry in survivors] == [("video-1", True)]
+    assert [entry.asset_id for entry in survivors] == _VIDEO_IDS
+    assert [entry.asset_id for entry in survivors if entry.is_favorite] == ["video-1"]
 
 
 def test_original_and_playback_downloads_are_valid_h264_sdr_media(
@@ -282,18 +287,18 @@ def test_original_and_playback_downloads_are_valid_h264_sdr_media(
         assert streams["video"] == {
             "codec_name": "h264",
             "codec_type": "video",
-            "width": 640,
-            "height": 360,
+            "width": 1920,
+            "height": 1080,
             "pix_fmt": "yuv420p",
             "color_transfer": "bt709",
         }
         assert streams["audio"]["codec_name"] == "aac"
-        assert float(probe["format"]["duration"]) == pytest.approx(2.0, abs=0.1)
+        assert float(probe["format"]["duration"]) == pytest.approx(4.0, abs=0.1)
 
 
 def test_photo_originals_are_generated_jpegs(fake_immich_server, tmp_path: Path) -> None:
-    """Both fake photo assets download as real, locally generated JPEG files."""
-    assert set(fake_immich_server.photo_paths) == {"photo-1", "photo-2"}
+    """Every fake photo downloads as a real JPEG above the source-quality floor."""
+    assert set(fake_immich_server.photo_paths) == set(_PHOTO_IDS)
     assert all(
         path.is_relative_to(fake_immich_server.root)
         for path in fake_immich_server.photo_paths.values()
@@ -305,34 +310,34 @@ def test_photo_originals_are_generated_jpegs(fake_immich_server, tmp_path: Path)
         api_version="v3",
     ) as client:
         downloaded = [
-            client.download_asset(asset_id, tmp_path / f"{asset_id}.jpg")
-            for asset_id in ("photo-1", "photo-2")
+            client.download_asset(asset_id, tmp_path / f"{asset_id}.jpg") for asset_id in _PHOTO_IDS
         ]
 
     for path in downloaded:
         assert _probe_image(path)["streams"] == [
-            {"codec_name": "mjpeg", "codec_type": "video", "width": 320, "height": 240}
+            {"codec_name": "mjpeg", "codec_type": "video", "width": 2016, "height": 1512}
         ]
 
 
-def test_real_client_downloads_generated_step2_thumbnail(
-    fake_immich_server,
-    tmp_path: Path,
-) -> None:
-    """Step 2 thumbnail traffic receives real generated JPEG bytes."""
+def test_every_asset_thumbnail_shows_its_own_scene(fake_immich_server) -> None:
+    """One preview served for every asset made Phase 1 collapse the pool (#525)."""
     with SyncImmichClient(
         fake_immich_server.base_url,
         fake_immich_server.api_key,
         api_version="v3",
     ) as client:
-        thumbnail = client.get_asset_thumbnail("video-1", size="preview")
+        hashes = {
+            asset_id: compute_thumbnail_hash(client.get_asset_thumbnail(asset_id, size="preview"))
+            for asset_id in _VIDEO_IDS + _PHOTO_IDS
+        }
 
-    thumbnail_path = tmp_path / "video-1-thumbnail.jpg"
-    thumbnail_path.write_bytes(thumbnail)
-    assert thumbnail == fake_immich_server.photo_paths["photo-1"].read_bytes()
-    assert _probe_image(thumbnail_path)["streams"] == [
-        {"codec_name": "mjpeg", "codec_type": "video", "width": 320, "height": 240}
-    ]
+    threshold = AnalysisConfig().duplicate_hash_threshold
+    distances = {
+        (left, right): hamming_distance(hashes[left], hashes[right])
+        for left, right in combinations(sorted(hashes), 2)
+    }
+    assert all(hashes.values())
+    assert min(distances.values()) > threshold, f"near-duplicate previews: {distances}"
 
 
 def test_real_auto_client_uploads_and_fake_records_v3_multipart(fake_immich_server) -> None:
@@ -348,8 +353,8 @@ def test_real_auto_client_uploads_and_fake_records_v3_multipart(fake_immich_serv
     assert len(fake_immich_server.uploads) == 1
     upload = fake_immich_server.uploads[0]
     assert set(upload.fields) == {"filename", "fileCreatedAt", "fileModifiedAt"}
-    assert upload.fields["filename"] == "source.mp4"
-    assert upload.filename == "source.mp4"
+    assert upload.fields["filename"] == "video-1.mp4"
+    assert upload.filename == "video-1.mp4"
     assert upload.content_type == "video/mp4"
     assert upload.data == fake_immich_server.source_video.read_bytes()
 

--- a/tests/e2e/test_launch_smoke.py
+++ b/tests/e2e/test_launch_smoke.py
@@ -189,8 +189,15 @@ def _drive_to_step4(page: Page, launch_app_url: str) -> None:
     expect(include_photos).to_have_attribute("aria-checked", "true")
     page.get_by_role("button", name="Next: Review Clips").click()
 
-    expect(page.get_by_text("2 Videos, 2 Photos Found", exact=True)).to_be_visible(timeout=60_000)
-    for filename in ("video-1.mp4", "video-2.mp4", "photo-1.jpg", "photo-2.jpg"):
+    expect(page.get_by_text("3 Videos, 3 Photos Found", exact=True)).to_be_visible(timeout=60_000)
+    for filename in (
+        "video-1.mp4",
+        "video-2.mp4",
+        "video-3.mp4",
+        "photo-1.jpg",
+        "photo-2.jpg",
+        "photo-3.jpg",
+    ):
         expect(page.get_by_text(filename, exact=True).first).to_be_visible()
 
     page.get_by_role("button", name="Generate Memories", exact=True).click()

--- a/tests/test_docker_smoke_contract.py
+++ b/tests/test_docker_smoke_contract.py
@@ -1,13 +1,23 @@
-"""The release smoke gate must authenticate against its own fake server (#480).
+"""The release smoke gate has to survive the pipeline it exists to exercise.
 
-Every release since the gate landed failed with "Invalid API key": the script
-invented a key while FakeImmichServer checks `x-api-key` against its own.
+Two releases died here already. #480: the script invented an API key while
+FakeImmichServer checks `x-api-key` against its own. #525: the synthetic
+inventory was sub-1080p with no camera EXIF, so the real source gates emptied
+the pool and every run ended in "Pipeline selected no clips".
 """
 
 from __future__ import annotations
 
 import ast
+from datetime import timedelta
+from itertools import pairwise
 from pathlib import Path
+
+from immich_memories.analysis.source_filter import not_shot_here
+from immich_memories.analysis.source_quality import is_usable_source
+from immich_memories.api.models import Asset, VideoClipInfo
+from immich_memories.config_models import AnalysisConfig, PhotoConfig
+from tests.e2e.fake_immich import TIMELINE_ASSETS
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "docker_smoke.py"
 
@@ -30,3 +40,31 @@ def test_a_failure_prints_the_childs_own_output() -> None:
 
 def test_the_script_still_parses() -> None:
     ast.parse(_SCRIPT.read_text())
+
+
+def test_every_smoke_asset_survives_the_real_source_gates() -> None:
+    """A fixture the pipeline throws away tests nothing (#525)."""
+    analysis = AnalysisConfig()
+
+    for payload in TIMELINE_ASSETS:
+        asset = Asset.model_validate(payload)
+        assert not not_shot_here(
+            asset,
+            patterns=analysis.exclude_filename_patterns,
+            stills_need_a_camera=analysis.exclude_stills_without_camera_exif,
+        ), f"{asset.id} reads as something other than a camera original"
+        assert is_usable_source(
+            width=asset.width,
+            height=asset.height,
+            has_camera_exif=VideoClipInfo(asset=asset).is_camera_original,
+            min_short_side=analysis.min_source_short_side,
+        ), f"{asset.id} is dropped as a re-encode"
+        assert VideoClipInfo(asset=asset).is_camera_original, f"{asset.id} names no camera"
+
+
+def test_no_two_smoke_captures_fall_in_the_same_moment() -> None:
+    """A still beside a clip is dropped as already shown, which emptied the pool."""
+    window = timedelta(seconds=PhotoConfig().moment_gap_seconds)
+    taken_at = sorted(Asset.model_validate(payload).file_created_at for payload in TIMELINE_ASSETS)
+
+    assert all(later - earlier > window for earlier, later in pairwise(taken_at))


### PR DESCRIPTION
## What

The release Docker smoke test has died at the same line on every run since the
selection hardening merged: `Pipeline selected no clips`. The fake Immich
server's synthetic library could not survive the real rules:

| fixture fact | rule that removed it |
|---|---|
| `video-1` and `video-2` were the same file, and every asset got `photo-1`'s bytes as its thumbnail | Phase 1 thumbnail clustering, `2 -> 1 clips (1 duplicates)` |
| stills carried no EXIF make | `exclude_stills_without_camera_exif` (#493), `2 photo(s) from excluded sources` |
| 640x360 video, 320x240 stills, no camera EXIF | `min_source_short_side`, `dropped 1 clips under 1080p with no camera EXIF` |
| video-1/photo-1 shared a capture minute | moment suppression's 120s window |

The pipeline is right. The fixtures were wrong.

## Fix

`tests/e2e/fake_immich.py` now builds a library a camera could have produced,
with no gate touched in the smoke config:

- **1920x1080** videos (4s, h264/aac, bt709) and **2016x1512** stills
- **EXIF make and model on every asset**, videos and stills alike, which is
  also what makes `is_camera_original` true for the density-budget gate
- **six moments across six days of June** — no pair inside the 120s
  moment-suppression window
- **a distinct lavfi scene per asset** (`testsrc2`, `mandelbrot`, `testsrc`,
  `smptehdbars`, `rgbtestsrc`, `colorspectrum`), chosen by measurement: the
  closest pair is 21 hash bits apart, against a duplicate threshold of 8 and a
  suppression threshold of 10
- **each asset serves its own preview**, the way Immich does, instead of one
  shared JPEG that made every asset a perceptual duplicate of every other

Fixture build cost is 4.2s.

## Guardrails

`tests/test_docker_smoke_contract.py` (unit tier, runs in `make test`) now
asserts, through the production predicates themselves, that every synthetic
asset survives `not_shot_here` and `is_usable_source` at their default config,
that each names a camera, and that no two captures fall inside
`PhotoConfig().moment_gap_seconds`. Both were red before this change.
`tests/e2e/test_fake_immich.py` adds a contract that no two asset previews hash
within `duplicate_hash_threshold` of each other.

## Verified locally

- **The smoke path itself, without Docker**: the fake server plus the exact CLI
  invocation `scripts/docker_smoke.py` runs inside the image
  (`generate --memory-type monthly_highlights --year 2024 --month 6
  --duration 20 --no-music`), against a config-less `HOME`.
  - Before: `Clustered 2 -> 1`, `2 photo(s) from excluded sources`,
    `dropped 1 clips under 1080p`, `Phase 4: Final selection of 0 clips`, exit 1.
  - After: `Clustered 3 -> 3 clips (0 duplicates)`, `Unified pool: 3 video +
    3 photo candidates`, `Phase 4: Final selection of 4 clips`, an 18.0s
    playable MP4, exit 0.
- `make e2e` — 25 passed, including the hermetic browser render.
- `make ci` — 5444 passed, 9 skipped.

What CI still has to prove: the run inside the actual image on a 2-CPU
container. Selection is fixed; the render is now reached for the first time, so
the step's 1200s timeout has never been exercised end to end. Full generation
took 87s here on Apple silicon.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
