### PR TITLE
refactor(automation): split discovery and status out of the auto runner

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -321,17 +321,19 @@ src/immich_memories/
 │   ├── __init__.py             # Public API re-exports
 │   ├── candidates.py           # Memory candidate detection
 │   ├── candidate_scorer.py     # Candidate scoring & ranking
+│   ├── candidate_discovery.py  # CandidateDiscovery: one library snapshot -> ranked candidates
 │   ├── event_detectors.py      # Event-based detectors (activity bursts)
 │   ├── calendar_detectors.py   # Calendar-based detectors (monthly, yearly)
 │   ├── variety.py              # Cadence and rotation rules for candidates
 │   ├── models.py               # Typed values returned/persisted by automation
 │   ├── generation_request.py   # Typed boundary from candidates to the `generate` CLI
 │   ├── state_store.py          # SQLite persistence for automation attempts
+│   ├── status.py               # Cooldown gate + read-only AutomationStatus contract
 │   ├── delivery_retry.py       # Durable state for one pending delivery retry
 │   ├── notification_state.py   # Durable, sanitized notification delivery health
 │   ├── trip_input_cache.py     # Durable, identity-checked inputs for auto trip discovery
 │   ├── notifications.py        # Apprise notification integration
-│   ├── runner.py               # Auto-run orchestrator
+│   ├── runner.py               # Auto-run orchestrator (lease, subprocess, attempt record)
 │   ├── in_process_scheduler.py # Daily timer inside the UI/Docker process
 │   └── system_scheduler.py     # OS scheduler integration (launchd/systemd/cron)
 │

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -349,371 +349,211 @@
     "file_name": "runner.py",
     "functions": [
       {
-        "name": "AutoRunner::suggest",
-        "complexity": 21,
-        "line_start": 738,
-        "line_end": 828,
-        "line_complexities": [
-          {
-            "line": 742,
-            "complexity": 0
-          },
-          {
-            "line": 743,
-            "complexity": 0
-          },
-          {
-            "line": 744,
-            "complexity": 0
-          },
-          {
-            "line": 745,
-            "complexity": 0
-          },
-          {
-            "line": 746,
-            "complexity": 0
-          },
-          {
-            "line": 747,
-            "complexity": 0
-          },
-          {
-            "line": 748,
-            "complexity": 1
-          },
-          {
-            "line": 749,
-            "complexity": 0
-          },
-          {
-            "line": 750,
-            "complexity": 1
-          },
-          {
-            "line": 751,
-            "complexity": 0
-          },
-          {
-            "line": 753,
-            "complexity": 0
-          },
-          {
-            "line": 754,
-            "complexity": 0
-          },
-          {
-            "line": 755,
-            "complexity": 0
-          },
-          {
-            "line": 756,
-            "complexity": 0
-          },
-          {
-            "line": 762,
-            "complexity": 0
-          },
-          {
-            "line": 765,
-            "complexity": 0
-          },
-          {
-            "line": 768,
-            "complexity": 0
-          },
-          {
-            "line": 773,
-            "complexity": 0
-          },
-          {
-            "line": 774,
-            "complexity": 3
-          },
-          {
-            "line": 777,
-            "complexity": 0
-          },
-          {
-            "line": 778,
-            "complexity": 4
-          },
-          {
-            "line": 779,
-            "complexity": 0
-          },
-          {
-            "line": 780,
-            "complexity": 4
-          },
-          {
-            "line": 781,
-            "complexity": 0
-          },
-          {
-            "line": 784,
-            "complexity": 0
-          },
-          {
-            "line": 785,
-            "complexity": 3
-          },
-          {
-            "line": 786,
-            "complexity": 0
-          },
-          {
-            "line": 787,
-            "complexity": 4
-          },
-          {
-            "line": 788,
-            "complexity": 0
-          },
-          {
-            "line": 789,
-            "complexity": 0
-          },
-          {
-            "line": 797,
-            "complexity": 1
-          },
-          {
-            "line": 798,
-            "complexity": 0
-          },
-          {
-            "line": 800,
-            "complexity": 0
-          },
-          {
-            "line": 802,
-            "complexity": 0
-          },
-          {
-            "line": 813,
-            "complexity": 0
-          },
-          {
-            "line": 817,
-            "complexity": 0
-          },
-          {
-            "line": 822,
-            "complexity": 0
-          },
-          {
-            "line": 828,
-            "complexity": 0
-          }
-        ]
-      },
-      {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 856,
-        "line_end": 997,
+        "line_start": 462,
+        "line_end": 603,
         "line_complexities": [
           {
-            "line": 866,
+            "line": 472,
             "complexity": 0
           },
           {
-            "line": 870,
+            "line": 476,
             "complexity": 0
           },
           {
-            "line": 871,
+            "line": 477,
             "complexity": 2
           },
           {
-            "line": 872,
+            "line": 478,
             "complexity": 0
           },
           {
-            "line": 874,
+            "line": 480,
             "complexity": 0
           },
           {
-            "line": 875,
+            "line": 481,
             "complexity": 2
           },
           {
-            "line": 876,
+            "line": 482,
             "complexity": 0
           },
           {
-            "line": 878,
+            "line": 484,
             "complexity": 0
           },
           {
-            "line": 882,
+            "line": 488,
             "complexity": 3
           },
           {
-            "line": 883,
+            "line": 489,
             "complexity": 0
           },
           {
-            "line": 885,
+            "line": 491,
             "complexity": 0
           },
           {
-            "line": 886,
+            "line": 492,
             "complexity": 2
           },
           {
-            "line": 887,
+            "line": 493,
             "complexity": 0
           },
           {
-            "line": 888,
+            "line": 494,
             "complexity": 0
           },
           {
-            "line": 889,
+            "line": 495,
             "complexity": 1
           },
           {
-            "line": 890,
+            "line": 496,
             "complexity": 0
           },
           {
-            "line": 898,
+            "line": 504,
             "complexity": 2
           },
           {
-            "line": 900,
+            "line": 506,
             "complexity": 0
           },
           {
-            "line": 910,
+            "line": 516,
             "complexity": 0
           },
           {
-            "line": 911,
+            "line": 517,
             "complexity": 1
           },
           {
-            "line": 912,
+            "line": 518,
             "complexity": 0
           },
           {
-            "line": 913,
+            "line": 519,
             "complexity": 0
           },
           {
-            "line": 917,
+            "line": 523,
             "complexity": 0
           },
           {
-            "line": 923,
+            "line": 529,
             "complexity": 1
           },
           {
-            "line": 924,
+            "line": 530,
             "complexity": 1
           },
           {
-            "line": 925,
+            "line": 531,
             "complexity": 0
           },
           {
-            "line": 927,
+            "line": 533,
             "complexity": 0
           },
           {
-            "line": 934,
+            "line": 540,
             "complexity": 2
           },
           {
-            "line": 935,
+            "line": 541,
             "complexity": 0
           },
           {
-            "line": 936,
+            "line": 542,
             "complexity": 0
           },
           {
-            "line": 938,
+            "line": 544,
             "complexity": 0
           },
           {
-            "line": 945,
+            "line": 551,
             "complexity": 0
           },
           {
-            "line": 949,
+            "line": 555,
             "complexity": 2
           },
           {
-            "line": 950,
+            "line": 556,
             "complexity": 0
           },
           {
-            "line": 951,
+            "line": 557,
             "complexity": 0
           },
           {
-            "line": 957,
+            "line": 563,
             "complexity": 2
           },
           {
-            "line": 958,
+            "line": 564,
             "complexity": 0
           },
           {
-            "line": 959,
+            "line": 565,
             "complexity": 0
           },
           {
-            "line": 966,
+            "line": 572,
             "complexity": 0
           },
           {
-            "line": 967,
+            "line": 573,
             "complexity": 2
           },
           {
-            "line": 968,
+            "line": 574,
             "complexity": 0
           },
           {
-            "line": 969,
+            "line": 575,
             "complexity": 0
           },
           {
-            "line": 977,
+            "line": 583,
             "complexity": 0
           },
           {
-            "line": 985,
+            "line": 591,
             "complexity": 1
           },
           {
-            "line": 986,
+            "line": 592,
             "complexity": 0
           },
           {
-            "line": 987,
+            "line": 593,
             "complexity": 1
           },
           {
-            "line": 989,
+            "line": 595,
             "complexity": 0
           },
           {
-            "line": 996,
+            "line": 602,
             "complexity": 0
           },
           {
-            "line": 997,
+            "line": 603,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 117
+    "complexity": 60
   },
   {
     "path": "src/immich_memories/cli/_analyze_export.py",

--- a/src/immich_memories/automation/candidate_discovery.py
+++ b/src/immich_memories/automation/candidate_discovery.py
@@ -1,0 +1,328 @@
+"""Turn one live Immich library snapshot into ranked memory candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import Any, Protocol
+
+from immich_memories.automation.candidate_scorer import score_and_rank
+from immich_memories.automation.candidates import MemoryCandidate
+from immich_memories.automation.failure_backoff import drop_backed_off
+from immich_memories.automation.state_store import FailureStreak
+from immich_memories.automation.trip_input_cache import load_or_fetch_trip_assets
+from immich_memories.automation.variety import VarietyDecision, apply_variety_rules
+from immich_memories.config_loader import Config
+from immich_memories.config_models import AutomationConfig
+from immich_memories.timeperiod import DateRange, birthday_year
+from immich_memories.tracking.models import RunMetadata
+
+
+class ImmichDiscoveryError(RuntimeError):
+    """A live Immich library snapshot could not be collected."""
+
+
+class MemoryHistoryReader(Protocol):
+    """Small durable-history read seam required to avoid repeating a memory."""
+
+    def get_generated_memory_keys(self) -> set[str]: ...
+
+    def get_last_run_of_type(
+        self,
+        memory_type: str,
+        source: str | None = None,
+    ) -> RunMetadata | None: ...
+
+
+class FailureStreakReader(Protocol):
+    """Small attempt-history read seam required by failure backoff."""
+
+    def consecutive_failures_by_key(self) -> dict[str, FailureStreak]: ...
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    """Ranked candidates plus the filtering decisions that produced them."""
+
+    candidates: list[MemoryCandidate]
+    variety_decision: VarietyDecision
+    backoff_skips: dict[str, str]
+
+
+@dataclass(frozen=True)
+class _LibrarySnapshot:
+    """One live Immich read shared by every detector in a discovery pass."""
+
+    buckets: list
+    people: list
+    person_asset_counts: dict[str, int]
+    gps_assets: list | None
+
+
+def _time_buckets_to_month_counts(
+    buckets: list,
+) -> dict[str, int]:
+    """Convert Immich TimeBucket list to {YYYY-MM: count} dict."""
+    result: dict[str, int] = {}
+    for bucket in buckets:
+        try:
+            dt = datetime.fromisoformat(bucket.time_bucket)
+            key = f"{dt.year}-{dt.month:02d}"
+            result[key] = bucket.count
+        except (ValueError, AttributeError):
+            continue
+    return result
+
+
+def _trailing_year_range(today: date) -> DateRange:
+    """Return one inclusive calendar-year lookback ending on ``today``."""
+    try:
+        start_day = today.replace(year=today.year - 1)
+    except ValueError:
+        # February 29 has no same-day counterpart in a non-leap year.
+        start_day = today.replace(year=today.year - 1, day=28)
+
+    return DateRange(
+        start=datetime.combine(start_day, datetime.min.time()),
+        end=datetime.combine(today, datetime.max.time()),
+    )
+
+
+def _build_last_runs_by_type(db: MemoryHistoryReader) -> dict[str, date]:
+    """Query DB for the most recent completed run date per memory type."""
+    result: dict[str, date] = {}
+    for mem_type in (
+        "monthly_highlights",
+        "year_in_review",
+        "person_spotlight",
+        "trip",
+        "multi_person",
+    ):
+        run = db.get_last_run_of_type(mem_type, source="auto")
+        if run and run.created_at:
+            result[mem_type] = (run.completed_at or run.created_at).date()
+    return result
+
+
+def _compute_upcoming_birthday_ids(people: list, today: date, lookahead_days: int = 7) -> set[str]:
+    """Return person IDs whose birthday falls within the next N days."""
+    ids: set[str] = set()
+    for person in people:
+        if not getattr(person, "birth_date", None):
+            continue
+        bday = person.birth_date
+        next_bday = birthday_year(bday, today.year).start.date()
+        if next_bday < today:
+            next_bday = birthday_year(bday, today.year + 1).start.date()
+        days_until = (next_bday - today).days
+        if 0 <= days_until <= lookahead_days:
+            ids.add(person.id)
+    return ids
+
+
+def _run_all_detectors(
+    auto_cfg: AutomationConfig,
+    assets_by_month: dict[str, int],
+    people: list,
+    generated_keys: set[str],
+    config: Config,
+    today: date,
+    person_asset_counts: dict[str, int],
+    gps_assets: list | None,
+) -> list[MemoryCandidate]:
+    """Run all enabled detectors and collect candidates."""
+    from immich_memories.automation.calendar_detectors import (
+        BirthdayDetector,
+        MonthlyDetector,
+        OnThisDayDetector,
+        PersonSpotlightDetector,
+        YearlyDetector,
+    )
+    from immich_memories.automation.event_detectors import (
+        ActivityBurstDetector,
+        MultiPersonDetector,
+        TripDetector,
+    )
+
+    all_candidates: list[MemoryCandidate] = []
+
+    if auto_cfg.detect_monthly:
+        all_candidates.extend(
+            MonthlyDetector().detect(assets_by_month, people, generated_keys, config, today)
+        )
+    if auto_cfg.detect_yearly:
+        all_candidates.extend(
+            YearlyDetector().detect(assets_by_month, people, generated_keys, config, today)
+        )
+    if auto_cfg.detect_person_spotlight:
+        # WHY: suppress spotlights for people whose birthday is within 7 days
+        # so BirthdayDetector fires at the right time instead
+        upcoming_birthday_ids = _compute_upcoming_birthday_ids(people, today)
+        all_candidates.extend(
+            PersonSpotlightDetector().detect(
+                assets_by_month,
+                people,
+                generated_keys,
+                config,
+                today,
+                person_asset_counts=person_asset_counts,
+                upcoming_birthday_ids=upcoming_birthday_ids,
+            )
+        )
+        all_candidates.extend(
+            MultiPersonDetector().detect(
+                assets_by_month,
+                people,
+                generated_keys,
+                config,
+                today,
+                person_asset_counts=person_asset_counts,
+            )
+        )
+    if auto_cfg.detect_activity_burst:
+        all_candidates.extend(
+            ActivityBurstDetector().detect(
+                assets_by_month,
+                people,
+                generated_keys,
+                config,
+                today,
+                burst_threshold=auto_cfg.burst_threshold,
+            )
+        )
+
+    all_candidates.extend(
+        OnThisDayDetector().detect(assets_by_month, people, generated_keys, config, today)
+    )
+
+    # Birthday detector — always on, high priority near birthdays
+    if people:
+        all_candidates.extend(
+            BirthdayDetector().detect(
+                assets_by_month,
+                people,
+                generated_keys,
+                config,
+                today,
+                person_asset_counts=person_asset_counts,
+            )
+        )
+
+    if auto_cfg.detect_trips and gps_assets is not None:
+        all_candidates.extend(
+            TripDetector().detect(
+                assets_by_month,
+                people,
+                generated_keys,
+                config,
+                today,
+                assets=gps_assets,
+            )
+        )
+
+    return all_candidates
+
+
+class CandidateDiscovery:
+    """Detect, filter, score, and rank memory candidates for one library snapshot."""
+
+    def __init__(
+        self,
+        config: Config,
+        runs: MemoryHistoryReader,
+        attempts: FailureStreakReader,
+    ) -> None:
+        self._config = config
+        self._runs = runs
+        self._attempts = attempts
+
+    def discover(
+        self,
+        *,
+        limit: int,
+        recent_auto_runs: list[RunMetadata],
+    ) -> DiscoveryResult:
+        """Detect, score, and rank memory candidates from the Immich library."""
+        auto_cfg = self._config.automation
+        generated_keys = self._runs.get_generated_memory_keys()
+        last_runs = _build_last_runs_by_type(self._runs)
+        today = date.today()
+
+        snapshot = self._library_snapshot(auto_cfg, today)
+
+        all_candidates = _run_all_detectors(
+            auto_cfg,
+            _time_buckets_to_month_counts(snapshot.buckets),
+            snapshot.people,
+            generated_keys,
+            self._config,
+            today,
+            snapshot.person_asset_counts,
+            snapshot.gps_assets,
+        )
+
+        all_candidates, backoff_skips = drop_backed_off(
+            all_candidates,
+            self._attempts.consecutive_failures_by_key(),
+            datetime.now(tz=UTC),
+        )
+
+        variety_decision = apply_variety_rules(
+            all_candidates,
+            recent_auto_runs,
+            today,
+        )
+        ranked = score_and_rank(
+            variety_decision.eligible,
+            generated_keys,
+            today,
+            last_runs,
+        )
+        return DiscoveryResult(
+            candidates=ranked[:limit],
+            variety_decision=variety_decision,
+            backoff_skips=backoff_skips,
+        )
+
+    def _library_snapshot(self, auto_cfg: AutomationConfig, today: date) -> _LibrarySnapshot:
+        """Collect every live read in one session; any transport fault ends discovery."""
+        from immich_memories.api.immich import SyncImmichClient
+
+        try:
+            with SyncImmichClient(
+                base_url=self._config.immich.url,
+                api_key=self._config.immich.api_key,
+                api_version=self._config.immich.api_version,
+            ) as client:
+                buckets = client.get_time_buckets()
+                people = client.get_all_people() if auto_cfg.detect_person_spotlight else []
+                person_asset_counts = (
+                    _person_asset_counts(client, people) if auto_cfg.detect_person_spotlight else {}
+                )
+                gps_assets = (
+                    self._trip_assets(client, buckets, today) if auto_cfg.detect_trips else None
+                )
+        except Exception as exc:
+            raise ImmichDiscoveryError(str(exc)) from exc
+
+        return _LibrarySnapshot(buckets, people, person_asset_counts, gps_assets)
+
+    def _trip_assets(self, client: Any, buckets: list, today: date) -> list | None:
+        """Trips are measured against a homebase; without one there is nothing to measure."""
+        trips_cfg = self._config.trips
+        if trips_cfg.homebase_latitude == trips_cfg.homebase_longitude == 0.0:
+            return None
+        return load_or_fetch_trip_assets(
+            client,
+            cache_root=self._config.cache.cache_path,
+            server_url=self._config.immich.url,
+            buckets=buckets,
+            requested_range=_trailing_year_range(today),
+            now=datetime.now(tz=UTC),
+        )
+
+
+def _person_asset_counts(client: Any, people: list) -> dict[str, int]:
+    """Count assets for the top named people only — a spotlight cannot use the rest."""
+    named = [p for p in people if p.name and p.thumbnail_path][:10]
+    return {p.id: client.get_person_asset_count(p.id) for p in named}

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -1,4 +1,4 @@
-"""AutoRunner — detect, score, and generate memory candidates."""
+"""AutoRunner — decide, execute, and record one automation attempt."""
 
 from __future__ import annotations
 
@@ -6,15 +6,15 @@ import logging
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, timedelta
-from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from immich_memories.automation.candidate_scorer import score_and_rank
+from immich_memories.automation.candidate_discovery import (
+    CandidateDiscovery,
+    ImmichDiscoveryError,
+)
 from immich_memories.automation.candidates import MemoryCandidate
 from immich_memories.automation.delivery_retry import PendingDeliveryRetry, abandon_if_exhausted
-from immich_memories.automation.failure_backoff import drop_backed_off
 from immich_memories.automation.models import (
     AutoAction,
     AutomationAttempt,
@@ -23,20 +23,22 @@ from immich_memories.automation.models import (
     AutoRunResult,
     ProcessResult,
 )
-from immich_memories.automation.notification_state import (
-    NotificationHealth,
-    NotificationStateStore,
-)
+from immich_memories.automation.notification_state import NotificationStateStore
 from immich_memories.automation.notifications import (
     send_configured_notification as _send_notification,
 )
 from immich_memories.automation.state_store import AutomationStateStore
-from immich_memories.automation.trip_input_cache import load_or_fetch_trip_assets
-from immich_memories.automation.variety import VarietyDecision, apply_variety_rules
+from immich_memories.automation.status import (
+    AutomationStatus,
+    SuggestOutcome,
+    SuggestStatus,
+    cooldown_status,
+    is_within_cooldown,
+    resolve_cooldown_hours,
+)
+from immich_memories.automation.variety import VarietyDecision
 from immich_memories.config_loader import Config
-from immich_memories.config_models import AutomationConfig
 from immich_memories.security import configured_secret_values, sanitize_error_message
-from immich_memories.timeperiod import DateRange, birthday_year
 from immich_memories.tracking.models import RunMetadata
 from immich_memories.tracking.run_database import RunDatabase
 
@@ -45,15 +47,6 @@ logger = logging.getLogger(__name__)
 _GENERATION_TIMEOUT_SECONDS = 7200
 _GENERATION_TIMEOUT_REASON = "generation timed out after 2 hours"
 _OUTPUT_TAIL_LENGTH = 2000
-# A fixed-time scheduler (cron, launchd, in-process timer) fires at the same wall-clock
-# time every day; the child process records its start a few seconds later. Without slack,
-# "24h since the last run" is never quite true at the next day's fire and every other day
-# gets skipped (#330). 30 min still rejects any realistic double fire.
-_COOLDOWN_SCHEDULE_TOLERANCE = timedelta(minutes=30)
-
-
-class ImmichDiscoveryError(RuntimeError):
-    """A live Immich library snapshot could not be collected."""
 
 
 class AutomationAlreadyRunningError(RuntimeError):
@@ -89,169 +82,11 @@ class AutomationLease:
             self._fd = None
 
 
-class SuggestOutcome(StrEnum):
-    """Status of the most recent candidate discovery call."""
-
-    READY = "ready"
-    PREFLIGHT_FAILED = "preflight_failed"
-    DISCOVERY_FAILED = "discovery_failed"
-
-
-@dataclass(frozen=True)
-class SuggestStatus:
-    """Typed result for the most recent live candidate-discovery snapshot."""
-
-    outcome: SuggestOutcome = SuggestOutcome.READY
-    error: str | None = None
-
-
 @dataclass(frozen=True)
 class _BoundedProcessDetails:
     """Sanitized subprocess output with independent per-stream tail bounds."""
 
     text: str
-
-
-@dataclass(frozen=True)
-class CooldownStatus:
-    """Current cooldown derived from the latest completed automation run."""
-
-    hours: int
-    active: bool
-    until: datetime | None
-
-
-@dataclass(frozen=True)
-class AutomationStatus:
-    """Read-only durable automation facts used by CLI and UI status surfaces."""
-
-    last_attempt: AutomationAttempt | None
-    last_completed_auto_run: RunMetadata | None
-    cooldown: CooldownStatus
-    recent_categories: tuple[str, ...]
-    rejection_reasons: tuple[str, ...]
-    suggestion: SuggestStatus
-    pending_delivery_count: int
-    oldest_pending_delivery: RunMetadata | None
-    notification_health: NotificationHealth | None
-    notification_cooldown_hours: int
-
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize the stable machine-facing automation status contract."""
-        attempt = self.last_attempt
-        run = self.last_completed_auto_run
-        pending = self.oldest_pending_delivery
-        return {
-            "last_attempt": (
-                {
-                    "id": attempt.id,
-                    "started_at": attempt.started_at.isoformat(),
-                    "finished_at": (
-                        attempt.finished_at.isoformat() if attempt.finished_at else None
-                    ),
-                    "outcome": attempt.outcome.value,
-                    "reason": attempt.reason,
-                    "candidate_category": attempt.candidate_category,
-                    "memory_type": attempt.memory_type,
-                    "memory_key": attempt.memory_key,
-                    "run_id": attempt.run_id,
-                    "error": attempt.error,
-                    "last_phase": attempt.last_phase.value if attempt.last_phase else None,
-                }
-                if attempt
-                else None
-            ),
-            "last_completed_auto_run": (
-                {
-                    "run_id": run.run_id,
-                    "created_at": run.created_at.isoformat(),
-                    "completed_at": run.completed_at.isoformat() if run.completed_at else None,
-                    "memory_type": run.memory_type,
-                    "memory_key": run.memory_key,
-                    "category": run.memory_category,
-                    "output_path": run.output_path,
-                    "last_phase": run.last_phase.value if run.last_phase else None,
-                }
-                if run
-                else None
-            ),
-            "cooldown": {
-                "hours": self.cooldown.hours,
-                "active": self.cooldown.active,
-                "until": self.cooldown.until.isoformat() if self.cooldown.until else None,
-            },
-            "recent_categories": list(self.recent_categories),
-            "rejection_reasons": list(self.rejection_reasons),
-            "suggestion": {
-                "outcome": self.suggestion.outcome.value,
-                "error": self.suggestion.error,
-            },
-            "pending_delivery_count": self.pending_delivery_count,
-            "oldest_pending_delivery": (
-                {
-                    "run_id": pending.run_id,
-                    "completed_at": (
-                        pending.completed_at.isoformat() if pending.completed_at else None
-                    ),
-                    "output_path": pending.output_path,
-                    "delivery_attempts": pending.delivery_attempts,
-                    "delivery_error": pending.delivery_error,
-                    "delivery_album": pending.delivery_album,
-                }
-                if pending
-                else None
-            ),
-            "notification_health": (
-                self.notification_health.to_dict(cooldown_hours=self.notification_cooldown_hours)
-                if self.notification_health is not None
-                else None
-            ),
-        }
-
-
-def _time_buckets_to_month_counts(
-    buckets: list,
-) -> dict[str, int]:
-    """Convert Immich TimeBucket list to {YYYY-MM: count} dict."""
-    result: dict[str, int] = {}
-    for bucket in buckets:
-        try:
-            dt = datetime.fromisoformat(bucket.time_bucket)
-            key = f"{dt.year}-{dt.month:02d}"
-            result[key] = bucket.count
-        except (ValueError, AttributeError):
-            continue
-    return result
-
-
-def _trailing_year_range(today: date) -> DateRange:
-    """Return one inclusive calendar-year lookback ending on ``today``."""
-    try:
-        start_day = today.replace(year=today.year - 1)
-    except ValueError:
-        # February 29 has no same-day counterpart in a non-leap year.
-        start_day = today.replace(year=today.year - 1, day=28)
-
-    return DateRange(
-        start=datetime.combine(start_day, datetime.min.time()),
-        end=datetime.combine(today, datetime.max.time()),
-    )
-
-
-def _build_last_runs_by_type(db: RunDatabase) -> dict[str, date]:
-    """Query DB for the most recent completed run date per memory type."""
-    result: dict[str, date] = {}
-    for mem_type in (
-        "monthly_highlights",
-        "year_in_review",
-        "person_spotlight",
-        "trip",
-        "multi_person",
-    ):
-        run = db.get_last_run_of_type(mem_type, source="auto")
-        if run and run.created_at:
-            result[mem_type] = (run.completed_at or run.created_at).date()
-    return result
 
 
 def _build_generate_command(
@@ -271,51 +106,6 @@ def _build_generate_command(
         config_path=config_path,
         album_name=album_name,
     ).to_argv()
-
-
-def _cooldown_status(
-    last_run: RunMetadata | None,
-    cooldown_hours: int,
-    now: datetime | None = None,
-) -> CooldownStatus:
-    """Cooldown counts from the last run's *start* so a daily timer means once a day."""
-    if last_run is None:
-        return CooldownStatus(hours=cooldown_hours, active=False, until=None)
-    started_at = last_run.created_at
-    if started_at.tzinfo is None:
-        started_at = started_at.replace(tzinfo=UTC)
-    current = now or datetime.now(tz=UTC)
-    if current.tzinfo is None:
-        current = current.replace(tzinfo=UTC)
-    until = started_at + timedelta(hours=cooldown_hours) - _COOLDOWN_SCHEDULE_TOLERANCE
-    return CooldownStatus(hours=cooldown_hours, active=current < until, until=until)
-
-
-def _resolve_cooldown_hours(requested: int | None, configured: int) -> int:
-    """Keep explicit CLI cooldown provenance, including a zero override."""
-    return configured if requested is None else requested
-
-
-def _is_within_cooldown(db: RunDatabase, cooldown_hours: int) -> bool:
-    """Check if the most recent completed auto run is within the cooldown window."""
-    runs = db.list_runs(
-        limit=1,
-        status="completed",
-        source="auto",
-        order_by_completion=True,
-    )
-    status = _cooldown_status(runs[0] if runs else None, cooldown_hours)
-    if status.active:
-        assert status.until is not None
-        hours_since = cooldown_hours - (
-            (status.until - datetime.now(tz=UTC)).total_seconds() / 3600
-        )
-        logger.info(
-            "Cooldown active: %.1fh since last run (need %dh)",
-            hours_since,
-            cooldown_hours,
-        )
-    return status.active
 
 
 def _coerce_process_output(value: Any) -> str:
@@ -351,125 +141,6 @@ def _execute_generate(cmd: list[str]) -> ProcessResult:
     )
 
 
-def _compute_upcoming_birthday_ids(people: list, today: date, lookahead_days: int = 7) -> set[str]:
-    """Return person IDs whose birthday falls within the next N days."""
-    ids: set[str] = set()
-    for person in people:
-        if not getattr(person, "birth_date", None):
-            continue
-        bday = person.birth_date
-        next_bday = birthday_year(bday, today.year).start.date()
-        if next_bday < today:
-            next_bday = birthday_year(bday, today.year + 1).start.date()
-        days_until = (next_bday - today).days
-        if 0 <= days_until <= lookahead_days:
-            ids.add(person.id)
-    return ids
-
-
-def _run_all_detectors(
-    auto_cfg: AutomationConfig,
-    assets_by_month: dict[str, int],
-    people: list,
-    generated_keys: set[str],
-    config: Config,
-    today: date,
-    person_asset_counts: dict[str, int],
-    gps_assets: list | None,
-) -> list[MemoryCandidate]:
-    """Run all enabled detectors and collect candidates."""
-    from immich_memories.automation.calendar_detectors import (
-        BirthdayDetector,
-        MonthlyDetector,
-        OnThisDayDetector,
-        PersonSpotlightDetector,
-        YearlyDetector,
-    )
-    from immich_memories.automation.event_detectors import (
-        ActivityBurstDetector,
-        MultiPersonDetector,
-        TripDetector,
-    )
-
-    all_candidates: list[MemoryCandidate] = []
-
-    if auto_cfg.detect_monthly:
-        all_candidates.extend(
-            MonthlyDetector().detect(assets_by_month, people, generated_keys, config, today)
-        )
-    if auto_cfg.detect_yearly:
-        all_candidates.extend(
-            YearlyDetector().detect(assets_by_month, people, generated_keys, config, today)
-        )
-    if auto_cfg.detect_person_spotlight:
-        # WHY: suppress spotlights for people whose birthday is within 7 days
-        # so BirthdayDetector fires at the right time instead
-        upcoming_birthday_ids = _compute_upcoming_birthday_ids(people, today)
-        all_candidates.extend(
-            PersonSpotlightDetector().detect(
-                assets_by_month,
-                people,
-                generated_keys,
-                config,
-                today,
-                person_asset_counts=person_asset_counts,
-                upcoming_birthday_ids=upcoming_birthday_ids,
-            )
-        )
-        all_candidates.extend(
-            MultiPersonDetector().detect(
-                assets_by_month,
-                people,
-                generated_keys,
-                config,
-                today,
-                person_asset_counts=person_asset_counts,
-            )
-        )
-    if auto_cfg.detect_activity_burst:
-        all_candidates.extend(
-            ActivityBurstDetector().detect(
-                assets_by_month,
-                people,
-                generated_keys,
-                config,
-                today,
-                burst_threshold=auto_cfg.burst_threshold,
-            )
-        )
-
-    all_candidates.extend(
-        OnThisDayDetector().detect(assets_by_month, people, generated_keys, config, today)
-    )
-
-    # Birthday detector — always on, high priority near birthdays
-    if people:
-        all_candidates.extend(
-            BirthdayDetector().detect(
-                assets_by_month,
-                people,
-                generated_keys,
-                config,
-                today,
-                person_asset_counts=person_asset_counts,
-            )
-        )
-
-    if auto_cfg.detect_trips and gps_assets is not None:
-        all_candidates.extend(
-            TripDetector().detect(
-                assets_by_month,
-                people,
-                generated_keys,
-                config,
-                today,
-                assets=gps_assets,
-            )
-        )
-
-    return all_candidates
-
-
 class AutoRunner:
     """Orchestrates candidate detection and one-shot generation."""
 
@@ -488,6 +159,7 @@ class AutoRunner:
         self.last_variety_decision = VarietyDecision(eligible=[], rejected=[])
         self.last_recent_categories: tuple[str, ...] = ()
         self.last_suggest_status = SuggestStatus()
+        self._discovery = CandidateDiscovery(config, self.db, self.state)
         self._prepared_immich_preflight: Any | None = None
         self._prepared_pending_delivery: RunMetadata | None = None
 
@@ -518,19 +190,14 @@ class AutoRunner:
         effective_cooldown = (
             cooldown_hours if cooldown_hours is not None else self.config.automation.cooldown_hours
         )
-        recent_runs = self.db.list_runs(
-            limit=6,
-            status="completed",
-            source="auto",
-            order_by_completion=True,
-        )
+        recent_runs = self._recent_auto_runs()
         rejection_reasons = tuple(
             dict.fromkeys(item.rule for item in self.last_variety_decision.rejected)
         )
         return AutomationStatus(
             last_attempt=self.state.get_last_attempt(),
             last_completed_auto_run=recent_runs[0] if recent_runs else None,
-            cooldown=_cooldown_status(
+            cooldown=cooldown_status(
                 recent_runs[0] if recent_runs else None,
                 effective_cooldown,
             ),
@@ -543,6 +210,15 @@ class AutoRunner:
             oldest_pending_delivery=self.db.get_oldest_pending_delivery(source="auto"),
             notification_health=self.notification_state.get(),
             notification_cooldown_hours=self.config.notifications.cooldown_hours,
+        )
+
+    def _recent_auto_runs(self) -> list[RunMetadata]:
+        """The completed auto history that both status and variety rules read."""
+        return self.db.list_runs(
+            limit=6,
+            status="completed",
+            source="auto",
+            order_by_completion=True,
         )
 
     def _process_details(self, stdout: Any, stderr: Any) -> _BoundedProcessDetails:
@@ -737,8 +413,6 @@ class AutoRunner:
 
     def suggest(self, limit: int = 10) -> list[MemoryCandidate]:
         """Detect, score, and rank memory candidates from the Immich library."""
-        from immich_memories.api.immich import SyncImmichClient
-
         self.last_variety_decision = VarietyDecision(eligible=[], rejected=[])
         self.last_backoff_skips: dict[str, str] = {}
         self.last_recent_categories = ()
@@ -750,82 +424,14 @@ class AutoRunner:
         if self._preflight_error(immich_result) is not None:
             return []
 
-        auto_cfg = self.config.automation
-        generated_keys = self.db.get_generated_memory_keys()
-        last_runs = _build_last_runs_by_type(self.db)
-        recent_auto_runs = self.db.list_runs(
-            limit=6,
-            status="completed",
-            source="auto",
-            order_by_completion=True,
-        )
+        recent_auto_runs = self._recent_auto_runs()
         self.last_recent_categories = tuple(
             run.memory_category for run in recent_auto_runs if run.memory_category is not None
         )
-        today = date.today()
-
-        try:
-            with SyncImmichClient(
-                base_url=self.config.immich.url,
-                api_key=self.config.immich.api_key,
-                api_version=self.config.immich.api_version,
-            ) as client:
-                buckets = client.get_time_buckets()
-                people = client.get_all_people() if auto_cfg.detect_person_spotlight else []
-
-                # Fetch per-person asset counts (top 10 named people only)
-                person_asset_counts: dict[str, int] = {}
-                if auto_cfg.detect_person_spotlight and people:
-                    named = [p for p in people if p.name and p.thumbnail_path][:10]
-                    for p in named:
-                        person_asset_counts[p.id] = client.get_person_asset_count(p.id)
-
-                # Fetch GPS assets for trip detection (past year only)
-                gps_assets = None
-                if auto_cfg.detect_trips:
-                    trips_cfg = self.config.trips
-                    if not (trips_cfg.homebase_latitude == trips_cfg.homebase_longitude == 0.0):
-                        dr = _trailing_year_range(today)
-                        gps_assets = load_or_fetch_trip_assets(
-                            client,
-                            cache_root=self.config.cache.cache_path,
-                            server_url=self.config.immich.url,
-                            buckets=buckets,
-                            requested_range=dr,
-                            now=datetime.now(tz=UTC),
-                        )
-        except Exception as exc:
-            raise ImmichDiscoveryError(str(exc)) from exc
-
-        assets_by_month = _time_buckets_to_month_counts(buckets)
-
-        all_candidates = _run_all_detectors(
-            auto_cfg,
-            assets_by_month,
-            people,
-            generated_keys,
-            self.config,
-            today,
-            person_asset_counts,
-            gps_assets,
-        )
-
-        all_candidates, self.last_backoff_skips = drop_backed_off(
-            all_candidates, self.state.consecutive_failures_by_key(), datetime.now(tz=UTC)
-        )
-
-        self.last_variety_decision = apply_variety_rules(
-            all_candidates,
-            recent_auto_runs,
-            today,
-        )
-        ranked = score_and_rank(
-            self.last_variety_decision.eligible,
-            generated_keys,
-            today,
-            last_runs,
-        )
-        return ranked[:limit]
+        discovered = self._discovery.discover(limit=limit, recent_auto_runs=recent_auto_runs)
+        self.last_variety_decision = discovered.variety_decision
+        self.last_backoff_skips = discovered.backoff_skips
+        return discovered.candidates
 
     def run_one(
         self,
@@ -875,11 +481,11 @@ class AutoRunner:
             if retry_result is not None:
                 return retry_result
 
-            effective_cooldown = _resolve_cooldown_hours(
+            effective_cooldown = resolve_cooldown_hours(
                 cooldown_hours,
                 self.config.automation.cooldown_hours,
             )
-            if not force and _is_within_cooldown(self.db, effective_cooldown):
+            if not force and is_within_cooldown(self.db, effective_cooldown):
                 return self._finish(attempt, AutoOutcome.SKIPPED, "cooldown active")
 
             candidate, candidate_result = self._suggest_one_for_attempt(attempt)

--- a/src/immich_memories/automation/status.py
+++ b/src/immich_memories/automation/status.py
@@ -1,0 +1,192 @@
+"""Read-only automation status: the cooldown gate and the durable status contract."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any, Protocol
+
+from immich_memories.automation.models import AutomationAttempt
+from immich_memories.automation.notification_state import NotificationHealth
+from immich_memories.tracking.models import RunMetadata
+
+logger = logging.getLogger(__name__)
+
+# A fixed-time scheduler (cron, launchd, in-process timer) fires at the same wall-clock
+# time every day; the child process records its start a few seconds later. Without slack,
+# "24h since the last run" is never quite true at the next day's fire and every other day
+# gets skipped (#330). 30 min still rejects any realistic double fire.
+_COOLDOWN_SCHEDULE_TOLERANCE = timedelta(minutes=30)
+
+
+class CompletedRunReader(Protocol):
+    """Small durable read seam required by the cooldown gate."""
+
+    def list_runs(
+        self,
+        *,
+        limit: int = 50,
+        status: str | None = None,
+        source: str | None = None,
+        order_by_completion: bool = False,
+    ) -> list[RunMetadata]: ...
+
+
+class SuggestOutcome(StrEnum):
+    """Status of the most recent candidate discovery call."""
+
+    READY = "ready"
+    PREFLIGHT_FAILED = "preflight_failed"
+    DISCOVERY_FAILED = "discovery_failed"
+
+
+@dataclass(frozen=True)
+class SuggestStatus:
+    """Typed result for the most recent live candidate-discovery snapshot."""
+
+    outcome: SuggestOutcome = SuggestOutcome.READY
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class CooldownStatus:
+    """Current cooldown derived from the latest completed automation run."""
+
+    hours: int
+    active: bool
+    until: datetime | None
+
+
+@dataclass(frozen=True)
+class AutomationStatus:
+    """Read-only durable automation facts used by CLI and UI status surfaces."""
+
+    last_attempt: AutomationAttempt | None
+    last_completed_auto_run: RunMetadata | None
+    cooldown: CooldownStatus
+    recent_categories: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    suggestion: SuggestStatus
+    pending_delivery_count: int
+    oldest_pending_delivery: RunMetadata | None
+    notification_health: NotificationHealth | None
+    notification_cooldown_hours: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable machine-facing automation status contract."""
+        attempt = self.last_attempt
+        run = self.last_completed_auto_run
+        pending = self.oldest_pending_delivery
+        return {
+            "last_attempt": (
+                {
+                    "id": attempt.id,
+                    "started_at": attempt.started_at.isoformat(),
+                    "finished_at": (
+                        attempt.finished_at.isoformat() if attempt.finished_at else None
+                    ),
+                    "outcome": attempt.outcome.value,
+                    "reason": attempt.reason,
+                    "candidate_category": attempt.candidate_category,
+                    "memory_type": attempt.memory_type,
+                    "memory_key": attempt.memory_key,
+                    "run_id": attempt.run_id,
+                    "error": attempt.error,
+                    "last_phase": attempt.last_phase.value if attempt.last_phase else None,
+                }
+                if attempt
+                else None
+            ),
+            "last_completed_auto_run": (
+                {
+                    "run_id": run.run_id,
+                    "created_at": run.created_at.isoformat(),
+                    "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+                    "memory_type": run.memory_type,
+                    "memory_key": run.memory_key,
+                    "category": run.memory_category,
+                    "output_path": run.output_path,
+                    "last_phase": run.last_phase.value if run.last_phase else None,
+                }
+                if run
+                else None
+            ),
+            "cooldown": {
+                "hours": self.cooldown.hours,
+                "active": self.cooldown.active,
+                "until": self.cooldown.until.isoformat() if self.cooldown.until else None,
+            },
+            "recent_categories": list(self.recent_categories),
+            "rejection_reasons": list(self.rejection_reasons),
+            "suggestion": {
+                "outcome": self.suggestion.outcome.value,
+                "error": self.suggestion.error,
+            },
+            "pending_delivery_count": self.pending_delivery_count,
+            "oldest_pending_delivery": (
+                {
+                    "run_id": pending.run_id,
+                    "completed_at": (
+                        pending.completed_at.isoformat() if pending.completed_at else None
+                    ),
+                    "output_path": pending.output_path,
+                    "delivery_attempts": pending.delivery_attempts,
+                    "delivery_error": pending.delivery_error,
+                    "delivery_album": pending.delivery_album,
+                }
+                if pending
+                else None
+            ),
+            "notification_health": (
+                self.notification_health.to_dict(cooldown_hours=self.notification_cooldown_hours)
+                if self.notification_health is not None
+                else None
+            ),
+        }
+
+
+def cooldown_status(
+    last_run: RunMetadata | None,
+    cooldown_hours: int,
+    now: datetime | None = None,
+) -> CooldownStatus:
+    """Cooldown counts from the last run's *start* so a daily timer means once a day."""
+    if last_run is None:
+        return CooldownStatus(hours=cooldown_hours, active=False, until=None)
+    started_at = last_run.created_at
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=UTC)
+    current = now or datetime.now(tz=UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    until = started_at + timedelta(hours=cooldown_hours) - _COOLDOWN_SCHEDULE_TOLERANCE
+    return CooldownStatus(hours=cooldown_hours, active=current < until, until=until)
+
+
+def resolve_cooldown_hours(requested: int | None, configured: int) -> int:
+    """Keep explicit CLI cooldown provenance, including a zero override."""
+    return configured if requested is None else requested
+
+
+def is_within_cooldown(db: CompletedRunReader, cooldown_hours: int) -> bool:
+    """Check if the most recent completed auto run is within the cooldown window."""
+    runs = db.list_runs(
+        limit=1,
+        status="completed",
+        source="auto",
+        order_by_completion=True,
+    )
+    status = cooldown_status(runs[0] if runs else None, cooldown_hours)
+    if status.active:
+        assert status.until is not None
+        hours_since = cooldown_hours - (
+            (status.until - datetime.now(tz=UTC)).total_seconds() / 3600
+        )
+        logger.info(
+            "Cooldown active: %.1fh since last run (need %dh)",
+            hours_since,
+            cooldown_hours,
+        )
+    return status.active

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -151,7 +151,8 @@ def auto() -> None:
 @click.pass_context
 def suggest(ctx: click.Context, as_json: bool, limit: int, memory_type: str | None) -> None:
     """Show prioritized memory candidates."""
-    from immich_memories.automation.runner import AutoRunner, SuggestOutcome
+    from immich_memories.automation.runner import AutoRunner
+    from immich_memories.automation.status import SuggestOutcome
 
     config: Config = ctx.obj["config"]
     runner = AutoRunner(config, config_path=ctx.obj["config_path"])

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -15,15 +15,17 @@ import pytest
 from rich.console import Console
 
 from immich_memories.api.compatibility import ApiVersionPolicy
+from immich_memories.automation.candidate_discovery import (
+    _build_last_runs_by_type,
+    _trailing_year_range,
+)
 from immich_memories.automation.candidate_scorer import score_and_rank
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoOutcome, ProcessResult
 from immich_memories.automation.runner import (
     AutoRunner,
     _build_generate_command,
-    _build_last_runs_by_type,
     _execute_generate,
-    _trailing_year_range,
 )
 from immich_memories.cli.auto_cmd import _candidates_to_json, _print_candidates_table
 from immich_memories.config_loader import Config
@@ -182,7 +184,7 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.analysis.trip_detection.detect_trips",
                 return_value=[trip],
             ),
-            patch("immich_memories.automation.runner.date") as clock,
+            patch("immich_memories.automation.candidate_discovery.date") as clock,
         ):
             clock.today.return_value = today
             clock.side_effect = date
@@ -267,7 +269,7 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
         ):
             mock_date.today.return_value = date(2026, 8, 11)
             runner = AutoRunner(config)
@@ -302,7 +304,7 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
         ):
             mock_date.today.return_value = date(2025, 3, 10)
             mock_date.side_effect = date
@@ -337,7 +339,7 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
         ):
             mock_date.today.return_value = date(2025, 12, 27)
             mock_date.side_effect = date
@@ -411,7 +413,7 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
             patch.object(runner.db, "list_runs", wraps=runner.db.list_runs) as mock_list_runs,
         ):
             mock_date.today.return_value = date(2026, 8, 11)
@@ -460,9 +462,9 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
             patch(
-                "immich_memories.automation.runner.score_and_rank",
+                "immich_memories.automation.candidate_discovery.score_and_rank",
                 wraps=score_and_rank,
             ) as mock_score,
         ):
