### PR TITLE
refactor(analysis): lift the selection quality pass out of the pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,11 +35,12 @@ The four core orchestrators and their composed services:
 - `AudioMixerService` (audio_mixer_service.py): background music mixing
 - `TitleInserter` (title_inserter.py): title screen concatenation
 
-**SmartPipeline** (analysis/smart_pipeline.py) composes 4 services:
+**SmartPipeline** (analysis/smart_pipeline.py) composes 5 services:
 - `ClipAnalyzer` (clip_analyzer.py): download, analyze, and score clips
 - `PreviewBuilder` (preview_builder.py): extract preview segments
 - `ClipRefiner` (clip_refiner.py): select and distribute final clips
 - `ClipScaler` (clip_scaler.py): scale to target duration, deduplicate
+- `SelectionQuality` (selection_quality.py): verify, judge and review the finished cut
 
 It also owns a `ProviderCircuit` (provider_health.py, LLM provider circuit breaker) and an
 optional `VideoDownloadCache`. The density-proportional asset budget is a plain function,
@@ -103,13 +104,14 @@ src/immich_memories/
 │   └── factory.py              # Registry + 7 built-in preset factories (incl. trip)
 │
 ├── analysis/                   # Video analysis & clip selection
-│   ├── smart_pipeline.py       # SmartPipeline (composes 4 services)
+│   ├── smart_pipeline.py       # SmartPipeline (composes 5 services)
 │   ├── pipeline.py             # ClusterManager / DuplicateCluster: duplicate cluster bookkeeping
 │   ├── provider_health.py      # ProviderCircuit: bounded, credential-safe LLM provider health
 │   ├── cache_projection.py     # Project compatible cached analysis back onto in-memory clips
 │   ├── clip_analyzer.py        # ClipAnalyzer: download + analyze + score
 │   ├── clip_refiner.py         # ClipRefiner: final selection + distribution
 │   ├── clip_scaler.py          # ClipScaler: duration scaling + dedup
