### PR TITLE
fix(analysis): a failed look is not a verdict of zero, and a stale one can be redone

### DIFF
--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -537,13 +537,31 @@ class ClipAnalyzer:
 
         return start, end, score, llm_analysis
 
+    def _cache_hit_is_complete(self, cached: tuple) -> bool:
+        """Whether this cached row answers everything this run needs.
+
+        A model switch leaves every clip objective-fresh and semantics-stale:
+        _check_analysis_cache keeps the scores and drops the semantics, and
+        returning the hit anyway meant nothing could ever regenerate them.
+        _needs_a_real_look then re-flagged the clip every round and the verify
+        pass "analyzed" it as a cache-hit no-op, forever — leaving the holistic
+        review judging bare lines it is instructed never to drop for missing
+        information, library-wide, until ANALYSIS_VERSION happened to bump.
+
+        Falling through costs one real analysis per clip per model switch, and
+        the run after it is warm again.
+        """
+        if not self._app_config.content_analysis.enabled:
+            return True
+        return cached[4] is not None
+
     def _analyze_clip_with_preview(
         self,
         clip: VideoClipInfo,
     ) -> tuple[float, float, float, str | None, dict[str, object] | None]:
         """Analyze a clip and extract a preview segment."""
         cached_result = self._check_analysis_cache(clip)
-        if cached_result is not None:
+        if cached_result is not None and self._cache_hit_is_complete(cached_result):
             return cached_result
 
         config = self._app_config

--- a/src/immich_memories/analysis/clip_analyzer.py
+++ b/src/immich_memories/analysis/clip_analyzer.py
@@ -153,6 +153,11 @@ class ClipAnalyzer:
                         start_time=0.0,
                         end_time=min(duration, self.config.avg_clip_duration),
                         score=0.0,
+                        # Not a verdict of zero: nothing looked at this clip.
+                        # The verify pass reads this to know it must keep the
+                        # score it already had rather than write the
+                        # placeholder over it.
+                        analyzed=False,
                     )
                 )
 

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -388,15 +388,7 @@ class SmartPipeline:
             finally:
                 with contextlib.suppress(Exception):
                     self.analyzer.close()
-            # WHY only what we asked for: analysis can hand back more than it
-            # was given (a Live Photo expands into its components), and any
-            # extra id lands straight back in the pool — resurrecting a clip
-            # the judge or the review had just dropped.
-            requested = {u.clip.asset.id for u in unverified}
-            verified = [v for v in verified if v.clip.asset.id in requested]
-            verified_ids = {v.clip.asset.id for v in verified}
-            for v in verified:
-                by_id[v.clip.asset.id] = v
+            verified_ids = self._absorb_verified(by_id, verified, unverified)
             for u in unverified:
                 if u.clip.asset.id not in verified_ids:
                     by_id[u.clip.asset.id] = ClipWithSegment(
@@ -408,6 +400,36 @@ class SmartPipeline:
                     )
             result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
         return result, list(by_id.values())