@@ -550,9 +552,9 @@ class TestSuggestReturnsCandidates:
                 "immich_memories.preflight.check_immich",
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
             patch(
-                "immich_memories.automation.runner._run_all_detectors",
+                "immich_memories.automation.candidate_discovery._run_all_detectors",
                 return_value=[monthly, alice],
             ),
         ):
@@ -739,10 +741,10 @@ class TestRunOneNoCandidates:
             ),
             patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
             patch(
-                "immich_memories.automation.runner._run_all_detectors",
+                "immich_memories.automation.candidate_discovery._run_all_detectors",
                 return_value=rejected_candidates,
             ),
-            patch("immich_memories.automation.runner.date") as clock,
+            patch("immich_memories.automation.candidate_discovery.date") as clock,
         ):
             clock.today.return_value = date(2026, 8, 11)
             clock.side_effect = date
@@ -1739,7 +1741,7 @@ class TestFailedCandidateBackoff:
                 return_value=MagicMock(status=CheckStatus.OK),
             ),
             # WHY: pins today so the month fixtures stay in range
-            patch("immich_memories.automation.runner.date") as mock_date,
+            patch("immich_memories.automation.candidate_discovery.date") as mock_date,
         ):
             mock_date.today.return_value = date(2026, 8, 11)
             runner = AutoRunner(config)

