### PR TITLE
fix(automation): refuse to schedule a binary inside a linked git worktree

### DIFF
--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -219,6 +219,7 @@ once a day itself. See [automated generation](../recipes/automated-generation.md
 | `--cooldown` | int | `24` | Cooldown hours between runs |
 | `--uninstall` | flag | `false` | Remove installed scheduler |
 | `--show` | flag | `false` | Print config without installing |
+| `--force` | flag | `false` | Install even from a linked git worktree |
 
 | Platform | What gets created | How to activate |
 |----------|-------------------|-----------------|
@@ -227,6 +228,19 @@ once a day itself. See [automated generation](../recipes/automated-generation.md
 | **Other** | Prints a crontab entry | `crontab -e` |
 
 On macOS the plist uses `StartCalendarInterval`; launchd runs a missed job the next time the Mac wakes rather than waking it from sleep. If the Mac is asleep at the scheduled time, expect the run once it wakes.
+
+### Which binary gets scheduled
+
+The installer writes the absolute path of the `immich-memories` on your `PATH` into the plist,
+unit, or crontab line. The OS never re-resolves it, so whichever environment you install from is
+the one the nightly job runs forever.
+
+That is fine for a system install, a venv, or a plain clone. It is a trap inside a **linked git
+worktree** (`git worktree add`): a worktree stays frozen on the commit it was left at, or gets
+pruned, and the scheduled job keeps quietly running that stale code. `auto install` detects this
+(a linked worktree's root holds a `.git` *file* rather than a directory) and refuses, naming the
+worktree. Re-run it from your canonical checkout. `--force` schedules the worktree path anyway if
+you really mean it.
 
 ### Installing with a custom config
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -56,6 +56,7 @@ immich-memories auto install [OPTIONS]
 | `--cooldown` | integer | 24 | Cooldown hours between runs |
 | `--uninstall` | boolean | false | Remove installed scheduler |
 | `--show` | boolean | false | Show config without installing |
+| `--force` | boolean | false | Schedule the resolved binary even when it lives in a linked git worktree |
 
 ### `auto run`
 

--- a/src/immich_memories/automation/system_scheduler.py
+++ b/src/immich_memories/automation/system_scheduler.py
@@ -38,6 +38,19 @@ _SYSTEMD_SERVICE = "immich-memories-auto.service"
 _SYSTEMD_TIMER = "immich-memories-auto.timer"
 
 
+class WorktreePinnedBinaryError(RuntimeError):
+    """The binary that would be persisted into the scheduler lives in a linked git worktree."""
+
+    def __init__(self, binary: str, worktree: Path) -> None:
+        super().__init__(
+            f"Refusing to schedule {binary}: it lives in the linked git worktree {worktree}. "
+            "A worktree is scratch space — it stays frozen on the commit it was left at, or "
+            "gets pruned — so the scheduled job would silently keep running stale code. "
+            "Install from your canonical checkout (or a system/user install) instead, "
+            "or pass --force to schedule this exact path anyway."
+        )
+
+
 def detect_platform() -> str:
     """Return 'launchd' on macOS, 'systemd' if systemctl exists, else 'crontab'."""
     if sys.platform == "darwin":
@@ -53,6 +66,25 @@ def _resolve_binary() -> str:
         msg = "immich-memories binary not found in PATH"
         raise FileNotFoundError(msg)
     return binary
+
+
+def _linked_worktree_root(binary: str) -> Path | None:
+    """Return the linked-worktree checkout holding this path, if it sits in one.
+
+    A linked worktree's root holds a `.git` *file* pointing at `.../worktrees/<name>`, where a
+    plain clone holds a `.git` directory and a submodule's `.git` file points at `.../modules/`.
+    """
+    for directory in Path(binary).parents:
+        marker = directory / ".git"
+        if not marker.is_file():
+            continue
+        try:
+            gitdir = marker.read_text(errors="replace").partition("gitdir:")[2].strip()
+        except OSError:
+            continue
+        if gitdir and "worktrees" in Path(gitdir).parts:
+            return directory
+    return None
 
 
 def _default_log_dir() -> Path:
@@ -261,10 +293,18 @@ def install_scheduler(
     schedule_minute: int = 0,
     cooldown_hours: int = 24,
     config_path: Path | None = None,
+    force: bool = False,
 ) -> SchedulerInstallResult:
-    """Detect platform, generate scheduler files, write them, and return result."""
+    """Detect platform, generate scheduler files, write them, and return result.
+
+    Raises WorktreePinnedBinaryError when the resolved binary sits inside a linked git worktree,
+    unless `force` is set — the OS never re-resolves the absolute path persisted here.
+    """
     platform = detect_platform()
     binary = _resolve_binary()
+    worktree = None if force else _linked_worktree_root(binary)
+    if worktree is not None:
+        raise WorktreePinnedBinaryError(binary, worktree)
 
     if platform == "launchd":
         return _install_launchd(

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -11,7 +11,7 @@ import click
 from rich.table import Table
 
 from immich_memories.automation.models import AutoOutcome, AutoRunResult
-from immich_memories.cli._helpers import console, print_info, print_success
+from immich_memories.cli._helpers import console, print_error, print_info, print_success
 from immich_memories.config_loader import Config
 
 
@@ -331,6 +331,11 @@ def status(ctx: click.Context, as_json: bool) -> None:
 @click.option("--cooldown", default=24, help="Cooldown hours between runs")
 @click.option("--uninstall", is_flag=True, help="Remove installed scheduler")
 @click.option("--show", is_flag=True, help="Show config without installing")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Schedule the resolved binary even when it lives in a linked git worktree",
+)
 @click.pass_context
 def install(
     ctx: click.Context,
@@ -339,9 +344,11 @@ def install(
     cooldown: int,
     uninstall: bool,
     show: bool,
+    force: bool,
 ) -> None:
     """Install system-level scheduler (launchd/systemd/cron)."""
     from immich_memories.automation.system_scheduler import (
+        WorktreePinnedBinaryError,
         install_scheduler,
         show_scheduler_config,
         uninstall_scheduler,
@@ -365,10 +372,13 @@ def install(
         return
 
     try:
-        result = install_scheduler(hour, minute, cooldown, config_path=config_path)
+        result = install_scheduler(hour, minute, cooldown, config_path=config_path, force=force)
     except FileNotFoundError:
         print_info("immich-memories binary not found in PATH")
         return
+    except WorktreePinnedBinaryError as exc:
+        print_error(str(exc))
+        ctx.exit(1)
 
     print_success(f"Installed {result.platform} scheduler")
     for path in result.files_written:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -14,6 +14,10 @@ from click.testing import CliRunner, Result
 import immich_memories
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoAction, AutoOutcome, AutoRejection, AutoRunResult
+from immich_memories.automation.system_scheduler import (
+    SchedulerInstallResult,
+    WorktreePinnedBinaryError,
+)
 from immich_memories.cli import main
 from immich_memories.config_loader import Config
 
@@ -360,6 +364,30 @@ class TestAutoRunOutput:
 
         assert result.exit_code == 0, result.output
         show.assert_called_once_with(9, 0, 24, config_path=config_path.resolve())
+
+    def test_worktree_pinned_install_fails_loudly_and_points_at_force(self) -> None:
+        """A scheduler pinned to scratch space is a silent stale-code bug, so refuse it."""
+        # WHY: install_scheduler touches launchd/systemd/crontab on the host
+        with patch(
+            "immich_memories.automation.system_scheduler.install_scheduler",
+            side_effect=WorktreePinnedBinaryError("/wt/.venv/bin/immich-memories", Path("/wt")),
+        ):
+            result = _invoke(["auto", "install"])
+
+        assert result.exit_code == 1
+        assert "/wt" in result.output
+        assert "--force" in result.output
+
+    def test_force_passes_the_override_through_to_the_installer(self) -> None:
+        # WHY: install_scheduler touches launchd/systemd/crontab on the host
+        with patch(
+            "immich_memories.automation.system_scheduler.install_scheduler",
+            return_value=SchedulerInstallResult(platform="crontab"),
+        ) as install:
+            result = _invoke(["auto", "install", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert install.call_args.kwargs["force"] is True
 
     def test_quiet_completed_emits_exactly_one_json_object(self, tmp_path: Path) -> None:
         output = tmp_path / "memory.mp4"

--- a/tests/test_system_scheduler.py
+++ b/tests/test_system_scheduler.py
@@ -13,6 +13,7 @@ import pytest
 
 from immich_memories.automation.system_scheduler import (
     SchedulerInstallResult,
+    WorktreePinnedBinaryError,
     detect_platform,
     generate_crontab_entry,
     generate_launchd_plist,
@@ -22,6 +23,14 @@ from immich_memories.automation.system_scheduler import (
     show_scheduler_config,
     uninstall_scheduler,
 )
+
+
+def _checkout_binary(checkout: Path) -> str:
+    """Create the venv console script a `pip install -e .` leaves inside a checkout."""
+    binary = checkout / ".venv" / "bin" / "immich-memories"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\n")
+    return str(binary)
 
 
 class TestDetectPlatform:
@@ -256,6 +265,61 @@ class TestInstallScheduler:
         # WHY: _resolve_binary checks PATH
         with pytest.raises(FileNotFoundError):
             install_scheduler()
+
+
+class TestEphemeralBinaryRefusal:
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_binary_inside_linked_worktree_is_refused(self, _plat: object, tmp_path: Path) -> None:
+        worktree = tmp_path / "agent-branch"
+        worktree.mkdir()
+        (worktree / ".git").write_text(
+            f"gitdir: {tmp_path}/canonical/.git/worktrees/agent-branch\n"
+        )
+        binary = _checkout_binary(worktree)
+
+        # WHY: shutil.which reads the real PATH
+        with (
+            patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary),
+            pytest.raises(WorktreePinnedBinaryError) as excinfo,
+        ):
+            install_scheduler()
+
+        message = str(excinfo.value)
+        assert str(worktree) in message
+        assert "--force" in message
+
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_binary_inside_plain_clone_is_installed(self, _plat: object, tmp_path: Path) -> None:
+        """Self-hosters deploy by cloning — only the ephemeral worktree case is rejected."""
+        clone = tmp_path / "immich-video-memory-generator"
+        (clone / ".git").mkdir(parents=True)
+        binary = _checkout_binary(clone)
+
+        # WHY: shutil.which reads the real PATH
+        with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
+            result = install_scheduler()
+
+        assert binary in result.activate_command
+
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_force_schedules_the_worktree_binary_anyway(
+        self, _plat: object, tmp_path: Path
+    ) -> None:
+        worktree = tmp_path / "agent-branch"
+        worktree.mkdir()
+        (worktree / ".git").write_text(
+            f"gitdir: {tmp_path}/canonical/.git/worktrees/agent-branch\n"
+        )
+        binary = _checkout_binary(worktree)
+
+        # WHY: shutil.which reads the real PATH
+        with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
+            result = install_scheduler(force=True)
+
+        assert binary in result.activate_command
 
 
 class TestUninstallScheduler:


### PR DESCRIPTION
## What

`auto install` resolved the binary with `shutil.which("immich-memories")` and wrote that
absolute path into the launchd plist / systemd unit / crontab line. The OS never re-resolves
it, so the scheduled job is permanently pinned to whichever environment the install happened
to run from — including a linked `git worktree` that later goes stale or gets pruned, at which
point the nightly job silently keeps executing frozen code.

Now `install_scheduler()` refuses when the path it is about to persist sits inside a linked
worktree, and names the offending worktree in the message. `--force` schedules it anyway.

## Detection

Structural, not heuristic: a linked worktree's root holds a `.git` **file** pointing at
`.../worktrees/<name>`. A plain clone holds a `.git` **directory**; a submodule's `.git` file
points at `.../modules/<name>`. Only the first case is rejected, so cloning — the way most
self-hosters deploy — keeps working, as do venvs and system/user installs.

## On resolving to a stable launcher instead

Considered and rejected as not viable without redesigning packaging: systemd's `ExecStart`
requires an absolute path, and launchd's `ProgramArguments[0]` is not a reliable `PATH`
lookup either. Only crontab could take a bare name, and making one backend behave differently
from the other two trades one silent failure mode for another. A `uv tool` shim on `PATH` is
already picked up by the existing `shutil.which` call and passes the new check unchanged, so
the stable-launcher case needs no code. Refusing the foot-gun is the whole fix.

## Deliberate non-change

`auto install --show` still prints the worktree path. It writes nothing, it is the natural way
to inspect what would be installed, and the actual install is now refused — the hole is closed
where it mattered.

## Tests

TDD, three behaviors in `tests/test_system_scheduler.py` plus two CLI contracts in
`tests/test_cli_smoke.py`:

- a binary under a linked worktree is refused, with the worktree and `--force` in the message
- a binary under a plain clone installs normally (verified non-vacuous: it fails against an
  over-broad "any `.git` ancestor" heuristic)
- `force=True` schedules the worktree path anyway
- `auto install` exits 1 and prints the refusal
- `--force` reaches the installer

## Verification

`make ci` passes end to end locally (5491 passed, 9 skipped). `make docs-build` passes.
`make docs-cli` regenerated the auto-generated CLI reference for the new flag.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
