### PR TITLE
fix(ci): a passed smoke must survive its own teardown

### DIFF
--- a/scripts/docker_smoke.py
+++ b/scripts/docker_smoke.py
@@ -31,7 +31,10 @@ def main() -> int:
     parser.add_argument("--timeout", type=int, default=900)
     args = parser.parse_args()
 
-    with tempfile.TemporaryDirectory() as tmp:
+    # The container runs as UID 1000 and leaves files the runner user cannot
+    # delete; a cleanup failure after a PASSED smoke must not fail the release
+    # (#525 follow-up: the first run to ever reach teardown died exactly there).
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         root = Path(tmp)
         out_dir = root / "output"
         out_dir.mkdir()


### PR DESCRIPTION
The container runs as UID 1000 and leaves files the runner user cannot delete; the first release ever to reach teardown (post-#525) saved its video successfully and then died in TemporaryDirectory cleanup with a PermissionError — exit 1 on a passed smoke. ignore_cleanup_errors keeps a cleanup failure from failing the release; the OS reaps the runner temp dir anyway.

Follow-up to #525 (no separate issue per the settle-down rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f