--- a/tests/test_auto_status.py
+++ b/tests/test_auto_status.py
@@ -11,15 +11,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from immich_memories.automation.candidate_discovery import ImmichDiscoveryError
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoOutcome
-from immich_memories.automation.runner import (
-    AutoRunner,
-    ImmichDiscoveryError,
-    SuggestOutcome,
-    SuggestStatus,
-)
+from immich_memories.automation.runner import AutoRunner
 from immich_memories.automation.state_store import AutomationStateStore
+from immich_memories.automation.status import SuggestOutcome, SuggestStatus
 from immich_memories.automation.system_scheduler import SchedulerStatus
 from immich_memories.automation.variety import RejectedCandidate, VarietyDecision
 from immich_memories.cli import main
@@ -525,7 +522,7 @@ def test_status_does_not_hide_detector_programming_failures(tmp_path: Path) -> N
         ),
         patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
         patch(
-            "immich_memories.automation.runner._run_all_detectors",
+            "immich_memories.automation.candidate_discovery._run_all_detectors",
             side_effect=RuntimeError("detector invariant failed"),
         ),
         pytest.raises(RuntimeError, match="detector invariant failed"),

--- a/tests/test_timestamp_migration.py
+++ b/tests/test_timestamp_migration.py
@@ -14,8 +14,9 @@ from unittest.mock import patch
 import pytest
 
 from immich_memories.automation.models import AutoOutcome
