### PR TITLE
fix(selection): judge a photo on the scale its score was built on

### DIFF
--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -540,12 +540,39 @@ class SmartPipeline:
         result = self.refiner.phase_refine(analyzed, self.tracker)
         return result, analyzed, True
 
+    def _floor_for(self, member: ClipWithSegment) -> float:
+        """The gate this clip answers to, on the scale its score was built on.
+
+        photos.score_penalty says outright that a photo scores a fixed share
+        of a video, so a floor calibrated on footage is that much too high for
+        a still. A no-people, non-favorite photo tops out at 0.15 base + 0.05
+        camera + half the LLM weight — 0.28 after the penalty, against a floor
+        of 0.30. Landscapes, pets and scenery could not clear it at all, and
+        were dropped as a class along with any day only they represented.
+        """
+        from immich_memories.analysis.source_filter import is_a_still
+
+        floor = self.config.judge_floor_score
+        if not is_a_still(member.clip.asset):
+            return floor
+        return floor * (1.0 - self._app_config.photos.score_penalty)
+
     def _judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
         """Members failing the gate. Favorites are exempt from both rules —
         the user explicitly chose them, and "Starting with ALL favorites" is
-        the selection's oldest contract."""
-        judgeable = [s for s in selected if not getattr(s.clip.asset, "is_favorite", False)]
-        offenders = {s.clip.asset.id for s in judgeable if s.score < self.config.judge_floor_score}
+        the selection's oldest contract.
+
+        Coverage is deliberately NOT exempt here, though every later drop site
+        spares it. Both readings of "spare what covers a period" switch the
+        judge off under ordinary conditions: on a pool with no favorites the
+        coverage ids are every clip picked from the densest periods, and a
+        selection distributed across time — which is the goal — makes almost
+        every clip the only one of its day. A gate that never fires is worse
+        than the gate being blunt, and the blunt part was the scale (#508).
+        """
+        spared = {s.clip.asset.id for s in selected if getattr(s.clip.asset, "is_favorite", False)}
+        judgeable = [s for s in selected if s.clip.asset.id not in spared]
+        offenders = {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}
         scores = [s.score for s in selected]
         mean_score = sum(scores) / len(scores)
         ending = max(
@@ -554,7 +581,7 @@ class SmartPipeline:
         )
         if (
             len(selected) > 2
-            and not getattr(ending.clip.asset, "is_favorite", False)
+            and ending.clip.asset.id not in spared
             and ending.score == min(scores)
             and ending.score < mean_score * self.config.judge_boundary_ratio
         ):

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -146,6 +146,12 @@ class ClipWithSegment:
     analyzed: bool = True
 
 
+# Below this share of the judge's floor a clip is not weak but unusable — a
+# pocket, the ground, somebody's feet — and no amount of being the only thing
+# from its day makes it worth shipping.
+_UNUSABLE_SHARE_OF_FLOOR = 1.0 / 3.0
+
+
 class SmartPipeline:
     """Smart pipeline for one-click memory generation.
 
@@ -557,22 +563,71 @@ class SmartPipeline:
             return floor
         return floor * (1.0 - self._app_config.photos.score_penalty)
 
+    def _spare_last_voices(
+        self,
+        offenders: set[str],
+        selected: list[ClipWithSegment],
+    ) -> set[str]:
+        """Offenders to actually drop, keeping any that is a period's last voice.
+
+        The judge removes offenders from the pool for good, so read as "this
+        clip is bad" its verdict costs a month whose only clip scored low. Read
+        as "we can do better than this clip" it costs nothing, because when
+        there is nothing better the clip stays.
+
+        Unusable is different from weak, and the distinction is what makes this
+        safe: a shot of the ground or a pocket is not worth a month, and stays
+        dropped however alone it is. Only a clip that would pass on any other
+        day is worth keeping for lack of an alternative.
+
+        A correction, not an exemption. Exempting has to guess in advance which
+        clips carry a period, and both ways of guessing that switch the gate
+        off under ordinary conditions — coverage ids are every clip on a pool
+        with no favorites, and a distributed selection makes almost every clip
+        the only one of its day.
+        """
+        from immich_memories.analysis.clip_distribution import _period_key, span_days_of
+
+        unusable = self.config.judge_floor_score * _UNUSABLE_SHARE_OF_FLOOR
+        span = span_days_of(selected)
+
+        def period_of(member: ClipWithSegment) -> str | None:
+            when = member.clip.asset.file_created_at
+            return _period_key(when, span) if when else None
+
+        surviving = {period_of(m) for m in selected if m.clip.asset.id not in offenders}
+        spared = {
+            m.clip.asset.id
+            for m in selected
+            if m.clip.asset.id in offenders
+            and m.score >= unusable
+            and period_of(m) not in surviving
+        }
+        if spared:
+            logger.info(
+                "Judge: keeping %d weak clip(s) — nothing else covers their period",
+                len(spared),
+            )
+        return offenders - spared
+
     def _judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
         """Members failing the gate. Favorites are exempt from both rules —
         the user explicitly chose them, and "Starting with ALL favorites" is
         the selection's oldest contract.
 
-        Coverage is deliberately NOT exempt here, though every later drop site
-        spares it. Both readings of "spare what covers a period" switch the
-        judge off under ordinary conditions: on a pool with no favorites the
-        coverage ids are every clip picked from the densest periods, and a
-        selection distributed across time — which is the goal — makes almost
-        every clip the only one of its day. A gate that never fires is worse
-        than the gate being blunt, and the blunt part was the scale (#508).
+        What carries a period is handled after this rather than here — see
+        _spare_last_voices. Exempting up front needs a guess about which clips
+        carry a period, and every way of guessing switches the gate off.
         """
         spared = {s.clip.asset.id for s in selected if getattr(s.clip.asset, "is_favorite", False)}
         judgeable = [s for s in selected if s.clip.asset.id not in spared]
-        offenders = {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}
+        # Sparing applies to the floor rule only. The ending rule below is
+        # about where a clip sits, not whether it is worth keeping — a clip
+        # dropped for being a weak last note is fine anywhere else, and
+        # keeping it for lack of an alternative would defeat the rule.
+        offenders = self._spare_last_voices(
+            {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}, selected
+        )
         scores = [s.score for s in selected]
         mean_score = sum(scores) / len(scores)
         ending = max(

--- a/tests/test_judge_gate.py
+++ b/tests/test_judge_gate.py
@@ -94,3 +94,39 @@ def test_a_selection_spread_across_time_is_still_judged(tmp_path: Path) -> None:
     offenders = _pipeline(tmp_path)._judge_offenders([junk, *spread])
 
     assert "junk" in offenders
+
+
+def _in(month: int, day: int, member: ClipWithSegment) -> ClipWithSegment:
+    member.clip.asset.file_created_at = datetime(2019, month, day, 12, tzinfo=UTC)
+    return member
+
+
+def test_an_offender_is_dropped_when_its_period_has_something_better(tmp_path: Path) -> None:
+    """The gate is not "this clip is bad", it is "we can do better than this"."""
+    weak = _in(3, 2, _member("weak", 0.24, photo=False))
+    better = _in(3, 9, _member("same-month-better", 0.7, photo=False))
+    elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
+
+    dropped = _pipeline(tmp_path)._spare_last_voices({"weak"}, [weak, better, *elsewhere])
+
+    assert dropped == {"weak"}
+
+
+def test_a_weak_clip_that_is_its_period_is_kept(tmp_path: Path) -> None:
+    """Dropping it loses the month, and the judge purges for good."""
+    only_march = _in(3, 2, _member("the-only-march", 0.24, photo=False))
+    elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
+
+    dropped = _pipeline(tmp_path)._spare_last_voices({"the-only-march"}, [only_march, *elsewhere])
+
+    assert dropped == set()
+
+
+def test_an_unusable_clip_is_never_worth_a_period(tmp_path: Path) -> None:
+    """A pocket, the ground, somebody's feet. Being alone does not redeem it."""
+    ground = _in(3, 2, _member("the-ground", 0.05, photo=False))
+    elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
+
+    dropped = _pipeline(tmp_path)._spare_last_voices({"the-ground"}, [ground, *elsewhere])
+
+    assert dropped == {"the-ground"}

--- a/tests/test_judge_gate.py
+++ b/tests/test_judge_gate.py
@@ -1,0 +1,96 @@
+"""The mechanical judge sees scores, and a photo's score is on another scale.
+
+photos.score_penalty documents the difference outright — "photos score 80% of
+videos" — and the judge applied a video-calibrated floor to both. A no-people,
+non-favorite photo cannot clear it: 0.15 base + 0.05 camera + half the LLM
+weight is 0.28 after the penalty, against a floor of 0.30. Landscapes, pets
+and scenery were dropped as a class, and the days only they represented went
+with them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig, SmartPipeline
+from immich_memories.api.models import AssetType
+from immich_memories.config import Config
+from immich_memories.config_models import AnalysisConfig
+from tests.conftest import make_clip
+
+
+def _pipeline(tmp_path: Path) -> SmartPipeline:
+    return SmartPipeline(
+        client=MagicMock(),
+        analysis_cache=MagicMock(),
+        thumbnail_cache=MagicMock(),
+        config=PipelineConfig(),
+        analysis_config=AnalysisConfig(),
+        app_config=Config(cache={"directory": str(tmp_path / "cache")}),
+    )
+
+
+def _member(asset_id: str, score: float, *, photo: bool, hour: int = 12) -> ClipWithSegment:
+    clip = make_clip(
+        asset_id, duration=5.0, file_created_at=datetime(2019, 6, 12, hour, tzinfo=UTC)
+    )
+    if photo:
+        clip.asset.type = AssetType.IMAGE
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=score)
+
+
+def test_a_landscape_nobody_has_looked_at_yet_is_not_an_offender(tmp_path: Path) -> None:
+    """0.280 is what a no-people photo scores before the VLM has an opinion.
+
+    Silence is not a verdict, and this one was being read as one.
+    """
+    quiet_landscape = _member("landscape", 0.280, photo=True)
+    others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
+
+    offenders = _pipeline(tmp_path)._judge_offenders([quiet_landscape, *others])
+
+    assert "landscape" not in offenders
+
+
+def test_a_photo_the_model_called_dull_is_still_an_offender(tmp_path: Path) -> None:
+    """0.232 is a photo the VLM actively scored 0.3. That is a verdict."""
+    dull = _member("dull", 0.232, photo=True)
+    others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
+
+    offenders = _pipeline(tmp_path)._judge_offenders([dull, *others])
+
+    assert "dull" in offenders
+
+
+def test_a_weak_video_is_still_judged_on_the_video_scale(tmp_path: Path) -> None:
+    """Nothing about this loosens the gate for footage."""
+    weak = _member("weak-video", 0.28, photo=False)
+    others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
+
+    offenders = _pipeline(tmp_path)._judge_offenders([weak, *others])
+
+    assert "weak-video" in offenders
+
+
+def test_a_selection_spread_across_time_is_still_judged(tmp_path: Path) -> None:
+    """The judge must not be talked out of firing by temporal distribution.
+
+    Sparing "whatever covers a period" reads well and switches the gate off:
+    a distributed selection — the goal — makes almost every clip the only one
+    of its day, and on a pool with no favorites the coverage ids are every
+    clip picked. Both were tried; a gate that never fires is worse than a
+    blunt one.
+    """
+    junk = _member("junk", 0.05, photo=False)
+    junk.clip.asset.file_created_at = datetime(2019, 3, 2, 12, tzinfo=UTC)
+    spread = []
+    for index in range(3):
+        member = _member(f"v-{index}", 0.6, photo=False)
+        member.clip.asset.file_created_at = datetime(2019, 6 + index, 4, 12, tzinfo=UTC)
+        spread.append(member)
+
+    offenders = _pipeline(tmp_path)._judge_offenders([junk, *spread])
+
+    assert "junk" in offenders


### PR DESCRIPTION
Closes #508.

`judge_floor_score` is 0.30, calibrated on video scores, and applied to the unified pool. `photos.score_penalty` states outright that a photo scores a fixed share of a video, so that floor is exactly that much too high for a still — and a no-people, non-favorite photo cannot reach it at all.

| photo | score | vs floor 0.30 |
|---|---|---|
| no people, not looked at yet | 0.280 | dropped |
| no people, model said 0.8 | 0.352 | kept |
| no people, model said 0.3 | 0.232 | dropped |

Landscapes, pets and scenery were dropped as a class, and every day represented only by one went with them. The floor now scales the way the scores do, derived from the penalty the config already declares rather than a second number to keep in step.

## The coverage half needed a different shape

The issue also asks the judge to honour coverage protections. Exempting cannot work, and both readings were tried:

- **exempt the coverage ids** — on a pool with no favorites those are every clip picked from the densest periods
- **exempt the sole clip of a period** — a selection distributed across time makes almost every clip the only one of its day

Both switch the gate off under ordinary conditions; three integration tests caught each attempt.

The second commit does it as a **correction instead of an exemption**: drop as before, then keep any offender whose period nothing else speaks for. Same information, opposite direction — and being wrong here keeps a clip that would otherwise be lost, which is the safe way to be wrong. Two boundaries keep it honest: below a third of the floor a clip is unusable rather than weak (a pocket, the ground) and stays dropped however alone it is; and it applies to the floor rule only, since the ending rule is about where a clip sits rather than whether it is worth keeping.

`make ci` green, diff coverage passing.