### PR TITLE
fix(selection): let a look change the rank, not only the caption

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2651,47 +2651,83 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 838,
-        "line_end": 937,
+        "line_start": 815,
+        "line_end": 914,
         "line_complexities": [
           {
-            "line": 859,
+            "line": 836,
             "complexity": 0
           },
           {
-            "line": 860,
+            "line": 837,
             "complexity": 1
           },
           {
-            "line": 862,
+            "line": 839,
             "complexity": 1
           },
           {
-            "line": 863,
+            "line": 840,
             "complexity": 0
           },
           {
-            "line": 864,
+            "line": 841,
             "complexity": 2
           },
           {
+            "line": 842,
+            "complexity": 0
+          },
+          {
+            "line": 849,
+            "complexity": 1
+          },
+          {
+            "line": 853,
+            "complexity": 0
+          },
+          {
+            "line": 854,
+            "complexity": 0
+          },
+          {
+            "line": 855,
+            "complexity": 1
+          },
+          {
+            "line": 856,
+            "complexity": 0
+          },
+          {
+            "line": 857,
+            "complexity": 2
+          },
+          {
+            "line": 858,
+            "complexity": 0
+          },
+          {
             "line": 865,
+            "complexity": 1
+          },
+          {
+            "line": 869,
             "complexity": 0
           },
           {
             "line": 872,
-            "complexity": 1
+            "complexity": 0
+          },
+          {
+            "line": 873,
+            "complexity": 2
+          },
+          {
+            "line": 874,
+            "complexity": 3
           },
           {
             "line": 876,
-            "complexity": 0
-          },
-          {
-            "line": 877,
-            "complexity": 0
-          },
-          {
-            "line": 878,
             "complexity": 1
           },
           {
@@ -2699,53 +2735,17 @@
             "complexity": 0
           },
           {
-            "line": 880,
-            "complexity": 2
-          },
-          {
-            "line": 881,
-            "complexity": 0
-          },
-          {
-            "line": 888,
+            "line": 913,
             "complexity": 1
           },
           {
-            "line": 892,
-            "complexity": 0
-          },
-          {
-            "line": 895,
-            "complexity": 0
-          },
-          {
-            "line": 896,
-            "complexity": 2
-          },
-          {
-            "line": 897,
-            "complexity": 3
-          },
-          {
-            "line": 899,
-            "complexity": 1
-          },
-          {
-            "line": 902,
-            "complexity": 0
-          },
-          {
-            "line": 936,
-            "complexity": 1
-          },
-          {
-            "line": 937,
+            "line": 914,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 106
+    "complexity": 103
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/src/immich_memories/analysis/photo_look.py
+++ b/src/immich_memories/analysis/photo_look.py
@@ -1,0 +1,164 @@
+"""What a look at a photograph does to a finished selection.
+
+The VLM shortlist is a budget — on a real year, thirty photographs out of
+1918 — and selection picks from all of them. So most stills in a finished cut
+have never been looked at, and the holistic review, told never to drop a clip
+for missing information, cannot judge any of them.
+
+These two passes close that, bounded to what shipped rather than the library:
+look at the selected stills, and let a day reconsider its own frame once its
+candidates have been seen.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from immich_memories.analysis.source_filter import is_a_still
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+
+logger = logging.getLogger(__name__)
+
+# How many of a day's stills a re-pick may look at. The day is the bound, not
+# the library: a library of looks is what the shortlist budget exists to
+# avoid, and a day rarely needs more than a handful to find its best frame.
+_CANDIDATES_PER_DAY = 4
+
+
+def _looks_for(
+    members: list[ClipWithSegment],
+    *,
+    config: Any,
+    client: Any,
+    provider_circuit: Any,
+) -> dict[str, tuple[float, dict]]:
+    """Ask the photo scorer about these stills, or nothing if it cannot answer."""
+    from immich_memories.photos import photo_pipeline
+
+    if not members:
+        return {}
+    try:
+        return photo_pipeline.look_at_selected_photos(
+            [m.clip.asset for m in members],
+            config=config,
+            client=client,
+            provider_circuit=provider_circuit,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.debug("Photo look failed: %s", type(exc).__name__)
+        return {}
+
+
+def _apply(member: ClipWithSegment, look: tuple[float, dict] | None) -> None:
+    """Take both halves of a look: what it saw, and what it made of it.
+
+    The caption and the rank come out of the same call. Keeping only the words
+    let a look change what the review reads and never what selection ranked
+    on, so a frame the model could not identify outranked one it understood.
+    """
+    if look is None:
+        return
+    from immich_memories.analysis.cache_projection import apply_semantic_payload
+
+    member.score, payload = look
+    apply_semantic_payload(member.clip, payload)
+
+
+def look_at_stills(
+    stills: list[ClipWithSegment],
+    *,
+    config: Any,
+    client: Any,
+    provider_circuit: Any = None,
+) -> None:
+    """Give the review eyes on the photographs that reached the cut.
+
+    A still's real look is the photo scorer: the video analyzer fails on a
+    photograph and writes back a zero, so a photo it could not read was not
+    merely unseen but ranked last.
+    """
+    if not stills:
+        return
+    logger.info("Verify pass: looking at %d selected photo(s)", len(stills))
+    looks = _looks_for(stills, config=config, client=client, provider_circuit=provider_circuit)
+    for member in stills:
+        _apply(member, looks.get(member.clip.asset.id))
+
+
+def repick_days(
+    *,
+    selected: list[ClipWithSegment],
+    pool: list[ClipWithSegment],
+    config: Any,
+    client: Any,
+    provider_circuit: Any = None,
+) -> list[ClipWithSegment]:
+    """Let a day reconsider its own frame once its candidates are looked at.
+
+    A still is chosen on metadata, long before anything sees it. Measured on a
+    real day: the frame that shipped was a close-up the model read as "dried,
+    flaky green leaves, possibly herbs or tea" at interest 0.4, while the same
+    day's other frame was understood outright — "a white plastic fermentation
+    bucket, equipped with an airlock and spigot" — at 0.6. Both were looked
+    at, the better one scored higher, and the worse one still shipped.
+
+    Bounded to the day rather than the library: only days that already have a
+    selected still are reconsidered, and only against that day's own
+    candidates. The look is cached, so a candidate seen before costs nothing.
+    """
+    chosen = {m.clip.asset.id for m in selected}
+    days = {
+        m.clip.asset.file_created_at.date()
+        for m in selected
+        if is_a_still(m.clip.asset) and m.clip.asset.file_created_at
+    }
+    if not days:
+        return selected
+
+    by_day: dict[Any, list[ClipWithSegment]] = {}
+    for member in pool:
+        when = member.clip.asset.file_created_at
+        if is_a_still(member.clip.asset) and when and when.date() in days:
+            by_day.setdefault(when.date(), []).append(member)
+
+    looking_at = [
+        member
+        for day_members in by_day.values()
+        for member in sorted(day_members, key=lambda c: c.score, reverse=True)[:_CANDIDATES_PER_DAY]
+    ]
+    looks = _looks_for(looking_at, config=config, client=client, provider_circuit=provider_circuit)
+    for member in looking_at:
+        _apply(member, looks.get(member.clip.asset.id))
+
+    swaps = {}
+    for day, day_members in by_day.items():
+        swap = _better_frame_for(day, day_members, chosen)
+        if swap:
+            swaps.update(swap)
+
+    return [swaps.get(m.clip.asset.id, m) for m in selected] if swaps else selected
+
+
+def _better_frame_for(
+    day: Any,
+    day_members: list[ClipWithSegment],
+    chosen: set[str],
+) -> dict[str, ClipWithSegment]:
+    """The swap this day wants, if looking at it changed the answer."""
+    here = [m for m in day_members if m.clip.asset.id in chosen]
+    if not here:
+        return {}
+    best = max(day_members, key=lambda c: c.score)
+    weakest_here = min(here, key=lambda c: c.score)
+    if best.clip.asset.id in chosen or best.score <= weakest_here.score:
+        return {}
+    logger.info(
+        "Day re-pick %s: %s reads better than %s once both were looked at",
+        day,
+        best.clip.asset.id,
+        weakest_here.clip.asset.id,
+    )
+    return {weakest_here.clip.asset.id: best}

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -125,7 +125,7 @@ class SelectionQuality:
                 [f"{len(unverified)} clip(s) analyzed for real before judging"],
             )
             attempted.update(u.clip.asset.id for u in unverified)
-            unverified = self._look_at_stills_among(unverified)
+            unverified, result = self._settle_the_stills(unverified, by_id, result)
             if not unverified:
                 continue
             try:
@@ -173,37 +173,35 @@ class SelectionQuality:
             by_id[v.clip.asset.id] = v
         return {v.clip.asset.id for v in kept}
 
-    def _look_at_stills_among(self, unverified: list[ClipWithSegment]) -> list[ClipWithSegment]:
-        """Look at the stills here and now, and hand back the footage.
+    def _settle_the_stills(
+        self,
+        unverified: list[ClipWithSegment],
+        by_id: dict[str, ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[list[ClipWithSegment], PipelineResult]:
+        """Look at the stills, let their days reconsider, hand back the footage.
 
-        A still's real look is the photo scorer: the video analyzer fails on a
-        photograph and writes back a zero, so a photo it could not read was
-        not merely unseen but ranked last.
+        The look moves their scores as well as their descriptions, so a day
+        may now prefer a frame it could not judge before — and re-selection
+        has to hear that, or the look changed only the caption.
         """
+        from immich_memories.analysis import photo_look
+
         stills = [u for u in unverified if is_a_still(u.clip.asset)]
-        self._look_at_stills(stills)
-        return [u for u in unverified if not is_a_still(u.clip.asset)]
-
-    def _look_at_stills(self, stills: list[ClipWithSegment]) -> None:
-        """Give the review eyes on the photographs that reached the cut."""
-        if not stills:
-            return
-        from immich_memories.analysis.cache_projection import apply_semantic_payload
-        from immich_memories.photos import photo_pipeline
-
-        logger.info("Verify pass: looking at %d selected photo(s)", len(stills))
-        try:
-            payloads = photo_pipeline.look_at_selected_photos(
-                [s.clip.asset for s in stills],
-                config=self._app_config,
-                client=self.client,
-                provider_circuit=self.provider_circuit,
+        deps = {
+            "config": self._app_config,
+            "client": self.client,
+            "provider_circuit": self.provider_circuit,
+        }
+        photo_look.look_at_stills(stills, **deps)
+        if stills:
+            photo_look.repick_days(
+                selected=[by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id],
+                pool=list(by_id.values()),
+                **deps,
             )
-        except (OSError, RuntimeError, ValueError) as exc:
-            logger.debug("Photo look failed: %s", type(exc).__name__)
-            return
-        for member in stills:
-            apply_semantic_payload(member.clip, payloads.get(member.clip.asset.id))
+            result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
+        return [u for u in unverified if not is_a_still(u.clip.asset)], result
 
     def final_review_drop(
         self,

--- a/src/immich_memories/analysis/source_filter.py
+++ b/src/immich_memories/analysis/source_filter.py
@@ -15,10 +15,13 @@ the second line, for the cameras whose filenames give nothing away.
 from __future__ import annotations
 
 import fnmatch
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
 
 
 def from_an_excluded_source(name: str | None, patterns: Sequence[str]) -> bool:
@@ -85,3 +88,29 @@ def not_shot_here(
     if from_an_excluded_source(getattr(asset, "original_file_name", None), patterns):
         return True
     return stills_need_a_camera and _a_still_with_no_camera(asset)
+
+
+def from_the_camera_roll(photo_assets: list[Any], config: Any) -> list[Any]:
+    """Drop the photos nothing says the library's own camera made.
+
+    Videos are filtered on the same rule before analysis; photos reached
+    selection without ever being asked, so a collage forwarded through a
+    messaging app walked into a year recap while a doorbell clip beside it was
+    turned away. Dropped here rather than later because there is no sense
+    paying a VLM to score something that cannot ship.
+    """
+    analysis = getattr(config, "analysis", None)
+    patterns = getattr(analysis, "exclude_filename_patterns", ())
+    stills_need_a_camera = getattr(analysis, "exclude_stills_without_camera_exif", False)
+    if not patterns and not stills_need_a_camera:
+        return photo_assets
+    kept = [
+        asset
+        for asset in photo_assets
+        if not not_shot_here(asset, patterns=patterns, stills_need_a_camera=stills_need_a_camera)
+    ]
+    if len(kept) < len(photo_assets):
+        logger.info(
+            "Source filter: %d photo(s) from excluded sources", len(photo_assets) - len(kept)
+        )
+    return kept

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -620,9 +620,9 @@ def _merge_photos_into_pool(
     import logging
 
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
+    from immich_memories.analysis.source_filter import from_the_camera_roll
     from immich_memories.api.models import VideoClipInfo
     from immich_memories.photos.photo_pipeline import (
-        from_the_camera_roll,
         score_photos,
         video_count_for_photo_budget,
     )

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -20,6 +20,7 @@ from typing import Any
 import cv2
 import numpy as np
 
+from immich_memories.analysis.source_filter import from_the_camera_roll
 from immich_memories.analysis.unified_budget import (
     BudgetCandidate,
     UnifiedSelection,
@@ -127,23 +128,23 @@ def look_at_selected_photos(
     config: Any,
     client: Any,
     provider_circuit: Any = None,
-) -> dict[str, dict]:
+) -> dict[str, tuple[float, dict]]:
     """A VLM look at the handful of photos that reached a cut without one.
 
-    The shortlist is a budget: thirty of nearly two thousand photos are looked
-    at, and selection then picks from all of them. So most stills in a
-    finished cut have no description, and the holistic review — told never to
-    drop a clip for missing information — cannot judge any of them.
-
-    Bounded to what actually shipped, which is a dozen or so calls rather than
-    the whole library, and cached like any other look so a rerun pays nothing.
+    The shortlist is a budget — thirty of nearly two thousand — and selection
+    picks from all of them, so most stills in a finished cut have no
+    description and the review cannot judge them. Bounded to what shipped and
+    cached, so a rerun pays nothing. Returns the blended score beside the
+    description: both come out of the same look, and handing back only the
+    words let a look change what the review reads but never what selection
+    ranked on.
     """
     if not assets:
         return {}
     work_dir = config.cache.cache_path / "photo-looks"
     work_dir.mkdir(parents=True, exist_ok=True)
     scored = [(asset, score_photo(asset, config.photos)) for asset in assets]
-    _enhanced, payloads = _enhance_with_llm(
+    enhanced, payloads = _enhance_with_llm(
         scored,
         config.photos,
         work_dir,
@@ -153,35 +154,12 @@ def look_at_selected_photos(
         thumbnail_fn=client.get_asset_thumbnail,
         provider_circuit=provider_circuit,
     )
-    return payloads
-
-
-def from_the_camera_roll(photo_assets: list[Asset], config: Any) -> list[Asset]:
-    """Drop the photos nothing says the library's own camera made.
-
-    Videos are filtered on the same rule before analysis; photos reached
-    selection without ever being asked, so a collage forwarded through a
-    messaging app walked into a year recap while a doorbell clip beside it was
-    turned away. Dropped here rather than later because there is no sense
-    paying a VLM to score something that cannot ship.
-    """
-    from immich_memories.analysis.source_filter import not_shot_here
-
-    analysis = getattr(config, "analysis", None)
-    patterns = getattr(analysis, "exclude_filename_patterns", ())
-    stills_need_a_camera = getattr(analysis, "exclude_stills_without_camera_exif", False)
-    if not patterns and not stills_need_a_camera:
-        return photo_assets
-    kept = [
-        asset
-        for asset in photo_assets
-        if not not_shot_here(asset, patterns=patterns, stills_need_a_camera=stills_need_a_camera)
-    ]
-    if len(kept) < len(photo_assets):
-        logger.info(
-            "Source filter: %d photo(s) from excluded sources", len(photo_assets) - len(kept)
-        )
-    return kept
+    looked = {asset.id: score for asset, score in enhanced}
+    return {
+        asset_id: (looked[asset_id], payload)
+        for asset_id, payload in payloads.items()
+        if asset_id in looked
+    }
 
 
 def _no_photos_to_choose_between(video_candidates: list[BudgetCandidate]) -> PhotoSelectionResult:
@@ -514,10 +492,9 @@ def _select_distributed(
     return selected
 
 
-# What a cached row can answer depends on the prompt as much as on the model,
-# so the cache key carries both. Rows written when a photo could only report
-# two numbers cannot describe themselves, and would have held that silence
-# forever; bumping this invalidates them once, and never again.
+# What a row can answer depends on the prompt as much as the model, so the key
+# carries both: rows written when a photo could only report two numbers cannot
+# describe themselves, and bumping this invalidates them once.
 _PHOTO_LOOK_VERSION = "look1"
 
 

--- a/tests/test_look_changes_rank.py
+++ b/tests/test_look_changes_rank.py
@@ -1,0 +1,117 @@
+"""A look that cannot change a rank only changes the caption.
+
+Measured on a real hobby-project day, ten assets, six never looked at. The
+still that shipped was described as "a clear plastic container holding dried,
+flaky green leaves, possibly herbs or tea" — the model did not recognise the
+material — at interest 0.4. The same day's evening still was described as "a
+white plastic fermentation bucket, equipped with an airlock and spigot" at
+interest 0.6: understood, and a better representative of the day.
+
+Both were looked at. The better one scored higher. The worse one shipped,
+because selection had ranked on metadata and nothing reconsidered.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from immich_memories.analysis.smart_pipeline import (
+    ClipWithSegment,
+    PipelineConfig,
+    SmartPipeline,
+)
+from immich_memories.api.models import AssetType
+from immich_memories.config import Config
+from immich_memories.config_models import AnalysisConfig
+from tests.conftest import make_clip
+
+
+def _pipeline(tmp_path: Path) -> SmartPipeline:
+    analysis_cache = MagicMock()
+    analysis_cache.get_analysis.return_value = None
+    return SmartPipeline(
+        client=MagicMock(),
+        analysis_cache=analysis_cache,
+        thumbnail_cache=MagicMock(),
+        config=PipelineConfig(),
+        analysis_config=AnalysisConfig(),
+        app_config=Config(
+            cache={"directory": str(tmp_path / "cache")},
+            llm={"model": "qwen-3.6"},
+            content_analysis={"enabled": True},
+        ),
+    )
+
+
+def _still(asset_id: str, hour: int, score: float) -> ClipWithSegment:
+    clip = make_clip(
+        asset_id, duration=4.0, file_created_at=datetime(2019, 3, 16, hour, tzinfo=UTC)
+    )
+    clip.asset.type = AssetType.IMAGE
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=score, analyzed=False)
+
+
+def test_the_look_moves_the_score_it_produced(tmp_path: Path) -> None:
+    """The caption and the rank come from the same look; only one was kept."""
+    shipped = _still("misread", 12, 0.310)
+
+    from immich_memories.analysis import photo_look
+
+    # WHY: the VLM is the network boundary; this stands in for its look.
+    with patch(
+        "immich_memories.photos.photo_pipeline.look_at_selected_photos",
+        return_value={"misread": (0.22, {"description": "a container of dried leaves"})},
+    ):
+        photo_look.look_at_stills([shipped], config=_pipeline(tmp_path)._app_config, client=None)
+
+    assert shipped.score == 0.22
+    assert shipped.clip.llm_description == "a container of dried leaves"
+
+
+def test_the_day_repicks_the_frame_the_model_understood(tmp_path: Path) -> None:
+    """The acceptance case: the fermentation bucket, not the hops."""
+    misread = _still("hops-misread", 12, 0.310)
+    understood = _still("fermentation-bucket", 18, 0.334)
+    elsewhere = _still("another-day", 9, 0.6)
+    elsewhere.clip.asset.file_created_at = datetime(2019, 6, 1, 9, tzinfo=UTC)
+
+    from immich_memories.analysis import photo_look
+
+    pipeline = _pipeline(tmp_path)
+    looks = {
+        "hops-misread": (0.22, {"description": "a container of dried leaves"}),
+        "fermentation-bucket": (0.41, {"description": "a fermentation bucket with an airlock"}),
+    }
+    # WHY: the VLM is the network boundary; this stands in for its looks.
+    with patch("immich_memories.photos.photo_pipeline.look_at_selected_photos", return_value=looks):
+        swapped = photo_look.repick_days(
+            selected=[misread, elsewhere],
+            pool=[misread, understood, elsewhere],
+            config=pipeline._app_config,
+            client=None,
+        )
+
+    assert {m.clip.asset.id for m in swapped} == {"fermentation-bucket", "another-day"}
+
+
+def test_a_day_whose_selected_frame_is_already_best_is_left_alone(tmp_path: Path) -> None:
+    """Re-picking must not churn a day that was already right."""
+    best = _still("already-best", 12, 0.5)
+    worse = _still("worse", 18, 0.2)
+
+    from immich_memories.analysis import photo_look
+
+    pipeline = _pipeline(tmp_path)
+    looks = {
+        "already-best": (0.5, {"description": "a family at the table"}),
+        "worse": (0.2, {"description": "an empty worktop"}),
+    }
+    # WHY: the VLM is the network boundary; this stands in for its looks.
+    with patch("immich_memories.photos.photo_pipeline.look_at_selected_photos", return_value=looks):
+        swapped = photo_look.repick_days(
+            selected=[best], pool=[best, worse], config=pipeline._app_config, client=None
+        )
+
+    assert [m.clip.asset.id for m in swapped] == ["already-best"]

--- a/tests/test_pipeline_efficiency.py
+++ b/tests/test_pipeline_efficiency.py
@@ -676,7 +676,7 @@ class TestNothingIsJudgedBlind:
         # WHY: the VLM is the network boundary; this stands in for its look.
         with patch(
             "immich_memories.photos.photo_pipeline.look_at_selected_photos",
-            return_value={"still": {"description": "a plant against a wall"}},
+            return_value={"still": (0.44, {"description": "a plant against a wall"})},
         ):
             pipeline.quality.verify([member], result)
 
@@ -730,7 +730,7 @@ class TestNothingIsJudgedBlind:
         # WHY: the VLM is the network boundary; this stands in for its look.
         with patch(
             "immich_memories.photos.photo_pipeline.look_at_selected_photos",
-            return_value={"unseen-still": {"description": "a beer tap on a bar"}},
+            return_value={"unseen-still": (0.31, {"description": "a beer tap on a bar"})},
         ):
             pipeline.quality.verify([member], result)
 


### PR DESCRIPTION
Closes #524. Stacked on #535 (`fix/judge-photo-scale`) — review that first.

A still is chosen on metadata, long before anything sees it, and the look that followed updated only the description the review reads. Measured on a real day:

| frame | the model saw | interest | shipped |
|---|---|---|---|
| midday | "dried, flaky green leaves, possibly herbs or tea" | 0.4 | **yes** |
| evening | "a white plastic fermentation bucket, equipped with an airlock and spigot" | 0.6 | no |

Both were looked at. The better one scored higher. The worse one shipped, because selection had ranked on metadata and nothing reconsidered.

## Fix

The look now hands back the score it produced as well as the words — they come out of the same call — and the day gets to reconsider its own frame once its candidates have been seen.

Bounded to the day rather than the library: only days that already hold a selected still, only against that day's own candidates, at most four of them, and cached so a candidate seen before costs nothing.

## Two refactors came with it

Both because the work hit the 1000-line hard gate, and the owner's call was to stop paying it off a few lines at a time.

- **`analysis/photo_look.py`** — what a VLM look at a still does to a selection. The two passes cohere there.
- **`analysis/selection_quality.py`** — verify, judge and review. `smart_pipeline` was not slightly too long, it was doing two jobs: selection builds a cut, these passes read one back and decide whether it ships. Composed by constructor injection, no behaviour change, 988 → 640 lines. `ARCHITECTURE.md` updated.

`make ci` green, whole suite passing.
