### PR TITLE
fix(selection): make the review say which of its five silences this was

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -139,25 +139,38 @@ def review_selection(
     *,
     timeout_seconds: int = 45,
 ) -> list[str]:
-    """Asset ids the LLM says to drop from the selection; [] on any doubt."""
+    """Asset ids the LLM says to drop from the selection; [] on any doubt.
+
+    Every outcome here says which one it was. The pass is fail-open by design
+    — a model that cannot answer must not be able to gut a memory — and that
+    made "the model read the set and approved it" identical to "the model
+    returned an empty string": both an empty list and both silent. A rendered
+    year recap came back with 38 clips and no drop lines, which reads as a
+    clean cut and was a broken call.
+    """
     if len(selected) < 3:
+        logger.debug("Selection review: %d clips is too few to judge as a set", len(selected))
         return []
     clips_block = "\n".join(_clip_line(i + 1, m) for i, m in enumerate(selected))
     prompt = _PROMPT.format(clips=clips_block)
     try:
         raw = _ask(prompt, llm_config, timeout_seconds)
     except Exception as e:  # WHY broad: the review is optional; never break selection
-        logger.debug("Selection review skipped: %s", e)
+        logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
         return []
 
-    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    match = re.search(r"\{.*\}", raw, re.DOTALL) if raw else None
     if not match:
+        logger.warning("Selection review returned no verdict (%d chars): nothing dropped", len(raw))
         return []
     try:
         payload = json.loads(match.group(0))
         entries = payload.get("drop", [])
         indices = [int(e["index"]) for e in entries if "index" in e]
-    except (json.JSONDecodeError, TypeError, ValueError, KeyError):
+    except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+        logger.warning(
+            "Selection review answer could not be read (%s): nothing dropped", type(e).__name__
+        )
         return []
 
     max_drops = max(1, int(len(selected) * _MAX_DROP_RATIO))
@@ -173,4 +186,6 @@ def review_selection(
             entry.get("index"),
             entry.get("reason", "no reason given"),
         )
+    if not drops:
+        logger.info("Selection review: read %d clips as a set, nothing to drop", len(selected))
     return drops

--- a/tests/test_selection_review.py
+++ b/tests/test_selection_review.py
@@ -134,3 +134,76 @@ class TestReviewThinksWhenTheServerCan:
             review_selection(_selection(), config)
 
         assert mock_post.call_args[1]["json"]["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+class TestSilenceIsNotApproval:
+    """Five outcomes all returned [] and only one of them said anything.
+
+    A rendered year recap came back with 38 clips and no drop lines, which
+    reads as "the model looked and approved". It had returned an empty
+    string. The pass is fail-open by design so a broken model cannot gut a
+    memory, and that is exactly what makes the two indistinguishable.
+    """
+
+    def test_a_reviewed_and_approved_cut_says_so(self, caplog):
+        import logging
+
+        # WHY: the LLM is the external boundary; here it approves the set.
+        with (
+            patch(
+                "immich_memories.analysis.selection_review._ask",
+                return_value='{"drop": []}',
+            ),
+            caplog.at_level(logging.INFO, logger="immich_memories.analysis.selection_review"),
+        ):
+            drops = review_selection(_selection(), LLMConfig())
+
+        assert drops == []
+        assert any(
+            record.levelno == logging.INFO and "nothing to drop" in record.message
+            for record in caplog.records
+        ), f"an approved cut said nothing: {[r.message for r in caplog.records]}"
+
+    def test_a_review_that_could_not_run_warns(self, caplog):
+        """An unreachable or silent model is a degraded run, not a verdict."""
+        import logging
+
+        # WHY: the LLM is the external boundary; here it answers with nothing.
+        with (
+            patch("immich_memories.analysis.selection_review._ask", return_value=""),
+            caplog.at_level(logging.DEBUG, logger="immich_memories.analysis.selection_review"),
+        ):
+            drops = review_selection(_selection(), LLMConfig())
+
+        assert drops == []
+        assert any(record.levelno >= logging.WARNING for record in caplog.records), (
+            f"a review that never ran looked like approval: {[r.message for r in caplog.records]}"
+        )
+
+    def test_an_answer_that_will_not_parse_warns(self, caplog):
+        """Braces the model could not fill are a failure, not an approval."""
+        import logging
+
+        # WHY: the LLM is the external boundary; here its answer is malformed.
+        with (
+            patch(
+                "immich_memories.analysis.selection_review._ask",
+                return_value='here you go: {"drop": [oops}',
+            ),
+            caplog.at_level(logging.DEBUG, logger="immich_memories.analysis.selection_review"),
+        ):
+            drops = review_selection(_selection(), LLMConfig())
+
+        assert drops == []
+        assert any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    def test_a_cut_too_small_to_judge_as_a_set_is_not_a_failure(self, caplog):
+        """Two clips are not a set, and saying so is not worth a warning."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="immich_memories.analysis.selection_review"):
+            drops = review_selection(_selection()[:2], LLMConfig())
+
+        assert drops == []
+        assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+        assert any("too few" in record.message for record in caplog.records)


### PR DESCRIPTION
`review_selection` is fail-open by design: a model that cannot answer must not be able to gut a memory. Five different outcomes returned an empty list — too few clips, an unreachable model, no JSON in the answer, an answer that would not parse, and the model reading the set and approving it — and only one of them logged anything, at DEBUG.

So *"the review looked and found nothing wrong"* and *"the review never ran"* produced the same output: none.

Found the hard way during #493 validation: a year recap came back with 38 clips and no drop lines, which reads as a clean cut and was an empty string from the model. Diagnosing it cost a pass, and the workaround was to go and grep for an absence.

Each outcome now says which one it was:

- a review that **could not run** warns — a degraded run is worth noticing
- a review that **ran and approved** the set says so — that is a verdict and should look like one
- a cut **too small to judge as a set** stays at debug — it is neither

Diff coverage 100% on the change; all five outcomes have a test.