### PR TITLE
fix(analysis): close the setting vocabulary on the fallback path too

### DIFF
--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -99,8 +99,20 @@ def build_content_analysis_prompt(transcript: str | None = None) -> str:
 
 
 MAX_LIST = 10
+MAX_STR = 500
 
 CONTENT_ANALYSIS_PROMPT = build_content_analysis_prompt()
+
+
+def _setting_in_vocabulary(raw: str) -> str:
+    """One of SETTING_VALUES, or "" for anything else.
+
+    Shared by both parse paths on purpose: the malformed-JSON fallback is taken
+    exactly when the model is ignoring the schema, so it is the likeliest source
+    of the free text the closed vocabulary exists to keep out (#519).
+    """
+    value = raw.strip().lower()[:MAX_STR]
+    return value if value in SETTING_VALUES else ""
 
 
 @dataclass
@@ -400,17 +412,15 @@ class ContentAnalyzer:
         Returns:
             ContentAnalysis instance.
         """
-        MAX_STR = 500
         description = str(data.get("description", ""))[:MAX_STR]
         subjects = [str(s)[:MAX_STR] for s in data.get("subjects", [])[:MAX_LIST]]
         category = str(data.get("category", ""))[:MAX_STR]
-        # An unlisted value is dropped rather than stored: a model that ignores
-        # the enum must not quietly reintroduce free text (#483).
         activities = [
             str(a).strip().lower()[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]
         ]
-        raw_setting = str(data.get("setting", "")).strip().lower()
-        setting = raw_setting if raw_setting in SETTING_VALUES else ""
+        # An unlisted value is dropped rather than stored: a model that ignores
+        # the enum must not quietly reintroduce free text (#483).
+        setting = _setting_in_vocabulary(str(data.get("setting", "")))
         emotion = emotion[:MAX_STR]
 
         raw_interest = float(data.get("interestingness", 0.5))
@@ -517,7 +527,7 @@ class ContentAnalyzer:
 
         setting_match = re.search(r'"setting"\s*:\s*"([^"]+)"', text)
         if setting_match:
-            result.setting = setting_match.group(1)
+            result.setting = _setting_in_vocabulary(setting_match.group(1))
 
         # WHY: the subject policy decides on the category alone, so a response that
         # reaches this path without one silently drops out of the filter. Sampled

--- a/tests/test_llm_response_parser.py
+++ b/tests/test_llm_response_parser.py
@@ -437,10 +437,18 @@ class TestExtractPartialData:
         result = analyzer._extract_partial_data(text)
         assert result.quality == pytest.approx(0.65)
 
-    def test_extracts_setting(self, analyzer: ContentAnalyzer):
-        text = '"description": "x", "setting": "indoor office"'
+    def test_extracts_a_listed_setting(self, analyzer: ContentAnalyzer):
+        text = '"description": "x", "setting": "Indoor_Home "'
         result = analyzer._extract_partial_data(text)
-        assert result.setting == "indoor office"
+        assert result.setting == "indoor_home"
+
+    def test_an_unlisted_setting_is_dropped_here_too(self, analyzer: ContentAnalyzer):
+        """This path runs exactly when the model is misbehaving, so it is the
+        likeliest source of the free text the closed vocabulary exists to keep
+        out — and an unchecked value persists into the analysis cache (#519)."""
+        text = '"description": "x", "setting": "restaurant patio"'
+        result = analyzer._extract_partial_data(text)
+        assert result.setting == ""
 
     def test_nothing_found_returns_low_confidence(self, analyzer: ContentAnalyzer):
         text = "totally unparseable garbage with no json patterns"


### PR DESCRIPTION
## What

`setting` is a closed vocabulary on purpose (#483): free text gave 39+ values including both "indoor" and "indoors", and the indoor/outdoor split is the one signal that survived every control in the #475 study. The main parse path enforces it — `raw_setting if raw_setting in SETTING_VALUES else ""`.

The malformed-JSON fallback did not. `_extract_partial_data` stored the raw regex capture verbatim, uncapped and unchecked — and that path is taken *exactly* when the model is misbehaving, which is when free text is most likely. The value persists through `segment.llm_setting` into the analysis cache and survives until the asset is re-analysed.

## Changes

Both paths now go through one `_setting_in_vocabulary` helper that strips, lowercases, caps at `MAX_STR` and drops anything outside `SETTING_VALUES`. `MAX_STR` moves from a local in `_build_content_analysis` to a module constant beside `MAX_LIST`, since two functions need it.

## Tests

TDD RED first: the fallback given `"setting": "indoor office"` stores `""`, and given `"setting": "Indoor_Home "` stores `indoor_home`.

`test_extracts_setting` asserted `result.setting == "indoor office"` — it encoded the bug, so it is replaced by the two tests above.

## Note on the cap

The `MAX_STR` cap is applied as the issue asks, but it is belt-and-braces: the membership check already bounds the stored value to one of six short tokens. The check is what closes the vocabulary; the cap only bounds the string that gets compared.

`make ci` passes.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
