### PR TITLE
fix(speech): announce optional-feature degradation instead of no-opping

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -858,7 +858,7 @@
         "name": "register_config_commands",
         "complexity": 52,
         "line_start": 41,
-        "line_end": 250,
+        "line_end": 254,
         "line_complexities": [
           {
             "line": 58,
@@ -997,51 +997,39 @@
             "complexity": 3
           },
           {
-            "line": 195,
+            "line": 199,
             "complexity": 0
           },
           {
-            "line": 200,
-            "complexity": 0
-          },
-          {
-            "line": 203,
+            "line": 204,
             "complexity": 0
           },
           {
             "line": 207,
-            "complexity": 2
-          },
-          {
-            "line": 210,
             "complexity": 0
           },
           {
-            "line": 217,
+            "line": 211,
             "complexity": 2
           },
           {
-            "line": 218,
+            "line": 214,
             "complexity": 0
           },
           {
-            "line": 223,
+            "line": 221,
+            "complexity": 2
+          },
+          {
+            "line": 222,
+            "complexity": 0
+          },
+          {
+            "line": 227,
             "complexity": 3
           },
           {
-            "line": 231,
-            "complexity": 0
-          },
-          {
-            "line": 232,
-            "complexity": 0
-          },
-          {
-            "line": 233,
-            "complexity": 0
-          },
-          {
-            "line": 234,
+            "line": 235,
             "complexity": 0
           },
           {
@@ -1053,19 +1041,31 @@
             "complexity": 0
           },
           {
-            "line": 239,
-            "complexity": 2
+            "line": 238,
+            "complexity": 0
           },
           {
             "line": 240,
-            "complexity": 3
+            "complexity": 0
+          },
+          {
+            "line": 241,
+            "complexity": 0
+          },
+          {
+            "line": 243,
+            "complexity": 2
           },
           {
             "line": 244,
+            "complexity": 3
+          },
+          {
+            "line": 248,
             "complexity": 1
           },
           {
-            "line": 246,
+            "line": 250,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/deploy/installation/uv-pip.md
+++ b/docs-site/docs/deploy/installation/uv-pip.md
@@ -165,6 +165,17 @@ Set `advanced.transcription.model: base` for a ~148 MB download at a measured co
 Without the extra, no transcripts are produced and nothing else changes. Both `all` and `all-mac`
 include it.
 
+### Check what this install actually has
+
+```bash
+immich-memories preflight
+```
+
+Every optional feature gets a row saying what it costs when its extra is absent — speech
+boundaries, transcription, semantic audio labels, GPU title rendering. A missing runtime is a
+`WARNING`, never a silent no-op: the pipeline also logs one warning at startup when speech
+boundaries are enabled but the FireRedVAD runtime is not installed.
+
 ## Optional System Dependencies
 
 These are **not required** but improve specific features:

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -387,6 +387,10 @@ Checks:
 - Immich server connection and API key
 - LLM availability (Ollama or OpenAI-compatible)
 - Semantic audio analysis (PANNs or energy fallback)
+- Speech boundaries (FireRedVAD runtime)
+- Speech transcription (whisper.cpp runtime)
+- Title rendering (GPU or PIL fallback)
+- Notification delivery health
 - Hardware acceleration
 
 ```bash

--- a/src/immich_memories/analysis/speech_analysis.py
+++ b/src/immich_memories/analysis/speech_analysis.py
@@ -370,16 +370,20 @@ class SpeechAnalysisService:
 
         Both boundary placement and the transcription gate need them; running
         FireRedVAD twice over one cached array buys nothing.
+
+        The detector is checked before the extraction, not after: with no
+        detector there is nothing to feed, and asking ffmpeg for 16 kHz audio
+        first billed every clip for an answer that was always `[]`.
         """
+        if self._speech_detector is None:
+            return []
+
         cache_key = str(video_path)
         if cache_key not in self._vad_regions_cache:
             audio = self.extract_audio_cached(video_path)
-            if audio is None or self._speech_detector is None:
-                self._vad_regions_cache[cache_key] = []
-            else:
-                self._vad_regions_cache[cache_key] = self._speech_detector.detect(
-                    audio, VAD_SAMPLE_RATE
-                )
+            self._vad_regions_cache[cache_key] = (
+                [] if audio is None else self._speech_detector.detect(audio, VAD_SAMPLE_RATE)
+            )
         return self._vad_regions_cache[cache_key]
 
     def transcribe_segment(self, video_path: Path, start: float, end: float) -> Transcript | None:

--- a/src/immich_memories/cli/config_cmd.py
+++ b/src/immich_memories/cli/config_cmd.py
@@ -188,6 +188,10 @@ def register_config_commands(main: click.Group) -> None:
         - Immich server connection and API key
         - LLM availability (Ollama or OpenAI-compatible)
         - Semantic audio analysis (PANNs or energy fallback)
+        - Speech boundaries (FireRedVAD runtime)
+        - Speech transcription (whisper.cpp runtime)
+        - Title rendering (GPU or PIL fallback)
+        - Notification delivery health
         - Hardware acceleration
         """
         from immich_memories.preflight import CheckStatus, run_preflight_checks

--- a/src/immich_memories/preflight.py
+++ b/src/immich_memories/preflight.py
@@ -376,6 +376,77 @@ def check_audio_content(config: Config) -> CheckResult:
     )
 
 
+def _optional_runtime_check(
+    name: str, modules: tuple[str, ...], *, extra: str, ready: str, cost: str
+) -> CheckResult:
+    """OK when the extra's runtime imports, else a WARNING naming what is lost.
+
+    `cost` is the point: an install missing an extra otherwise learns nothing
+    until the feature silently does nothing, so the WARNING states the feature
+    that is gone rather than the package that is absent.
+    """
+    missing = [module for module in modules if importlib.util.find_spec(module) is None]
+    if not missing:
+        return CheckResult(name=name, status=CheckStatus.OK, message=ready)
+    return CheckResult(
+        name=name,
+        status=CheckStatus.WARNING,
+        message=cost,
+        details=f"Missing {', '.join(missing)}; install with pip install 'immich-memories[{extra}]'",
+    )
+
+
+def check_speech_boundaries(config: Config) -> CheckResult:
+    """Report whether speech-aware cut boundaries can actually run."""
+    if not config.speech.enabled:
+        return CheckResult(
+            name="Speech boundaries",
+            status=CheckStatus.SKIPPED,
+            message="Speech boundaries disabled",
+        )
+    return _optional_runtime_check(
+        "Speech boundaries",
+        ("onnxruntime", "kaldi_native_fbank"),
+        extra="speech",
+        ready="Speech-aware cut boundaries ready",
+        cost="Speech boundaries unavailable; cuts may land mid-sentence",
+    )
+
+
+def check_transcription(config: Config) -> CheckResult:
+    """Report whether speech transcription can actually run."""
+    if not config.transcription.enabled:
+        return CheckResult(
+            name="Transcription",
+            status=CheckStatus.SKIPPED,
+            message="Speech transcription disabled",
+        )
+    return _optional_runtime_check(
+        "Transcription",
+        ("pywhispercpp",),
+        extra="transcribe",
+        ready="Speech transcription ready",
+        cost="Speech transcription unavailable; clips are chosen without what was said",
+    )
+
+
+def check_title_rendering(config: Config) -> CheckResult:
+    """Report whether title screens get the GPU renderer or the PIL fallback."""
+    if not config.title_screens.enabled:
+        return CheckResult(
+            name="Title rendering",
+            status=CheckStatus.SKIPPED,
+            message="Title screens disabled",
+        )
+    return _optional_runtime_check(
+        "Title rendering",
+        ("taichi",),
+        extra="gpu",
+        ready="GPU-accelerated title rendering available",
+        cost="GPU-accelerated title rendering unavailable; titles use the PIL fallback",
+    )
+
+
 def run_preflight_checks(config: Config) -> list[CheckResult]:
     """Run all preflight checks.
 
@@ -389,6 +460,9 @@ def run_preflight_checks(config: Config) -> list[CheckResult]:
         check_immich(config),
         check_llm(config),
         check_audio_content(config),
+        check_speech_boundaries(config),
+        check_transcription(config),
+        check_title_rendering(config),
         check_notifications(config),
         check_hardware(),
     ]

--- a/src/immich_memories/speech/vad.py
+++ b/src/immich_memories/speech/vad.py
@@ -63,16 +63,31 @@ class SpeechDetector(Protocol):
 
 
 def select_detector(config: SpeechConfig) -> SpeechDetector | None:
-    """FireRedVAD, or `None` when speech-derived boundaries are disabled.
+    """FireRedVAD, or `None` when speech-derived boundaries cannot run.
 
     `None` leaves PANNs-derived protected ranges untouched (see
     `_apply_vad_ranges`).
+
+    The runtime is probed here rather than on the first `detect()` call. A
+    detector whose ONNX/fbank imports are missing answers `[]` to every clip,
+    so callers would pay a per-clip ffmpeg extraction to feed a detector that
+    cannot run -- and, on a bare install without the `speech` extra, learn
+    about it only from a debug line. Probing once at selection turns that into
+    one warning and no extraction.
     """
     if not config.enabled:
         return None
 
     from immich_memories.speech.fireredvad import FireRedSpeechDetector
 
-    return FireRedSpeechDetector(
+    detector = FireRedSpeechDetector(
         threshold=config.vad_threshold, min_silence_ms=config.min_silence_ms
     )
+    if not detector.available:
+        logger.warning(
+            "Speech boundaries are enabled but the VAD runtime is unavailable -- "
+            "cuts fall back to PANNs speech tags and may land mid-sentence. "
+            "Install with: pip install 'immich-memories[speech]'"
+        )
+        return None
+    return detector

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -13,6 +13,10 @@ from immich_memories.preflight import (
     check_immich,
     check_llm,
     check_notifications,
+    check_speech_boundaries,
+    check_title_rendering,
+    check_transcription,
+    run_preflight_checks,
 )
 
 
@@ -171,3 +175,54 @@ def test_notification_preflight_is_optional_when_disabled() -> None:
 
     assert result.status is CheckStatus.SKIPPED
     assert result.message == "Notifications disabled"
+
+
+def test_speech_boundaries_preflight_names_the_feature_lost_without_the_extra() -> None:
+    """A bare install must see the cost, not just a missing package name."""
+    # WHY: replaces the installed-package probe with what a bare pip install sees.
+    with patch("immich_memories.preflight.importlib.util.find_spec", return_value=None):
+        result = check_speech_boundaries(Config())
+
+    assert result.status is CheckStatus.WARNING
+    assert result.message == "Speech boundaries unavailable; cuts may land mid-sentence"
+    assert "onnxruntime" in (result.details or "")
+    assert "immich-memories[speech]" in (result.details or "")
+
+
+def test_transcription_preflight_names_the_feature_lost_without_the_extra() -> None:
+    config = Config(transcription={"enabled": True, "languages": ["en"]})
+
+    # WHY: replaces the installed-package probe with what a no-transcribe install sees.
+    with patch("immich_memories.preflight.importlib.util.find_spec", return_value=None):
+        result = check_transcription(config)
+
+    assert result.status is CheckStatus.WARNING
+    assert result.message == (
+        "Speech transcription unavailable; clips are chosen without what was said"
+    )
+    assert "immich-memories[transcribe]" in (result.details or "")
+
+
+def test_title_rendering_preflight_reports_the_pil_fallback_without_taichi() -> None:
+    # WHY: replaces the installed-package probe with what a no-gpu install sees.
+    with patch("immich_memories.preflight.importlib.util.find_spec", return_value=None):
+        result = check_title_rendering(Config())
+
+    assert result.status is CheckStatus.WARNING
+    assert "PIL fallback" in result.message
+    assert "immich-memories[gpu]" in (result.details or "")
+
+
+def test_preflight_run_lists_every_absent_optional_feature() -> None:
+    """The degraded-install summary is the whole point: one line per lost feature."""
+    config = Config(
+        audio_content={"enabled": True},
+        transcription={"enabled": True, "languages": ["en"]},
+    )
+
+    # WHY: replaces the installed-package probe with what a bare pip install sees.
+    with patch("immich_memories.preflight.importlib.util.find_spec", return_value=None):
+        checks = run_preflight_checks(config)
+
+    degraded = {c.name for c in checks if c.status is CheckStatus.WARNING}
+    assert {"Audio content", "Speech boundaries", "Transcription", "Title rendering"} <= degraded

--- a/tests/test_speech_analysis.py
+++ b/tests/test_speech_analysis.py
@@ -68,6 +68,27 @@ class TestSpeechDetectorConstruction:
         assert isinstance(service._speech_detector, FireRedSpeechDetector)
 
 
+class TestDetectRegionsCachedWithoutRuntime:
+    """A detector that cannot run must not cost an ffmpeg extraction per clip."""
+
+    def test_unavailable_runtime_skips_the_per_clip_audio_extraction(self, tmp_path: Path):
+        from immich_memories.speech.fireredvad import FireRedSpeechDetector
+
+        # WHY: stands in for FireRedVAD's runtime import, which succeeds here
+        # because the speech extra is installed -- this is the bare install.
+        with patch.object(FireRedSpeechDetector, "_load", return_value=False):
+            service = SpeechAnalysisService(
+                audio_content_config=AudioContentConfig(),
+                speech_config=SpeechConfig(enabled=True),
+            )
+
+        # WHY: the per-clip ffmpeg extraction; not being called is the assertion.
+        with patch("immich_memories.analysis.speech_analysis.extract_audio_16k") as extract:
+            assert service.detect_regions_cached(tmp_path / "clip.mov") == []
+
+        extract.assert_not_called()
+
+
 class TestApplyVadRanges:
     """`apply_vad_ranges` replaces PANNs-derived protected ranges with VAD ones."""
 

--- a/tests/test_speech_vad.py
+++ b/tests/test_speech_vad.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -20,6 +21,29 @@ from immich_memories.speech.vad import extract_audio_16k, select_detector
 class TestSelectDetector:
     def test_disabled_config_returns_none(self):
         assert select_detector(SpeechConfig(enabled=False)) is None
+
+    def test_missing_speech_runtime_returns_none_and_warns_once(self, caplog):
+        """A bare install must be told, once, that speech boundaries are off.
+
+        Returning the detector anyway is what made the degradation silent: it
+        answers `[]` to every clip, and only a debug line says why.
+        """
+        from immich_memories.speech.fireredvad import FireRedSpeechDetector
+
+        # Patching sys.modules instead works exactly once: the restore drops
+        # kaldi_native_fbank, and re-importing a pybind11 extension raises
+        # "type is already registered" for every later test in the session.
+        # WHY: stands in for FireRedVAD's runtime import inside _load.
+        with (
+            patch.object(FireRedSpeechDetector, "_load", return_value=False),
+            caplog.at_level(logging.WARNING),
+        ):
+            detector = select_detector(SpeechConfig(enabled=True))
+
+        assert detector is None
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "immich-memories[speech]" in warnings[0].getMessage()
 
     def test_enabled_config_returns_a_configured_fireredvad_detector(self):
         from immich_memories.speech.fireredvad import FireRedSpeechDetector


### PR DESCRIPTION
## The problem

On any bare `pip install immich-memories`, speech-aware cutting quietly stopped existing.
`select_detector` handed back a `FireRedSpeechDetector` without ever probing whether its ONNX
and fbank imports resolve. The detector's own `available` property was lazy, so the first
`detect()` call swallowed the `ImportError` into a `logger.debug` line and returned `[]` — and
kept returning `[]` for every clip after that. The Docker image (extras=all) and a pip install
were different products with nothing telling them apart.

`detect_regions_cached` made it cost money too: it extracted 16 kHz audio via ffmpeg *before*
discovering the detector could not run, so every clip paid a subprocess for an answer that was
always empty.

## The fix

**Announce the degradation.**

- `select_detector` probes the runtime once, at construction, and returns `None` with a single
  `WARNING` naming the lost feature and the extra to install. One line per pipeline, not per clip.
- `preflight` gains rows for speech boundaries, transcription and title rendering, beside the
  audio-content check that was already there. Each states what the absence *costs* — "cuts may
  land mid-sentence", "clips are chosen without what was said", "titles use the PIL fallback" —
  rather than only naming the absent package.

```
WARNING  Speech boundaries    Speech boundaries unavailable; cuts may land mid-sentence
                              Missing onnxruntime, kaldi_native_fbank; install with pip install 'immich-memories[speech]'
WARNING  Transcription        Speech transcription unavailable; clips are chosen without what was said
                              Missing pywhispercpp; install with pip install 'immich-memories[transcribe]'
WARNING  Title rendering      GPU-accelerated title rendering unavailable; titles use the PIL fallback
                              Missing taichi; install with pip install 'immich-memories[gpu]'
```

**Stop paying before failing.** `detect_regions_cached` checks the detector before the
extraction, not after, so a detector that cannot run never triggers ffmpeg. This matters most
for an install with `transcribe` but not `speech`, where the transcription gate calls it per
segment.

## Tests

TDD, three RED→GREEN cycles:

- `select_detector` returns `None` and logs exactly one WARNING when the runtime import fails.
- `detect_regions_cached` performs no audio extraction when the detector is `None`.
- `preflight` lists each absent optional feature with the cost of its absence.

The runtime is mocked at `FireRedSpeechDetector._load` rather than via `sys.modules`. Patching
`sys.modules` works exactly once: `patch.dict`'s restore clears the dict, dropping
`kaldi_native_fbank`, and re-importing a pybind11 extension raises "type is already registered"
for every later test in the session.

## Docs

`preflight`'s check list (the auto-generated CLI reference, regenerated with `make docs-cli`)
and a "Check what this install actually has" section on the uv/pip installation page.

## Verification

`make ci` — 5448 passed, 9 skipped. `make docs-check` passes.

## Note on "a single warning"

The warning fires once per `SpeechAnalysisService` construction. On the real pipeline path
`ClipAnalyzer` caches its `UnifiedSegmentAnalyzer`, so that is once per run. The two other
construction sites (`preview_builder`, and the unreferenced public helper
`analyze_clip_for_highlight`) would warn once per builder/call — still never per clip.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
