### PR TITLE
fix(titles): ceiling HDR title text at HLG graphics white

### DIFF
--- a/src/immich_memories/titles/colors.py
+++ b/src/immich_memories/titles/colors.py
@@ -142,6 +142,42 @@ def ensure_minimum_brightness(
     return brighten_color(rgb, factor)
 
 
+# HLG graphics white — 0xBF, 75% of full range. Measured on the 10-bit pipe: text
+# drawn at plain white lands at 872/1023, above the diffuse white of the picture
+# behind it, so it glows on an HDR display; ceilinged it lands at 721. Same value
+# the per-clip date captions use (processing/clip_caption.py).
+HDR_GRAPHICS_WHITE = 0xBF
+
+# Above this, a colour is carrying real hue — an accent that happens to be bright,
+# not a white. Off-whites in the palettes sit well under it (#E0F2FE is 0.12).
+_NEUTRAL_SATURATION = 0.15
+
+
+def ceil_rgb_for_hdr(rgb: tuple[int, int, int]) -> tuple[int, int, int]:
+    """Bring a white or near-white down to HLG graphics white.
+
+    Graphics rendered at full white sit above the diffuse white of the HDR
+    picture behind them, so title text glows rather than reads as paper white.
+    A colour carrying real hue comes back untouched — this is a ceiling on
+    whites, not a global dimmer — as does anything already below the ceiling.
+    Tinted whites keep their tint: every channel scales by the same factor.
+    """
+    r, g, b = rgb
+    peak = max(r, g, b)
+    if peak <= HDR_GRAPHICS_WHITE:
+        return rgb
+    if (peak - min(r, g, b)) / peak > _NEUTRAL_SATURATION:
+        return rgb
+
+    scale = HDR_GRAPHICS_WHITE / peak
+    return (round(r * scale), round(g * scale), round(b * scale))
+
+
+def ceil_white_for_hdr(hex_color: str) -> str:
+    """`ceil_rgb_for_hdr` for the renderers that carry colours as hex strings."""
+    return rgb_to_hex(ceil_rgb_for_hdr(hex_to_rgb(hex_color)))
+
+
 def quantize_colors(
     colors: list[tuple[int, int, int]],
     num_clusters: int = 8,

--- a/src/immich_memories/titles/map_animation.py
+++ b/src/immich_memories/titles/map_animation.py
@@ -18,6 +18,7 @@ from staticmap import CircleMarker, StaticMap
 from immich_memories.processing.encoding_plan import EncodingPlan
 from immich_memories.titles.ffmpeg_pipe import StderrDrain
 
+from .colors import ceil_rgb_for_hdr
 from .encoding import standalone_title_encoding_plan, title_color_filter, title_encoder_args
 from .map_renderer import _draw_gradient_band, _overlay_composite, _wrap_text
 
@@ -53,6 +54,8 @@ class _FlyConfig:
     width: int = 1920
     height: int = 1080
     dest_zoom: float = 9.0  # zoom level at destination (pins reference size)
+    # Graphics drawn straight onto the tiles, so they need the HDR ceiling (#506)
+    hdr: bool = False
 
 
 _tile_cache: dict[str, bytes] = {}
@@ -204,12 +207,10 @@ def _draw_pins(
     cam_lat: float,
     cam_lon: float,
     zoom: float,
-    pins: list[_PinData],
-    dest_zoom: float,
-    w: int,
-    h: int,
+    cfg: _FlyConfig,
 ) -> Image.Image:
     """Draw destination pins + city labels, fading in near destination zoom."""
+    pins, dest_zoom, w, h = cfg.pins, cfg.dest_zoom, cfg.width, cfg.height
     if not pins:
         return frame
     pin_alpha = max(0.0, min(1.0, (zoom - dest_zoom + 2.5) / 2.5))
@@ -224,6 +225,7 @@ def _draw_pins(
     font = _get_font(max(12, int(min(w, h) * 0.022)), bold=True)
     a_w, a_f = int(200 * pin_alpha), int(230 * pin_alpha)
     a_l, a_s = int(220 * pin_alpha), int(140 * pin_alpha)
+    white = ceil_rgb_for_hdr((255, 255, 255)) if cfg.hdr else (255, 255, 255)
 
     for pin in pins:
         sx, sy = _geo_to_screen(pin.lat, pin.lon, cam_lat, cam_lon, zoom, w, h)
@@ -231,7 +233,7 @@ def _draw_pins(
         if sx < -margin or sx > w + margin or sy < -margin or sy > h + margin:
             continue
         r_out = base_r + 3
-        draw.ellipse((sx - r_out, sy - r_out, sx + r_out, sy + r_out), fill=(255, 255, 255, a_w))
+        draw.ellipse((sx - r_out, sy - r_out, sx + r_out, sy + r_out), fill=(*white, a_w))
         draw.ellipse((sx - base_r, sy - base_r, sx + base_r, sy + base_r), fill=(232, 93, 74, a_f))
 
         if pin.name:
@@ -239,7 +241,7 @@ def _draw_pins(
             lx = sx - (bbox[2] - bbox[0]) // 2
             ly = sy - r_out - getattr(font, "size", 14) - 6
             draw.text((lx + 1, ly + 1), pin.name, fill=(0, 0, 0, a_s), font=font)
-            draw.text((lx, ly), pin.name, fill=(255, 255, 255, a_l), font=font)
+            draw.text((lx, ly), pin.name, fill=(*white, a_l), font=font)
 
     return Image.alpha_composite(frame.convert("RGBA"), overlay).convert("RGB")
 
@@ -252,7 +254,7 @@ def _render_frame(
 ) -> Image.Image:
     """Render satellite + pins + title for one animation frame."""
     frame = _render_satellite(lat, lon, zoom, cfg.width, cfg.height)
-    return _draw_pins(frame, lat, lon, zoom, cfg.pins, cfg.dest_zoom, cfg.width, cfg.height)
+    return _draw_pins(frame, lat, lon, zoom, cfg)
 
 
 def _destination_overview(
@@ -312,13 +314,15 @@ def create_map_fly_video(
     ]
 
     dz = math.log2(width / w_overview) if w_overview > 0 else float(_CITY_ZOOM)
+    hdr = bool(encoding_plan and encoding_plan.hdr)
     cfg = _FlyConfig(
         interps=interps,
         pins=pins,
-        title_overlay=_render_title_overlay(title_text, width, height),
+        title_overlay=_render_title_overlay(title_text, width, height, hdr),
         width=width,
         height=height,
         dest_zoom=max(3.0, min(14.0, dz)),
+        hdr=hdr,
     )
 
     _tile_cache.clear()
@@ -469,7 +473,7 @@ def _title_alpha(p: float) -> float:
     return max(0.0, (1.0 - p) / 0.15) if p > 0.85 else 1.0
 
 
-def _render_title_overlay(text: str, w: int, h: int) -> Image.Image | None:
+def _render_title_overlay(text: str, w: int, h: int, hdr: bool = False) -> Image.Image | None:
     """Pre-render title text as an RGBA overlay — big, centered."""
     if not text:
         return None
@@ -482,6 +486,7 @@ def _render_title_overlay(text: str, w: int, h: int) -> Image.Image | None:
     fs = int(w * 0.12) if is_portrait else int(h * 0.09)
     font = _get_font(fs, bold=True)
 
+    white = ceil_rgb_for_hdr((255, 255, 255)) if hdr else (255, 255, 255)
     lines = _wrap_text(text, draw, font, int(w * 0.88))
     line_h = int(fs * 1.2)
     total_h = line_h * len(lines)
@@ -494,6 +499,6 @@ def _render_title_overlay(text: str, w: int, h: int) -> Image.Image | None:
         x = (w - tw) // 2
         y = block_y + i * line_h
         draw.text((x + 2, y + 2), line, fill=(0, 0, 0, 130), font=font)
-        draw.text((x, y), line, fill=(255, 255, 255, 240), font=font)
+        draw.text((x, y), line, fill=(*white, 240), font=font)
 
     return img

--- a/src/immich_memories/titles/renderer_pil.py
+++ b/src/immich_memories/titles/renderer_pil.py
@@ -29,6 +29,7 @@ from .animations import (
 )
 from .backgrounds import create_background_for_style
 from .backgrounds_animated import create_animated_background
+from .colors import ceil_white_for_hdr
 from .fonts import get_font_path as get_cached_font_path
 from .styles import TitleStyle
 
@@ -62,6 +63,8 @@ class RenderSettings:
     duration: float = 3.5
     animation_duration: float = 0.5
     animated_background: bool = True  # Enable animated backgrounds by default
+    # Frames stay 8-bit either way; this only ceilings text to graphics white (#506)
+    hdr: bool = False
 
 
 class TitleRenderer:
@@ -550,6 +553,12 @@ class TitleRenderer:
         else:
             text_color = "#FFFFFF"
             blend_mode = "screen"
+
+        # WHY (#506): in an HDR run this text is graphics drawn over picture, and
+        # full white sits above the picture's own diffuse white. The dark-on-light
+        # choices above are already well under the ceiling and come back untouched.
+        if self.settings.hdr:
+            text_color = ceil_white_for_hdr(text_color)
 
         self._cached_text_settings = (text_color, blend_mode)
         return self._cached_text_settings

--- a/src/immich_memories/titles/renderer_taichi.py
+++ b/src/immich_memories/titles/renderer_taichi.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+from immich_memories.titles.colors import ceil_white_for_hdr
 from immich_memories.titles.safe_zones import safe_text_width
 
 if TYPE_CHECKING:
@@ -246,7 +247,15 @@ class TaichiTitleRenderer:
 
         self.color1 = _hex_to_rgb(self.config.bg_color1)
         self.color2 = _hex_to_rgb(self.config.bg_color2)
-        self.text_rgb = _hex_to_rgb(self.config.text_color)
+        # WHY (#506): text is the one thing here drawn at graphics white. In an
+        # HDR run full white sits above the diffuse white of the picture behind
+        # it and the title glows; the ceiling applies to the parsed colour so
+        # every text path downstream — SDF, kernel, and the PIL layers — gets it.
+        # The background colours are picture, not graphics, and are left alone.
+        text_color = self.config.text_color
+        if self.config.hdr:
+            text_color = ceil_white_for_hdr(text_color)
+        self.text_rgb = _hex_to_rgb(text_color)
 
         if self.config.enable_bokeh:
             self._init_bokeh_particles()

--- a/src/immich_memories/titles/video_encoding.py
+++ b/src/immich_memories/titles/video_encoding.py
@@ -186,6 +186,7 @@ def create_title_video(
         fps=fps,
         duration=duration,
         animated_background=animated_background,
+        hdr=bool(encoding_plan and encoding_plan.hdr),
     )
     renderer = TitleRenderer(style, settings, background_image=background_image)
 

--- a/tests/integration/titles/test_hdr_graphics_white.py
+++ b/tests/integration/titles/test_hdr_graphics_white.py
@@ -1,0 +1,188 @@
+"""Title text must not exceed HLG graphics white in an HDR run.
+
+#506: graphics drawn at full white sit above the diffuse white of the picture
+behind them, so on an HDR display the title glows instead of reading as paper
+white. The measured ceiling is 0xBF — plain white lands at 872/1023 in the
+10-bit pipe, ceilinged it lands at 721. The per-clip captions already do this
+(processing/clip_caption.py:39); the title stack did not.
+
+Run: make test-integration-titles
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+os.environ["IMMICH_FORCE_CPU"] = "1"
+
+from immich_memories.titles.colors import HDR_GRAPHICS_WHITE  # noqa: E402
+from immich_memories.titles.renderer_taichi import (  # noqa: E402
+    TaichiTitleConfig,
+    TaichiTitleRenderer,
+)
+from immich_memories.titles.taichi_kernels import TAICHI_AVAILABLE, init_taichi  # noqa: E402
+
+requires_taichi = pytest.mark.skipif(not TAICHI_AVAILABLE, reason="Taichi not installed")
+pytestmark = [pytest.mark.integration]
+
+_CEILING = HDR_GRAPHICS_WHITE / 255.0
+
+# Quantisation and the renderer's own blending cost a code value or two; this is
+# about a 25% difference in level, not about the last bit.
+_TOLERANCE = 0.01
+
+
+@pytest.fixture(scope="module")
+def _taichi_cpu():
+    if not TAICHI_AVAILABLE:
+        pytest.skip("Taichi not installed")
+    backend = init_taichi()
+    assert backend is not None
+    return backend
+
+
+def _config(*, hdr: bool) -> TaichiTitleConfig:
+    return TaichiTitleConfig(
+        width=320,
+        height=180,
+        fps=10.0,
+        duration=3.5,
+        # A near-black background so the brightest pixel in the frame is text
+        # and nothing else — no bokeh, no gradient ramp to confuse the peak.
+        bg_color1="#0A0A0A",
+        bg_color2="#0A0A0A",
+        enable_bokeh=False,
+        blur_radius=3,
+        use_sdf_text=False,
+        text_color="#FFFFFF",
+        hdr=hdr,
+    )
+
+
+def _peak_level(hdr: bool) -> float:
+    """Brightest pixel in a fully-faded-in title frame, as a fraction of full scale."""
+    renderer = TaichiTitleRenderer(_config(hdr=hdr))
+    # 1.5s in: past the 0.6s fade-in, well before the fade-out.
+    frame = renderer.render_frame(15, "Title", "Subtitle")
+    full_scale = 65535.0 if hdr else 255.0
+    return float(frame.max()) / full_scale
+
+
+@requires_taichi
+def test_sdr_title_text_still_reaches_full_white(_taichi_cpu) -> None:
+    """Control: the ceiling is an HDR-only concession, not a global dimmer."""
+    peak = _peak_level(hdr=False)
+
+    assert peak > _CEILING + _TOLERANCE, (
+        f"SDR text peaked at {peak:.3f} — the ceiling leaked into SDR output"
+    )
+
+
+@requires_taichi
+def test_hdr_title_text_stays_at_or_below_graphics_white(_taichi_cpu) -> None:
+    peak = _peak_level(hdr=True)
+
+    assert peak <= _CEILING + _TOLERANCE, (
+        f"HDR title text peaked at {peak:.3f} of full scale, above HLG graphics "
+        f"white ({_CEILING:.3f}) — it will glow on an HDR display"
+    )
+
+
+@requires_taichi
+def test_the_hdr_frame_still_has_readable_text(_taichi_cpu) -> None:
+    """The ceiling must dim the text, not erase it."""
+    renderer = TaichiTitleRenderer(_config(hdr=True))
+    frame = renderer.render_frame(15, "Title", "Subtitle")
+
+    background = float(np.median(frame)) / 65535.0
+    peak = float(frame.max()) / 65535.0
+
+    assert peak - background > 0.3, (
+        f"text ({peak:.3f}) barely stands out from the background ({background:.3f})"
+    )
+
+
+def _pil_peak(hdr: bool) -> float:
+    """Brightest pixel of a PIL-rendered title, as a fraction of full scale.
+
+    The PIL renderer is the fallback used when Taichi is unavailable — a
+    CPU-only deployment renders every title through it, and `title_color_filter`
+    still maps its output into HLG, so the glow reproduces there too.
+    """
+    from immich_memories.titles.renderer_pil import RenderSettings, TitleRenderer
+    from immich_memories.titles.styles import TitleStyle
+
+    style = TitleStyle(name="probe", background_type="solid", background_colors=["#0A0A0A"])
+    settings = RenderSettings(
+        width=320, height=180, fps=10.0, duration=3.5, animated_background=False, hdr=hdr
+    )
+    frame = np.array(TitleRenderer(style, settings).render_frame("Title", "Subtitle", 30))
+    return float(frame.max()) / 255.0
+
+
+def test_pil_fallback_pulls_hdr_text_down_from_full_white() -> None:
+    """The PIL path composites text with a 'screen' blend over the background,
+    which lifts the result a few levels back up — measured 193/255 on this
+    near-black background against a ceiling of 191. So this asserts the drop is
+    real and lands near the ceiling, not that it hits it exactly."""
+    sdr_peak = _pil_peak(hdr=False)
+    hdr_peak = _pil_peak(hdr=True)
+
+    assert sdr_peak > 0.99, f"SDR text no longer reaches full white ({sdr_peak:.3f})"
+    assert hdr_peak < 0.80, (
+        f"HDR text peaked at {hdr_peak:.3f} — still glowing above graphics white"
+    )
+    assert hdr_peak > 0.6, f"HDR text at {hdr_peak:.3f} is dimmer than the ceiling asked for"
+
+
+def _brightest_text_channel(overlay) -> int:
+    """Peak RGB level among pixels the overlay actually painted.
+
+    Transparent pixels carry junk colour, so alpha gates what counts.
+    """
+    pixels = np.array(overlay.convert("RGBA"))
+    painted = pixels[pixels[:, :, 3] > 0]
+    assert painted.size > 0, "overlay painted nothing"
+    return int(painted[:, :3].max())
+
+
+class TestMapFlyOverText:
+    """The fly-over composites its own text straight onto the map tiles — no
+    dimming pass stands between it and the output, unlike the static map, which
+    the Taichi path dims to 55% before compositing."""
+
+    def test_title_overlay_is_ceilinged_in_hdr(self) -> None:
+        from immich_memories.titles.map_animation import _render_title_overlay
+
+        overlay = _render_title_overlay("Lisbon", 640, 360, hdr=True)
+
+        assert _brightest_text_channel(overlay) <= HDR_GRAPHICS_WHITE
+
+    def test_title_overlay_still_full_white_in_sdr(self) -> None:
+        from immich_memories.titles.map_animation import _render_title_overlay
+
+        overlay = _render_title_overlay("Lisbon", 640, 360, hdr=False)
+
+        assert _brightest_text_channel(overlay) == 255
+
+    def test_pin_labels_are_ceilinged_in_hdr(self) -> None:
+        from PIL import Image
+
+        from immich_memories.titles.map_animation import _draw_pins, _FlyConfig, _PinData
+
+        frame = Image.new("RGB", (640, 360), (0, 0, 0))
+        pins = [_PinData(lat=38.72, lon=-9.14, name="Lisbon")]
+        cfg = _FlyConfig(pins=pins, width=640, height=360, dest_zoom=9.0, hdr=True)
+
+        drawn = np.array(_draw_pins(frame, 38.72, -9.14, 12.0, cfg)).astype(int)
+
+        # The pin's own marker is a saturated orange and keeps its punch; only
+        # the near-neutral pixels — the white ring and the label — are graphics.
+        peak = drawn.max(axis=2)
+        neutral = (peak - drawn.min(axis=2)) <= 20
+        assert int(peak[neutral].max()) <= HDR_GRAPHICS_WHITE, (
+            "a pin label or ring is still drawn above graphics white"
+        )

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -20,6 +20,7 @@ from immich_memories.titles.backgrounds import (
 )
 from immich_memories.titles.colors import (
     brighten_color,
+    ceil_white_for_hdr,
     ensure_minimum_brightness,
     hex_to_rgb,
     rgb_to_hex,
@@ -454,6 +455,36 @@ class TestColors:
         brightened = ensure_minimum_brightness(dark_color, min_brightness=100)
         # Should be brighter than original
         assert sum(brightened) >= sum(dark_color)
+
+
+class TestGraphicsWhiteCeiling:
+    """#506: graphics drawn at full white sit above the diffuse white of the HDR
+    picture behind them, so title text glows on an HDR display. The measured
+    ceiling is HLG graphics white — the same 0xBF the per-clip captions use."""
+
+    def test_full_white_lands_on_graphics_white(self):
+        assert ceil_white_for_hdr("#FFFFFF").upper() == "#BFBFBF"
+
+    def test_near_white_is_brought_down_too(self):
+        """The palettes are full of off-whites; they glare just as much."""
+        assert hex_to_rgb(ceil_white_for_hdr("#F5F5F4")) <= (0xBF, 0xBF, 0xBF)
+        assert hex_to_rgb(ceil_white_for_hdr("#FAFAF9")) <= (0xBF, 0xBF, 0xBF)
+
+    def test_a_tinted_near_white_keeps_its_tint(self):
+        """#F0F9FF is a white with a breath of blue in it — still a white."""
+        r, g, b = hex_to_rgb(ceil_white_for_hdr("#F0F9FF"))
+
+        assert max(r, g, b) == 0xBF
+        assert r < g < b, "the blue cast was flattened out"
+
+    def test_a_saturated_colour_is_left_alone(self):
+        """A ceiling on whites, not a global dimmer: accents keep their punch."""
+        assert ceil_white_for_hdr("#E94560").upper() == "#E94560"
+        assert ceil_white_for_hdr("#FF0000").upper() == "#FF0000"
+
+    def test_anything_already_below_the_ceiling_is_untouched(self):
+        assert ceil_white_for_hdr("#2D2D2D").upper() == "#2D2D2D"
+        assert ceil_white_for_hdr("#374151").upper() == "#374151"
 
 
 class TestBackgrounds:


### PR DESCRIPTION
## What

The measured HDR graphics-white fix lived only in the per-clip date captions (`processing/clip_caption.py:39-42`). No title renderer referenced any graphics-white constant, so in HDR runs title, divider and ending text rendered at whatever full-range white the palette specified — above HLG graphics white, glowing rather than reading as paper white on an HDR display.

Measured, unchanged from the caption side: plain white lands at 872/1023 in the 10-bit pipe; ceilinged at `0xBF` it lands at 721.

## Fix

`titles/colors.py` gains `ceil_rgb_for_hdr` (and a hex wrapper) next to the other colour utilities. It scales whites and near-whites down so no channel exceeds `0xBF`, every channel by the same factor so tinted whites like `#F0F9FF` keep their tint. Anything carrying real hue, or already under the ceiling, comes back untouched — a ceiling on whites, not a global dimmer. The palettes' coloured values are not touched.

Applied at the three seams that actually draw title text in an HDR run:

1. **Taichi renderer** (`renderer_taichi.py:249`) — the one place `text_color` is parsed, so it covers every downstream text path: SDF, kernel, and the cached PIL layers. `cfg.hdr` is already set from the encoding plan at `taichi_video.py:188`, before the renderer is constructed. This covers titles, month/year dividers, location cards, and the static-map title, without editing the `"#FFFFFF"` literals at `rendering_service.py:219/343`.
2. **PIL fallback** (`renderer_pil.py`) — `RenderSettings` gains `hdr`, set from the plan in `video_encoding.py`, applied in `_get_optimal_text_settings`. Not optional: a CPU-only deployment without Taichi renders every title through this path, and `title_color_filter` still maps its output into HLG. Note `style.text_color` is never read here — this function is the real source of the colour.
3. **Map fly-over** (`map_animation.py`) — its title overlay and pin labels composite straight onto the map tiles with no dimming pass in between.

## What I deliberately did not change

- **Static-map baked labels** (`map_renderer.py`) — `create_map_video` already dims that array to 55% before compositing, which puts the labels (255 → 140) and the OSM attribution (200 → 110) under the 191 ceiling on their own. Ceiling-ing them too would double-dim.
- **`renderer_ffmpeg.py`** — zero callers in `src/`, not exported from the package. Dead path.
- The `0xBF` value now appears in both `titles/colors.py` and `processing/clip_caption.py`. I left the duplication rather than couple the packages or invent a third home for one constant; each references the other in a comment.

## Tests

**Unit** (`tests/test_titles.py`, `TestGraphicsWhiteCeiling`) — the colour mapping: full white → `#BFBFBF`, off-whites brought down, a tinted white keeps `r < g < b`, saturated accents and already-dark values untouched.

**Pixel-level integration** (`tests/integration/titles/test_hdr_graphics_white.py`) — 7 tests, all rendering real frames:

- Taichi HDR frame peaks at or below the ceiling; SDR control still reaches full white; the HDR text still stands well clear of its background (the ceiling must dim, not erase).
- Map fly-over title overlay ceilinged in HDR, still full white in SDR; pin labels and ring ceilinged, with the assertion scoped to near-neutral pixels so the pin's saturated orange marker is correctly left alone.
- PIL fallback drops from full white. Honest caveat encoded in the test: that path composites text with a `screen` blend, which lifts the result back up a few levels — measured 193/255 against a ceiling of 191 on a near-black background, more on lighter ones. So it asserts the drop is real and lands near the ceiling, not that it hits it exactly.

Verified RED before the fix: the HDR Taichi test failed at `peak = 1.000` while the SDR control passed.

## Note on one signature

`_draw_pins` took 8 positional params; rather than add a 9th for `hdr` it now takes the `_FlyConfig` it was already being fed values from (5 params). Single private caller, no behaviour change.

## Verification

`make ci` passes: 5447 passed, 9 skipped. `make test-integration-titles` passes: 143 passed. Diff coverage passes once the titles integration coverage is present, which is what CI generates via `make integration-coverage-for-diff`.

No docs change: this is internal rendering behaviour with no CLI flag, config option, or UI surface.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
