### PR TITLE
fix(photos): let the tie-break read the pixels, and stop mixing two formulas

### DIFF
--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -672,7 +672,7 @@ def _merge_photos_into_pool(
     # photograph the way it reads a video. Without it every still arrived as a
     # bare line and survived on the rule that protects unanalysed material.
     from immich_memories.analysis.cache_projection import apply_semantic_payload
-    from immich_memories.photos.photo_pipeline import semantic_payloads_for
+    from immich_memories.photos.scoring import semantic_payloads_for
 
     payloads = semantic_payloads_for(
         config.cache.database_path, [asset.id for asset, _ in scored], config.llm.model

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -37,11 +37,15 @@ from immich_memories.photos.renderer import (
     face_aware_pan,
     render_ken_burns_streaming,
 )
-from immich_memories.photos.scoring import PhotoLook, score_photo
+from immich_memories.photos.scoring import _enhance_with_llm, score_photo
 from immich_memories.processing.assembly_config import AssemblyClip
 from immich_memories.processing.ffmpeg_runner import write_frames_to_ffmpeg
 
 logger = logging.getLogger(__name__)
+# How many previews the tie-break may fetch when nothing cached them. The
+# photos in contention are what it is for, and a library's worth of previews
+# is the cost the LLM shortlist exists to avoid.
+_QUALITY_FETCH_BUDGET = 120
 
 
 @dataclass
@@ -89,7 +93,9 @@ def score_photos(
 
     # The metadata score alone ties hundreds of photos onto a handful of
     # values; what the pixels say breaks those ties (#489).
-    metadata_scored = _apply_frame_quality(metadata_scored, config, thumbnail_cache)
+    metadata_scored = _apply_frame_quality(
+        metadata_scored, config, thumbnail_cache, thumbnail_fn=thumbnail_fn
+    )
 
     # Cap only the expensive semantic-scoring shortlist.
     shortlist_size = llm_shortlist_size(video_clip_count, len(metadata_scored), config.max_ratio)
@@ -328,10 +334,55 @@ _CONTRAST_SHARE = 0.2
 _EXPOSURE_SHARE = 0.2
 
 
+def _frames_for_quality(
+    scored: list[tuple[Asset, float]],
+    thumbnail_cache: Any,
+    thumbnail_fn: Any,
+    budget: int,
+) -> list[bytes | None]:
+    """The thumbnail behind each photo, fetching where nothing cached one.
+
+    Reading the cache alone was enough on the UI path and empty on the CLI
+    one, where the only writers are the video prefetcher and burst dedup — so
+    nearly every photo arrived unmeasured and kept the flat share, while the
+    log claimed quality decided a third of the score.
+
+    Fetching is bounded and spread across the timeline, the same way the LLM
+    shortlist is drawn: what the tie-break is for is the photos in contention,
+    and a library's worth of previews is the cost the shortlist exists to
+    avoid.
+    """
+    frames: list[bytes | None] = [
+        thumbnail_cache.get(asset.id, "preview") if thumbnail_cache else None
+        for asset, _score in scored
+    ]
+    if thumbnail_fn is None:
+        return frames
+
+    missing = [index for index, data in enumerate(frames) if not data]
+    if len(missing) > budget:
+        chosen = _select_distributed([scored[index] for index in missing], budget)
+        wanted = {asset.id for asset, _score in chosen}
+        missing = [index for index in missing if scored[index][0].id in wanted]
+
+    fetched = 0
+    for index in missing:
+        try:
+            frames[index] = thumbnail_fn(scored[index][0].id, size="preview")
+            fetched += 1
+        except (ImmichAPIError, OSError, RuntimeError, ValueError) as exc:  # noqa: PERF203
+            logger.debug("No preview for %s: %s", scored[index][0].id, type(exc).__name__)
+    if fetched:
+        logger.info("Frame quality: fetched %d preview(s) to break the score ties", fetched)
+    return frames
+
+
 def _apply_frame_quality(
     scored: list[tuple[Asset, float]],
     config: PhotoConfig,
     thumbnail_cache: Any,
+    thumbnail_fn: Any = None,
+    budget: int = _QUALITY_FETCH_BUDGET,
 ) -> list[tuple[Asset, float]]:
     """Re-weight scores so a share of each is decided by the image itself.
 
@@ -339,15 +390,13 @@ def _apply_frame_quality(
     "best N" means "first N of the largest group". Measured on four months:
     227-648 photos collapsing onto 5-8 distinct scores, all inside 0.24-0.48.
     """
-    if thumbnail_cache is None or len(scored) < 2:
+    if (thumbnail_cache is thumbnail_fn is None) or len(scored) < 2:
         return scored
 
     from immich_memories.photos.frame_quality import measure, rank
 
-    measured = []
-    for asset, _score in scored:
-        data = thumbnail_cache.get(asset.id, "preview")
-        measured.append(measure(data) if data else None)
+    frames = _frames_for_quality(scored, thumbnail_cache, thumbnail_fn, budget)
+    measured = [measure(data) if data else None for data in frames]
 
     usable = [(i, m) for i, m in enumerate(measured) if m is not None]
     if len(usable) < 2:
@@ -490,236 +539,6 @@ def _select_distributed(
             seen.add(best[0].id)
 
     return selected
-
-
-# What a row can answer depends on the prompt as much as the model, so the key
-# carries both: rows written when a photo could only report two numbers cannot
-# describe themselves, and bumping this invalidates them once.
-_PHOTO_LOOK_VERSION = "look1"
-
-
-def _photo_look_version(model: str) -> str:
-    """The cache key for a photo look: which model, answering which prompt."""
-    return f"{model}#{_PHOTO_LOOK_VERSION}"
-
-
-def semantic_payloads_for(
-    db_path: Path | None,
-    asset_ids: list[str],
-    model_version: str | None,
-) -> dict[str, dict]:
-    """What the VLM said about these photos, keyed by asset id.
-
-    Read from the score cache rather than threaded back through scoring: the
-    row is written as each photo is scored, so this answers for the ones just
-    looked at and for the ones a previous run paid for. Callers hand the
-    result to cache_projection.apply_semantic_payload.
-    """
-    if not db_path or not asset_ids:
-        return {}
-    cache = _get_score_cache(db_path)
-    if cache is None:
-        return {}
-    rows = _cached_scores(cache, asset_ids, _photo_look_version(model_version or ""))
-    return {asset_id: _payload_from_cache(row) for asset_id, row in rows.items()}
-
-
-def _as_float(value: object) -> float | None:
-    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
-
-
-def _as_text(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
-
-
-def _payload_from_cache(row: dict) -> dict:
-    """What a cached row can tell the review, in the shape a clip expects."""
-    return {
-        "description": row.get("llm_description"),
-        "category": None,
-        "emotion": row.get("llm_emotion"),
-        "subjects": None,
-        "setting": None,
-        "interestingness": row.get("llm_interest"),
-        "quality": row.get("llm_quality"),
-    }
-
-
-def _enhance_with_llm(
-    scored: list[tuple[Asset, float]],
-    config: PhotoConfig,
-    work_dir: Path,
-    download_fn: Any,
-    db_path: Path | None = None,
-    app_config: Any = None,
-    thumbnail_fn: Any = None,
-    provider_circuit: Any = None,
-) -> tuple[list[tuple[Asset, float]], dict[str, dict]]:
-    """Check cache first, then LLM-score uncached photos.
-
-    Returns the scores and, beside them, what the model said about each photo
-    — keyed by asset id, in the shape apply_semantic_payload expects. A photo
-    that cannot describe itself is one the holistic review cannot judge.
-    """
-
-    if app_config is None or not app_config.content_analysis.enabled or not app_config.llm.model:
-        return scored, {}
-
-    cache = _get_score_cache(db_path) if db_path else None
-    asset_ids = [a.id for a, _ in scored]
-    model_version = _photo_look_version(app_config.llm.model)
-    cached = _cached_scores(cache, asset_ids, model_version)
-
-    cache_hits = 0
-    enhanced: list[tuple[Asset, float]] = []
-    payloads: dict[str, dict] = {}
-    for asset, meta_score in scored:
-        # Cache hit — use stored score, and the words stored with it
-        if asset.id in cached:
-            row = cached[asset.id]
-            enhanced.append((asset, row["combined_score"]))
-            payloads[asset.id] = _payload_from_cache(row)
-            cache_hits += 1
-            continue
-
-        # Cache miss — download + LLM
-        look = _llm_score_photo(
-            asset,
-            meta_score,
-            config,
-            work_dir,
-            download_fn,
-            app_config,
-            thumbnail_fn=thumbnail_fn,
-            provider_circuit=provider_circuit,
-        )
-        effective_score = look.score if look is not None else meta_score
-        enhanced.append((asset, effective_score))
-        if look is not None:
-            payloads[asset.id] = look.payload
-
-        # Only successful semantic results belong to the configured model.
-        if cache and look is not None and model_version:
-            cache.save_asset_score(
-                asset_id=asset.id,
-                asset_type="photo",
-                metadata_score=meta_score,
-                combined_score=effective_score,
-                llm_interest=_as_float(look.payload.get("interestingness")),
-                llm_quality=_as_float(look.payload.get("quality")),
-                llm_emotion=_as_text(look.payload.get("emotion")),
-                llm_description=_as_text(look.payload.get("description")),
-                model_version=model_version,
-            )
-
-    if cache_hits:
-        logger.info(f"Photo score cache: {cache_hits} hits, {len(scored) - cache_hits} misses")
-
-    return enhanced, payloads
-
-
-def _llm_score_photo(
-    asset: Asset,
-    meta_score: float,
-    config: PhotoConfig,
-    work_dir: Path,
-    download_fn: Any,
-    app_config: Any,
-    thumbnail_fn: Any = None,
-    provider_circuit: Any = None,
-) -> PhotoLook | None:
-    """Look at a photo with the VLM, using a lightweight thumbnail.
-
-    Uses Immich thumbnail API (~100 KB) instead of downloading the full
-    HEIC (5-15 MB). Falls back to full download if no thumbnail_fn.
-    """
-    from immich_memories.photos.scoring import score_photo_with_llm
-
-    if provider_circuit is not None and not provider_circuit.available:
-        return None
-
-    thumb_path = work_dir / f"{asset.id}_thumb.jpg"
-
-    # WHY: Thumbnails are ~100 KB vs 5-15 MB for full HEICs. The VLM
-    # doesn't need HDR gain maps or 4K resolution to score a photo.
-    if thumbnail_fn and not thumb_path.exists():
-        try:
-            thumb_bytes = thumbnail_fn(asset.id, size="preview")
-            thumb_path.write_bytes(thumb_bytes)
-        except (ImmichAPIError, OSError, RuntimeError, ValueError):
-            thumbnail_fn = None  # Fall back to full download
-
-    if thumb_path.exists():
-        try:
-            return score_photo_with_llm(
-                thumb_path,
-                meta_score,
-                config,
-                app_config,
-                provider_circuit=provider_circuit,
-            )
-        except (OSError, RuntimeError, ValueError):
-            return None
-
-    # Fallback: download full file (old behavior)
-    ext = Path(asset.original_file_name).suffix if asset.original_file_name else ".jpg"
-    raw_path = work_dir / f"{asset.id}{ext}"
-    if not raw_path.exists():
-        try:
-            download_fn(asset.id, raw_path)
-        except (ImmichAPIError, OSError, RuntimeError, ValueError):
-            return None
-
-    try:
-        from immich_memories.photos.animator import prepare_photo_source
-
-        prepared = prepare_photo_source(raw_path, work_dir)
-        return score_photo_with_llm(
-            prepared.path,
-            meta_score,
-            config,
-            app_config,
-            provider_circuit=provider_circuit,
-        )
-    except (OSError, RuntimeError, ValueError):
-        return None
-
-
-def _cached_scores(cache, asset_ids: list[str], model_version: str | None) -> dict:
-    """Previously computed scores, or nothing if the cache cannot answer.
-
-    The cache opens lazily, so an unwritable database survives construction
-    and raises on the first read instead — which took photo scoring down with
-    it. Losing the cache costs LLM calls, not the run.
-    """
-    import sqlite3
-
-    if not cache or not model_version:
-        return {}
-    try:
-        return cache.get_asset_scores_batch(asset_ids, model_version=model_version)
-    except (OSError, sqlite3.Error) as exc:
-        logger.debug("Photo score cache unreadable (%s): rescoring", exc)
-        return {}
-
-
-def _get_score_cache(db_path: Path):
-    """Get the asset score cache, or None when it cannot be opened.
-
-    sqlite raises OperationalError rather than OSError for an unwritable or
-    missing directory, so that case escaped the guard and took photo scoring
-    down with it. A cache that cannot be opened costs repeated LLM calls, not
-    a failed run.
-    """
-    import sqlite3
-
-    try:
-        from immich_memories.cache.asset_score_cache import AssetScoreCache
-
-        return AssetScoreCache(db_path=db_path)
-    except (ImportError, OSError, sqlite3.Error) as exc:
-        logger.debug("Photo score cache unavailable (%s): scores will not persist", exc)
-        return None
 
 
 def _render_single_photo(

--- a/src/immich_memories/photos/scoring.py
+++ b/src/immich_memories/photos/scoring.py
@@ -17,7 +17,9 @@ import math
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import Asset
 from immich_memories.config import Config
 from immich_memories.config_models import PhotoConfig
@@ -253,3 +255,242 @@ def _note_provider_health(response: object, config: object, provider_circuit) ->
         and provider_circuit.set_health(health)
     ):
         logger.warning("Photo content analysis disabled for this run: %s", health.message)
+
+
+# A cached row is only as good as everything that produced it: the model, the
+# prompt it answered, and the formula that blended the answer into a score.
+# The key carries all three, because a row that predates any of them is not a
+# cheaper version of today's answer, it is a different one. Warm-cache photos
+# ranked on the pre-#489 formula while cache-miss photos beside them ranked on
+# the new one — two scoring regimes inside a single selection.
+#
+# Bump this whenever the prompt or the scoring weights change. It invalidates
+# the affected rows exactly once.
+# What a row can answer depends on the prompt as much as the model, so the key
+# carries both: rows written when a photo could only report two numbers cannot
+# describe themselves, and bumping this invalidates them once.
+_PHOTO_LOOK_VERSION = "look2"
+
+
+def _photo_look_version(model: str) -> str:
+    """The cache key for a photo look: which model, answering which prompt."""
+    return f"{model}#{_PHOTO_LOOK_VERSION}"
+
+
+def semantic_payloads_for(
+    db_path: Path | None,
+    asset_ids: list[str],
+    model_version: str | None,
+) -> dict[str, dict]:
+    """What the VLM said about these photos, keyed by asset id.
+
+    Read from the score cache rather than threaded back through scoring: the
+    row is written as each photo is scored, so this answers for the ones just
+    looked at and for the ones a previous run paid for. Callers hand the
+    result to cache_projection.apply_semantic_payload.
+    """
+    if not db_path or not asset_ids:
+        return {}
+    cache = _get_score_cache(db_path)
+    if cache is None:
+        return {}
+    rows = _cached_scores(cache, asset_ids, _photo_look_version(model_version or ""))
+    return {asset_id: _payload_from_cache(row) for asset_id, row in rows.items()}
+
+
+def _as_float(value: object) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _as_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _payload_from_cache(row: dict) -> dict:
+    """What a cached row can tell the review, in the shape a clip expects."""
+    return {
+        "description": row.get("llm_description"),
+        "category": None,
+        "emotion": row.get("llm_emotion"),
+        "subjects": None,
+        "setting": None,
+        "interestingness": row.get("llm_interest"),
+        "quality": row.get("llm_quality"),
+    }
+
+
+def _enhance_with_llm(
+    scored: list[tuple[Asset, float]],
+    config: PhotoConfig,
+    work_dir: Path,
+    download_fn: Any,
+    db_path: Path | None = None,
+    app_config: Any = None,
+    thumbnail_fn: Any = None,
+    provider_circuit: Any = None,
+) -> tuple[list[tuple[Asset, float]], dict[str, dict]]:
+    """Check cache first, then LLM-score uncached photos.
+
+    Returns the scores and, beside them, what the model said about each photo
+    — keyed by asset id, in the shape apply_semantic_payload expects. A photo
+    that cannot describe itself is one the holistic review cannot judge.
+    """
+
+    if app_config is None or not app_config.content_analysis.enabled or not app_config.llm.model:
+        return scored, {}
+
+    cache = _get_score_cache(db_path) if db_path else None
+    asset_ids = [a.id for a, _ in scored]
+    model_version = _photo_look_version(app_config.llm.model)
+    cached = _cached_scores(cache, asset_ids, model_version)
+
+    cache_hits = 0
+    enhanced: list[tuple[Asset, float]] = []
+    payloads: dict[str, dict] = {}
+    for asset, meta_score in scored:
+        # Cache hit — use stored score, and the words stored with it
+        if asset.id in cached:
+            row = cached[asset.id]
+            enhanced.append((asset, row["combined_score"]))
+            payloads[asset.id] = _payload_from_cache(row)
+            cache_hits += 1
+            continue
+
+        # Cache miss — download + LLM
+        look = _llm_score_photo(
+            asset,
+            meta_score,
+            config,
+            work_dir,
+            download_fn,
+            app_config,
+            thumbnail_fn=thumbnail_fn,
+            provider_circuit=provider_circuit,
+        )
+        effective_score = look.score if look is not None else meta_score
+        enhanced.append((asset, effective_score))
+        if look is not None:
+            payloads[asset.id] = look.payload
+
+        # Only successful semantic results belong to the configured model.
+        if cache and look is not None and model_version:
+            cache.save_asset_score(
+                asset_id=asset.id,
+                asset_type="photo",
+                metadata_score=meta_score,
+                combined_score=effective_score,
+                llm_interest=_as_float(look.payload.get("interestingness")),
+                llm_quality=_as_float(look.payload.get("quality")),
+                llm_emotion=_as_text(look.payload.get("emotion")),
+                llm_description=_as_text(look.payload.get("description")),
+                model_version=model_version,
+            )
+
+    if cache_hits:
+        logger.info(f"Photo score cache: {cache_hits} hits, {len(scored) - cache_hits} misses")
+
+    return enhanced, payloads
+
+
+def _llm_score_photo(
+    asset: Asset,
+    meta_score: float,
+    config: PhotoConfig,
+    work_dir: Path,
+    download_fn: Any,
+    app_config: Any,
+    thumbnail_fn: Any = None,
+    provider_circuit: Any = None,
+) -> PhotoLook | None:
+    """Look at a photo with the VLM, using a lightweight thumbnail.
+
+    Uses Immich thumbnail API (~100 KB) instead of downloading the full
+    HEIC (5-15 MB). Falls back to full download if no thumbnail_fn.
+    """
+    from immich_memories.photos.scoring import score_photo_with_llm
+
+    if provider_circuit is not None and not provider_circuit.available:
+        return None
+
+    thumb_path = work_dir / f"{asset.id}_thumb.jpg"
+
+    # WHY: Thumbnails are ~100 KB vs 5-15 MB for full HEICs. The VLM
+    # doesn't need HDR gain maps or 4K resolution to score a photo.
+    if thumbnail_fn and not thumb_path.exists():
+        try:
+            thumb_bytes = thumbnail_fn(asset.id, size="preview")
+            thumb_path.write_bytes(thumb_bytes)
+        except (ImmichAPIError, OSError, RuntimeError, ValueError):
+            thumbnail_fn = None  # Fall back to full download
+
+    if thumb_path.exists():
+        try:
+            return score_photo_with_llm(
+                thumb_path,
+                meta_score,
+                config,
+                app_config,
+                provider_circuit=provider_circuit,
+            )
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+    # Fallback: download full file (old behavior)
+    ext = Path(asset.original_file_name).suffix if asset.original_file_name else ".jpg"
+    raw_path = work_dir / f"{asset.id}{ext}"
+    if not raw_path.exists():
+        try:
+            download_fn(asset.id, raw_path)
+        except (ImmichAPIError, OSError, RuntimeError, ValueError):
+            return None
+
+    try:
+        from immich_memories.photos.animator import prepare_photo_source
+
+        prepared = prepare_photo_source(raw_path, work_dir)
+        return score_photo_with_llm(
+            prepared.path,
+            meta_score,
+            config,
+            app_config,
+            provider_circuit=provider_circuit,
+        )
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _cached_scores(cache, asset_ids: list[str], model_version: str | None) -> dict:
+    """Previously computed scores, or nothing if the cache cannot answer.
+
+    The cache opens lazily, so an unwritable database survives construction
+    and raises on the first read instead — which took photo scoring down with
+    it. Losing the cache costs LLM calls, not the run.
+    """
+    import sqlite3
+
+    if not cache or not model_version:
+        return {}
+    try:
+        return cache.get_asset_scores_batch(asset_ids, model_version=model_version)
+    except (OSError, sqlite3.Error) as exc:
+        logger.debug("Photo score cache unreadable (%s): rescoring", exc)
+        return {}
+
+
+def _get_score_cache(db_path: Path):
+    """Get the asset score cache, or None when it cannot be opened.
+
+    sqlite raises OperationalError rather than OSError for an unwritable or
+    missing directory, so that case escaped the guard and took photo scoring
+    down with it. A cache that cannot be opened costs repeated LLM calls, not
+    a failed run.
+    """
+    import sqlite3
+
+    try:
+        from immich_memories.cache.asset_score_cache import AssetScoreCache
+
+        return AssetScoreCache(db_path=db_path)
+    except (ImportError, OSError, sqlite3.Error) as exc:
+        logger.debug("Photo score cache unavailable (%s): scores will not persist", exc)
+        return None

--- a/tests/test_frame_quality_runs.py
+++ b/tests/test_frame_quality_runs.py
@@ -1,0 +1,117 @@
+"""The tie-break that reads the pixels has to be able to see them.
+
+Metadata alone ties hundreds of photos onto a handful of values — measured
+across four months, 227-648 photos collapsing onto 5-8 distinct scores, all
+inside 0.24-0.48 — so "best N" means "first N of the largest group". #489
+added a quality share to break that, and it only ever read a thumbnail cache
+that, on a CLI run, nothing had filled: the re-weighting silently did nothing
+while the log claimed quality decided a third of the score.
+"""
+
+from __future__ import annotations
+
+import io
+
+from immich_memories.config_models import PhotoConfig
+from immich_memories.photos.photo_pipeline import _apply_frame_quality
+from tests.conftest import make_asset
+
+
+def _jpeg(*, blurry: bool) -> bytes:
+    """A real, readable frame — sharp edges or a flat wash."""
+    import numpy as np
+    from PIL import Image
+
+    if blurry:
+        pixels = np.full((64, 64), 128, dtype="uint8")
+    else:
+        pixels = np.indices((64, 64))[1].astype("uint8") * 4
+        pixels[::2] = 255 - pixels[::2]
+    buffer = io.BytesIO()
+    Image.fromarray(pixels, mode="L").convert("RGB").save(buffer, format="JPEG", quality=95)
+    return buffer.getvalue()
+
+
+def _tied_pool(count: int) -> list[tuple[object, float]]:
+    return [(make_asset(f"photo-{i}"), 0.30) for i in range(count)]
+
+
+def test_the_pixels_break_the_tie_when_nothing_cached_them(tmp_path) -> None:
+    """On a CLI run the only cache writers are the video prefetcher and burst
+    dedup, so nearly every photo arrives unmeasured and keeps the flat share.
+    """
+    pool = _tied_pool(6)
+    frames = {asset.id: _jpeg(blurry=index % 2 == 0) for index, (asset, _score) in enumerate(pool)}
+
+    class _EmptyCache:
+        def get(self, _asset_id: str, _size: str) -> bytes | None:
+            return None
+
+    rescored = _apply_frame_quality(
+        pool,
+        PhotoConfig(),
+        _EmptyCache(),
+        thumbnail_fn=lambda asset_id, **_kw: frames[asset_id],
+    )
+
+    assert len({round(score, 6) for _asset, score in rescored}) > 1, (
+        "every photo kept the same score; the pixels were never read"
+    )
+
+
+def test_a_cached_frame_is_not_fetched_again(tmp_path) -> None:
+    """The cache exists so a warm run costs nothing."""
+    pool = _tied_pool(4)
+    sharp = _jpeg(blurry=False)
+    blurry = _jpeg(blurry=True)
+
+    class _WarmCache:
+        def get(self, asset_id: str, _size: str) -> bytes:
+            return sharp if asset_id.endswith(("0", "1")) else blurry
+
+    fetched: list[str] = []
+
+    rescored = _apply_frame_quality(
+        pool,
+        PhotoConfig(),
+        _WarmCache(),
+        thumbnail_fn=lambda asset_id, **_kw: fetched.append(asset_id) or sharp,
+    )
+
+    assert fetched == []
+    assert len({round(score, 6) for _asset, score in rescored}) > 1
+
+
+def test_without_a_way_to_fetch_it_still_uses_what_is_cached(tmp_path) -> None:
+    """The old call signature keeps working; it just cannot reach further."""
+    pool = _tied_pool(4)
+    sharp = _jpeg(blurry=False)
+    blurry = _jpeg(blurry=True)
+
+    class _PartialCache:
+        def get(self, asset_id: str, _size: str) -> bytes | None:
+            return sharp if asset_id.endswith("0") else (blurry if asset_id.endswith("1") else None)
+
+    rescored = _apply_frame_quality(pool, PhotoConfig(), _PartialCache())
+
+    assert len({round(score, 6) for _asset, score in rescored}) > 1
+
+
+def test_a_row_scored_by_an_older_formula_is_not_reused() -> None:
+    """The key names the model and the prompt; the formula changes too.
+
+    A warm-cache photo ranked on the pre-#489 formula while a cache-miss
+    photo beside it ranked on the new one — two scoring regimes inside one
+    selection, and no column to tell them apart.
+    """
+    from immich_memories.photos.scoring import _PHOTO_LOOK_VERSION, _photo_look_version
+
+    key = _photo_look_version("some-model")
+
+    assert key.startswith("some-model#")
+    assert _photo_look_version("other-model") != key
+    # Pinned on purpose: changing the prompt or the scoring weights without
+    # bumping this silently mixes two regimes in one selection, and nothing
+    # else in the system would notice. If this assertion fails, that is the
+    # question being asked — bump it, do not edit the number here.
+    assert _PHOTO_LOOK_VERSION == "look2"

--- a/tests/test_photo_pipeline.py
+++ b/tests/test_photo_pipeline.py
@@ -98,7 +98,7 @@ def test_the_description_survives_scoring_and_the_score_stays_a_number(tmp_path,
     handed a bare line and protected by the rule that says never to drop a
     clip for missing information.
     """
-    from immich_memories.photos import photo_pipeline
+    from immich_memories.photos import photo_pipeline, scoring
     from immich_memories.photos.scoring import PhotoLook
 
     asset = _photo("shot", "IMG_1375.HEIC")
@@ -106,7 +106,7 @@ def test_the_description_survives_scoring_and_the_score_stays_a_number(tmp_path,
 
     # WHY: the VLM is the network boundary; this stands in for its answer.
     monkeypatch.setattr(
-        photo_pipeline,
+        scoring,
         "_llm_score_photo",
         lambda *_a, **_k: PhotoLook(
             score=0.42,
@@ -136,7 +136,7 @@ def test_a_score_cached_before_photos_could_describe_themselves_is_re_asked(tmp_
     answer is now a property of the prompt as well, so the key carries both —
     which invalidates the scores-only rows exactly once, and never again.
     """
-    from immich_memories.photos import photo_pipeline
+    from immich_memories.photos import photo_pipeline, scoring
     from immich_memories.photos.scoring import PhotoLook
 
     asset = _photo("shot", "IMG_1375.HEIC")
@@ -149,9 +149,9 @@ def test_a_score_cached_before_photos_could_describe_themselves_is_re_asked(tmp_
         ),
         save_asset_score=lambda **_kw: None,
     )
-    monkeypatch.setattr(photo_pipeline, "_get_score_cache", lambda _db: cache)
+    monkeypatch.setattr(scoring, "_get_score_cache", lambda _db: cache)
     monkeypatch.setattr(
-        photo_pipeline,
+        scoring,
         "_llm_score_photo",
         lambda *_a, **_k: PhotoLook(score=0.42, payload={"description": "a whiteboard"}),
     )

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -9,8 +9,12 @@ import pytest
 
 from immich_memories.api.models import Person
 from immich_memories.config_models import PhotoConfig
-from immich_memories.photos.photo_pipeline import _photo_look_version
-from immich_memories.photos.scoring import PhotoLook, score_photo, score_photo_with_llm
+from immich_memories.photos.scoring import (
+    PhotoLook,
+    _photo_look_version,
+    score_photo,
+    score_photo_with_llm,
+)
 from tests.conftest import make_asset
 
 
@@ -194,7 +198,7 @@ class TestCacheFirstScoring:
 
     def test_cache_hit_returns_cached_score_no_llm(self):
         """When score is cached, return it without calling LLM."""
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         scored = [(_photo("cached-1"), 0.4)]
 
@@ -205,11 +209,11 @@ class TestCacheFirstScoring:
 
         with (
             patch(
-                "immich_memories.photos.photo_pipeline._get_score_cache",
+                "immich_memories.photos.scoring._get_score_cache",
                 return_value=mock_cache,
             ),
             patch(
-                "immich_memories.photos.photo_pipeline._llm_score_photo",
+                "immich_memories.photos.scoring._llm_score_photo",
             ) as mock_llm,
         ):
             result, _payloads = _enhance_with_llm(
@@ -229,7 +233,7 @@ class TestCacheFirstScoring:
         from immich_memories.cache.asset_score_cache import AssetScoreCache
         from immich_memories.cache.database import VideoAnalysisCache
         from immich_memories.config_loader import Config
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         db_path = tmp_path / "scores.db"
         VideoAnalysisCache(db_path)
@@ -241,7 +245,7 @@ class TestCacheFirstScoring:
         )
 
         with patch(
-            "immich_memories.photos.photo_pipeline._llm_score_photo",
+            "immich_memories.photos.scoring._llm_score_photo",
             return_value=PhotoLook(score=0.77, payload={"description": "a photograph"}),
         ):
             result, _payloads = _enhance_with_llm(
@@ -263,7 +267,7 @@ class TestCacheFirstScoring:
         from immich_memories.cache.asset_score_cache import AssetScoreCache
         from immich_memories.cache.database import VideoAnalysisCache
         from immich_memories.config_loader import Config
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         db_path = tmp_path / "scores.db"
         VideoAnalysisCache(db_path)
@@ -273,7 +277,7 @@ class TestCacheFirstScoring:
         )
 
         with patch(
-            "immich_memories.photos.photo_pipeline._llm_score_photo",
+            "immich_memories.photos.scoring._llm_score_photo",
             return_value=None,
         ):
             result, _payloads = _enhance_with_llm(
@@ -296,7 +300,7 @@ class TestCacheFirstScoring:
         from immich_memories.cache.asset_score_cache import AssetScoreCache
         from immich_memories.cache.database import VideoAnalysisCache
         from immich_memories.config_loader import Config
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         db_path = tmp_path / "scores.db"
         VideoAnalysisCache(db_path)
@@ -328,7 +332,7 @@ class TestCacheFirstScoring:
         self, tmp_path: Path
     ) -> None:
         from immich_memories.config_loader import Config
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         thumbnail_fn = MagicMock(return_value=b"jpeg")
         download_fn = MagicMock()
@@ -348,7 +352,7 @@ class TestCacheFirstScoring:
 
     def test_cache_miss_calls_llm_and_saves(self):
         """When score is NOT cached, run LLM and save result to cache."""
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         scored = [(_photo("uncached-1"), 0.5)]
 
@@ -358,12 +362,12 @@ class TestCacheFirstScoring:
 
         with (
             patch(
-                "immich_memories.photos.photo_pipeline._get_score_cache",
+                "immich_memories.photos.scoring._get_score_cache",
                 return_value=mock_cache,
             ),
             # WHY: external LLM API
             patch(
-                "immich_memories.photos.photo_pipeline._llm_score_photo",
+                "immich_memories.photos.scoring._llm_score_photo",
                 return_value=PhotoLook(score=0.75, payload={"description": "a photograph"}),
             ) as mock_llm,
         ):
@@ -396,7 +400,7 @@ class TestCacheFirstScoring:
 
     def test_mix_of_cached_and_uncached(self):
         """Batch with some hits and some misses handles both correctly."""
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         scored = [
             (_photo("hit-1"), 0.3),
@@ -413,12 +417,12 @@ class TestCacheFirstScoring:
 
         with (
             patch(
-                "immich_memories.photos.photo_pipeline._get_score_cache",
+                "immich_memories.photos.scoring._get_score_cache",
                 return_value=mock_cache,
             ),
             # WHY: external LLM API — only called for the miss
             patch(
-                "immich_memories.photos.photo_pipeline._llm_score_photo",
+                "immich_memories.photos.scoring._llm_score_photo",
                 return_value=PhotoLook(score=0.55, payload={"description": "a photograph"}),
             ) as mock_llm,
         ):
@@ -442,19 +446,19 @@ class TestCacheFirstScoring:
 
     def test_no_cache_available_still_runs_llm(self):
         """When _get_score_cache returns None, LLM runs for all assets."""
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         scored = [(_photo("no-cache-1"), 0.5)]
 
         with (
             # WHY: database unavailable
             patch(
-                "immich_memories.photos.photo_pipeline._get_score_cache",
+                "immich_memories.photos.scoring._get_score_cache",
                 return_value=None,
             ),
             # WHY: external LLM API
             patch(
-                "immich_memories.photos.photo_pipeline._llm_score_photo",
+                "immich_memories.photos.scoring._llm_score_photo",
                 return_value=PhotoLook(score=0.7, payload={"description": "a photograph"}),
             ) as mock_llm,
         ):
@@ -474,7 +478,7 @@ class TestCacheFirstScoring:
         self, tmp_path: Path
     ) -> None:
         """A failed request must not look like a model-authored score to the cache."""
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _photo("fail-1", exif_make="Apple")
         meta_score = 0.42
@@ -490,7 +494,7 @@ class TestCacheFirstScoring:
 
     def test_llm_prepare_failure_is_not_a_semantic_score(self, tmp_path: Path):
         """A decode failure remains distinguishable so callers avoid caching it."""
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _photo("fail-2")
         asset.original_file_name = "photo.jpg"
@@ -516,7 +520,7 @@ class TestCacheFirstScoring:
 
     def test_get_score_cache_returns_none_on_import_error(self):
         """_get_score_cache returns None when dependencies are unavailable."""
-        from immich_memories.photos.photo_pipeline import _get_score_cache
+        from immich_memories.photos.scoring import _get_score_cache
 
         with patch(
             "immich_memories.cache.asset_score_cache.AssetScoreCache",

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -677,7 +677,7 @@ class TestEnhanceWithLlm:
     def test_cache_hit_skips_llm(self, tmp_path):
         from immich_memories.config_loader import Config
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
+        from immich_memories.photos.scoring import _enhance_with_llm
 
         asset = _make_asset(id="cached-001")
         scored = [(asset, 0.5)]
@@ -689,7 +689,7 @@ class TestEnhanceWithLlm:
 
         # WHY: _get_score_cache imports from cache module — mock to avoid DB
         with patch(
-            "immich_memories.photos.photo_pipeline._get_score_cache",
+            "immich_memories.photos.scoring._get_score_cache",
             return_value=mock_cache,
         ):
             result, _payloads = _enhance_with_llm(
@@ -706,8 +706,7 @@ class TestEnhanceWithLlm:
     def test_cache_miss_calls_llm(self, tmp_path):
         from immich_memories.config_loader import Config
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _enhance_with_llm
-        from immich_memories.photos.scoring import PhotoLook
+        from immich_memories.photos.scoring import PhotoLook, _enhance_with_llm
 
         asset = _make_asset(id="uncached-001")
         scored = [(asset, 0.5)]
@@ -719,11 +718,11 @@ class TestEnhanceWithLlm:
 
         with (
             patch(
-                "immich_memories.photos.photo_pipeline._get_score_cache",
+                "immich_memories.photos.scoring._get_score_cache",
                 return_value=mock_cache,
             ),
             patch(
-                "immich_memories.photos.photo_pipeline._llm_score_photo",
+                "immich_memories.photos.scoring._llm_score_photo",
                 return_value=PhotoLook(score=0.85, payload={"description": "a photograph"}),
             ),
         ):
@@ -745,7 +744,7 @@ class TestLlmScorePhoto:
 
     def test_thumbnail_path_used_when_available(self, tmp_path):
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _make_asset(id="thumb-001")
         config = PhotoConfig()
@@ -767,7 +766,7 @@ class TestLlmScorePhoto:
 
     def test_llm_error_is_not_reported_as_a_semantic_score(self, tmp_path):
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _make_asset(id="err-001")
         config = PhotoConfig()
@@ -792,7 +791,7 @@ class TestLlmScorePhoto:
 
     def test_falls_back_to_full_download(self, tmp_path):
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _make_asset(id="no-thumb-001", originalFileName="IMG.HEIC")
         config = PhotoConfig()
@@ -824,7 +823,7 @@ class TestLlmScorePhoto:
 
     def test_download_failure_is_not_reported_as_a_semantic_score(self, tmp_path):
         from immich_memories.config_models import PhotoConfig
-        from immich_memories.photos.photo_pipeline import _llm_score_photo
+        from immich_memories.photos.scoring import _llm_score_photo
 
         asset = _make_asset(id="dl-fail-001")
         config = PhotoConfig()


### PR DESCRIPTION
Closes #513.

Two gaps left the #489 re-weighting largely inert.

## It could not see the pixels

`_apply_frame_quality` only ever *read* a thumbnail cache. On the UI path something had filled it; on the CLI path the only writers are the video prefetcher and burst dedup — so nearly every photo arrived unmeasured and kept the flat quality share, while the log claimed quality decided 35% of the score.

It now fetches what nothing cached, **bounded and spread across the timeline** the same way the LLM shortlist is drawn: the photos in contention are what a tie-break is for, and a library's worth of previews is the cost the shortlist exists to avoid.

Tested with real JPEGs — sharp edges versus a flat wash — rather than mocks, so it asserts the pixels actually moved the scores apart.

## It mixed two formulas in one selection

A cached row was keyed by the model alone, so a warm-cache photo ranked on the pre-#489 formula while a cache-miss photo beside it ranked on the new one.

The key already carried the prompt; it now carries the scoring formula too. A test **pins the version**, so changing the weights without bumping it fails loudly rather than silently mixing regimes again — the failure message says exactly that.

## Refactor

The score cache and the model call moved to `photos/scoring.py`. `photo_pipeline` had crossed the thousand-line hard gate and I had been paying that off a few lines at a time across this wave; the file was not slightly too long, it was carrying a second job. `scoring.py` owns what a photo scores — including when a model does the scoring and when a stored row is worth reusing. 1050 → 815.

An existing repo guard (`test_thumbnail_404_survives`) caught the new fetch swallowing `ImmichNotFoundError` through a bare `except Exception`; it now names the API error explicitly.

`make ci` green, diff coverage passing.