-from immich_memories.automation.runner import AutoRunner, _cooldown_status
+from immich_memories.automation.runner import AutoRunner
 from immich_memories.automation.state_store import AutomationStateStore
+from immich_memories.automation.status import cooldown_status
 from immich_memories.cache import database as cache_database
 from immich_memories.cache.database import VideoAnalysisCache
 from immich_memories.config_loader import Config
@@ -246,7 +247,7 @@ def test_v11_canonical_utc_keeps_completion_order_and_cooldown_chronological(
     assert runs[0].memory_category == "monthly_review"
     assert runs[0].completed_at == datetime(2026, 8, 10, 8, 0, tzinfo=UTC)
     assert runs[1].completed_at == datetime(2026, 8, 10, 7, 30, tzinfo=UTC)
-    assert _cooldown_status(
+    assert cooldown_status(
         runs[0],
         24,
         now=datetime(2026, 8, 11, 7, 0, tzinfo=UTC),
@@ -343,7 +344,7 @@ def test_brussels_daily_auto_run_is_not_inside_24_hour_cooldown(
     runner = AutoRunner(config)
 
     with (
-        patch("immich_memories.automation.runner.datetime", wraps=datetime) as clock,
+        patch("immich_memories.automation.status.datetime", wraps=datetime) as clock,
         patch.object(runner, "suggest", return_value=[]),
     ):
         clock.now.return_value = datetime(2026, 8, 11, 7, 0, tzinfo=UTC)


### PR DESCRIPTION
## Why

`automation/runner.py` was **997 lines** against a 1000-line hard limit — three lines from breaking `make file-length` for everyone.

## The cohesion boundary

The file held three jobs that never needed to share a module:

1. **Finding candidates** — read the library, run detectors, drop backed-off keys, apply variety rules, score and rank.
2. **Reporting durable status** — the read-only snapshot CLI and UI render, plus the cooldown arithmetic.
3. **Executing one attempt** — take the OS lease, launch the generation subprocess, bound and redact its output, record the outcome.

The first two moved out; the third is what `AutoRunner` uniquely is.

### `automation/candidate_discovery.py` (new, 328 lines)

`CandidateDiscovery` owns the whole library-snapshot-to-ranked-candidates pipeline. Dependencies come in through the constructor: `Config` plus two Protocol read seams — `MemoryHistoryReader` (generated keys, last run per type) and `FailureStreakReader` (consecutive failures per key), matching the `RunReader` pattern in `operations/storage_report.py`. `ImmichDiscoveryError` moved here with it, since this is the only place that raises it.

The Immich session also got its own method, so one `try` block still turns any transport fault into `ImmichDiscoveryError` while the per-call detail sits in small helpers.

### `automation/status.py` (new, 192 lines)

The read-only status contract — `AutomationStatus` and its `to_dict`, `CooldownStatus`, `SuggestStatus`/`SuggestOutcome` — plus the cooldown gate (`cooldown_status`, `is_within_cooldown`, `resolve_cooldown_hours`) behind a `CompletedRunReader` seam. The three cooldown helpers lost their leading underscore because they are now cross-module API.

## Line counts

| File | Before | After |
|---|---|---|
| `automation/runner.py` | 997 | **603** |
| `automation/candidate_discovery.py` | — | 328 |
| `automation/status.py` | — | 192 |

## Behavior

Pure move. Two details worth calling out because they were easy to get wrong:

- `suggest()` still publishes `last_recent_categories` **before** the Immich read, so a failed library read leaves the real categories on the result instead of blanking them.
- The DB reads still happen before the client is constructed, which is what `test_status_does_not_hide_generated_key_database_failures` asserts.

The recent-auto-runs query that `status()` and `suggest()` each ran separately is now one `_recent_auto_runs` helper with identical arguments — two callers, same query, no new indirection.

No re-export shims. Every import site was updated directly, including the `unittest.mock.patch` targets in `tests/` that pointed at `automation.runner`.

## Left alone deliberately

- `analysis/smart_pipeline.py` is **1012 lines on `origin/main`** and already trips the hard limit. It is not this file and a sibling PR owns it. The pre-commit `file-length` hook was skipped for that pre-existing failure only; every other hook ran and passed.
- The `hours_since` figure in the cooldown log line subtracts the schedule tolerance twice, so it reads about 30 minutes low. Log-only, pre-existing, not touched here.

## Verification

`make ci` gates, run individually: lint, format-check, mypy, complexity, cognitive-complexity, dead-code, security-lint, semgrep (777 rules, 0 findings), refurb, dep-check, arch-check, duplication, critique, docs-cli-check — all pass. Full suite: **5485 passed, 9 skipped**. Diff coverage ≥80% passed in the commit hook.

The complexipy snapshot loses `AutoRunner::suggest` (was 21, over the 15 limit) because the split retired it — the ratchet tightening the Makefile target describes. Sibling refactor PRs also touch that shared file, so a conflict there is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL