### PR TITLE
refactor(processing): split decoding and blending out of the streaming assembler

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,6 +59,12 @@ injected service.
 - `EndingService` (ending_service.py): fade-to-white ending generation
 - `TripService` (trip_service.py): trip map and location card screens
 
+**`assemble_streaming()`** (processing/streaming_assembler.py) is the streaming render path,
+a three-stage pipe rather than a class: `make_decoder()` (streaming_frame_decoder.py) turns a
+clip into normalized raw frames, `FrameBlender` (streaming_frame_blender.py) writes those
+frames to a `FrameSink` and crossfades across clip boundaries, and `StreamingEncoder` (the
+sink it is constructed with) pipes them into FFmpeg.
+
 **`generate_memory()`** (generate.py) is the top-level orchestrator above the four; it runs
 the `OperationalPhase` lifecycle end to end (there is no `GenerationPipeline` class) with
 these helper modules:
@@ -146,7 +152,9 @@ src/immich_memories/
 │   ├── assembly_engine.py      # AssemblyEngine (composes ConcatService)
 │   ├── ffmpeg_filter_graph.py  # ConcatService: batch merge/direct assembly
 │   ├── assembly_config.py      # Dataclasses: AssemblySettings, AssemblyClip, etc.
-│   ├── streaming_assembler.py  # StreamingAssembler: low-memory 4K assembly via frame blending
+│   ├── streaming_assembler.py  # StreamingEncoder + assemble_streaming(): low-memory 4K assembly
+│   ├── streaming_frame_decoder.py # FrameDecoder / make_decoder(): clip -> normalized raw frames
+│   ├── streaming_frame_blender.py # FrameBlender: frames -> sink, crossfades, progress/preview
 │   ├── streaming_audio.py      # Streaming audio processing helpers
 │   ├── ffmpeg_prober.py        # FFmpegProber: ffprobe-based duration/resolution
 │   ├── filter_builder.py       # FilterBuilder: FFmpeg filter graph construction

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3198,79 +3198,79 @@
       {
         "name": "streaming_assemble_full",
         "complexity": 16,
-        "line_start": 895,
-        "line_end": 998,
+        "line_start": 418,
+        "line_end": 521,
         "line_complexities": [
           {
-            "line": 917,
+            "line": 440,
             "complexity": 1
           },
           {
-            "line": 918,
+            "line": 441,
             "complexity": 0
           },
           {
-            "line": 921,
+            "line": 444,
             "complexity": 0
           },
           {
-            "line": 922,
+            "line": 445,
             "complexity": 0
           },
           {
-            "line": 923,
+            "line": 446,
             "complexity": 0
           },
           {
-            "line": 927,
+            "line": 450,
             "complexity": 2
           },
           {
-            "line": 933,
+            "line": 456,
             "complexity": 3
           },
           {
-            "line": 934,
+            "line": 457,
             "complexity": 0
           },
           {
-            "line": 935,
+            "line": 458,
             "complexity": 0
           },
           {
-            "line": 936,
+            "line": 459,
             "complexity": 3
           },
           {
-            "line": 937,
+            "line": 460,
             "complexity": 3
           },
           {
-            "line": 938,
+            "line": 461,
             "complexity": 0
           },
           {
-            "line": 939,
+            "line": 462,
             "complexity": 0
           },
           {
-            "line": 948,
+            "line": 471,
             "complexity": 0
           },
           {
-            "line": 969,
+            "line": 492,
             "complexity": 2
           },
           {
-            "line": 975,
+            "line": 498,
             "complexity": 0
           },
           {
-            "line": 990,
+            "line": 513,
             "complexity": 2
           },
           {
-            "line": 996,
+            "line": 519,
             "complexity": 0
           }
         ]
@@ -3278,177 +3278,173 @@
       {
         "name": "assemble_streaming",
         "complexity": 24,
-        "line_start": 642,
-        "line_end": 776,
+        "line_start": 207,
+        "line_end": 344,
         "line_complexities": [
           {
-            "line": 667,
+            "line": 232,
             "complexity": 1
           },
           {
-            "line": 668,
+            "line": 233,
             "complexity": 0
           },
           {
-            "line": 670,
+            "line": 235,
             "complexity": 0
           },
           {
-            "line": 671,
+            "line": 236,
             "complexity": 0
           },
           {
-            "line": 673,
+            "line": 238,
             "complexity": 0
           },
           {
-            "line": 674,
+            "line": 239,
             "complexity": 1
           },
           {
-            "line": 675,
+            "line": 240,
             "complexity": 1
           },
           {
-            "line": 676,
+            "line": 241,
             "complexity": 0
           },
           {
-            "line": 677,
+            "line": 242,
             "complexity": 0
           },
           {
-            "line": 679,
-            "complexity": 0
-          },
-          {
-            "line": 682,
+            "line": 255,
             "complexity": 3
           },
           {
-            "line": 683,
+            "line": 256,
             "complexity": 0
           },
           {
-            "line": 684,
+            "line": 257,
             "complexity": 0
           },
           {
-            "line": 690,
+            "line": 263,
             "complexity": 0
           },
           {
-            "line": 714,
+            "line": 287,
             "complexity": 1
           },
           {
-            "line": 715,
+            "line": 288,
             "complexity": 0
           },
           {
-            "line": 716,
+            "line": 289,
             "complexity": 2
           },
           {
-            "line": 717,
+            "line": 290,
             "complexity": 0
           },
           {
-            "line": 718,
+            "line": 291,
             "complexity": 0
           },
           {
-            "line": 742,
+            "line": 310,
             "complexity": 1
           },
           {
-            "line": 743,
+            "line": 311,
             "complexity": 0
           },
           {
-            "line": 745,
+            "line": 313,
             "complexity": 0
           },
           {
-            "line": 746,
+            "line": 314,
             "complexity": 2
           },
           {
-            "line": 747,
+            "line": 315,
             "complexity": 0
           },
           {
-            "line": 748,
+            "line": 316,
             "complexity": 0
           },
           {
-            "line": 749,
+            "line": 317,
             "complexity": 1
           },
           {
-            "line": 750,
+            "line": 318,
             "complexity": 0
           },
           {
-            "line": 752,
+            "line": 320,
             "complexity": 0
           },
           {
-            "line": 756,
+            "line": 324,
             "complexity": 1
           },
           {
-            "line": 757,
+            "line": 325,
             "complexity": 0
           },
           {
-            "line": 758,
+            "line": 326,
             "complexity": 2
           },
           {
-            "line": 759,
+            "line": 327,
             "complexity": 0
           },
           {
-            "line": 760,
+            "line": 328,
             "complexity": 0
           },
           {
-            "line": 762,
+            "line": 330,
             "complexity": 1
           },
           {
-            "line": 768,
+            "line": 336,
             "complexity": 0
           },
           {
-            "line": 769,
+            "line": 337,
             "complexity": 1
           },
           {
-            "line": 770,
+            "line": 338,
             "complexity": 2
           },
           {
-            "line": 771,
+            "line": 339,
             "complexity": 0
           },
           {
-            "line": 772,
+            "line": 340,
             "complexity": 3
           },
           {
-            "line": 774,
+            "line": 342,
             "complexity": 1
           },
           {
-            "line": 776,
+            "line": 344,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 123
+    "complexity": 63
   },
   {
     "path": "src/immich_memories/processing/title_inserter.py",

--- a/src/immich_memories/processing/streaming_assembler.py
+++ b/src/immich_memories/processing/streaming_assembler.py
@@ -9,12 +9,11 @@ import subprocess
 import threading
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
-import cv2
 import numpy as np
 
+from immich_memories.processing.clip_caption import ClipCaption, timeline_captions
 from immich_memories.processing.clip_encoder import encoder_args_for_plan
 from immich_memories.processing.encoding_plan import (
     EncodingPlan,
@@ -24,26 +23,17 @@ from immich_memories.processing.encoding_plan import (
     uses_hardware_encoder,
 )
 from immich_memories.processing.ffmpeg_runner import drain_stderr_tail
-from immich_memories.processing.hdr_utilities import (
-    _detect_color_primaries,
-    _detect_hdr_type,
-    _get_colorspace_filter,
-    _resolve_clip_hdr,
-)
+from immich_memories.processing.hdr_utilities import _get_colorspace_filter
 from immich_memories.processing.streaming_audio import (
     _probe_duration,
     extract_and_mix_audio,
     mux_video_audio,
 )
+from immich_memories.processing.streaming_frame_blender import FrameBlender
+from immich_memories.processing.streaming_frame_decoder import make_decoder
 
 if TYPE_CHECKING:
     from immich_memories.processing.probe_cache import ProbeCache
-
-from immich_memories.processing.clip_caption import (
-    ClipCaption,
-    caption_filters,
-    timeline_captions,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -60,229 +50,6 @@ def _default_streaming_plan() -> EncodingPlan:
         container="mp4",
         crf=18,
     )
-
-
-def blend_crossfade(
-    frame_a: np.ndarray,
-    frame_b: np.ndarray,
-    alpha: float,
-    out: np.ndarray,
-) -> None:
-    """In-place crossfade blend: alpha=0 → frame_a, alpha=1 → frame_b.
-
-    WHY cv2 rather than numpy: the three-pass numpy version measured 37.5 ms a
-    frame at 4K against 3.5 ms here, and its `casting="unsafe"` truncated every
-    element toward zero -- up to 1.6 levels of error where rounding costs 0.5.
-    addWeighted also writes straight into `out`, so the second scratch buffer
-    the numpy path needed (another 25 MB at 4K) is gone.
-    """
-    cv2.addWeighted(frame_a, 1.0 - alpha, frame_b, alpha, 0.0, dst=out)
-
-
-class FrameDecoder:
-    """Decode a video clip to raw frames via FFmpeg stdout pipe."""
-
-    def __init__(
-        self,
-        clip_path: Path,
-        width: int,
-        height: int,
-        fps: int,
-        pix_fmt: str = "rgb24",
-        rotation: int = 0,
-        privacy_blur: bool = False,
-        hdr_conversion: str = "",
-        colorspace_filter: str = "",
-        output_pix_fmt: str = "",
-        scale_mode: str = "black",
-        sdr_to_hdr_filter: str = "",
-        input_seek: float = 0.0,
-        audio_output: Path | None = None,
-        caption: ClipCaption | None = None,
-        caption_font: str | None = None,
-    ) -> None:
-        self._clip_path = clip_path
-        self._input_seek = input_seek
-        self._audio_output = audio_output
-        self._width = width
-        self._height = height
-        self._fps = fps
-        self._pix_fmt = pix_fmt
-        self._frame_size = width * height * 3  # Same for yuv420p10le and rgb24
-        self._rotation = rotation
-        self._privacy_blur = privacy_blur
-        self._hdr_conversion = hdr_conversion
-        self._colorspace_filter = colorspace_filter
-        self._output_pix_fmt = output_pix_fmt
-        self._scale_mode = scale_mode
-        # WHY: SDR clips in HDR output need zscale to convert sRGB→HLG/PQ.
-        # Without this, SDR full-range data piped as yuv420p10le gets
-        # interpreted as TV-range HLG = red/wrong tint.
-        self._sdr_to_hdr_filter = sdr_to_hdr_filter
-        self._caption = caption
-        self._caption_font = caption_font
-
-    def _build_vf(self) -> str:
-        """Build the -vf filter chain matching filter_builder.build_clip_video_filter."""
-        parts: list[str] = []
-
-        # Rotation (transpose/hflip) — must come before scale
-        if self._rotation == 90:
-            parts.append("transpose=1")
-        elif self._rotation == 180:
-            parts.append("hflip,vflip")
-        elif self._rotation == 270:
-            parts.append("transpose=2")
-
-        # WHY: frosted glass effect — gaussian blur + noise texture + smooth.
-        # Looks cinematic/artistic rather than surveillance-like pixelation.
-        # Scales with shorter dimension so portrait/landscape match.
-        if self._privacy_blur:
-            short_side = min(self._width, self._height)
-            sigma = int(short_side * 0.035)
-            parts.append(f"gblur=sigma={sigma},noise=alls=15:allf=t,gblur=sigma=10")
-
-        # PTS reset — critical for multi-clip concat
-        parts.append("setpts=PTS-STARTPTS")
-
-        # Scale + fill to target resolution
-        if self._scale_mode == "blur":
-            # WHY: Blur background fills the entire frame with a blurred, zoomed version
-            # of the source, then overlays the sharp scaled version centered on top.
-            # Uses split to avoid re-reading the source.
-            # When privacy blur is active, skip the extra sigma=30 on the background
-            # because the frame is already blurred — adding more makes it unrecognizable.
-            bg_blur = "" if self._privacy_blur else ",gblur=sigma=30"
-            parts.extend(
-                (
-                    "split[_bg][_fg]",
-                    f"[_bg]scale={self._width}:{self._height}:force_original_aspect_ratio=increase:flags=lanczos,"
-                    f"crop={self._width}:{self._height}{bg_blur}[_blurred]",
-                    f"[_fg]scale={self._width}:{self._height}:force_original_aspect_ratio=decrease:flags=lanczos[_sharp]",
-                    "[_blurred][_sharp]overlay=(W-w)/2:(H-h)/2",
-                )
-            )
-            self._use_filter_complex = True
-        else:
-            # "fit": scale down inside the frame and pad the rest black. There is
-            # no face-aware crop on the video path, so anything that is not
-            # "blur" lands here — which is why no such mode is offered.
-            parts.extend(
-                (
-                    f"scale={self._width}:{self._height}:force_original_aspect_ratio=decrease:flags=lanczos",
-                    f"pad={self._width}:{self._height}:(ow-iw)/2:(oh-ih)/2:black",
-                )
-            )
-            self._use_filter_complex = False
-
-        # FPS + timebase reset
-        parts.append(f"fps={self._fps},settb=1/{self._fps}")
-
-        # SDR→HDR conversion (only for SDR clips in HDR output)
-        if self._sdr_to_hdr_filter:
-            parts.append(self._sdr_to_hdr_filter)
-
-        # Apply the shared per-source transfer conversion and tag the decoded
-        # frames before they enter the metadata-free rawvideo pipe.
-        for color_filter in (
-            self._hdr_conversion,
-            self._colorspace_filter,
-            self._output_pix_fmt,
-        ):
-            if color_filter:
-                parts.append(color_filter.removeprefix(","))
-
-        # Drawn last so the text is never scaled, padded or blurred with the
-        # source, and lands in target-frame coordinates.
-        if self._caption:
-            parts.extend(
-                caption_filters(
-                    self._caption,
-                    self._width,
-                    self._height,
-                    is_hdr=self._pix_fmt != "rgb24",
-                    font_path=self._caption_font,
-                )
-            )
-
-        # Square pixels
-        parts.append("setsar=1")
-
-        return ",".join(parts)
-
-    def __iter__(self) -> Iterator[np.ndarray]:
-        """Yield decoded frames one at a time."""
-        vf = self._build_vf()
-        use_fc = getattr(self, "_use_filter_complex", False)
-
-        if use_fc:
-            # WHY: Blur background uses split which requires -filter_complex
-            filter_args = ["-filter_complex", f"[0:v]{vf}[out]", "-map", "[out]"]
-        else:
-            filter_args = ["-vf", vf]
-
-        seek_args = ["-ss", str(self._input_seek)] if self._input_seek > 0 else []
-
-        # WHY: Extract audio alongside video in the same FFmpeg pass.
-        # Audio timing matches the decoded video frames exactly, preventing
-        # the cumulative drift from independent video/audio assembly.
-        audio_args: list[str] = []
-        if self._audio_output:
-            audio_args = [
-                "-map",
-                "0:a?",
-                "-c:a",
-                "pcm_s16le",
-                "-ar",
-                "48000",
-                "-ac",
-                "2",
-                str(self._audio_output),
-            ]
-
-        cmd = [
-            "ffmpeg",
-            *seek_args,
-            "-i",
-            str(self._clip_path),
-            "-f",
-            "rawvideo",
-            "-pix_fmt",
-            self._pix_fmt,
-            *filter_args,
-            "-s",
-            f"{self._width}x{self._height}",
-            "-r",
-            str(self._fps),
-            "pipe:1",
-            *audio_args,
-        ]
-        logger.debug(f"FrameDecoder cmd: {' '.join(cmd)}")
-        proc = subprocess.Popen(  # noqa: S603, S607
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            bufsize=self._frame_size,
-        )
-        assert proc.stdout is not None  # noqa: S101
-
-        try:
-            while True:
-                raw = proc.stdout.read(self._frame_size)
-                if len(raw) < self._frame_size:
-                    break
-                frame: np.ndarray
-                if self._pix_fmt == "yuv420p10le":
-                    # WHY: Keep as flat uint16 — YUV planar can't reshape to (H,W,3).
-                    # Crossfade blends each sample independently which works for all planes.
-                    frame = np.frombuffer(raw, dtype=np.uint16).copy()
-                else:
-                    frame = np.frombuffer(raw, dtype=np.uint8).reshape(self._height, self._width, 3)
-                yield frame
-        finally:
-            proc.stdout.close()
-            proc.terminate()
-            proc.wait(timeout=5)
 
 
 class StreamingEncoderWriteError(RuntimeError):
@@ -427,200 +194,6 @@ class StreamingEncoder:
             )
 
 
-def _emit_body_frames(
-    active_iter: Iterator[np.ndarray],
-    count: int,
-    encoder: StreamingEncoder,
-    progress_callback: Callable[[int, int], None] | None = None,
-    frames_written: int = 0,
-    total_frames: int = 0,
-    report_interval: int = 1,
-    frame_preview_callback: Callable[[bytes], None] | None = None,
-    last_preview_time: float = 0.0,
-    is_hdr: bool = False,
-    preview_height: int = 0,
-    preview_width: int = 0,
-) -> tuple[int, float]:
-    """Write body frames to the encoder, optionally reporting progress.
-
-    Returns (frames_written, last_preview_time).
-    """
-    from immich_memories.processing.frame_preview import _maybe_emit_preview
-
-    for emitted in range(max(count, 0)):
-        frame = next(active_iter, None)
-        if frame is None:
-            if emitted < count:
-                logger.warning(
-                    f"Frame underrun: expected {count} frames, got {emitted} "
-                    f"(missing {count - emitted} frames = {(count - emitted) / max(total_frames, 1) * 100:.1f}%)"
-                )
-            break
-        encoder.write_frame(frame)
-        frames_written += 1
-        if progress_callback and frames_written % report_interval == 0:
-            progress_callback(frames_written, total_frames)
-        last_preview_time = _maybe_emit_preview(
-            frame,
-            last_preview_time,
-            frame_preview_callback,
-            is_hdr,
-            preview_height,
-            preview_width,
-        )
-    return frames_written, last_preview_time
-
-
-def _match_blend_bufs(ref: np.ndarray, blend_buf: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Create black frame and ensure blend buffers match actual frame shape.
-
-    WHY: HDR mode pre-allocates flat uint16 YUV buffers, but some clips
-    (title screens, FFmpeg filter fallback on Linux) may decode as 3D RGB.
-    """
-    black = np.zeros_like(ref)
-    # WHY: in YUV, all-zeros = GREEN (U=0, V=0 = green chroma).
-    # For flat uint16 arrays (yuv420p10le), set chroma planes to 512.
-    if ref.ndim == 1 and ref.dtype == np.uint16:
-        # Y plane occupies first 2/3 of the flat array, U+V the last 1/3
-        y_size = len(ref) * 2 // 3
-        black[y_size:] = 512
-    if blend_buf.shape != ref.shape or blend_buf.dtype != ref.dtype:
-        blend_buf = np.zeros_like(ref)
-    return black, blend_buf
-
-
-def _hold_or_fallback(
-    frame: np.ndarray | None,
-    last: np.ndarray | None,
-    black: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray | None]:
-    """Return frame (or held last frame) and update last-seen cache."""
-    if frame is not None:
-        return frame, frame
-    return (last if last is not None else black), last
-
-
-def _emit_crossfade(
-    active_iter: Iterator[np.ndarray],
-    next_iter: Iterator[np.ndarray],
-    fade_frames: int,
-    encoder: StreamingEncoder,
-    blend_buf: np.ndarray,
-    height: int,
-    width: int,
-    frame_preview_callback: Callable[[bytes], None] | None = None,
-    last_preview_time: float = 0.0,
-    is_hdr: bool = False,
-) -> float:
-    """Blend fade_frames from two iterators and write to encoder.
-
-    Returns updated last_preview_time.
-    """
-    from immich_memories.processing.frame_preview import _maybe_emit_preview
-
-    black: np.ndarray | None = None
-    last_a: np.ndarray | None = None
-    last_b: np.ndarray | None = None
-    for fade_idx in range(fade_frames):
-        frame_a = next(active_iter, None)
-        frame_b = next(next_iter, None)
-
-        if frame_a is None is frame_b:
-            break
-
-        if black is None:
-            ref = frame_a if frame_a is not None else frame_b
-            assert ref is not None  # noqa: S101
-            black, blend_buf = _match_blend_bufs(ref, blend_buf)
-
-        frame_a, last_a = _hold_or_fallback(frame_a, last_a, black)
-        frame_b, last_b = _hold_or_fallback(frame_b, last_b, black)
-
-        alpha = (fade_idx + 1) / fade_frames
-        blend_crossfade(frame_a, frame_b, alpha, out=blend_buf)
-        encoder.write_frame(blend_buf)
-        last_preview_time = _maybe_emit_preview(
-            blend_buf,
-            last_preview_time,
-            frame_preview_callback,
-            is_hdr,
-            height,
-            width,
-        )
-    return last_preview_time
-
-
-def _make_decoder(
-    clip: Any,
-    clip_idx: int,
-    width: int,
-    height: int,
-    fps: int,
-    ctx: Any | None = None,
-    privacy_mode: bool = False,
-    caption: ClipCaption | None = None,
-    caption_font: str | None = None,
-    scale_mode: str = "black",
-    hdr_type: str | None = None,
-    audio_work_dir: Path | None = None,
-) -> FrameDecoder:
-    """Create a FrameDecoder with per-clip normalization filters."""
-    rotation = 0
-    is_title = getattr(clip, "is_title_screen", False)
-
-    rotation_override = getattr(clip, "rotation_override", None)
-    if rotation_override is not None and rotation_override != 0:
-        rotation = rotation_override
-
-    if ctx is None and Path(clip.path).exists():
-        target_type = hdr_type or "sdr"
-        source_types: list[str | None] = [None] * (clip_idx + 1)
-        source_primaries: list[str | None] = [None] * (clip_idx + 1)
-        source_types[clip_idx] = _detect_hdr_type(clip.path)
-        source_primaries[clip_idx] = _detect_color_primaries(clip.path)
-        ctx = SimpleNamespace(
-            hdr_type=target_type,
-            pix_fmt="yuv420p10le" if hdr_type else "yuv420p",
-            clip_hdr_types=source_types,
-            clip_primaries=source_primaries,
-            colorspace_filter=_get_colorspace_filter(target_type),
-        )
-
-    # Title videos may be pre-encoded, but only an exact transfer match may
-    # bypass conversion. The shared resolver makes the same decision for all clips.
-    hdr_conversion, colorspace_filter, output_pix_fmt, sdr_to_hdr_filter, _ = _resolve_clip_hdr(
-        clip_idx, ctx, hdr_type
-    )
-    pix_fmt = "yuv420p10le" if hdr_type else "rgb24"
-    logger.info(
-        f"Decoder[{clip_idx}] pix={pix_fmt} title={is_title} hdr_type={hdr_type} "
-        f"sdr2hdr={bool(sdr_to_hdr_filter)} {clip.path.name}"
-    )
-
-    audio_output = None
-    if audio_work_dir:
-        audio_output = audio_work_dir / f"clip_{clip_idx}_audio.wav"
-
-    return FrameDecoder(
-        clip_path=clip.path,
-        width=width,
-        height=height,
-        fps=fps,
-        pix_fmt=pix_fmt,
-        rotation=rotation,
-        privacy_blur=privacy_mode and not is_title,
-        hdr_conversion=hdr_conversion,
-        colorspace_filter=colorspace_filter,
-        output_pix_fmt=output_pix_fmt,
-        scale_mode=scale_mode,
-        sdr_to_hdr_filter=sdr_to_hdr_filter,
-        input_seek=getattr(clip, "input_seek", 0.0),
-        audio_output=audio_output,
-        caption=caption if not is_title else None,
-        caption_font=caption_font,
-    )
-
-
 def _estimate_total_frames(
     clips: list, transitions: list[str], fps: int, fade_duration: float
 ) -> int:
@@ -629,14 +202,6 @@ def _estimate_total_frames(
     total = sum(int(c.duration * fps) for c in clips)
     fade_count = sum(1 for t in transitions if t == "fade")
     return max(1, total - fade_count * fade_frames)
-
-
-def _alloc_blend_bufs(width: int, height: int, hdr_type: str | None) -> np.ndarray:
-    """Allocate the blend destination. One buffer: cv2 writes straight into it."""
-    if hdr_type:
-        # WHY: yuv420p10le is flat uint16 — W*H*3 bytes = W*H*3/2 uint16 samples
-        return np.zeros(width * height * 3 // 2, dtype=np.uint16)
-    return np.zeros((height, width, 3), dtype=np.uint8)
 
 
 def assemble_streaming(
@@ -674,9 +239,17 @@ def assemble_streaming(
     plan = encoding_plan or _default_streaming_plan()
     hdr_type = plan.target_transfer.value if plan.hdr else None
     encoder = StreamingEncoder(output_path, width, height, fps, encoding_plan=plan)
-    blend_buf = _alloc_blend_bufs(width, height, hdr_type)
-    # WHY: Throttle callbacks to every ~0.5s worth of frames to avoid UI overhead
-    report_interval = max(1, fps // 2)
+    blender = FrameBlender(
+        sink=encoder,
+        width=width,
+        height=height,
+        is_hdr=hdr_type is not None,
+        total_frames=total_frames,
+        # WHY: Throttle callbacks to every ~0.5s worth of frames to avoid UI overhead
+        report_interval=max(1, fps // 2),
+        progress_callback=progress_callback,
+        frame_preview_callback=frame_preview_callback,
+    )
 
     def retry_in_software() -> list[Path] | None:
         if not _allow_runtime_fallback or not uses_hardware_encoder(plan):
@@ -721,11 +294,8 @@ def assemble_streaming(
         _encode_clip_sequence(
             clips,
             transitions,
-            encoder,
+            blender,
             fade_frames,
-            total_frames,
-            report_interval,
-            blend_buf,
             width,
             height,
             fps,
@@ -735,8 +305,6 @@ def assemble_streaming(
             caption_font,
             scale_mode,
             hdr_type,
-            progress_callback,
-            frame_preview_callback,
             audio_work_dir=audio_work_dir,
         )
     except StreamingEncoderWriteError:
@@ -779,11 +347,8 @@ def assemble_streaming(
 def _encode_clip_sequence(
     clips: list,
     transitions: list[str],
-    encoder: StreamingEncoder,
+    blender: FrameBlender,
     fade_frames: int,
-    total_frames: int,
-    report_interval: int,
-    blend_buf: np.ndarray,
     width: int,
     height: int,
     fps: int,
@@ -793,25 +358,20 @@ def _encode_clip_sequence(
     caption_font: str | None,
     scale_mode: str,
     hdr_type: str | None,
-    progress_callback: Callable[[int, int], None] | None,
-    frame_preview_callback: Callable[[bytes], None] | None = None,
     audio_work_dir: Path | None = None,
 ) -> int:
     """Encode all clips with transitions, tracking frame count for progress."""
     active_iter: Iterator[np.ndarray] | None = None
     skip_frames = 0
-    frames_written = 0
-    last_preview_time = 0.0
-    is_hdr = hdr_type is not None
 
     clip_captions: list[ClipCaption | None] = (
         list(captions) if captions is not None else [None] * len(clips)
     )
 
-    for clip_idx, clip in enumerate(clips):
-        if active_iter is None:
-            decoder = _make_decoder(
-                clip,
+    def decoder_for(clip_idx: int) -> Iterator[np.ndarray]:
+        return iter(
+            make_decoder(
+                clips[clip_idx],
                 clip_idx,
                 width,
                 height,
@@ -824,58 +384,21 @@ def _encode_clip_sequence(
                 hdr_type,
                 audio_work_dir=audio_work_dir,
             )
-            active_iter = iter(decoder)
+        )
+
+    for clip_idx, clip in enumerate(clips):
+        if active_iter is None:
+            active_iter = decoder_for(clip_idx)
 
         clip_frames = int(clip.duration * fps)
         has_fade_out = clip_idx < len(transitions) and transitions[clip_idx] == "fade"
         body_frames = clip_frames - skip_frames - (fade_frames if has_fade_out else 0)
 
-        frames_written, last_preview_time = _emit_body_frames(
-            active_iter,
-            body_frames,
-            encoder,
-            progress_callback,
-            frames_written,
-            total_frames,
-            report_interval,
-            frame_preview_callback,
-            last_preview_time,
-            is_hdr,
-            height,
-            width,
-        )
+        blender.emit_body(active_iter, body_frames)
 
         if has_fade_out and clip_idx + 1 < len(clips):
-            next_decoder = _make_decoder(
-                clips[clip_idx + 1],
-                clip_idx + 1,
-                width,
-                height,
-                fps,
-                ctx,
-                privacy_mode,
-                clip_captions[clip_idx + 1],
-                caption_font,
-                scale_mode,
-                hdr_type,
-                audio_work_dir=audio_work_dir,
-            )
-            next_iter = iter(next_decoder)
-            last_preview_time = _emit_crossfade(
-                active_iter,
-                next_iter,
-                fade_frames,
-                encoder,
-                blend_buf,
-                height,
-                width,
-                frame_preview_callback,
-                last_preview_time,
-                is_hdr,
-            )
-            frames_written += fade_frames
-            if progress_callback:
-                progress_callback(frames_written, total_frames)
+            next_iter = decoder_for(clip_idx + 1)
+            blender.emit_crossfade(active_iter, next_iter, fade_frames)
             active_iter = next_iter
             skip_frames = fade_frames
         else:
@@ -889,7 +412,7 @@ def _encode_clip_sequence(
     # (proc.terminate + wait), ensuring the FD is released.
     if active_iter is not None and hasattr(active_iter, "close"):
         active_iter.close()
-    return frames_written
+    return blender.frames_written
 
 
 def streaming_assemble_full(

--- a/src/immich_memories/processing/streaming_frame_blender.py
+++ b/src/immich_memories/processing/streaming_frame_blender.py
@@ -1,0 +1,177 @@
+"""Composing decoded frames into the output stream.
+
+Kept apart from the assembler because none of it runs FFmpeg: it takes frame
+iterators and a sink, owns the crossfade scratch buffer, and keeps the frame
+count, progress reporting and preview throttling that the assembler used to
+thread through argument lists.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator
+from typing import Protocol
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def blend_crossfade(
+    frame_a: np.ndarray,
+    frame_b: np.ndarray,
+    alpha: float,
+    out: np.ndarray,
+) -> None:
+    """In-place crossfade blend: alpha=0 → frame_a, alpha=1 → frame_b.
+
+    WHY cv2 rather than numpy: the three-pass numpy version measured 37.5 ms a
+    frame at 4K against 3.5 ms here, and its `casting="unsafe"` truncated every
+    element toward zero -- up to 1.6 levels of error where rounding costs 0.5.
+    addWeighted also writes straight into `out`, so the second scratch buffer
+    the numpy path needed (another 25 MB at 4K) is gone.
+    """
+    cv2.addWeighted(frame_a, 1.0 - alpha, frame_b, alpha, 0.0, dst=out)
+
+
+class FrameSink(Protocol):
+    """The encoder end of the pipe, as the blender needs to see it."""
+
+    def write_frame(self, frame: np.ndarray) -> None: ...
+
+
+def _alloc_blend_buf(width: int, height: int, is_hdr: bool) -> np.ndarray:
+    """Allocate the blend destination. One buffer: cv2 writes straight into it."""
+    if is_hdr:
+        # WHY: yuv420p10le is flat uint16 — W*H*3 bytes = W*H*3/2 uint16 samples
+        return np.zeros(width * height * 3 // 2, dtype=np.uint16)
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+def _match_blend_bufs(ref: np.ndarray, blend_buf: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Create black frame and ensure blend buffers match actual frame shape.
+
+    WHY: HDR mode pre-allocates flat uint16 YUV buffers, but some clips
+    (title screens, FFmpeg filter fallback on Linux) may decode as 3D RGB.
+    """
+    black = np.zeros_like(ref)
+    # WHY: in YUV, all-zeros = GREEN (U=0, V=0 = green chroma).
+    # For flat uint16 arrays (yuv420p10le), set chroma planes to 512.
+    if ref.ndim == 1 and ref.dtype == np.uint16:
+        # Y plane occupies first 2/3 of the flat array, U+V the last 1/3
+        y_size = len(ref) * 2 // 3
+        black[y_size:] = 512
+    if blend_buf.shape != ref.shape or blend_buf.dtype != ref.dtype:
+        blend_buf = np.zeros_like(ref)
+    return black, blend_buf
+
+
+def _hold_or_fallback(
+    frame: np.ndarray | None,
+    last: np.ndarray | None,
+    black: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Return frame (or held last frame) and update last-seen cache."""
+    if frame is not None:
+        return frame, frame
+    return (last if last is not None else black), last
+
+
+class FrameBlender:
+    """Feed decoded frames to a sink, crossfading across clip boundaries."""
+
+    def __init__(
+        self,
+        sink: FrameSink,
+        width: int,
+        height: int,
+        is_hdr: bool = False,
+        total_frames: int = 0,
+        report_interval: int = 1,
+        progress_callback: Callable[[int, int], None] | None = None,
+        frame_preview_callback: Callable[[bytes], None] | None = None,
+    ) -> None:
+        self._sink = sink
+        self._width = width
+        self._height = height
+        self._is_hdr = is_hdr
+        self._total_frames = total_frames
+        self._report_interval = report_interval
+        self._progress_callback = progress_callback
+        self._frame_preview_callback = frame_preview_callback
+        self._blend_buf = _alloc_blend_buf(width, height, is_hdr)
+        self._frames_written = 0
+        self._last_preview_time = 0.0
+
+    @property
+    def frames_written(self) -> int:
+        """Frames handed to the sink so far, crossfade frames included."""
+        return self._frames_written
+
+    def emit_body(self, active_iter: Iterator[np.ndarray], count: int) -> None:
+        """Write `count` frames from one clip straight through to the sink."""
+        for emitted in range(max(count, 0)):
+            frame = next(active_iter, None)
+            if frame is None:
+                if emitted < count:
+                    logger.warning(
+                        f"Frame underrun: expected {count} frames, got {emitted} "
+                        f"(missing {count - emitted} frames = "
+                        f"{(count - emitted) / max(self._total_frames, 1) * 100:.1f}%)"
+                    )
+                break
+            self._sink.write_frame(frame)
+            self._frames_written += 1
+            if self._progress_callback and self._frames_written % self._report_interval == 0:
+                self._progress_callback(self._frames_written, self._total_frames)
+            self._emit_preview(frame)
+
+    def emit_crossfade(
+        self,
+        active_iter: Iterator[np.ndarray],
+        next_iter: Iterator[np.ndarray],
+        fade_frames: int,
+    ) -> None:
+        """Blend `fade_frames` from two clips and write the result to the sink."""
+        blend_buf = self._blend_buf
+        black: np.ndarray | None = None
+        last_a: np.ndarray | None = None
+        last_b: np.ndarray | None = None
+        for fade_idx in range(fade_frames):
+            frame_a = next(active_iter, None)
+            frame_b = next(next_iter, None)
+
+            if frame_a is None is frame_b:
+                break
+
+            if black is None:
+                ref = frame_a if frame_a is not None else frame_b
+                assert ref is not None  # noqa: S101
+                black, blend_buf = _match_blend_bufs(ref, blend_buf)
+
+            frame_a, last_a = _hold_or_fallback(frame_a, last_a, black)
+            frame_b, last_b = _hold_or_fallback(frame_b, last_b, black)
+
+            alpha = (fade_idx + 1) / fade_frames
+            blend_crossfade(frame_a, frame_b, alpha, out=blend_buf)
+            self._sink.write_frame(blend_buf)
+            self._emit_preview(blend_buf)
+
+        # WHY: the fade is billed at its nominal length even if a clip ran
+        # short, so the progress bar stays aligned with the estimated total.
+        self._frames_written += fade_frames
+        if self._progress_callback:
+            self._progress_callback(self._frames_written, self._total_frames)
+
+    def _emit_preview(self, frame: np.ndarray) -> None:
+        from immich_memories.processing.frame_preview import _maybe_emit_preview
+
+        self._last_preview_time = _maybe_emit_preview(
+            frame,
+            self._last_preview_time,
+            self._frame_preview_callback,
+            self._is_hdr,
+            self._height,
+            self._width,
+        )

--- a/src/immich_memories/processing/streaming_frame_decoder.py
+++ b/src/immich_memories/processing/streaming_frame_decoder.py
@@ -1,0 +1,305 @@
+"""Decoding one clip into normalized frames for the streaming assembler.
+
+Kept apart from the assembler because this is the source half of the pipe: it
+owns the per-clip FFmpeg filter chain (rotation, privacy blur, fit/blur fill,
+HDR transfer, captions) and hands back raw frames plus the clip's audio. The
+assembler only consumes the frames.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from immich_memories.processing.clip_caption import ClipCaption, caption_filters
+from immich_memories.processing.hdr_utilities import (
+    _detect_color_primaries,
+    _detect_hdr_type,
+    _get_colorspace_filter,
+    _resolve_clip_hdr,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FrameDecoder:
+    """Decode a video clip to raw frames via FFmpeg stdout pipe."""
+
+    def __init__(
+        self,
+        clip_path: Path,
+        width: int,
+        height: int,
+        fps: int,
+        pix_fmt: str = "rgb24",
+        rotation: int = 0,
+        privacy_blur: bool = False,
+        hdr_conversion: str = "",
+        colorspace_filter: str = "",
+        output_pix_fmt: str = "",
+        scale_mode: str = "black",
+        sdr_to_hdr_filter: str = "",
+        input_seek: float = 0.0,
+        audio_output: Path | None = None,
+        caption: ClipCaption | None = None,
+        caption_font: str | None = None,
+    ) -> None:
+        self._clip_path = clip_path
+        self._input_seek = input_seek
+        self._audio_output = audio_output
+        self._width = width
+        self._height = height
+        self._fps = fps
+        self._pix_fmt = pix_fmt
+        self._frame_size = width * height * 3  # Same for yuv420p10le and rgb24
+        self._rotation = rotation
+        self._privacy_blur = privacy_blur
+        self._hdr_conversion = hdr_conversion
+        self._colorspace_filter = colorspace_filter
+        self._output_pix_fmt = output_pix_fmt
+        self._scale_mode = scale_mode
+        # WHY: SDR clips in HDR output need zscale to convert sRGB→HLG/PQ.
+        # Without this, SDR full-range data piped as yuv420p10le gets
+        # interpreted as TV-range HLG = red/wrong tint.
+        self._sdr_to_hdr_filter = sdr_to_hdr_filter
+        self._caption = caption
+        self._caption_font = caption_font
+
+    def _build_vf(self) -> str:
+        """Build the -vf filter chain matching filter_builder.build_clip_video_filter."""
+        parts: list[str] = []
+
+        # Rotation (transpose/hflip) — must come before scale
+        if self._rotation == 90:
+            parts.append("transpose=1")
+        elif self._rotation == 180:
+            parts.append("hflip,vflip")
+        elif self._rotation == 270:
+            parts.append("transpose=2")
+
+        # WHY: frosted glass effect — gaussian blur + noise texture + smooth.
+        # Looks cinematic/artistic rather than surveillance-like pixelation.
+        # Scales with shorter dimension so portrait/landscape match.
+        if self._privacy_blur:
+            short_side = min(self._width, self._height)
+            sigma = int(short_side * 0.035)
+            parts.append(f"gblur=sigma={sigma},noise=alls=15:allf=t,gblur=sigma=10")
+
+        # PTS reset — critical for multi-clip concat
+        parts.append("setpts=PTS-STARTPTS")
+
+        # Scale + fill to target resolution
+        if self._scale_mode == "blur":
+            # WHY: Blur background fills the entire frame with a blurred, zoomed version
+            # of the source, then overlays the sharp scaled version centered on top.
+            # Uses split to avoid re-reading the source.
+            # When privacy blur is active, skip the extra sigma=30 on the background
+            # because the frame is already blurred — adding more makes it unrecognizable.
+            bg_blur = "" if self._privacy_blur else ",gblur=sigma=30"
+            parts.extend(
+                (
+                    "split[_bg][_fg]",
+                    f"[_bg]scale={self._width}:{self._height}:force_original_aspect_ratio=increase:flags=lanczos,"
+                    f"crop={self._width}:{self._height}{bg_blur}[_blurred]",
+                    f"[_fg]scale={self._width}:{self._height}:force_original_aspect_ratio=decrease:flags=lanczos[_sharp]",
+                    "[_blurred][_sharp]overlay=(W-w)/2:(H-h)/2",
+                )
+            )
+            self._use_filter_complex = True
+        else:
+            # "fit": scale down inside the frame and pad the rest black. There is
+            # no face-aware crop on the video path, so anything that is not
+            # "blur" lands here — which is why no such mode is offered.
+            parts.extend(
+                (
+                    f"scale={self._width}:{self._height}:force_original_aspect_ratio=decrease:flags=lanczos",
+                    f"pad={self._width}:{self._height}:(ow-iw)/2:(oh-ih)/2:black",
+                )
+            )
+            self._use_filter_complex = False
+
+        # FPS + timebase reset
+        parts.append(f"fps={self._fps},settb=1/{self._fps}")
+
+        # SDR→HDR conversion (only for SDR clips in HDR output)
+        if self._sdr_to_hdr_filter:
+            parts.append(self._sdr_to_hdr_filter)
+
+        # Apply the shared per-source transfer conversion and tag the decoded
+        # frames before they enter the metadata-free rawvideo pipe.
+        for color_filter in (
+            self._hdr_conversion,
+            self._colorspace_filter,
+            self._output_pix_fmt,
+        ):
+            if color_filter:
+                parts.append(color_filter.removeprefix(","))
+
+        # Drawn last so the text is never scaled, padded or blurred with the
+        # source, and lands in target-frame coordinates.
+        if self._caption:
+            parts.extend(
+                caption_filters(
+                    self._caption,
+                    self._width,
+                    self._height,
+                    is_hdr=self._pix_fmt != "rgb24",
+                    font_path=self._caption_font,
+                )
+            )
+
+        # Square pixels
+        parts.append("setsar=1")
+
+        return ",".join(parts)
+
+    def __iter__(self) -> Iterator[np.ndarray]:
+        """Yield decoded frames one at a time."""
+        vf = self._build_vf()
+        use_fc = getattr(self, "_use_filter_complex", False)
+
+        if use_fc:
+            # WHY: Blur background uses split which requires -filter_complex
+            filter_args = ["-filter_complex", f"[0:v]{vf}[out]", "-map", "[out]"]
+        else:
+            filter_args = ["-vf", vf]
+
+        seek_args = ["-ss", str(self._input_seek)] if self._input_seek > 0 else []
+
+        # WHY: Extract audio alongside video in the same FFmpeg pass.
+        # Audio timing matches the decoded video frames exactly, preventing
+        # the cumulative drift from independent video/audio assembly.
+        audio_args: list[str] = []
+        if self._audio_output:
+            audio_args = [
+                "-map",
+                "0:a?",
+                "-c:a",
+                "pcm_s16le",
+                "-ar",
+                "48000",
+                "-ac",
+                "2",
+                str(self._audio_output),
+            ]
+
+        cmd = [
+            "ffmpeg",
+            *seek_args,
+            "-i",
+            str(self._clip_path),
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            self._pix_fmt,
+            *filter_args,
+            "-s",
+            f"{self._width}x{self._height}",
+            "-r",
+            str(self._fps),
+            "pipe:1",
+            *audio_args,
+        ]
+        logger.debug(f"FrameDecoder cmd: {' '.join(cmd)}")
+        proc = subprocess.Popen(  # noqa: S603, S607
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=self._frame_size,
+        )
+        assert proc.stdout is not None  # noqa: S101
+
+        try:
+            while True:
+                raw = proc.stdout.read(self._frame_size)
+                if len(raw) < self._frame_size:
+                    break
+                frame: np.ndarray
+                if self._pix_fmt == "yuv420p10le":
+                    # WHY: Keep as flat uint16 — YUV planar can't reshape to (H,W,3).
+                    # Crossfade blends each sample independently which works for all planes.
+                    frame = np.frombuffer(raw, dtype=np.uint16).copy()
+                else:
+                    frame = np.frombuffer(raw, dtype=np.uint8).reshape(self._height, self._width, 3)
+                yield frame
+        finally:
+            proc.stdout.close()
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def make_decoder(
+    clip: Any,
+    clip_idx: int,
+    width: int,
+    height: int,
+    fps: int,
+    ctx: Any | None = None,
+    privacy_mode: bool = False,
+    caption: ClipCaption | None = None,
+    caption_font: str | None = None,
+    scale_mode: str = "black",
+    hdr_type: str | None = None,
+    audio_work_dir: Path | None = None,
+) -> FrameDecoder:
+    """Create a FrameDecoder with per-clip normalization filters."""
+    rotation = 0
+    is_title = getattr(clip, "is_title_screen", False)
+
+    rotation_override = getattr(clip, "rotation_override", None)
+    if rotation_override is not None and rotation_override != 0:
+        rotation = rotation_override
+
+    if ctx is None and Path(clip.path).exists():
+        target_type = hdr_type or "sdr"
+        source_types: list[str | None] = [None] * (clip_idx + 1)
+        source_primaries: list[str | None] = [None] * (clip_idx + 1)
+        source_types[clip_idx] = _detect_hdr_type(clip.path)
+        source_primaries[clip_idx] = _detect_color_primaries(clip.path)
+        ctx = SimpleNamespace(
+            hdr_type=target_type,
+            pix_fmt="yuv420p10le" if hdr_type else "yuv420p",
+            clip_hdr_types=source_types,
+            clip_primaries=source_primaries,
+            colorspace_filter=_get_colorspace_filter(target_type),
+        )
+
+    # Title videos may be pre-encoded, but only an exact transfer match may
+    # bypass conversion. The shared resolver makes the same decision for all clips.
+    hdr_conversion, colorspace_filter, output_pix_fmt, sdr_to_hdr_filter, _ = _resolve_clip_hdr(
+        clip_idx, ctx, hdr_type
+    )
+    pix_fmt = "yuv420p10le" if hdr_type else "rgb24"
+    logger.info(
+        f"Decoder[{clip_idx}] pix={pix_fmt} title={is_title} hdr_type={hdr_type} "
+        f"sdr2hdr={bool(sdr_to_hdr_filter)} {clip.path.name}"
+    )
+
+    audio_output = None
+    if audio_work_dir:
+        audio_output = audio_work_dir / f"clip_{clip_idx}_audio.wav"
+
+    return FrameDecoder(
+        clip_path=clip.path,
+        width=width,
+        height=height,
+        fps=fps,
+        pix_fmt=pix_fmt,
+        rotation=rotation,
+        privacy_blur=privacy_mode and not is_title,
+        hdr_conversion=hdr_conversion,
+        colorspace_filter=colorspace_filter,
+        output_pix_fmt=output_pix_fmt,
+        scale_mode=scale_mode,
+        sdr_to_hdr_filter=sdr_to_hdr_filter,
+        input_seek=getattr(clip, "input_seek", 0.0),
+        audio_output=audio_output,
+        caption=caption if not is_title else None,
+        caption_font=caption_font,
+    )

--- a/src/immich_memories/processing/title_inserter.py
+++ b/src/immich_memories/processing/title_inserter.py
@@ -72,17 +72,17 @@ class TitleInserter:
             create_assembly_context,
         )
         from immich_memories.processing.clip_encoder import encoder_args_for_plan
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         plan = self.settings.encoding_plan
         output_path = output_dir / f"first_clip_processed.{plan.container}"
         ctx = create_assembly_context(self.settings, self.prober, clips, target_w, target_h)
 
-        # WHY: _make_decoder applies the EXACT same filter chain as the
+        # WHY: make_decoder applies the EXACT same filter chain as the
         # streaming assembler: rotation, scale_mode (blur bg), HDR conversion,
         # resolution, fps, SAR. The output is pixel-identical to what the
         # assembler will produce for this clip.
-        decoder = _make_decoder(
+        decoder = make_decoder(
             clips[0],
             0,
             target_w,
@@ -304,14 +304,14 @@ class TitleInserter:
 
         from immich_memories.processing.assembly_engine import create_assembly_context
         from immich_memories.processing.clip_encoder import encoder_args_for_plan
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         clip = clips[-1]
         plan = self.settings.encoding_plan
         output_path = output_dir / f"last_clip_processed.{plan.container}"
         ctx = create_assembly_context(self.settings, self.prober, clips, target_w, target_h)
 
-        decoder = _make_decoder(
+        decoder = make_decoder(
             clip,
             len(clips) - 1,
             target_w,

--- a/src/immich_memories/ui/pages/step3_options.py
+++ b/src/immich_memories/ui/pages/step3_options.py
@@ -42,7 +42,7 @@ _RESOLUTION_LABELS = {"4k": "4K", "1080p": "1080p", "720p": "720p"}
 
 # WHY: the assembler fills an aspect mismatch two ways and no more — a blurred,
 # zoomed copy of the frame behind the sharp one, or black bars. Offering a third
-# choice here would just relabel the black bars (see streaming_assembler._build_vf).
+# choice here would just relabel the black bars (see FrameDecoder._build_vf).
 SCALE_MODE_OPTIONS = {
     "Blur background": "blur",
     "Letterbox (black bars)": "fit",

--- a/tests/integration/processing/test_date_overlay_real.py
+++ b/tests/integration/processing/test_date_overlay_real.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 
 from immich_memories.processing.clip_caption import ClipCaption
-from immich_memories.processing.streaming_assembler import FrameDecoder
+from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_crossfade_blend.py
+++ b/tests/test_crossfade_blend.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from immich_memories.processing.streaming_assembler import blend_crossfade
+from immich_memories.processing.streaming_frame_blender import blend_crossfade
 
 
 def _exact(a: np.ndarray, b: np.ndarray, alpha: float) -> np.ndarray:

--- a/tests/test_date_overlay.py
+++ b/tests/test_date_overlay.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from immich_memories.processing.clip_caption import ClipCaption
-from immich_memories.processing.streaming_assembler import FrameDecoder
+from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
 
 def _decoder(**kwargs) -> FrameDecoder:
@@ -68,34 +68,34 @@ class TestWhatGetsCaptioned:
     """The date comes off the clip; the option decides whether it is drawn."""
 
     def test_the_clips_date_is_captioned_when_the_option_is_on(self):
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
-        decoder = _make_decoder(
+        decoder = make_decoder(
             _fake_clip(date="2026-01-05"), 0, 1920, 1080, 30, caption=ClipCaption(date="5 Jan 2026")
         )
 
         assert "5 JAN 2026" in decoder._build_vf()
 
     def test_nothing_is_drawn_when_the_option_is_off(self):
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
-        decoder = _make_decoder(_fake_clip(date="2026-01-05"), 0, 1920, 1080, 30)
+        decoder = make_decoder(_fake_clip(date="2026-01-05"), 0, 1920, 1080, 30)
 
         assert "drawtext" not in decoder._build_vf()
 
     def test_a_title_card_gets_no_date(self):
         """The title card is not a moment; stamping it with a date reads as a bug."""
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         clip = _fake_clip(date="2026-01-05", is_title_screen=True)
-        decoder = _make_decoder(clip, 0, 1920, 1080, 30, caption=ClipCaption(date="5 Jan 2026"))
+        decoder = make_decoder(clip, 0, 1920, 1080, 30, caption=ClipCaption(date="5 Jan 2026"))
 
         assert "drawtext" not in decoder._build_vf()
 
     def test_a_clip_with_no_date_is_left_alone(self):
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
-        decoder = _make_decoder(_fake_clip(date=None), 0, 1920, 1080, 30, caption=ClipCaption())
+        decoder = make_decoder(_fake_clip(date=None), 0, 1920, 1080, 30, caption=ClipCaption())
 
         assert "drawtext" not in decoder._build_vf()
 

--- a/tests/test_streaming_assembler.py
+++ b/tests/test_streaming_assembler.py
@@ -126,7 +126,7 @@ def test_streaming_broken_pipe_retries_same_codec_in_software(tmp_path: Path) ->
             EarlyFailingHardwareEncoder,
         ),
         patch(
-            "immich_memories.processing.streaming_assembler._make_decoder",
+            "immich_memories.processing.streaming_assembler.make_decoder",
             side_effect=lambda *_args, **_kwargs: iter([frame]),
         ),
     ):
@@ -191,7 +191,7 @@ def test_streaming_callback_broken_pipe_does_not_retry_software(tmp_path: Path) 
     with (
         patch("immich_memories.processing.streaming_assembler.StreamingEncoder", WorkingEncoder),
         patch(
-            "immich_memories.processing.streaming_assembler._make_decoder",
+            "immich_memories.processing.streaming_assembler.make_decoder",
             side_effect=lambda *_args, **_kwargs: iter([frame]),
         ),
         pytest.raises(BrokenPipeError, match="preview consumer"),
@@ -227,7 +227,7 @@ class TestFrameDecoder:
         """FrameDecoder should yield numpy arrays of (height, width, 3)."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         tmp = Path(str(tmp_path))
 
@@ -317,7 +317,7 @@ class TestStreamingEncoder:
 class TestFrameBlender:
     def test_crossfade_blend_produces_interpolated_frames(self) -> None:
         """Blending two frames at alpha=0.5 should average pixel values."""
-        from immich_memories.processing.streaming_assembler import blend_crossfade
+        from immich_memories.processing.streaming_frame_blender import blend_crossfade
 
         frame_a = np.full((4, 4, 3), 100, dtype=np.uint8)
         frame_b = np.full((4, 4, 3), 200, dtype=np.uint8)
@@ -330,7 +330,7 @@ class TestFrameBlender:
 
     def test_crossfade_alpha_zero_is_frame_a(self) -> None:
         """Alpha=0 should return frame_a unchanged."""
-        from immich_memories.processing.streaming_assembler import blend_crossfade
+        from immich_memories.processing.streaming_frame_blender import blend_crossfade
 
         frame_a = np.full((4, 4, 3), 100, dtype=np.uint8)
         frame_b = np.full((4, 4, 3), 200, dtype=np.uint8)
@@ -341,7 +341,7 @@ class TestFrameBlender:
 
     def test_crossfade_alpha_one_is_frame_b(self) -> None:
         """Alpha=1 should return frame_b unchanged."""
-        from immich_memories.processing.streaming_assembler import blend_crossfade
+        from immich_memories.processing.streaming_frame_blender import blend_crossfade
 
         frame_a = np.full((4, 4, 3), 100, dtype=np.uint8)
         frame_b = np.full((4, 4, 3), 200, dtype=np.uint8)
@@ -383,7 +383,7 @@ def test_full_streaming_prores_threads_plan_and_uses_mov_work_video(tmp_path) ->
 
 def test_frame_decoder_applies_hdr_to_sdr_color_chain() -> None:
     """Streaming decode must consume conversion, output tags, and pixel format."""
-    from immich_memories.processing.streaming_assembler import FrameDecoder
+    from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
     decoder = FrameDecoder(
         Path("hlg.mp4"),
@@ -409,7 +409,7 @@ def test_frame_decoder_applies_hdr_to_sdr_color_chain() -> None:
 
 
 def _vf_for_scale_mode(mode: str) -> str:
-    from immich_memories.processing.streaming_assembler import FrameDecoder
+    from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
     return FrameDecoder(
         Path("clip.mp4"), width=1920, height=1080, fps=30, scale_mode=mode
@@ -442,7 +442,7 @@ def test_fit_scale_mode_renders_black_bars() -> None:
 def test_streaming_decoder_builds_plan_targeted_hlg_to_sdr_chain() -> None:
     from unittest.mock import MagicMock, patch
 
-    from immich_memories.processing.streaming_assembler import _make_decoder
+    from immich_memories.processing.streaming_frame_decoder import make_decoder
 
     clip = MagicMock(path=Path("hlg.mp4"), is_title_screen=False, rotation_override=None)
     ctx = MagicMock(
@@ -457,7 +457,7 @@ def test_streaming_decoder_builds_plan_targeted_hlg_to_sdr_chain() -> None:
         "immich_memories.processing.hdr_utilities._check_zscale_available",
         return_value=True,
     ):
-        decoder = _make_decoder(clip, 0, 320, 240, 30, ctx=ctx, hdr_type=None)
+        decoder = make_decoder(clip, 0, 320, 240, 30, ctx=ctx, hdr_type=None)
 
     vf = decoder._build_vf()
     assert "zscale=t=linear" in vf
@@ -479,7 +479,7 @@ def test_streaming_decoder_fails_when_required_hdr_conversion_is_unavailable(
     from unittest.mock import MagicMock, patch
 
     from immich_memories.processing.hdr_utilities import RequiredColorConversionUnavailable
-    from immich_memories.processing.streaming_assembler import _make_decoder
+    from immich_memories.processing.streaming_frame_decoder import make_decoder
 
     clip = MagicMock(path=Path("hdr.mp4"), is_title_screen=False, rotation_override=None)
     ctx = MagicMock(
@@ -500,7 +500,7 @@ def test_streaming_decoder_fails_when_required_hdr_conversion_is_unavailable(
         ),
         pytest.raises(RequiredColorConversionUnavailable),
     ):
-        _make_decoder(clip, 0, 320, 240, 30, ctx=ctx, hdr_type=target_transfer)
+        make_decoder(clip, 0, 320, 240, 30, ctx=ctx, hdr_type=target_transfer)
 
 
 @requires_ffmpeg
@@ -887,7 +887,7 @@ class TestFrameDecoderFilterChain:
         """PTS reset and timebase are critical for multi-clip concat."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30)
         vf = decoder._build_vf()
@@ -900,7 +900,7 @@ class TestFrameDecoderFilterChain:
         """90° rotation must apply transpose=1 before scale."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30, rotation=90)
         vf = decoder._build_vf()
@@ -912,7 +912,7 @@ class TestFrameDecoderFilterChain:
     def test_rotation_180_includes_hflip_vflip(self) -> None:
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30, rotation=180)
         vf = decoder._build_vf()
@@ -921,7 +921,7 @@ class TestFrameDecoderFilterChain:
     def test_rotation_270_includes_transpose_2(self) -> None:
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30, rotation=270)
         vf = decoder._build_vf()
@@ -931,7 +931,7 @@ class TestFrameDecoderFilterChain:
         """Privacy mode must apply heavy gaussian blur."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(
             Path("/fake.mp4"), width=1920, height=1080, fps=30, privacy_blur=True
@@ -945,7 +945,7 @@ class TestFrameDecoderFilterChain:
         """Per-source transfer normalization must happen before frame blending."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(
             Path("/fake.mp4"),
@@ -966,7 +966,7 @@ class TestFrameDecoderFilterChain:
         """rotation=0 should NOT add any transpose filter."""
         from pathlib import Path
 
-        from immich_memories.processing.streaming_assembler import FrameDecoder
+        from immich_memories.processing.streaming_frame_decoder import FrameDecoder
 
         decoder = FrameDecoder(Path("/fake.mp4"), width=1920, height=1080, fps=30, rotation=0)
         vf = decoder._build_vf()
@@ -1241,34 +1241,34 @@ class TestAudioFilterChain:
 
 
 class TestMakeDecoderIntegration:
-    """Verify _make_decoder wires clip metadata to FrameDecoder correctly."""
+    """Verify make_decoder wires clip metadata to FrameDecoder correctly."""
 
     def test_rotation_override_passed_through(self) -> None:
         from immich_memories.processing.assembly_config import AssemblyClip
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         clip = AssemblyClip(path=Path("/clip.mp4"), duration=5.0, rotation_override=90)
-        decoder = _make_decoder(clip, 0, 1920, 1080, 30)
+        decoder = make_decoder(clip, 0, 1920, 1080, 30)
 
         assert decoder._rotation == 90
         assert "transpose=1" in decoder._build_vf()
 
     def test_privacy_mode_applied_to_non_title(self) -> None:
         from immich_memories.processing.assembly_config import AssemblyClip
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         clip = AssemblyClip(path=Path("/clip.mp4"), duration=5.0)
-        decoder = _make_decoder(clip, 0, 1920, 1080, 30, privacy_mode=True)
+        decoder = make_decoder(clip, 0, 1920, 1080, 30, privacy_mode=True)
 
         assert decoder._privacy_blur is True
         assert "gblur=sigma=37" in decoder._build_vf()
 
     def test_privacy_mode_not_applied_to_title_screen(self) -> None:
         from immich_memories.processing.assembly_config import AssemblyClip
-        from immich_memories.processing.streaming_assembler import _make_decoder
+        from immich_memories.processing.streaming_frame_decoder import make_decoder
 
         clip = AssemblyClip(path=Path("/title.mp4"), duration=3.0, is_title_screen=True)
-        decoder = _make_decoder(clip, 0, 1920, 1080, 30, privacy_mode=True)
+        decoder = make_decoder(clip, 0, 1920, 1080, 30, privacy_mode=True)
 
         assert decoder._privacy_blur is False
         assert "gblur" not in decoder._build_vf()


### PR DESCRIPTION
## Why

`processing/streaming_assembler.py` was **998 lines** — two under the 1000-line hard
limit. The next line anyone added to it broke CI for everyone.

## The cohesion boundary

The file was one pipe wearing three hats, so I cut it where the frames flow:

**source → compose → sink**

| Stage | Module | What it owns |
|---|---|---|
| source | `streaming_frame_decoder.py` (new) | `FrameDecoder`, `make_decoder()` — the per-clip FFmpeg filter chain (rotation, privacy blur, fit/blur fill, HDR transfer, captions) and the raw-frame + audio output |
| compose | `streaming_frame_blender.py` (new) | `FrameBlender` — writes frames to a `FrameSink` and crossfades across clip boundaries; owns the blend buffer, frame count, progress reporting, preview throttling |
| sink | `streaming_assembler.py` | `StreamingEncoder`, `assemble_streaming()`, `streaming_assemble_full()` |

Not a line-count split: the decoder never needed the encoder, and the blender never
needed FFmpeg. The two halves that came out are the two that were only ever coupled
through a long argument list.

## Line counts

| File | Before | After |
|---|---|---|
| `streaming_assembler.py` | 998 | **521** |
| `streaming_frame_decoder.py` | — | 305 |
| `streaming_frame_blender.py` | — | 177 |

## Composition, not mixins

`FrameBlender` takes its encoder through the constructor as a `FrameSink` Protocol
(`write_frame(frame)`), so the blender module does not import the encoder — the
dependency points the right way and there is no cycle.

That injection also absorbed the state the old helpers threaded by hand:
`_emit_body_frames` took 12 arguments and returned `(frames_written,
last_preview_time)` for the caller to thread back in. `_encode_clip_sequence` drops
from 19 parameters to 14, and its two byte-identical `_make_decoder(...)` call sites
collapse into one local closure.

## Pure move

No behaviour change. `FrameDecoder` and `make_decoder` are byte-identical to what
they were (verified by diff); the only edit is `_make_decoder` → `make_decoder`,
since `title_inserter.py` already imported the private name across module lines.
Every import site was updated directly — no re-export shims.

## Verification

Every `make ci` gate run individually and green: lint, format-check, typecheck,
complexity, cognitive-complexity, dead-code, security-lint, semgrep, refurb,
dep-check, arch-check, duplication, critique, docs-cli-check, and `make test`
(5485 passed, 9 skipped). `complexipy-snapshot.json` regenerated via the make
target — only line numbers moved, no new violation.

**One pre-existing failure this branch does not touch:** `make file-length` is red
on `main` for `analysis/smart_pipeline.py` at 1012 lines. Sibling refactor PRs are
in flight for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL
