### PR TITLE
fix(music): the bundled fallback tells the truth and varies its pick

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -27,8 +27,11 @@ The Docker image and the `all` extra already include it.
 
 Tracks cover five moods (calm, energetic, happy, nostalgic, tender) in acoustic
 and electronic styles, roughly 30 seconds each, and are repeated with a crossfade
-to fill longer videos. Selection follows the memory's detected mood, and a mood
-with no bundled folder falls back to another track rather than to silence.
+to fill longer videos. Selection follows the memory's detected mood: the per-clip
+emotions the vision LLM reported are aggregated into a dominant mood, and near
+neighbours share a folder — playful draws from happy, peaceful from calm,
+romantic from tender. A mood that maps to no folder at all, and a memory with no
+emotions at all, draw from the whole library rather than falling to silence.
 
 They were generated locally with ACE-Step 1.5 — nothing sampled from or derived
 from third-party recordings, so there is no attribution requirement. The models,

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -108,9 +108,17 @@ Measured on the 28 bundled tracks, ACE-Step honours a requested tempo to within
 is also why cuts are aligned in *rate*, not yet locked to the beat.
 
 A bundled track cannot be asked for a tempo; its own is already fixed. So the
-choice runs the other way — the tracks are measured and the one whose beat
-divides the photo cadence is picked, instead of one at random. With no photos
-there is no rhythm to sync to, and the pick stays random so repeats differ.
+choice runs the other way — the tracks are measured, the ones whose beat lands
+within 0.2 beats of the photo cadence become the candidates, and one of those is
+picked at random. Alignment narrows the field; it does not name a winner, or the
+same memory would get the same song every time it was regenerated. When nothing
+lands close enough the pick falls back to any track. With no photos there is no
+rhythm to sync to, and the pick stays random too.
+
+That 0.2 is the detector's floor, not a preference: the onset envelope quantizes
+the beat period to 23 ms frames, so a track built at 120 bpm measures 117.5, and
+a track that really does land on a 4 s cadence can still measure 0.18 beats out.
+A tighter window would throw away tracks that fit and measure only the noise.
 
 Tempo is measured with an onset envelope and autocorrelation over an FFmpeg
 decode, using numpy alone. librosa would be a line, but it is not a dependency

--- a/docs-site/docs/create/pipeline/pipeline-overview.md
+++ b/docs-site/docs/create/pipeline/pipeline-overview.md
@@ -237,10 +237,12 @@ GPU speeds up the write side of assembly, not the read side.
 
 ### 7. Music
 
-`resolve_music_file()` in `generate_music.py` walks a fixed chain: an explicit
+`resolve_music()` in `generate_music.py` walks a fixed chain: an explicit
 `--music` file wins; otherwise AI generation if a backend is enabled; otherwise
 a bundled track chosen by mood. A generation failure falls through to bundled
-rather than aborting the run.
+rather than aborting the run — and the run is told: the substitution comes back
+as a warning on the finished artifact, so a dead backend shows up in the UI and
+in the nightly notification instead of sounding like working music forever.
 
 ACE-Step has two modes, and which one you pick decides the cost class:
 

--- a/src/immich_memories/audio/bundled_music.py
+++ b/src/immich_memories/audio/bundled_music.py
@@ -56,7 +56,8 @@ def bundled_track_for_mood(
     if root is None or not root.is_dir():
         return None
 
-    folder = root / _folder_for(mood)
+    family = (mood or "").lower()
+    folder = root / _MOOD_FOLDERS.get(family, family)
     candidates = _tracks_in(folder) if folder.is_dir() else []
     if not candidates:
         candidates = sorted(
@@ -68,12 +69,6 @@ def bundled_track_for_mood(
     chosen = _fitting_track(candidates, cadence_seconds) or random.choice(candidates)
     logger.info("Using bundled music: %s/%s", chosen.parent.name, chosen.name)
     return chosen
-
-
-def _folder_for(mood: str | None) -> str:
-    if not mood:
-        return ""
-    return _MOOD_FOLDERS.get(mood.lower(), mood.lower())
 
 
 def _tracks_in(folder: Path) -> list[Path]:

--- a/src/immich_memories/audio/bundled_music.py
+++ b/src/immich_memories/audio/bundled_music.py
@@ -15,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 _SUFFIXES = (".opus", ".mp3", ".m4a", ".flac", ".ogg", ".wav")
 
+# The package ships five folders; the analyser's mood families are wider than
+# that. A near neighbour is better music for the memory than the flat pool, so
+# the families with no folder of their own borrow the closest one that has.
+_MOOD_FOLDERS = {
+    "playful": "happy",
+    "peaceful": "calm",
+    "exciting": "energetic",
+    "romantic": "tender",
+}
+
 
 def bundled_library() -> Path | None:
     """Directory of bundled tracks, or None when the music package is absent."""
@@ -46,7 +56,7 @@ def bundled_track_for_mood(
     if root is None or not root.is_dir():
         return None
 
-    folder = root / (mood or "")
+    folder = root / _folder_for(mood)
     candidates = _tracks_in(folder) if folder.is_dir() else []
     if not candidates:
         candidates = sorted(
@@ -58,6 +68,12 @@ def bundled_track_for_mood(
     chosen = _fitting_track(candidates, cadence_seconds) or random.choice(candidates)
     logger.info("Using bundled music: %s/%s", chosen.parent.name, chosen.name)
     return chosen
+
+
+def _folder_for(mood: str | None) -> str:
+    if not mood:
+        return ""
+    return _MOOD_FOLDERS.get(mood.lower(), mood.lower())
 
 
 def _tracks_in(folder: Path) -> list[Path]:

--- a/src/immich_memories/audio/track_tempo.py
+++ b/src/immich_memories/audio/track_tempo.py
@@ -2,8 +2,8 @@
 
 #312's first half asks a generator for a tempo whose beat divides the photo
 cadence. A bundled track cannot be asked — its tempo is already fixed — so the
-choice runs the other way: measure what ships, then pick the track that lands on
-the cadence.
+choice runs the other way: measure what ships, then pick from the tracks that
+land on the cadence.
 
 Detection is numpy over an ffmpeg decode on purpose. librosa would be one line,
 but it is not a dependency of this project (it arrives transitively with the
@@ -18,6 +18,7 @@ strongest. That is the beat period.
 from __future__ import annotations
 
 import logging
+import random
 import subprocess
 from pathlib import Path
 
@@ -31,7 +32,14 @@ _FRAME = 512
 _MIN_BPM = 60
 _MAX_BPM = 180
 # How near a whole number of beats a cadence must fall to count as aligned.
-_BEAT_TOLERANCE = 0.12
+# Set by what the detector can actually resolve, not by taste. Autocorrelation
+# quantizes the beat period to whole 23 ms frames, so a click track built at a
+# known tempo reads back a few BPM out — 120 measures 117.5, 110 measures 107.7 —
+# and a track that truly lands on a 4 s cadence still measures up to ~0.18 beats
+# off. A tighter gate would reject tracks that do fit and would only be measuring
+# the detector's own noise. A real miss (100 BPM against 4 s) measures 0.37, so
+# the two are still separated. Narrow this only alongside a finer onset hop.
+_BEAT_TOLERANCE = 0.2
 
 
 def _decode_mono(path: Path) -> np.ndarray | None:
@@ -89,25 +97,36 @@ def _beat_misfit(bpm: float, cadence_seconds: float) -> float:
 
 
 def track_for_cadence(candidates: list[Path], cadence_seconds: float) -> Path | None:
-    """The candidate whose beat divides the cadence most exactly.
+    """One of the candidates whose beat lands on the cadence, chosen at random.
 
-    A track that cannot be read costs itself its turn, not the run. With nothing
-    measurable, the caller's own fallback applies.
+    Returning the single least-misfitting track would hand the same memory the
+    same song forever, however badly the winner actually fit — so the tolerance
+    decides who qualifies and chance decides between them.
+
+    A track that cannot be read costs itself its turn, not the run. None means
+    nothing was near enough, and the caller's own fallback applies.
     """
     if not candidates or cadence_seconds <= 0:
         return None
 
-    best: tuple[float, Path] | None = None
+    aligned = []
     for track in candidates:
         bpm = detect_bpm(track)
         if bpm is None:
             logger.debug("No tempo read from %s; skipping it for cadence matching", track.name)
             continue
-        misfit = _beat_misfit(bpm, cadence_seconds)
-        if best is None or misfit < best[0]:
-            best = (misfit, track)
+        if _beat_misfit(bpm, cadence_seconds) <= _BEAT_TOLERANCE:
+            aligned.append(track)
 
-    if best is None:
+    if not aligned:
+        logger.debug("No bundled track lands on a %.1fs cadence", cadence_seconds)
         return None
-    logger.info("Bundled track %s fits a %.1fs cadence", best[1].name, cadence_seconds)
-    return best[1]
+    chosen = random.choice(aligned)  # noqa: S311  # WHY: variety, not secrecy
+    logger.info(
+        "Bundled track %s fits a %.1fs cadence (%d of %d did)",
+        chosen.name,
+        cadence_seconds,
+        len(aligned),
+        len(candidates),
+    )
+    return chosen

--- a/src/immich_memories/audio/track_tempo.py
+++ b/src/immich_memories/audio/track_tempo.py
@@ -121,7 +121,7 @@ def track_for_cadence(candidates: list[Path], cadence_seconds: float) -> Path | 
     if not aligned:
         logger.debug("No bundled track lands on a %.1fs cadence", cadence_seconds)
         return None
-    chosen = random.choice(aligned)  # noqa: S311  # WHY: variety, not secrecy
+    chosen = random.choice(aligned)
     logger.info(
         "Bundled track %s fits a %.1fs cadence (%d of %d did)",
         chosen.name,

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -43,6 +43,19 @@ class MusicPhaseResult:
     warning: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class MusicSelection:
+    """The track the run will use, and what it had to settle for to get there.
+
+    The warning travels with the path rather than only reaching the log,
+    because a bundled substitution is a success the user still needs told
+    about: otherwise a dead backend looks like working music forever.
+    """
+
+    path: Path | None
+    warning: str | None = None
+
+
 def optional_music_warning(exc: Exception, config: Config | None = None) -> str:
     """Build one user-safe optional-music warning with configured secrets removed."""
     safe_message = sanitize_error_message(str(exc))
@@ -115,7 +128,7 @@ def music_config_available(config: Config) -> bool:
     return bool((ace and ace.enabled) or (mg and mg.enabled))
 
 
-def resolve_music_file(
+def resolve_music(
     config: Config,
     music_path: Path | None,
     no_music: bool,
@@ -124,12 +137,14 @@ def resolve_music_file(
     memory_type: str | None,
     report_fn: Callable[[str, float, str], None] | None = None,
     bundled_library: Path | None = None,
-) -> Path | None:
-    """Determine the music file to use: provided path, generated, bundled, or None."""
+) -> MusicSelection:
+    """Determine the music to use: provided path, generated, bundled, or none."""
     if no_music:
-        return None
+        return MusicSelection(None)
     if music_path and music_path.exists():
-        return music_path
+        return MusicSelection(music_path)
+
+    warning: str | None = None
     if not music_path and music_config_available(config):
         if report_fn:
             report_fn("music", 0.85, "Generating AI music...")
@@ -141,16 +156,19 @@ def resolve_music_file(
             # A configured generator that fails used to be worse than no generator
             # at all: the exception unwound past the bundled branch below and the
             # whole music phase was abandoned, so the most-configured setup got
-            # the only silent video. Fall through to bundled and keep the warning.
-            logger.warning("%s; using a bundled track", optional_music_warning(exc, config))
+            # the only silent video. Fall through to bundled and carry the warning
+            # out with the track — a log line alone never reaches the run artifact,
+            # the UI or the nightly notification, so a dead backend stayed invisible.
+            warning = f"{optional_music_warning(exc, config)}; used a bundled track instead"
+            logger.warning(warning)
             generated = None
         if generated:
-            return _master(generated, run_output_dir)
+            return MusicSelection(_master(generated, run_output_dir))
 
     if music_path is not None:
         # An explicit track that is missing is a user error; substituting bundled
         # music would hide the typo.
-        return None
+        return MusicSelection(None)
 
     # WHY: with no generator configured this used to return silence, which is what
     # the Docker/NAS path gets by default.
@@ -161,7 +179,9 @@ def resolve_music_file(
         library=bundled_library,
         cadence_seconds=photo_cadence_seconds(assembly_clips),
     )
-    return _master(bundled, run_output_dir) if bundled else bundled
+    if not bundled:
+        return MusicSelection(None, warning)
+    return MusicSelection(_master(bundled, run_output_dir), warning)
 
 
 def _master(track: Path, run_output_dir: Path) -> Path:

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -24,6 +24,7 @@ from immich_memories.processing.output_contract import (
     probe_output,
     publish_validated_output,
 )
+from immich_memories.processing.scaling_utilities import aggregate_mood_from_clips
 from immich_memories.security import configured_secret_values, sanitize_error_message
 
 if TYPE_CHECKING:
@@ -174,8 +175,12 @@ def resolve_music(
     # the Docker/NAS path gets by default.
     from immich_memories.audio.bundled_music import bundled_track_for_mood
 
+    # The mood used to be read off a `clip.mood` field AssemblyClip has never
+    # had, so it was always None and the bundled mood folders never served their
+    # purpose. What the clips actually carry is llm_emotion, which the title
+    # stack already aggregates into mood families.
     bundled = bundled_track_for_mood(
-        _mood_for_clips(assembly_clips),
+        aggregate_mood_from_clips(assembly_clips),
         library=bundled_library,
         cadence_seconds=photo_cadence_seconds(assembly_clips),
     )
@@ -203,19 +208,6 @@ def photo_cadence_seconds(assembly_clips: list[AssemblyClip]) -> float | None:
     if len(durations) < 2:
         return None
     return durations[len(durations) // 2]
-
-
-def _mood_for_clips(assembly_clips: list[AssemblyClip]) -> str | None:
-    """Mood to pick bundled music by, aggregated from what the analyser saw.
-
-    This used to read ``clip.mood``, a field AssemblyClip has never had, so it
-    was always None and the bundled library's mood folders never served their
-    purpose. The clips carry ``llm_emotion``, which the title stack already
-    aggregates into mood families.
-    """
-    from immich_memories.processing.scaling_utilities import aggregate_mood_from_clips
-
-    return aggregate_mood_from_clips(assembly_clips)
 
 
 def auto_generate_music(

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -206,12 +206,16 @@ def photo_cadence_seconds(assembly_clips: list[AssemblyClip]) -> float | None:
 
 
 def _mood_for_clips(assembly_clips: list[AssemblyClip]) -> str | None:
-    """Mood to pick bundled music by, taken from the clips when they carry one."""
-    for clip in assembly_clips:
-        mood = getattr(clip, "mood", None)
-        if mood:
-            return str(mood)
-    return None
+    """Mood to pick bundled music by, aggregated from what the analyser saw.
+
+    This used to read ``clip.mood``, a field AssemblyClip has never had, so it
+    was always None and the bundled library's mood folders never served their
+    purpose. The clips carry ``llm_emotion``, which the title stack already
+    aggregates into mood families.
+    """
+    from immich_memories.processing.scaling_utilities import aggregate_mood_from_clips
+
+    return aggregate_mood_from_clips(assembly_clips)
 
 
 def auto_generate_music(

--- a/src/immich_memories/generate_settings.py
+++ b/src/immich_memories/generate_settings.py
@@ -253,7 +253,7 @@ def _run_music_phase(
     from immich_memories.generate_music import (
         MusicPhaseResult,
         apply_music_file,
-        resolve_music_file,
+        resolve_music,
     )
 
     def _report_fn(phase: str, progress: float, msg: str) -> None:
@@ -262,11 +262,11 @@ def _run_music_phase(
 
     phase_started = _music_phase_requested(params)
     if phase_started:
-        # WHY: resolve_music_file performs the expensive model generation and
+        # WHY: resolve_music performs the expensive model generation and
         # optional stem separation, so the phase must include that work.
         run_tracker.start_phase("music", 1)
     try:
-        music_file = resolve_music_file(
+        selection = resolve_music(
             config=params.config,
             music_path=params.music_path,
             no_music=params.no_music,
@@ -275,10 +275,12 @@ def _run_music_phase(
             memory_type=params.memory_type,
             report_fn=_report_fn,
         )
-        if not music_file:
-            if phase_started:
+        if not selection.path:
+            if phase_started and selection.warning:
+                run_tracker.complete_phase(items_processed=0, errors=[{"error": selection.warning}])
+            elif phase_started:
                 run_tracker.complete_phase(items_processed=0)
-            return MusicPhaseResult(applied=False)
+            return MusicPhaseResult(applied=False, warning=selection.warning)
         _report_fn("music", 0.9, "Mixing music...")
         if not phase_started:
             # Defensive fallback for custom resolvers that produce a track
@@ -287,7 +289,7 @@ def _run_music_phase(
             phase_started = True
         apply_music_file(
             result_path,
-            music_file,
+            selection.path,
             params.music_volume,
             encoding_plan,
             mute_windows=mute_windows,
@@ -300,7 +302,7 @@ def _run_music_phase(
             phase_started=phase_started,
         )
     run_tracker.complete_phase(items_processed=1)
-    return MusicPhaseResult(applied=True)
+    return MusicPhaseResult(applied=True, warning=selection.warning)
 
 
 def _upload_to_immich(

--- a/tests/test_bundled_music_fallback.py
+++ b/tests/test_bundled_music_fallback.py
@@ -136,6 +136,93 @@ def test_bundled_music_is_mastered_before_use(library, tmp_path):
     assert seen, "bundled music should be mastered"
 
 
+def _emotional_clips(emotion, tmp_path):
+    from immich_memories.processing.assembly_config import AssemblyClip
+
+    return [
+        AssemblyClip(path=tmp_path / f"clip{i}.mp4", duration=3.0, llm_emotion=emotion)
+        for i in range(3)
+    ]
+
+
+def _bundled_choice(clips, library, tmp_path, monkeypatch):
+    from immich_memories.generate_music import resolve_music
+
+    # WHY: replaces the FFmpeg mastering pass so the pick keeps its folder.
+    monkeypatch.setattr(
+        "immich_memories.audio.mastering.master_music_track", lambda source, _dest: source
+    )
+    config = Config()
+    config.ace_step.enabled = False
+    config.musicgen.enabled = False
+    return resolve_music(
+        config=config,
+        music_path=None,
+        no_music=False,
+        assembly_clips=clips,
+        run_output_dir=tmp_path,
+        memory_type=None,
+        bundled_library=library,
+    ).path
+
+
+def test_the_analysers_emotion_reaches_the_bundled_mood_folder(library, tmp_path, monkeypatch):
+    """The five mood folders were inert: AssemblyClip carries llm_emotion, not mood.
+
+    Asserted over repeats because a mood-blind pick would land in the right
+    folder by chance often enough to pass a single draw.
+    """
+    clips = _emotional_clips("joyful", tmp_path)
+
+    folders = {
+        _bundled_choice(clips, library, tmp_path, monkeypatch).parent.name for _ in range(30)
+    }
+
+    assert folders == {"happy"}, "joyful belongs to the happy family"
+
+
+def test_clips_with_no_emotion_still_draw_from_the_whole_library(library, tmp_path, monkeypatch):
+    clips = _emotional_clips(None, tmp_path)
+
+    folders = {
+        _bundled_choice(clips, library, tmp_path, monkeypatch).parent.name for _ in range(30)
+    }
+
+    assert folders == {"calm", "happy"}
+
+
+@pytest.mark.parametrize(
+    ("emotion", "folder"),
+    [
+        # The vocabulary the analysis prompt asks the vision LLM for.
+        ("happy", "happy"),
+        ("calm", "calm"),
+        ("excited", "energetic"),
+        ("playful", "happy"),
+        ("joyful", "happy"),
+        ("peaceful", "calm"),
+        # Families with no folder of their own borrow the closest that has one.
+        ("romantic", "tender"),
+        ("wistful", "nostalgic"),
+    ],
+)
+def test_every_emotion_the_prompt_asks_for_reaches_a_shipped_folder(tmp_path, emotion, folder):
+    """A vocabulary drift here is what left all five folders unreachable."""
+    from immich_memories.processing.scaling_utilities import aggregate_mood_from_clips
+
+    shipped = tmp_path / "shipped"
+    for name in ("calm", "energetic", "happy", "nostalgic", "tender"):
+        (shipped / name).mkdir(parents=True)
+        (shipped / name / f"{name}.opus").write_bytes(b"")
+    mood = aggregate_mood_from_clips(_emotional_clips(emotion, tmp_path))
+
+    # Repeated because a mood with no folder falls to the flat pool, which would
+    # land on the right one by chance once in five.
+    folders = {bundled_track_for_mood(mood, library=shipped).parent.name for _ in range(20)}
+
+    assert folders == {folder}
+
+
 def test_a_user_supplied_track_is_left_alone(library, tmp_path):
     from immich_memories.generate_music import resolve_music
 

--- a/tests/test_bundled_music_fallback.py
+++ b/tests/test_bundled_music_fallback.py
@@ -49,14 +49,14 @@ def test_returns_nothing_when_the_package_is_not_installed(tmp_path):
     assert bundled_track_for_mood("calm", library=tmp_path / "absent") is None
 
 
-def test_resolve_music_file_uses_the_bundle_when_no_backend_is_configured(library):
-    from immich_memories.generate_music import resolve_music_file
+def test_resolve_music_uses_the_bundle_when_no_backend_is_configured(library):
+    from immich_memories.generate_music import resolve_music
 
     config = Config()
     config.ace_step.enabled = False
     config.musicgen.enabled = False
 
-    chosen = resolve_music_file(
+    chosen = resolve_music(
         config=config,
         music_path=None,
         no_music=False,
@@ -66,13 +66,13 @@ def test_resolve_music_file_uses_the_bundle_when_no_backend_is_configured(librar
         bundled_library=library,
     )
 
-    assert chosen is not None
+    assert chosen.path is not None
 
 
 def test_no_music_still_means_no_music(library):
-    from immich_memories.generate_music import resolve_music_file
+    from immich_memories.generate_music import resolve_music
 
-    chosen = resolve_music_file(
+    chosen = resolve_music(
         config=Config(),
         music_path=None,
         no_music=True,
@@ -82,14 +82,14 @@ def test_no_music_still_means_no_music(library):
         bundled_library=library,
     )
 
-    assert chosen is None
+    assert chosen.path is None
 
 
 def test_a_missing_explicit_track_is_not_silently_replaced(library, tmp_path):
     """A typo in --music should fail loudly, not quietly play something else."""
-    from immich_memories.generate_music import resolve_music_file
+    from immich_memories.generate_music import resolve_music
 
-    chosen = resolve_music_file(
+    chosen = resolve_music(
         config=Config(),
         music_path=tmp_path / "typo.mp3",
         no_music=False,
@@ -99,12 +99,12 @@ def test_a_missing_explicit_track_is_not_silently_replaced(library, tmp_path):
         bundled_library=library,
     )
 
-    assert chosen is None
+    assert chosen.path is None
 
 
 def test_bundled_music_is_mastered_before_use(library, tmp_path):
     """Bundled and generated tracks get the tilt and loudness target; user files do not."""
-    from immich_memories.generate_music import resolve_music_file
+    from immich_memories.generate_music import resolve_music
 
     seen: list[Path] = []
 
@@ -121,7 +121,7 @@ def test_bundled_music_is_mastered_before_use(library, tmp_path):
         config = Config()
         config.ace_step.enabled = False
         config.musicgen.enabled = False
-        resolve_music_file(
+        resolve_music(
             config=config,
             music_path=None,
             no_music=False,
@@ -137,12 +137,12 @@ def test_bundled_music_is_mastered_before_use(library, tmp_path):
 
 
 def test_a_user_supplied_track_is_left_alone(library, tmp_path):
-    from immich_memories.generate_music import resolve_music_file
+    from immich_memories.generate_music import resolve_music
 
     theirs = tmp_path / "mine.mp3"
     theirs.write_bytes(b"")
 
-    chosen = resolve_music_file(
+    chosen = resolve_music(
         config=Config(),
         music_path=theirs,
         no_music=False,
@@ -152,4 +152,4 @@ def test_a_user_supplied_track_is_left_alone(library, tmp_path):
         bundled_library=library,
     )
 
-    assert chosen == theirs
+    assert chosen.path == theirs

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -33,6 +33,7 @@ from immich_memories.generate import (
     check_disk_space,
     generate_memory,
 )
+from immich_memories.generate_music import MusicSelection
 from immich_memories.processing.assembly_config import AssemblyClip
 from tests.conftest import make_asset, make_clip
 
@@ -1553,9 +1554,10 @@ class TestRunMusicPhase:
         )
         mock_tracker = MagicMock()
 
-        # WHY: resolve_music_file checks filesystem for music files
+        # WHY: resolve_music checks filesystem for music files
         with patch(
-            "immich_memories.generate_music.resolve_music_file", return_value=None
+            "immich_memories.generate_music.resolve_music",
+            return_value=MusicSelection(None),
         ) as mock_resolve:
             _run_music_phase(
                 params,
@@ -1583,9 +1585,12 @@ class TestRunMusicPhase:
         mock_tracker = MagicMock()
         encoding_plan = _h264_output_plan()
 
-        # WHY: resolve_music_file and apply_music_file touch filesystem + FFmpeg
+        # WHY: resolve_music and apply_music_file touch filesystem + FFmpeg
         with (
-            patch("immich_memories.generate_music.resolve_music_file", return_value=music_file),
+            patch(
+                "immich_memories.generate_music.resolve_music",
+                return_value=MusicSelection(music_file),
+            ),
             patch("immich_memories.generate_music.apply_music_file") as mock_apply,
         ):
             _run_music_phase(
@@ -1617,14 +1622,14 @@ class TestRunMusicPhase:
         mock_tracker = MagicMock()
         mock_tracker.start_phase.side_effect = lambda *_args: events.append("phase-start")
 
-        def resolve_music(**_kwargs):
+        def record_resolve(**_kwargs):
             events.append("resolve")
-            return music_file
+            return MusicSelection(music_file)
 
         with (
             patch(
-                "immich_memories.generate_music.resolve_music_file",
-                side_effect=resolve_music,
+                "immich_memories.generate_music.resolve_music",
+                side_effect=record_resolve,
             ),
             patch("immich_memories.generate_music.apply_music_file"),
         ):
@@ -1651,9 +1656,10 @@ class TestRunMusicPhase:
         )
         mock_tracker = MagicMock()
 
-        # WHY: resolve_music_file accesses the filesystem
+        # WHY: resolve_music accesses the filesystem
         with patch(
-            "immich_memories.generate_music.resolve_music_file", return_value=None
+            "immich_memories.generate_music.resolve_music",
+            return_value=MusicSelection(None),
         ) as mock_resolve:
             _run_music_phase(
                 params,
@@ -1664,7 +1670,7 @@ class TestRunMusicPhase:
                 encoding_plan=_h264_output_plan(),
             )
 
-        # Verify resolve_music_file received a report_fn callback
+        # Verify resolve_music received a report_fn callback
         call_kwargs = mock_resolve.call_args
         assert (
             call_kwargs.kwargs.get("report_fn") is not None
@@ -2232,11 +2238,11 @@ class TestTryMergeBurst:
 # ===========================================================================
 
 
-class TestResolveMusicFile:
+class TestResolveMusic:
     def test_no_music_flag_returns_none(self, tmp_path):
-        from immich_memories.generate_music import resolve_music_file
+        from immich_memories.generate_music import resolve_music
 
-        result = resolve_music_file(
+        result = resolve_music(
             config=Config(),
             music_path=None,
             no_music=True,
@@ -2244,14 +2250,14 @@ class TestResolveMusicFile:
             run_output_dir=tmp_path,
             memory_type=None,
         )
-        assert result is None
+        assert result.path is None
 
     def test_explicit_music_path_returned(self, tmp_path):
-        from immich_memories.generate_music import resolve_music_file
+        from immich_memories.generate_music import resolve_music
 
         music = tmp_path / "song.mp3"
         music.write_bytes(b"audio")
-        result = resolve_music_file(
+        result = resolve_music(
             config=Config(),
             music_path=music,
             no_music=False,
@@ -2259,12 +2265,12 @@ class TestResolveMusicFile:
             run_output_dir=tmp_path,
             memory_type=None,
         )
-        assert result == music
+        assert result.path == music
 
     def test_explicit_path_nonexistent_returns_none(self, tmp_path):
-        from immich_memories.generate_music import resolve_music_file
+        from immich_memories.generate_music import resolve_music
 
-        result = resolve_music_file(
+        result = resolve_music(
             config=Config(),
             music_path=tmp_path / "nonexistent.mp3",
             no_music=False,
@@ -2272,10 +2278,10 @@ class TestResolveMusicFile:
             run_output_dir=tmp_path,
             memory_type=None,
         )
-        assert result is None
+        assert result.path is None
 
     def test_auto_generate_when_no_path_and_config_available(self, tmp_path):
-        from immich_memories.generate_music import resolve_music_file
+        from immich_memories.generate_music import resolve_music
 
         config = Config()
         calls = []
@@ -2292,7 +2298,7 @@ class TestResolveMusicFile:
             def report_fn(p, pct, m):
                 return calls.append((p, pct, m))
 
-            result = resolve_music_file(
+            result = resolve_music(
                 config=config,
                 music_path=None,
                 no_music=False,
@@ -2303,16 +2309,16 @@ class TestResolveMusicFile:
             )
 
         mock_gen.assert_called_once()
-        assert result == tmp_path / "generated.mp3"
+        assert result.path == tmp_path / "generated.mp3"
         # report_fn should have been called with music progress
         assert any(c[0] == "music" for c in calls)
 
     def test_no_path_no_config_and_no_bundle_returns_none(self, tmp_path):
-        from immich_memories.generate_music import resolve_music_file
+        from immich_memories.generate_music import resolve_music
 
         # WHY: music_config_available checks external service configs
         with patch("immich_memories.generate_music.music_config_available", return_value=False):
-            result = resolve_music_file(
+            result = resolve_music(
                 config=Config(),
                 music_path=None,
                 no_music=False,
@@ -2322,7 +2328,7 @@ class TestResolveMusicFile:
                 bundled_library=tmp_path / "no-bundle",
             )
         # Silent only when there is no bundled music to fall back to (#308).
-        assert result is None
+        assert result.path is None
 
 
 class TestClipMonthFromDate:

--- a/tests/test_music_bundled_fallback.py
+++ b/tests/test_music_bundled_fallback.py
@@ -1,7 +1,7 @@
 """A failing generator must fall back to the bundled track, not to silence.
 
 Configuring a generator currently makes the failure mode worse than not
-configuring one: with none configured `resolve_music_file` returns a bundled
+configuring one: with none configured `resolve_music` returns a bundled
 track, but with ACE-Step enabled and unreachable the exception unwinds past
 that branch and the whole music phase is abandoned. The run exits 0 with a
 silent video, and under `--quiet` nothing surfaces.
@@ -13,11 +13,26 @@ than the bundled-music row — with an empty music/ directory.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from immich_memories.config_loader import Config
-from immich_memories.generate_music import resolve_music_file
+from immich_memories.generate import GenerationParams
+from immich_memories.generate_music import resolve_music
+from immich_memories.processing.encoding_plan import EncodingPlan, HdrTransfer, OutputCodec
+
+
+def _h264_plan() -> EncodingPlan:
+    return EncodingPlan(
+        codec=OutputCodec.H264,
+        encoder="libx264",
+        encoder_args=("-c:v", "libx264"),
+        target_transfer=HdrTransfer.NONE,
+        tone_map_to_sdr=False,
+        pixel_format="yuv420p",
+        container="mp4",
+    )
 
 
 def _library(tmp_path: Path) -> Path:
@@ -45,7 +60,7 @@ def test_a_failing_generator_falls_back_to_the_bundled_track(
 
     monkeypatch.setattr("immich_memories.generate_music.auto_generate_music", unreachable)
 
-    result = resolve_music_file(
+    result = resolve_music(
         generator_enabled,
         None,
         no_music=False,
@@ -55,15 +70,75 @@ def test_a_failing_generator_falls_back_to_the_bundled_track(
         bundled_library=_library(tmp_path),
     )
 
-    assert result is not None, "a failed generator must not produce silence"
-    assert result.suffix == ".mp3"
+    assert result.path is not None, "a failed generator must not produce silence"
+    assert result.path.suffix == ".mp3"
+
+
+def test_the_bundled_substitution_is_reported_not_swallowed(
+    tmp_path: Path, generator_enabled: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Silently succeeding on bundled music hides a dead backend indefinitely."""
+
+    # WHY: stands in for the ACE-Step backend, unreachable as on a fresh enable.
+    def unreachable(*args: object, **kwargs: object) -> Path:
+        raise ConnectionError("All connection attempts failed")
+
+    monkeypatch.setattr("immich_memories.generate_music.auto_generate_music", unreachable)
+
+    result = resolve_music(
+        generator_enabled,
+        None,
+        no_music=False,
+        assembly_clips=[],
+        run_output_dir=tmp_path,
+        memory_type=None,
+        bundled_library=_library(tmp_path),
+    )
+
+    assert result.warning is not None
+    assert "All connection attempts failed" in result.warning
+    assert "bundled" in result.warning
+
+
+def test_a_bundled_substitution_still_warns_the_finished_run(
+    tmp_path: Path, generator_enabled: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Applied music with a warning, not silent success: the artifact carries it."""
+    from immich_memories.generate_music import MusicSelection
+    from immich_memories.generate_settings import _run_music_phase
+
+    base_video = tmp_path / "memory.mp4"
+    base_video.write_bytes(b"validated-base")
+    track = _library(tmp_path) / "happy" / "track.mp3"
+    warning = "Optional music failed: unreachable; used a bundled track instead"
+
+    # WHY: replaces the resolver's generator call and library read, which need a
+    # backend and the installed music package.
+    monkeypatch.setattr(
+        "immich_memories.generate_music.resolve_music",
+        lambda **_kwargs: MusicSelection(track, warning),
+    )
+    # WHY: replaces the FFmpeg mix and republication of the base artifact.
+    monkeypatch.setattr("immich_memories.generate_music.apply_music_file", MagicMock())
+
+    result = _run_music_phase(
+        GenerationParams(clips=[], output_path=base_video, config=generator_enabled),
+        [],
+        base_video,
+        tmp_path,
+        MagicMock(),
+        encoding_plan=_h264_plan(),
+    )
+
+    assert result.applied is True
+    assert result.warning == warning
 
 
 def test_an_explicit_missing_track_is_still_a_user_error(
     tmp_path: Path, generator_enabled: Config
 ) -> None:
     """Substituting bundled music for a typo'd --music path would hide the typo."""
-    result = resolve_music_file(
+    result = resolve_music(
         generator_enabled,
         tmp_path / "absent.mp3",
         no_music=False,
@@ -73,11 +148,11 @@ def test_an_explicit_missing_track_is_still_a_user_error(
         bundled_library=_library(tmp_path),
     )
 
-    assert result is None
+    assert result.path is None
 
 
 def test_no_music_still_means_no_music(tmp_path: Path, generator_enabled: Config) -> None:
-    result = resolve_music_file(
+    result = resolve_music(
         generator_enabled,
         None,
         no_music=True,
@@ -87,4 +162,4 @@ def test_no_music_still_means_no_music(tmp_path: Path, generator_enabled: Config
         bundled_library=_library(tmp_path),
     )
 
-    assert result is None
+    assert result.path is None

--- a/tests/test_music_output_paths.py
+++ b/tests/test_music_output_paths.py
@@ -1477,7 +1477,7 @@ def test_music_resolution_failure_is_optional_and_sanitized(tmp_path: Path) -> N
     tracker = MagicMock()
 
     with patch(
-        "immich_memories.generate_music.resolve_music_file",
+        "immich_memories.generate_music.resolve_music",
         side_effect=RuntimeError("api_key=top-secret backend unavailable"),
     ):
         result = _run_music_phase(
@@ -1531,12 +1531,12 @@ def test_optional_music_logs_never_include_raw_backend_secret(
         )
 
     # A generator failure no longer ends the phase — it falls through to a
-    # bundled track (#422) — so the sanitized backend warning lands in the log
-    # rather than in the phase result. The property under test is that the raw
-    # secret reaches neither, whatever the phase ends on.
+    # bundled track (#422) — but the substitution is still reported (#515), so
+    # the sanitized warning has to reach both the log and the phase result.
     assert "Optional music failed: backend rejected ***" in caplog.text
     assert "top-secret" not in caplog.text
-    assert result.warning is None or "top-secret" not in result.warning
+    assert result.warning is not None
+    assert "top-secret" not in result.warning
 
 
 def test_music_phase_passes_exact_encoding_plan_to_publication(tmp_path: Path) -> None:

--- a/tests/test_track_tempo.py
+++ b/tests/test_track_tempo.py
@@ -2,7 +2,7 @@
 
 #312's first half asks a generator for a beat-aligned tempo. A bundled track
 cannot be asked — its tempo is already fixed — so the choice has to run the
-other way: measure what ships, then pick the one that lands on the cadence.
+other way: measure what ships, then pick from the ones that land on the cadence.
 
 Detection is numpy + ffmpeg on purpose. librosa is present in this venv only as
 a transitive dependency of an extra, so importing it would fail `make dep-check`
@@ -59,6 +59,51 @@ def test_the_track_whose_beat_divides_the_cadence_wins(tmp_path: Path) -> None:
     chosen = track_for_cadence([poor, good], cadence_seconds=4.0)
 
     assert chosen == good
+
+
+def _tracks_at(tmp_path: Path, bpms: dict[str, float], monkeypatch) -> list[Path]:
+    """Tracks with stated tempos — the gate is under test, not the measurement.
+
+    Real click tracks cannot express "0.3 beats off" precisely enough to sit on
+    either side of the tolerance on purpose, because detection quantizes to
+    whole autocorrelation lags.
+    """
+    paths = {}
+    for name, bpm in bpms.items():
+        path = tmp_path / name
+        path.write_bytes(b"")
+        paths[path] = bpm
+
+    # WHY: replaces the FFmpeg decode and autocorrelation, so each track's tempo
+    # is a stated fact rather than something the fixture has to synthesize.
+    monkeypatch.setattr(
+        "immich_memories.audio.track_tempo.detect_bpm", lambda path: paths.get(path)
+    )
+    return list(paths)
+
+
+def test_every_track_that_lands_on_the_cadence_is_a_candidate(tmp_path: Path, monkeypatch) -> None:
+    """Returning the single best fit makes every repeat of a memory sound the same."""
+    tracks = _tracks_at(tmp_path, {"a.opus": 120.0, "b.opus": 90.0, "c.opus": 150.0}, monkeypatch)
+
+    picks = {track_for_cadence(tracks, cadence_seconds=4.0) for _ in range(40)}
+
+    assert picks == set(tracks), "all three land on whole beats at 4s"
+
+
+def test_a_track_that_misses_the_beat_is_not_a_candidate(tmp_path: Path, monkeypatch) -> None:
+    tracks = _tracks_at(tmp_path, {"fits.opus": 120.0, "misses.opus": 97.0}, monkeypatch)
+
+    picks = {track_for_cadence(tracks, cadence_seconds=4.0) for _ in range(40)}
+
+    assert picks == {tracks[0]}
+
+
+def test_nothing_on_the_beat_defers_to_the_callers_own_choice(tmp_path: Path, monkeypatch) -> None:
+    """None means "no opinion", which is what makes the caller fall back to random."""
+    tracks = _tracks_at(tmp_path, {"a.opus": 97.0, "b.opus": 113.0}, monkeypatch)
+
+    assert track_for_cadence(tracks, cadence_seconds=4.0) is None
 
 
 def test_no_candidates_is_not_an_error() -> None:


### PR DESCRIPTION
Three ways the bundled-music fallback was lying about what it did. One concern, so one PR.

## The generator fails and nobody hears about it (#515)

`resolve_music_file()` caught a generator failure, logged a warning, and returned the bundled track as a plain `Path`. `MusicPhaseResult.warning` stayed `None`, so the run artifact, the UI ("Music ready") and the nightly auto-runner — which notifies on run warnings, not log lines — all reported plain success. A dead ACE-Step API or a missing package was invisible indefinitely: you heard bundled tracks forever while believing generated music worked.

The resolver now returns a `MusicSelection` carrying the track *and* the substitution warning, and the music phase passes that warning into `MusicPhaseResult` even when music was applied. Renamed to `resolve_music()` since it no longer returns a file.

Restores the strict assertion in `tests/test_music_output_paths.py` that had been weakened to `result.warning is None or ...` to let the old behavior through.

## The same song, forever (#516)

`_BEAT_TOLERANCE` was defined and never read. `track_for_cadence` returned the minimum-misfit track unconditionally, logging that a 0.49-beats-off track "fits", so any memory with two or more photos got the identical bundled track for its mood on every run — defeating the documented "at random so repeats differ".

Tracks within the tolerance are now the candidate set, the pick among them is random, and nothing near enough returns `None`, which is what makes the caller fall back to its own random choice.

**One judgement call worth reviewing.** Applying 0.12 as written breaks cadence matching entirely, so I widened it to 0.2. I measured this rather than guessed:

| built at | measures | misfit @ 4 s cadence |
| --- | --- | --- |
| 120 bpm | 117.5 | 0.167 |
| 110 bpm | 107.7 | 0.180 |
| 90 bpm | 92.3 | 0.153 |
| 100 bpm | 99.4 | 0.373 (a genuine miss) |

The onset envelope quantizes the beat period to whole 23 ms frames, so a track that *truly* lands on a 4 s cadence still measures up to ~0.18 beats off — under a 0.12 gate a 120 bpm track can never qualify at any cadence between 3 s and 5 s, and the existing tempo tests fail. 0.2 sits above the detector's noise and still separates a real fit from a real miss. I tried parabolic interpolation of the autocorrelation peak first; it does not help, because the error is the hop size, not the peak fit. Narrowing the tolerance needs a finer onset hop, which is a separate change — the constant says so.

## Five mood folders nobody could reach (#497)

`_mood_for_clips` read `getattr(clip, "mood", None)`, and `AssemblyClip` has never had a `mood` field — it carries `llm_emotion`. Mood was therefore always `None` and bundled selection always drew from the flat pool, so the mood organization shipped in #308/#364 was inert.

Selection now reuses `aggregate_mood_from_clips`, which the title stack already uses to turn per-clip emotions into a dominant mood family. Families wider than the five shipped folders borrow their closest neighbour: playful draws from happy, peaceful from calm, exciting from energetic, romantic from tender. Every emotion the analysis prompt asks the vision LLM for (`happy, calm, excited, playful, joyful, peaceful`) now lands on a real folder, and that prompt-to-folder contract is a test — it was exactly the seam that rotted silently.

## Tests

TDD throughout; every test below was confirmed RED first.

- The bundled substitution is reported, not swallowed — at the resolver, and again at the phase result where `applied=True` must still carry the warning.
- Both tolerance branches: every track that lands on the cadence is a candidate (the pick varies across repeats), and nothing on the beat returns `None`.
- A mood-carrying clip set selects from the matching folder; no emotion still draws from the whole library; the prompt's emotion vocabulary maps to shipped folders.

Two of the mood tests assert over 20-30 repeats rather than one draw: a mood-blind pick lands in the right folder by chance one time in three, so a single-draw assertion passed against the *unfixed* code. I caught that and tightened it.

`make ci`: passing — 5457 passed, 9 skipped. `make critique` reports nothing against the touched files. Docs updated (`audio-and-music.md`, `pipeline-overview.md`) and `make docs-build` passes.

Closes #515, Closes #516, Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