+│   ├── selection_quality.py    # SelectionQuality: verify + judge + review
 │   ├── clip_selection.py       # Standalone clip selection functions
 │   ├── density_budget.py       # compute_density_budget(): density-proportional asset budget
 │   ├── preview_builder.py      # PreviewBuilder: preview segment extraction

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -1,0 +1,434 @@
+"""The quality pass over a finished selection: verify, judge, review.
+
+Selection decides what a memory is made of; this decides whether that cut is
+good enough to ship. It re-analyzes anything the LLM review would otherwise
+judge blind, drops what fails a floor calibrated to the medium, and gives the
+review one look at the set as a whole.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from immich_memories.analysis import selection_trace as trace
+from immich_memories.analysis.source_filter import is_a_still
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.clip_analyzer import ClipAnalyzer
+    from immich_memories.analysis.clip_refiner import ClipRefiner
+    from immich_memories.analysis.progress import ProgressTracker
+    from immich_memories.analysis.provider_health import ProviderCircuit
+    from immich_memories.analysis.smart_pipeline import (
+        ClipWithSegment,
+        PipelineConfig,
+        PipelineResult,
+    )
+    from immich_memories.api.immich import SyncImmichClient
+    from immich_memories.config_loader import Config
+
+logger = logging.getLogger(__name__)
+
+# Below this share of the judge's floor a clip is not weak but unusable — a
+# pocket, the ground, somebody's feet — and no amount of being the only thing
+# from its day makes it worth shipping.
+_UNUSABLE_SHARE_OF_FLOOR = 1.0 / 3.0
+
+
+class SelectionQuality:
+    """Verify, judge and review a selection until it is worth shipping.
+
+    Holds the verify pass's memory of what it has already tried, so a clip
+    whose analysis fails is not downloaded and decoded again on every entry.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: PipelineConfig,
+        app_config: Config,
+        analyzer: ClipAnalyzer,
+        refiner: ClipRefiner,
+        tracker: ProgressTracker,
+        client: SyncImmichClient,
+        provider_circuit: ProviderCircuit,
+    ) -> None:
+        self.config = config
+        self.analyzer = analyzer
+        self.refiner = refiner
+        self.tracker = tracker
+        self.client = client
+        self.provider_circuit = provider_circuit
+        self._app_config = app_config
+        # Clips the verify pass has already looked at, across every entry.
+        self._verify_attempted: set[str] = set()
+
+    def stabilize(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
+        """Verify and judge until the selection is stable (#468).
+
+        Found live on the 2026-08-21 demo: a judge (or review) drop
+        re-selects, the re-selection admits a NEW fallback-scored clip, and
+        a straight verify→judge sequence ships it unverified. The stages
+        iterate together until a pass changes nothing or the budget is spent.
+        """
+        for _ in range(max(1, self.config.max_refinement_passes)):
+            result, analyzed = self.verify(analyzed, result)
+            result, analyzed, dropped = self._judge(analyzed, result)
+            if not dropped:
+                break
+        return result, analyzed
+
+    def verify(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
+        """Re-analyze any shipped fallback-scored clip and re-select (#468).
+
+        Heavy when cold, cheap when warm: every verified clip lands in the
+        analysis cache, so later runs start from real scores. A clip whose
+        analysis fails keeps its fallback score but stops being re-queued,
+        so the loop always terminates.
+        """
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        # On the pipeline, not the call: this method is re-entered once per
+        # stabilize pass and again for the final review, and a clip whose
+        # analysis fails can never come back with a description — so a
+        # call-local set had it downloaded and decoded again on every entry,
+        # for the same failure.
+        attempted: set[str] = self._verify_attempted
+        for _ in range(max(1, self.config.max_refinement_passes)):
+            unverified = [
+                by_id[c.asset.id]
+                for c in result.selected_clips
+                if c.asset.id in by_id
+                and c.asset.id not in attempted
+                and self._needs_a_real_look(by_id[c.asset.id])
+            ]
+            if not unverified:
+                break
+            logger.info(
+                "Verify pass: analyzing %d selected clip(s) the review cannot see",
+                len(unverified),
+            )
+            trace.record(
+                "verify: analyze unseen",
+                result.selected_clips,
+                result.selected_clips,
+                [f"{len(unverified)} clip(s) analyzed for real before judging"],
+            )
+            attempted.update(u.clip.asset.id for u in unverified)
+            unverified = self._look_at_stills_among(unverified)
+            if not unverified:
+                continue
+            try:
+                verified = self.analyzer.phase_analyze([u.clip for u in unverified], self.tracker)
+            finally:
+                with contextlib.suppress(Exception):
+                    self.analyzer.close()
+            verified_ids = self._absorb_verified(by_id, verified, unverified)
+            for u in unverified:
+                if u.clip.asset.id not in verified_ids:
+                    # replace, not a fresh ClipWithSegment: the dataclass
+                    # lives on the pipeline that composes this service, and
+                    # importing it back would close the loop.
+                    by_id[u.clip.asset.id] = replace(u, analyzed=True)
+            result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
+        return result, list(by_id.values())
+
+    def _absorb_verified(
+        self,
+        by_id: dict[str, ClipWithSegment],
+        verified: list[ClipWithSegment],
+        unverified: list[ClipWithSegment],
+    ) -> set[str]:
+        """Take back what the look actually established, and nothing else.
+
+        Only what we asked for: analysis can hand back more than it was given
+        (a Live Photo expands into its components), and any extra id lands
+        straight back in the pool — resurrecting a clip the judge or the
+        review had just dropped.
+
+        And only what it managed to look at. The analyzer returns a
+        placeholder scored 0.0 when a download blips or a decode dies, and
+        writing that over a real score sends the clip under the judge's floor,
+        which drops it from the pool for good — losing a clip to a transient
+        error. A failed look is not a verdict of zero.
+        """
+        requested = {u.clip.asset.id for u in unverified}
+        kept = [v for v in verified if v.clip.asset.id in requested]
+        for v in kept:
+            if not v.analyzed and v.clip.asset.id in by_id:
+                logger.debug(
+                    "Verify pass: keeping the score for %s, the look failed", v.clip.asset.id
+                )
+                continue
+            by_id[v.clip.asset.id] = v
+        return {v.clip.asset.id for v in kept}
+
+    def _look_at_stills_among(self, unverified: list[ClipWithSegment]) -> list[ClipWithSegment]:
+        """Look at the stills here and now, and hand back the footage.
+
+        A still's real look is the photo scorer: the video analyzer fails on a
+        photograph and writes back a zero, so a photo it could not read was
+        not merely unseen but ranked last.
+        """
+        stills = [u for u in unverified if is_a_still(u.clip.asset)]
+        self._look_at_stills(stills)
+        return [u for u in unverified if not is_a_still(u.clip.asset)]
+
+    def _look_at_stills(self, stills: list[ClipWithSegment]) -> None:
+        """Give the review eyes on the photographs that reached the cut."""
+        if not stills:
+            return
+        from immich_memories.analysis.cache_projection import apply_semantic_payload
+        from immich_memories.photos import photo_pipeline
+
+        logger.info("Verify pass: looking at %d selected photo(s)", len(stills))
+        try:
+            payloads = photo_pipeline.look_at_selected_photos(
+                [s.clip.asset for s in stills],
+                config=self._app_config,
+                client=self.client,
+                provider_circuit=self.provider_circuit,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            logger.debug("Photo look failed: %s", type(exc).__name__)
+            return
+        for member in stills:
+            apply_semantic_payload(member.clip, payloads.get(member.clip.asset.id))
+
+    def final_review_drop(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
+        """One last review that drops without refilling.
+
+        The iterating review always leaves its own last refill unjudged: it
+        stops when the budget runs out, and by then it has just re-selected.
+        Refilling again would only admit more unseen clips, so this pass takes
+        the cut it has and removes what does not belong.
+
+        It looks at them first. The review is told — correctly — never to drop
+        a clip for missing information, since a third of a real pool has no
+        analysis yet and treating silence as a verdict would gut the memory.
+        The cost of that rule is that an unanalysed clip is immune to the only
+        quality judgment in the pipeline, and a rendered year recap shipped
+        whiteboards and desks on exactly that immunity. Nothing is judged
+        blind, so the rule never has to protect anything that shipped.
+        """
+        if not self._app_config.content_analysis.enabled:
+            return result, analyzed
+        from immich_memories.analysis.selection_review import review_selection
+
+        result, analyzed = self.verify(analyzed, result)
+
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+        drops = set(review_selection(selected, self._app_config.llm))
+        if not drops:
+            return result, analyzed
+
+        kept = [c for c in result.selected_clips if c.asset.id not in drops]
+        if not kept:
+            return result, analyzed
+        logger.info(
+            "Selection review: budget spent, dropping %d unreviewed clip(s) "
+            "rather than shipping them",
+            len(result.selected_clips) - len(kept),
+        )
+        trimmed = replace(
+            result,
+            selected_clips=kept,
+            clip_segments={
+                asset_id: seg
+                for asset_id, seg in result.clip_segments.items()
+                if asset_id not in drops
+            },
+        )
+        return trimmed, [c for c in analyzed if c.clip.asset.id not in drops]
+
+    def _needs_a_real_look(self, member: ClipWithSegment) -> bool:
+        """Would the LLM review be judging this clip blind?
+
+        A metadata guess for a score is one way to ship unseen. The other is
+        subtler and was shipping: a clip carries a real visual score, so it
+        counts as analyzed, but no content analysis ever ran on it, so the
+        review is handed a bare line. It is then told — correctly — never to
+        drop a clip for missing information, and two near-identical hotel
+        mirror selfies from consecutive days both survive as a result.
+
+        A photograph is never queued. Its real look is the VLM photo scorer,
+        which has already run and now says what it saw; sending a still to the
+        video analyzer fails and replaces its score with zero, so a photo the
+        scorer could not describe was not merely unseen, it was ranked last.
+        """
+        if not member.analyzed:
+            return True
+        if not self._app_config.content_analysis.enabled:
+            return False
+        return not getattr(member.clip, "llm_description", None)
+
+    def _judge(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
+        """One judge sweep (#468): drop offenders, let selection refill.
+
+        A single sweep by design — the caller re-verifies whatever the
+        re-selection admitted before judging again.
+        """
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+        if len(selected) < 2:
+            return result, analyzed, False
+        offenders = self.judge_offenders(selected)
+        if not offenders:
+            return result, analyzed, False
+        logger.info(
+            "Judge: dropping %d clip(s) below the quality gate, re-selecting",
+            len(offenders),
+        )
+        analyzed = [c for c in analyzed if c.clip.asset.id not in offenders]
+        if not analyzed:
+            return result, analyzed, False
+        result = self.refiner.phase_refine(analyzed, self.tracker)
+        return result, analyzed, True
+
+    def _floor_for(self, member: ClipWithSegment) -> float:
+        """The gate this clip answers to, on the scale its score was built on.
+
+        photos.score_penalty says outright that a photo scores a fixed share
+        of a video, so a floor calibrated on footage is that much too high for
+        a still. A no-people, non-favorite photo tops out at 0.15 base + 0.05
+        camera + half the LLM weight — 0.28 after the penalty, against a floor
+        of 0.30. Landscapes, pets and scenery could not clear it at all, and
+        were dropped as a class along with any day only they represented.
+        """
+        floor = self.config.judge_floor_score
+        if not is_a_still(member.clip.asset):
+            return floor
+        return floor * (1.0 - self._app_config.photos.score_penalty)
+
+    def spare_last_voices(
+        self,
+        offenders: set[str],
+        selected: list[ClipWithSegment],
+    ) -> set[str]:
+        """Offenders to actually drop, keeping any that is a period's last voice.
+
+        The judge removes offenders from the pool for good, so read as "this
+        clip is bad" its verdict costs a month whose only clip scored low. Read
+        as "we can do better than this clip" it costs nothing, because when
+        there is nothing better the clip stays.
+
+        Unusable is different from weak, and the distinction is what makes this
+        safe: a shot of the ground or a pocket is not worth a month, and stays
+        dropped however alone it is. Only a clip that would pass on any other
+        day is worth keeping for lack of an alternative.
+
+        A correction, not an exemption. Exempting has to guess in advance which
+        clips carry a period, and both ways of guessing that switch the gate
+        off under ordinary conditions — coverage ids are every clip on a pool
+        with no favorites, and a distributed selection makes almost every clip
+        the only one of its day.
+        """
+        from immich_memories.analysis.clip_distribution import _period_key, span_days_of
+
+        unusable = self.config.judge_floor_score * _UNUSABLE_SHARE_OF_FLOOR
+        span = span_days_of(selected)
+
+        def period_of(member: ClipWithSegment) -> str | None:
+            when = member.clip.asset.file_created_at
+            return _period_key(when, span) if when else None
+
+        surviving = {period_of(m) for m in selected if m.clip.asset.id not in offenders}
+        spared = {
+            m.clip.asset.id
+            for m in selected
+            if m.clip.asset.id in offenders
+            and m.score >= unusable
+            and period_of(m) not in surviving
+        }
+        if spared:
+            logger.info(
+                "Judge: keeping %d weak clip(s) — nothing else covers their period",
+                len(spared),
+            )
+        return offenders - spared
+
+    def judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
+        """Members failing the gate. Favorites are exempt from both rules —
+        the user explicitly chose them, and "Starting with ALL favorites" is
+        the selection's oldest contract.
+
+        What carries a period is handled after this rather than here — see
+        spare_last_voices. Exempting up front needs a guess about which clips
+        carry a period, and every way of guessing switches the gate off.
+        """
+        spared = {s.clip.asset.id for s in selected if getattr(s.clip.asset, "is_favorite", False)}
+        judgeable = [s for s in selected if s.clip.asset.id not in spared]
+        # Sparing applies to the floor rule only. The ending rule below is
+        # about where a clip sits, not whether it is worth keeping — a clip
+        # dropped for being a weak last note is fine anywhere else, and
+        # keeping it for lack of an alternative would defeat the rule.
+        offenders = self.spare_last_voices(
+            {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}, selected
+        )
+        scores = [s.score for s in selected]
+        mean_score = sum(scores) / len(scores)
+        ending = max(
+            selected,
+            key=lambda s: s.clip.asset.file_created_at or datetime.min.replace(tzinfo=UTC),
+        )
+        if (
+            len(selected) > 2
+            and ending.clip.asset.id not in spared
+            and ending.score == min(scores)
+            and ending.score < mean_score * self.config.judge_boundary_ratio
+        ):
+            offenders.add(ending.clip.asset.id)
+        return offenders
+
+    def review(
+        self,
+        analyzed: list[ClipWithSegment],
+        result: PipelineResult,
+    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
+        """One LLM pass over the finished cut (#468): redundancy and feel.
+
+        The mechanical judge sees scores; only something reading the
+        descriptions can see the same birthday candles twice. Optional by
+        construction — no LLM, no drops, selection unchanged.
+        """
+        if not self._app_config.content_analysis.enabled:
+            return result, analyzed, False
+        from immich_memories.analysis.selection_review import review_selection
+
+        by_id = {c.clip.asset.id: c for c in analyzed}
+        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
+        drops = review_selection(selected, self._app_config.llm)
+        if not drops:
+            trace.record("llm review", selected, selected)
+            return result, analyzed, False
+        dropped = set(drops)
+        trace.record(
+            "llm review",
+            selected,
+            [c for c in selected if c.clip.asset.id not in dropped],
+        )
+        remaining = [c for c in analyzed if c.clip.asset.id not in dropped]
+        if not remaining:
+            return result, analyzed, False
+        # WHY the pool shrinks too: a later stabilization re-refines from the
+        # pool — returning the old one would resurrect the LLM's drops.
+        return self.refiner.phase_refine(remaining, self.tracker), remaining, True

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -13,8 +13,7 @@ import contextlib
 import logging
 import os
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,7 +23,8 @@ from immich_memories.analysis.clip_refiner import ClipRefiner
 from immich_memories.analysis.clip_scaler import ClipScaler
 from immich_memories.analysis.preview_builder import PreviewBuilder
 from immich_memories.analysis.progress import PipelinePhase, ProgressTracker
-from immich_memories.analysis.source_filter import is_a_still, not_shot_here
+from immich_memories.analysis.selection_quality import SelectionQuality
+from immich_memories.analysis.source_filter import not_shot_here
 from immich_memories.analysis.thumbnail_prefetch import ThumbnailPrefetcher
 from immich_memories.config_presets import resolve_analysis_depth
 
@@ -146,20 +146,15 @@ class ClipWithSegment:
     analyzed: bool = True
 
 
-# Below this share of the judge's floor a clip is not weak but unusable — a
-# pocket, the ground, somebody's feet — and no amount of being the only thing
-# from its day makes it worth shipping.
-_UNUSABLE_SHARE_OF_FLOOR = 1.0 / 3.0
-
-
 class SmartPipeline:
     """Smart pipeline for one-click memory generation.
 
-    Composes 4 services via constructor injection:
+    Composes 5 services via constructor injection:
     - ClipAnalyzer: downloads, analyzes, and scores clips
     - PreviewBuilder: extracts preview segments
     - ClipRefiner: selects and distributes final clips
     - ClipScaler: scales to target duration and deduplicates
+    - SelectionQuality: verifies, judges and reviews the finished cut
 
     Runs 4 phases:
     1. Cluster thumbnails to detect duplicates
@@ -180,8 +175,6 @@ class SmartPipeline:
         app_config: Config,
     ):
         self.client = client
-        # Clips the verify pass has already looked at, across every entry.
-        self._verify_attempted: set[str] = set()
         self.analysis_cache = analysis_cache
         self.thumbnail_cache = thumbnail_cache
         self.config = config or PipelineConfig()
@@ -229,6 +222,15 @@ class SmartPipeline:
             thumbnail_cache,
             api_policy=app_config.immich.api_version,
             max_workers=analysis_config.download_workers,
+        )
+        self.quality = SelectionQuality(
+            config=self.config,
+            app_config=app_config,
+            analyzer=self.analyzer,
+            refiner=self.refiner,
+            tracker=self.tracker,
+            client=client,
+            provider_circuit=self.provider_circuit,
         )
 
     def run(
@@ -327,378 +329,6 @@ class SmartPipeline:
         self.tracker.complete_item("filters")
         self.tracker.complete_phase()
 
-    def _stabilize_selection(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
-        """Verify and judge until the selection is stable (#468).
-
-        Found live on the 2026-08-21 demo: a judge (or review) drop
-        re-selects, the re-selection admits a NEW fallback-scored clip, and
-        a straight verify→judge sequence ships it unverified. The stages
-        iterate together until a pass changes nothing or the budget is spent.
-        """
-        for _ in range(max(1, self.config.max_refinement_passes)):
-            result, analyzed = self._verify_selection(analyzed, result)
-            result, analyzed, dropped = self._judge_selection(analyzed, result)
-            if not dropped:
-                break
-        return result, analyzed
-
-    def _verify_selection(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
-        """Re-analyze any shipped fallback-scored clip and re-select (#468).
-
-        Heavy when cold, cheap when warm: every verified clip lands in the
-        analysis cache, so later runs start from real scores. A clip whose
-        analysis fails keeps its fallback score but stops being re-queued,
-        so the loop always terminates.
-        """
-        by_id = {c.clip.asset.id: c for c in analyzed}
-        # On the pipeline, not the call: this method is re-entered once per
-        # stabilize pass and again for the final review, and a clip whose
-        # analysis fails can never come back with a description — so a
-        # call-local set had it downloaded and decoded again on every entry,
-        # for the same failure.
-        attempted: set[str] = self._verify_attempted
-        for _ in range(max(1, self.config.max_refinement_passes)):
-            unverified = [
-                by_id[c.asset.id]
-                for c in result.selected_clips
-                if c.asset.id in by_id
-                and c.asset.id not in attempted
-                and self._needs_a_real_look(by_id[c.asset.id])
-            ]
-            if not unverified:
-                break
-            logger.info(
-                "Verify pass: analyzing %d selected clip(s) the review cannot see",
-                len(unverified),
-            )
-            trace.record(
-                "verify: analyze unseen",
-                result.selected_clips,
-                result.selected_clips,
-                [f"{len(unverified)} clip(s) analyzed for real before judging"],
-            )
-            attempted.update(u.clip.asset.id for u in unverified)
-            unverified = self._look_at_stills_among(unverified)
-            if not unverified:
-                continue
-            try:
-                verified = self.analyzer.phase_analyze([u.clip for u in unverified], self.tracker)
-            finally:
-                with contextlib.suppress(Exception):
-                    self.analyzer.close()
-            verified_ids = self._absorb_verified(by_id, verified, unverified)
-            for u in unverified:
-                if u.clip.asset.id not in verified_ids:
-                    by_id[u.clip.asset.id] = ClipWithSegment(
-                        clip=u.clip,
-                        start_time=u.start_time,
-                        end_time=u.end_time,
-                        score=u.score,
-                        analyzed=True,
-                    )
-            result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
-        return result, list(by_id.values())
-
-    def _absorb_verified(
-        self,
-        by_id: dict[str, ClipWithSegment],
-        verified: list[ClipWithSegment],
-        unverified: list[ClipWithSegment],
-    ) -> set[str]:
-        """Take back what the look actually established, and nothing else.
-
-        Only what we asked for: analysis can hand back more than it was given
-        (a Live Photo expands into its components), and any extra id lands
-        straight back in the pool — resurrecting a clip the judge or the
-        review had just dropped.
-
-        And only what it managed to look at. The analyzer returns a
-        placeholder scored 0.0 when a download blips or a decode dies, and
-        writing that over a real score sends the clip under the judge's floor,
-        which drops it from the pool for good — losing a clip to a transient
-        error. A failed look is not a verdict of zero.
-        """
-        requested = {u.clip.asset.id for u in unverified}
-        kept = [v for v in verified if v.clip.asset.id in requested]
-        for v in kept:
-            if not v.analyzed and v.clip.asset.id in by_id:
-                logger.debug(
-                    "Verify pass: keeping the score for %s, the look failed", v.clip.asset.id
-                )
-                continue
-            by_id[v.clip.asset.id] = v
-        return {v.clip.asset.id for v in kept}
-
-    def _look_at_stills_among(self, unverified: list[ClipWithSegment]) -> list[ClipWithSegment]:
-        """Look at the stills here and now, and hand back the footage.
-
-        A still's real look is the photo scorer: the video analyzer fails on a
-        photograph and writes back a zero, so a photo it could not read was
-        not merely unseen but ranked last.
-        """
-        stills = [u for u in unverified if is_a_still(u.clip.asset)]
-        self._look_at_stills(stills)
-        return [u for u in unverified if not is_a_still(u.clip.asset)]
-
-    def _look_at_stills(self, stills: list[ClipWithSegment]) -> None:
-        """Give the review eyes on the photographs that reached the cut."""
-        if not stills:
-            return
-        from immich_memories.analysis.cache_projection import apply_semantic_payload
-        from immich_memories.photos import photo_pipeline
-
-        logger.info("Verify pass: looking at %d selected photo(s)", len(stills))
-        try:
-            payloads = photo_pipeline.look_at_selected_photos(
-                [s.clip.asset for s in stills],
-                config=self._app_config,
-                client=self.client,
-                provider_circuit=self.provider_circuit,
-            )
-        except (OSError, RuntimeError, ValueError) as exc:
-            logger.debug("Photo look failed: %s", type(exc).__name__)
-            return
-        for member in stills:
-            apply_semantic_payload(member.clip, payloads.get(member.clip.asset.id))
-
-    def _final_review_drop(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment]]:
-        """One last review that drops without refilling.
-
-        The iterating review always leaves its own last refill unjudged: it
-        stops when the budget runs out, and by then it has just re-selected.
-        Refilling again would only admit more unseen clips, so this pass takes
-        the cut it has and removes what does not belong.
-
-        It looks at them first. The review is told — correctly — never to drop
-        a clip for missing information, since a third of a real pool has no
-        analysis yet and treating silence as a verdict would gut the memory.
-        The cost of that rule is that an unanalysed clip is immune to the only
-        quality judgment in the pipeline, and a rendered year recap shipped
-        whiteboards and desks on exactly that immunity. Nothing is judged
-        blind, so the rule never has to protect anything that shipped.
-        """
-        if not self._app_config.content_analysis.enabled:
-            return result, analyzed
-        from immich_memories.analysis.selection_review import review_selection
-
-        result, analyzed = self._verify_selection(analyzed, result)
-
-        by_id = {c.clip.asset.id: c for c in analyzed}
-        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = set(review_selection(selected, self._app_config.llm))
-        if not drops:
-            return result, analyzed
-
-        kept = [c for c in result.selected_clips if c.asset.id not in drops]
-        if not kept:
-            return result, analyzed
-        logger.info(
-            "Selection review: budget spent, dropping %d unreviewed clip(s) "
-            "rather than shipping them",
-            len(result.selected_clips) - len(kept),
-        )
-        trimmed = replace(
-            result,
-            selected_clips=kept,
-            clip_segments={
-                asset_id: seg
-                for asset_id, seg in result.clip_segments.items()
-                if asset_id not in drops
-            },
-        )
-        return trimmed, [c for c in analyzed if c.clip.asset.id not in drops]
-
-    def _needs_a_real_look(self, member: ClipWithSegment) -> bool:
-        """Would the LLM review be judging this clip blind?
-
-        A metadata guess for a score is one way to ship unseen. The other is
-        subtler and was shipping: a clip carries a real visual score, so it
-        counts as analyzed, but no content analysis ever ran on it, so the
-        review is handed a bare line. It is then told — correctly — never to
-        drop a clip for missing information, and two near-identical hotel
-        mirror selfies from consecutive days both survive as a result.
-
-        A photograph is never queued. Its real look is the VLM photo scorer,
-        which has already run and now says what it saw; sending a still to the
-        video analyzer fails and replaces its score with zero, so a photo the
-        scorer could not describe was not merely unseen, it was ranked last.
-        """
-        if not member.analyzed:
-            return True
-        if not self._app_config.content_analysis.enabled:
-            return False
-        return not getattr(member.clip, "llm_description", None)
-
-    def _judge_selection(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
-        """One judge sweep (#468): drop offenders, let selection refill.
-
-        A single sweep by design — the caller re-verifies whatever the
-        re-selection admitted before judging again.
-        """
-        by_id = {c.clip.asset.id: c for c in analyzed}
-        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        if len(selected) < 2:
-            return result, analyzed, False
-        offenders = self._judge_offenders(selected)
-        if not offenders:
-            return result, analyzed, False
-        logger.info(
-            "Judge: dropping %d clip(s) below the quality gate, re-selecting",
-            len(offenders),
-        )
-        analyzed = [c for c in analyzed if c.clip.asset.id not in offenders]
-        if not analyzed:
-            return result, analyzed, False
-        result = self.refiner.phase_refine(analyzed, self.tracker)
-        return result, analyzed, True
-
-    def _floor_for(self, member: ClipWithSegment) -> float:
-        """The gate this clip answers to, on the scale its score was built on.
-
-        photos.score_penalty says outright that a photo scores a fixed share
-        of a video, so a floor calibrated on footage is that much too high for
-        a still. A no-people, non-favorite photo tops out at 0.15 base + 0.05
-        camera + half the LLM weight — 0.28 after the penalty, against a floor
-        of 0.30. Landscapes, pets and scenery could not clear it at all, and
-        were dropped as a class along with any day only they represented.
-        """
-        from immich_memories.analysis.source_filter import is_a_still
-
-        floor = self.config.judge_floor_score
-        if not is_a_still(member.clip.asset):
-            return floor
-        return floor * (1.0 - self._app_config.photos.score_penalty)
-
-    def _spare_last_voices(
-        self,
-        offenders: set[str],
-        selected: list[ClipWithSegment],
-    ) -> set[str]:
-        """Offenders to actually drop, keeping any that is a period's last voice.
-
-        The judge removes offenders from the pool for good, so read as "this
-        clip is bad" its verdict costs a month whose only clip scored low. Read
-        as "we can do better than this clip" it costs nothing, because when
-        there is nothing better the clip stays.
-
-        Unusable is different from weak, and the distinction is what makes this
-        safe: a shot of the ground or a pocket is not worth a month, and stays
-        dropped however alone it is. Only a clip that would pass on any other
-        day is worth keeping for lack of an alternative.
-
-        A correction, not an exemption. Exempting has to guess in advance which
-        clips carry a period, and both ways of guessing that switch the gate
-        off under ordinary conditions — coverage ids are every clip on a pool
-        with no favorites, and a distributed selection makes almost every clip
-        the only one of its day.
-        """
-        from immich_memories.analysis.clip_distribution import _period_key, span_days_of
-
-        unusable = self.config.judge_floor_score * _UNUSABLE_SHARE_OF_FLOOR
-        span = span_days_of(selected)
-
-        def period_of(member: ClipWithSegment) -> str | None:
-            when = member.clip.asset.file_created_at
-            return _period_key(when, span) if when else None
-
-        surviving = {period_of(m) for m in selected if m.clip.asset.id not in offenders}
-        spared = {
-            m.clip.asset.id
-            for m in selected
-            if m.clip.asset.id in offenders
-            and m.score >= unusable
-            and period_of(m) not in surviving
-        }
-        if spared:
-            logger.info(
-                "Judge: keeping %d weak clip(s) — nothing else covers their period",
-                len(spared),
-            )
-        return offenders - spared
-
-    def _judge_offenders(self, selected: list[ClipWithSegment]) -> set[str]:
-        """Members failing the gate. Favorites are exempt from both rules —
-        the user explicitly chose them, and "Starting with ALL favorites" is
-        the selection's oldest contract.
-
-        What carries a period is handled after this rather than here — see
-        _spare_last_voices. Exempting up front needs a guess about which clips
-        carry a period, and every way of guessing switches the gate off.
-        """
-        spared = {s.clip.asset.id for s in selected if getattr(s.clip.asset, "is_favorite", False)}
-        judgeable = [s for s in selected if s.clip.asset.id not in spared]
-        # Sparing applies to the floor rule only. The ending rule below is
-        # about where a clip sits, not whether it is worth keeping — a clip
-        # dropped for being a weak last note is fine anywhere else, and
-        # keeping it for lack of an alternative would defeat the rule.
-        offenders = self._spare_last_voices(
-            {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}, selected
-        )
-        scores = [s.score for s in selected]
-        mean_score = sum(scores) / len(scores)
-        ending = max(
-            selected,
-            key=lambda s: s.clip.asset.file_created_at or datetime.min.replace(tzinfo=UTC),
-        )
-        if (
-            len(selected) > 2
-            and ending.clip.asset.id not in spared
-            and ending.score == min(scores)
-            and ending.score < mean_score * self.config.judge_boundary_ratio
-        ):
-            offenders.add(ending.clip.asset.id)
-        return offenders
-
-    def _holistic_review(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
-        """One LLM pass over the finished cut (#468): redundancy and feel.
-
-        The mechanical judge sees scores; only something reading the
-        descriptions can see the same birthday candles twice. Optional by
-        construction — no LLM, no drops, selection unchanged.
-        """
-        if not self._app_config.content_analysis.enabled:
-            return result, analyzed, False
-        from immich_memories.analysis.selection_review import review_selection
-
-        by_id = {c.clip.asset.id: c for c in analyzed}
-        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = review_selection(selected, self._app_config.llm)
-        if not drops:
-            trace.record("llm review", selected, selected)
-            return result, analyzed, False
-        dropped = set(drops)
-        trace.record(
-            "llm review",
-            selected,
-            [c for c in selected if c.clip.asset.id not in dropped],
-        )
-        remaining = [c for c in analyzed if c.clip.asset.id not in dropped]
-        if not remaining:
-            return result, analyzed, False
-        # WHY the pool shrinks too: a later stabilization re-refines from the
-        # pool — returning the old one would resurrect the LLM's drops.
-        return self.refiner.phase_refine(remaining, self.tracker), remaining, True
-
     def _semantic_cache_miss_count(self, clips: list[VideoClipInfo]) -> int:
         """Count clips that need work under the exact active semantic model."""
         from immich_memories.analysis.cache_projection import is_compatible_analysis_cache
@@ -785,7 +415,7 @@ class SmartPipeline:
         try:
             result = self.refiner.phase_refine(analyzed, self.tracker)
             if verify:
-                result, analyzed = self._stabilize_selection(analyzed, result)
+                result, analyzed = self.quality.stabilize(analyzed, result)
                 # WHY a loop: one review pass drops what it can see, and the
                 # refill puts new clips in their place that nothing has looked
                 # at yet. Reviewing once leaves whatever the last refill
@@ -793,19 +423,19 @@ class SmartPipeline:
                 # cut that had already dropped two others.
                 review_changed = True
                 for _ in range(max(1, self.config.max_refinement_passes)):
-                    result, analyzed, review_changed = self._holistic_review(analyzed, result)
+                    result, analyzed, review_changed = self.quality.review(analyzed, result)
                     if not review_changed:
                         break
                     # The review's re-selection can admit new fallback clips,
                     # exactly like a judge drop — same stabilization.
-                    result, analyzed = self._stabilize_selection(analyzed, result)
+                    result, analyzed = self.quality.stabilize(analyzed, result)
                 if review_changed:
                     # Every pass so far dropped something and refilled, so the
                     # last refill has never been looked at — which is how a
                     # photo of a games console ended a December cut. Judge it
                     # once more and simply drop what fails: a cut four seconds
                     # short beats a cut that ends on a shelf.
-                    result, analyzed = self._final_review_drop(analyzed, result)
+                    result, analyzed = self.quality.final_review_drop(analyzed, result)
             self.tracker.finish()
             return result
         except (

--- a/tests/test_judge_gate.py
+++ b/tests/test_judge_gate.py
@@ -49,7 +49,7 @@ def test_a_landscape_nobody_has_looked_at_yet_is_not_an_offender(tmp_path: Path)
     quiet_landscape = _member("landscape", 0.280, photo=True)
     others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
 
-    offenders = _pipeline(tmp_path)._judge_offenders([quiet_landscape, *others])
+    offenders = _pipeline(tmp_path).quality.judge_offenders([quiet_landscape, *others])
 
     assert "landscape" not in offenders
 
@@ -59,7 +59,7 @@ def test_a_photo_the_model_called_dull_is_still_an_offender(tmp_path: Path) -> N
     dull = _member("dull", 0.232, photo=True)
     others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
 
-    offenders = _pipeline(tmp_path)._judge_offenders([dull, *others])
+    offenders = _pipeline(tmp_path).quality.judge_offenders([dull, *others])
 
     assert "dull" in offenders
 
@@ -69,7 +69,7 @@ def test_a_weak_video_is_still_judged_on_the_video_scale(tmp_path: Path) -> None
     weak = _member("weak-video", 0.28, photo=False)
     others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
 
-    offenders = _pipeline(tmp_path)._judge_offenders([weak, *others])
+    offenders = _pipeline(tmp_path).quality.judge_offenders([weak, *others])
 
     assert "weak-video" in offenders
 
@@ -91,7 +91,7 @@ def test_a_selection_spread_across_time_is_still_judged(tmp_path: Path) -> None:
         member.clip.asset.file_created_at = datetime(2019, 6 + index, 4, 12, tzinfo=UTC)
         spread.append(member)
 
-    offenders = _pipeline(tmp_path)._judge_offenders([junk, *spread])
+    offenders = _pipeline(tmp_path).quality.judge_offenders([junk, *spread])
 
     assert "junk" in offenders
 
@@ -107,7 +107,7 @@ def test_an_offender_is_dropped_when_its_period_has_something_better(tmp_path: P
     better = _in(3, 9, _member("same-month-better", 0.7, photo=False))
     elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
 
-    dropped = _pipeline(tmp_path)._spare_last_voices({"weak"}, [weak, better, *elsewhere])
+    dropped = _pipeline(tmp_path).quality.spare_last_voices({"weak"}, [weak, better, *elsewhere])
 
     assert dropped == {"weak"}
 
@@ -117,7 +117,9 @@ def test_a_weak_clip_that_is_its_period_is_kept(tmp_path: Path) -> None:
     only_march = _in(3, 2, _member("the-only-march", 0.24, photo=False))
     elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
 
-    dropped = _pipeline(tmp_path)._spare_last_voices({"the-only-march"}, [only_march, *elsewhere])
+    dropped = _pipeline(tmp_path).quality.spare_last_voices(
+        {"the-only-march"}, [only_march, *elsewhere]
+    )
 
     assert dropped == set()
 
@@ -127,6 +129,6 @@ def test_an_unusable_clip_is_never_worth_a_period(tmp_path: Path) -> None:
     ground = _in(3, 2, _member("the-ground", 0.05, photo=False))
     elsewhere = [_in(6 + i, 4, _member(f"v-{i}", 0.6, photo=False)) for i in range(2)]
 
-    dropped = _pipeline(tmp_path)._spare_last_voices({"the-ground"}, [ground, *elsewhere])
+    dropped = _pipeline(tmp_path).quality.spare_last_voices({"the-ground"}, [ground, *elsewhere])
 
     assert dropped == {"the-ground"}

--- a/tests/test_pipeline_efficiency.py
+++ b/tests/test_pipeline_efficiency.py
@@ -645,7 +645,7 @@ class TestNothingIsJudgedBlind:
 
         # WHY: the review is an LLM call; what it is handed is the subject here.
         with patch("immich_memories.analysis.selection_review.review_selection", _capture):
-            pipeline._final_review_drop([member], result)
+            pipeline.quality.final_review_drop([member], result)
 
         assert [c.clip.llm_description for c in judged] == [
             "a whiteboard covered in sticky notes"
@@ -678,7 +678,7 @@ class TestNothingIsJudgedBlind:
             "immich_memories.photos.photo_pipeline.look_at_selected_photos",
             return_value={"still": {"description": "a plant against a wall"}},
         ):
-            pipeline._verify_selection([member], result)
+            pipeline.quality.verify([member], result)
 
         assert still.llm_description == "a plant against a wall"
 
@@ -703,8 +703,8 @@ class TestNothingIsJudgedBlind:
         pipeline.analyzer.phase_analyze = MagicMock(return_value=[member])
         pipeline.refiner.phase_refine = MagicMock(return_value=result)
 
-        pipeline._verify_selection([member], result)
-        pipeline._verify_selection([member], result)
+        pipeline.quality.verify([member], result)
+        pipeline.quality.verify([member], result)
 
         assert pipeline.analyzer.phase_analyze.call_count == 1
 
@@ -732,6 +732,6 @@ class TestNothingIsJudgedBlind:
             "immich_memories.photos.photo_pipeline.look_at_selected_photos",
             return_value={"unseen-still": {"description": "a beer tap on a bar"}},
         ):
-            pipeline._verify_selection([member], result)
+            pipeline.quality.verify([member], result)
 
         assert still.llm_description == "a beer tap on a bar"

--- a/tests/test_verify_failure.py
+++ b/tests/test_verify_failure.py
@@ -68,7 +68,7 @@ def test_a_failed_look_leaves_the_score_it_could_not_improve(tmp_path: Path) -> 
     pipeline.analyzer.phase_analyze = MagicMock(return_value=[failed])
     pipeline.refiner.phase_refine = MagicMock(side_effect=lambda a, _t: _result(a[0].clip))
 
-    _result_out, analyzed = pipeline._verify_selection([member], _result(clip))
+    _result_out, analyzed = pipeline.quality.verify([member], _result(clip))
 
     assert [m.score for m in analyzed] == [0.72], "a failed look overwrote a real score"
 
@@ -90,7 +90,7 @@ def test_a_look_that_succeeded_does_replace_the_score(tmp_path: Path) -> None:
     pipeline.analyzer.phase_analyze = MagicMock(return_value=[looked])
     pipeline.refiner.phase_refine = MagicMock(side_effect=lambda a, _t: _result(a[0].clip))
 
-    _result_out, analyzed = pipeline._verify_selection([member], _result(clip))
+    _result_out, analyzed = pipeline.quality.verify([member], _result(clip))
 
     assert [m.score for m in analyzed] == [0.05]
 


### PR DESCRIPTION
## Why now

`main` is red. #535 and #540 each passed their own quality gate, but both added to `smart_pipeline.py` and together summed to **1012 lines**, past the hard 1000 limit. Neither PR's run could see the other's lines, so nothing caught it until the merge. Every PR opened since fails Quality Gates against `main`, and `main`'s own Release run failed the same gate.

This is the failure the soft warning at 800 exists to prevent, so the fix is a real split, not a shave.

## The boundary

Selection decides what a memory is made of; the quality pass decides whether that cut is worth shipping. That is the seam, and it moves whole into a `SelectionQuality` service:

| File | Before | After |
|---|---|---|
| `analysis/smart_pipeline.py` | 1012 | **642** |
| `analysis/selection_quality.py` | — | **434** |

Composed via constructor injection (`config`, `app_config`, `analyzer`, `refiner`, `tracker`, `client`, `provider_circuit`), so `SmartPipeline` now composes 5 services rather than 4.

Public: `stabilize`, `verify`, `review`, `final_review_drop`, plus `judge_offenders` and `spare_last_voices`, which the judge tests exercise directly. Private: `_judge`, `_floor_for`, `_needs_a_real_look`, `_absorb_verified` and the look-at-stills pair.

Two pieces of state moved to the code that actually reads them:
- `_UNUSABLE_SHARE_OF_FLOOR` travels with `spare_last_voices`, its only reader.
- `_verify_attempted` stops being pipeline state. It is the verify pass's memory of what it has already tried, and it belongs to the pass that keeps it.

## No import cycle

`PipelineConfig`, `PipelineResult` and `ClipWithSegment` stay where they are and arrive under `TYPE_CHECKING`, so the dependency points one way only.

That left exactly one runtime construction, in the verify loop, which becomes `dataclasses.replace(u, analyzed=True)` — identical for that five-field dataclass, and it keeps the import from closing the loop. Moving the three dataclasses to a shared module instead would have rewritten **35 import sites** while six sibling refactor PRs are in flight.

## Verification

Pure move, no behaviour change. `make ci` passes in full: lint, format-check, mypy, file-length, complexity, cognitive-complexity, dead-code, security-lint, refurb, dep-check, arch-check, duplication, critique, diff-cover. **5485 passed, 9 skipped.**

`complexipy-snapshot.json` is untouched — the methods moved unchanged, so no cognitive-complexity scores shifted.

Test call sites updated to `pipeline.quality.*`; `ARCHITECTURE.md` updated.

## Merge first

Sibling PRs #547, #548 and #549 all report this same pre-existing `file-length` failure and had to skip the hook to commit. They go green once this lands.