### PR TITLE
fix(ci): delete the container-owned output tree with sudo before cleanup

### DIFF
--- a/scripts/docker_smoke.py
+++ b/scripts/docker_smoke.py
@@ -35,91 +35,100 @@ def main() -> int:
     # delete; a cleanup failure after a PASSED smoke must not fail the release
     # (#525 follow-up: the first run to ever reach teardown died exactly there).
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
-        root = Path(tmp)
-        out_dir = root / "output"
-        out_dir.mkdir()
-        out_dir.chmod(0o777)  # the container runs as UID 1000
-        server = FakeImmichServer.start(root / "immich")
-        container = f"immich-memories-smoke-{uuid.uuid4().hex[:8]}"
-        print(f"fake Immich at {server.base_url}; image {args.image}")
         try:
-            proc = subprocess.run(
+            root = Path(tmp)
+            out_dir = root / "output"
+            out_dir.mkdir()
+            out_dir.chmod(0o777)  # the container runs as UID 1000
+            server = FakeImmichServer.start(root / "immich")
+            container = f"immich-memories-smoke-{uuid.uuid4().hex[:8]}"
+            print(f"fake Immich at {server.base_url}; image {args.image}")
+            try:
+                proc = subprocess.run(
+                    [
+                        "docker",
+                        "run",
+                        "--rm",
+                        "--name",
+                        container,
+                        "--network",
+                        "host",
+                        "--cpus",
+                        "2",
+                        "-e",
+                        f"IMMICH_URL={server.base_url}",
+                        "-e",
+                        # WHY the server's own key: FakeImmichServer rejects anything
+                        # else with "Invalid API key", which failed every release.
+                        f"IMMICH_API_KEY={server.api_key}",
+                        "-v",
+                        f"{out_dir}:/app/output",
+                        args.image,
+                        "immich-memories",
+                        "generate",
+                        "--memory-type",
+                        "monthly_highlights",
+                        "--year",
+                        "2024",
+                        "--month",
+                        "6",
+                        "--duration",
+                        "20",
+                        "--no-music",
+                        "--output",
+                        "/app/output/smoke.mp4",
+                    ],
+                    timeout=args.timeout,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.TimeoutExpired:
+                subprocess.run(["docker", "kill", container], capture_output=True)
+                print(f"FAIL: generation hung past {args.timeout}s", file=sys.stderr)
+                return 1
+            finally:
+                server.close()
+
+            print(proc.stdout[-4000:])
+            if proc.returncode != 0:
+                # WHY stderr AND stdout: the CLI logs to stdout (StreamHandler +
+                # Rich), so stderr alone hid the actual cause.
+                print(proc.stdout[-4000:], file=sys.stderr)
+                print(proc.stderr[-4000:], file=sys.stderr)
+                print(f"FAIL: exit {proc.returncode}", file=sys.stderr)
+                return 1
+
+            videos = sorted(out_dir.rglob("*.mp4"))
+            if not videos:
+                print("FAIL: no MP4 in the output volume", file=sys.stderr)
+                return 1
+            probe = subprocess.run(
                 [
-                    "docker",
-                    "run",
-                    "--rm",
-                    "--name",
-                    container,
-                    "--network",
-                    "host",
-                    "--cpus",
-                    "2",
-                    "-e",
-                    f"IMMICH_URL={server.base_url}",
-                    "-e",
-                    # WHY the server's own key: FakeImmichServer rejects anything
-                    # else with "Invalid API key", which failed every release.
-                    f"IMMICH_API_KEY={server.api_key}",
+                    "ffprobe",
                     "-v",
-                    f"{out_dir}:/app/output",
-                    args.image,
-                    "immich-memories",
-                    "generate",
-                    "--memory-type",
-                    "monthly_highlights",
-                    "--year",
-                    "2024",
-                    "--month",
-                    "6",
-                    "--duration",
-                    "20",
-                    "--no-music",
-                    "--output",
-                    "/app/output/smoke.mp4",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "csv=p=0",
+                    str(videos[0]),
                 ],
-                timeout=args.timeout,
                 capture_output=True,
                 text=True,
             )
-        except subprocess.TimeoutExpired:
-            subprocess.run(["docker", "kill", container], capture_output=True)
-            print(f"FAIL: generation hung past {args.timeout}s", file=sys.stderr)
-            return 1
+            if probe.returncode != 0 or float(probe.stdout.strip() or 0) <= 0:
+                print(f"FAIL: {videos[0].name} does not decode", file=sys.stderr)
+                return 1
+            print(f"OK: {videos[0].name} ({probe.stdout.strip()}s)")
+            return 0
         finally:
-            server.close()
-
-        print(proc.stdout[-4000:])
-        if proc.returncode != 0:
-            # WHY stderr AND stdout: the CLI logs to stdout (StreamHandler +
-            # Rich), so stderr alone hid the actual cause.
-            print(proc.stdout[-4000:], file=sys.stderr)
-            print(proc.stderr[-4000:], file=sys.stderr)
-            print(f"FAIL: exit {proc.returncode}", file=sys.stderr)
-            return 1
-
-        videos = sorted(out_dir.rglob("*.mp4"))
-        if not videos:
-            print("FAIL: no MP4 in the output volume", file=sys.stderr)
-            return 1
-        probe = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "csv=p=0",
-                str(videos[0]),
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if probe.returncode != 0 or float(probe.stdout.strip() or 0) <= 0:
-            print(f"FAIL: {videos[0].name} does not decode", file=sys.stderr)
-            return 1
-        print(f"OK: {videos[0].name} ({probe.stdout.strip()}s)")
-        return 0
+            # WHY sudo: the container (UID 1000) owns the output tree, the
+            # runner user cannot delete it, and Python 3.12's
+            # ignore_cleanup_errors still re-raises EPERM from its retry path --
+            # a release died on that AFTER printing "OK". GitHub runners have
+            # passwordless sudo; anywhere without it, ignore_cleanup_errors
+            # stays as the second line of defence.
+            subprocess.run(["sudo", "rm", "-rf", str(root / "output")], check=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Second teardown layer: the v0.53.4 release smoke printed OK: smoke_*.mp4 (18s) and then died anyway — Python 3.12's ignore_cleanup_errors re-raises EPERM from its retry path, so #543's fix was necessary but not sufficient. The finally now removes the UID-1000-owned output tree via the runner's passwordless sudo before TemporaryDirectory cleanup runs; the flag stays as second defence for environments without sudo.

Follow-up to #543/#525, no separate issue per the settle-down rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f