+
+    def _absorb_verified(
+        self,
+        by_id: dict[str, ClipWithSegment],
+        verified: list[ClipWithSegment],
+        unverified: list[ClipWithSegment],
+    ) -> set[str]:
+        """Take back what the look actually established, and nothing else.
+
+        Only what we asked for: analysis can hand back more than it was given
+        (a Live Photo expands into its components), and any extra id lands
+        straight back in the pool — resurrecting a clip the judge or the
+        review had just dropped.
+
+        And only what it managed to look at. The analyzer returns a
+        placeholder scored 0.0 when a download blips or a decode dies, and
+        writing that over a real score sends the clip under the judge's floor,
+        which drops it from the pool for good — losing a clip to a transient
+        error. A failed look is not a verdict of zero.
+        """
+        requested = {u.clip.asset.id for u in unverified}
+        kept = [v for v in verified if v.clip.asset.id in requested]
+        for v in kept:
+            if not v.analyzed and v.clip.asset.id in by_id:
+                logger.debug(
+                    "Verify pass: keeping the score for %s, the look failed", v.clip.asset.id
+                )
+                continue
+            by_id[v.clip.asset.id] = v
+        return {v.clip.asset.id for v in kept}
 
     def _look_at_stills_among(self, unverified: list[ClipWithSegment]) -> list[ClipWithSegment]:
         """Look at the stills here and now, and hand back the footage.

--- a/tests/test_verify_failure.py
+++ b/tests/test_verify_failure.py
@@ -93,3 +93,63 @@ def test_a_look_that_succeeded_does_replace_the_score(tmp_path: Path) -> None:
     _result_out, analyzed = pipeline._verify_selection([member], _result(clip))
 
     assert [m.score for m in analyzed] == [0.05]
+
+
+class TestAModelSwitchCanRegenerateSemantics:
+    """After changing llm.model every cached clip is objective-fresh and
+    semantics-stale, and the cache hit was returned before anything could
+    regenerate them. _needs_a_real_look then re-flagged the clip every round
+    and the verify pass "analyzed" it as a cache-hit no-op, forever.
+
+    The holistic review is left judging bare lines it is instructed never to
+    drop for missing information — the whole class of defect that having
+    descriptions is supposed to prevent, library-wide, until ANALYSIS_VERSION
+    happens to bump.
+    """
+
+    def _analyzer(self, tmp_path: Path, *, content_analysis: bool):
+        from immich_memories.analysis.clip_analyzer import ClipAnalyzer
+
+        return ClipAnalyzer(
+            config=PipelineConfig(),
+            client=MagicMock(),
+            analysis_cache=MagicMock(),
+            preview_builder=MagicMock(),
+            app_config=Config(
+                cache={"directory": str(tmp_path / "cache")},
+                llm={"model": "the-new-model"},
+                content_analysis={"enabled": content_analysis},
+            ),
+        )
+
+    def test_a_hit_with_no_semantics_is_not_a_complete_answer(self, tmp_path: Path) -> None:
+        """Objective scores survived the model switch; the semantics did not."""
+        analyzer = self._analyzer(tmp_path, content_analysis=True)
+
+        assert not analyzer._cache_hit_is_complete((1.0, 5.0, 0.7, None, None))
+        assert analyzer._cache_hit_is_complete((1.0, 5.0, 0.7, None, {"description": "a cake"}))
+
+    def test_a_hit_with_semantics_still_short_circuits(self, tmp_path: Path) -> None:
+        """A warm cache must stay warm — this is what makes reruns cheap."""
+        analyzer = self._analyzer(tmp_path, content_analysis=True)
+        analyzer._check_analysis_cache = MagicMock(
+            return_value=(1.0, 5.0, 0.7, None, {"description": "a birthday cake"})
+        )
+        analyzer._download_analysis_video = MagicMock(side_effect=AssertionError("re-downloaded"))
+
+        start, _end, _score, _preview, payload = analyzer._analyze_clip_with_preview(
+            make_clip("warm", duration=10.0)
+        )
+
+        assert start == 1.0
+        assert payload == {"description": "a birthday cake"}
+
+    def test_with_content_analysis_off_a_hit_is_complete(self, tmp_path: Path) -> None:
+        """Nothing is missing if nothing was going to be generated."""
+        analyzer = self._analyzer(tmp_path, content_analysis=False)
+        analyzer._check_analysis_cache = MagicMock(return_value=(1.0, 5.0, 0.7, None, None))
+        analyzer._download_analysis_video = MagicMock(side_effect=AssertionError("re-downloaded"))
+
+        start, *_rest = analyzer._analyze_clip_with_preview(make_clip("no-llm", duration=10.0))
+
+        assert start == 1.0

--- a/tests/test_verify_failure.py
+++ b/tests/test_verify_failure.py
@@ -1,0 +1,95 @@
+"""A failed analysis is not a verdict of zero.
+
+The verify pass looks again at clips the review cannot see and writes the
+result back over what selection had. When that look fails — a transient
+download error, a decode that dies — the analyzer hands back a placeholder
+scored 0.0, and writing it back replaces a real score with junk. The judge's
+floor then drops the clip and removes it from the pool for good, so a clip
+whose download blipped once is gone from the memory.
+
+The verify docstring already promised this could not happen: "a clip whose
+analysis fails keeps its fallback score".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from immich_memories.analysis.smart_pipeline import (
+    ClipWithSegment,
+    PipelineConfig,
+    PipelineResult,
+    SmartPipeline,
+)
+from immich_memories.config import Config
+from immich_memories.config_models import AnalysisConfig
+from tests.conftest import make_clip
+
+
+def _pipeline(tmp_path: Path) -> SmartPipeline:
+    analysis_cache = MagicMock()
+    analysis_cache.get_analysis.return_value = None
+    return SmartPipeline(
+        client=MagicMock(),
+        analysis_cache=analysis_cache,
+        thumbnail_cache=MagicMock(),
+        config=PipelineConfig(),
+        analysis_config=AnalysisConfig(),
+        app_config=Config(
+            cache={"directory": str(tmp_path / "cache")},
+            llm={"model": "qwen-3.6"},
+            content_analysis={"enabled": True},
+        ),
+    )
+
+
+def _result(clip) -> PipelineResult:
+    return PipelineResult(
+        selected_clips=[clip], clip_segments={clip.asset.id: (0.0, 4.0)}, errors=[]
+    )
+
+
+def test_a_failed_look_leaves_the_score_it_could_not_improve(tmp_path: Path) -> None:
+    """A download that blips must not cost the clip its place."""
+    clip = make_clip("blipped", duration=10.0)
+    member = ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.72, analyzed=False)
+
+    pipeline = _pipeline(tmp_path)
+    # WHY: analysis downloads and decodes video. This is the analyzer's own
+    # failure placeholder — scored 0.0 and marked unanalyzed.
+    failed = ClipWithSegment(
+        clip=make_clip("blipped", duration=10.0),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.0,
+        analyzed=False,
+    )
+    pipeline.analyzer.phase_analyze = MagicMock(return_value=[failed])
+    pipeline.refiner.phase_refine = MagicMock(side_effect=lambda a, _t: _result(a[0].clip))
+
+    _result_out, analyzed = pipeline._verify_selection([member], _result(clip))
+
+    assert [m.score for m in analyzed] == [0.72], "a failed look overwrote a real score"
+
+
+def test_a_look_that_succeeded_does_replace_the_score(tmp_path: Path) -> None:
+    """The pass exists to correct optimistic guesses; that must keep working."""
+    clip = make_clip("optimistic", duration=10.0)
+    member = ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.9, analyzed=False)
+
+    pipeline = _pipeline(tmp_path)
+    # WHY: analysis is the boundary; here it succeeds and the clip is poor.
+    looked = ClipWithSegment(
+        clip=make_clip("optimistic", duration=10.0),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.05,
+        analyzed=True,
+    )
+    pipeline.analyzer.phase_analyze = MagicMock(return_value=[looked])
+    pipeline.refiner.phase_refine = MagicMock(side_effect=lambda a, _t: _result(a[0].clip))
+
+    _result_out, analyzed = pipeline._verify_selection([member], _result(clip))
+
+    assert [m.score for m in analyzed] == [0.05]


### PR DESCRIPTION
Closes #496. Closes #509.

Two defects in the same call chain, both of which leave the holistic review judging bare lines it is instructed never to drop for missing information.

## A failed look is not a verdict of zero (#496)

The verify pass looks again at clips the review cannot see and writes the result back over what selection had. When that look **fails** — a download that blips, a decode that dies — the analyzer hands back a placeholder scored `0.0`, and writing it back replaces a real score with junk. The judge's floor then drops the clip and removes it **from the pool for good**, so a clip whose download failed once is gone from the memory for the rest of the run.

The verify docstring already promised this could not happen — *"a clip whose analysis fails keeps its fallback score"*. Only sub-1.5s clips were actually protected.

The placeholder now says what it is (`analyzed=False`, which is exactly what it means) and the verify pass keeps the score it could not improve on. A look that **succeeded** still replaces the score, including when it reveals the clip is poor — that is the whole point of the pass, and there is a test either way.

`_verify_selection` crossed the cognitive-complexity gate on the change, so the merge-back step came out as `_absorb_verified`, which also carries the existing "only what we asked for" rule.

The other two thirds of #496 landed with the photo-look work already on main: stills go to the photo scorer rather than the video analyzer — that routing is what produced these zeroes for *every* photo, on every round — and they no longer re-enter analysis each pass.

## A stale hit can be redone (#509)

After changing `llm.model` every cached clip is objective-fresh and semantics-stale. `_check_analysis_cache` handles that deliberately — keeps the scores, drops the semantics — and then the caller returned the hit anyway, so nothing could regenerate them. `_needs_a_real_look` re-flagged the clip every round and the verify pass "analyzed" it as a cache-hit no-op, forever, library-wide, until `ANALYSIS_VERSION` happened to bump.

A hit is now taken only when it answers everything this run needs. Falling through costs one real analysis per clip per model switch and the next run is warm again; with content analysis off nothing is missing, because nothing was going to be generated.

`make ci` green, diff coverage passing.
