### PR TITLE
fix(cache): count reading a thumbnail as using it, not just writing it

### DIFF
--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -116,7 +116,17 @@ cache:
 Thumbnails (`thumbnails/`) and clip previews (`preview-cache/`, `previews/`) are
 derived from your library rather than downloaded from it, so they are cheap to
 rebuild and get smaller budgets than the video cache. Each is evicted
-least-recently-used once it goes over its limit.
+least-recently-used once it goes over its limit — for thumbnails, reading one
+counts as using it, so a thumbnail the current run keeps coming back to is not
+the one thrown away.
+
+If a run's working set does not fit the thumbnail budget at all, the cache ends
+up deleting thumbnails that run is still using and fetching them again. You will
+see a `WARNING` per eviction pass saying how many files this run is still using
+went, which is your cue to raise `thumbnail_cache_max_size_mb` — a yearly memory
+over a large library can want several GB. Left alone it degrades selection
+quietly: duplicate clustering and burst dedup skip assets whose thumbnail
+vanished, and those photos score neutral instead of on their merits.
 
 Before these limits existed neither directory had a cap or an expiry, so both
 grew for as long as the app ran — on one real library, 5.2 GB of previews and

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -530,7 +530,9 @@ cache:
 
 The video cache defaults to 10 GB. If you're tight on disk, lower `video_cache_max_size_gb` or disable it entirely with `video_cache_enabled: false`.
 
-Thumbnails and clip previews are derived from your library and are cheap to rebuild, so they get their own smaller budgets. Each is evicted least-recently-used once it exceeds its limit — a file you keep opening keeps earning its place.
+Thumbnails and clip previews are derived from your library and are cheap to rebuild, so they get their own smaller budgets. Each is evicted least-recently-used once it exceeds its limit — a file you keep opening keeps earning its place, because reading a thumbnail counts as using it.
+
+If a single run needs more thumbnails than `thumbnail_cache_max_size_mb` allows, the cache starts evicting thumbnails that same run is still using and re-fetching them. That is not silent: you get a `WARNING` naming how many files went and telling you to raise the budget. A large yearly memory over a big library can want several GB of thumbnails, so if you see that warning during long runs, raise the limit rather than ignoring it.
 
 ## Server (UI)
 

--- a/src/immich_memories/cache/disk_budget.py
+++ b/src/immich_memories/cache/disk_budget.py
@@ -8,6 +8,12 @@ that was 9 GB of 19 unbounded, while the cache page reported thumbnails as
 Eviction is least-recently-used by mtime rather than by age alone: a cap answers
 "how much disk may this cost", which is the question a user actually has, and a
 file that is still being read keeps earning its place.
+
+That last part only holds if readers refresh mtime -- otherwise this is write-
+FIFO wearing an LRU label, and a caller whose working set exceeds its budget
+evicts the very files it is still reading. `ThumbnailCache.get` had to be taught
+to touch on read for that reason (#512); callers that pass `run_started_at` also
+get told when the budget is too small to hold what they are working on.
 """
 
 from __future__ import annotations
@@ -19,11 +25,22 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def evict_to_budget(directory: Path, *, max_bytes: int, pattern: str = "*") -> int:
+def evict_to_budget(
+    directory: Path,
+    *,
+    max_bytes: int,
+    pattern: str = "*",
+    run_started_at: float | None = None,
+) -> int:
     """Delete the least recently used files until the directory fits.
 
     Returns the number of bytes freed. Stops as soon as the budget is met --
     evicting past it throws away work that would have been reused.
+
+    Pass `run_started_at` (a wall-clock timestamp) to have the caller's own
+    working set watched: evicting anything used since the run began means the
+    budget is smaller than what the run needs, and it will re-fetch what it
+    just deleted. That is worth saying out loud rather than degrading quietly.
     """
     if max_bytes < 0 or not directory.exists():
         return 0
@@ -42,7 +59,8 @@ def evict_to_budget(directory: Path, *, max_bytes: int, pattern: str = "*") -> i
         return 0
 
     freed = 0
-    for _mtime, size, path in sorted(entries):
+    still_wanted = 0
+    for mtime, size, path in sorted(entries):
         if total - freed <= max_bytes:
             break
         try:
@@ -50,11 +68,22 @@ def evict_to_budget(directory: Path, *, max_bytes: int, pattern: str = "*") -> i
         except OSError:  # noqa: PERF203 - a file that vanished is already evicted
             continue
         freed += size
+        if run_started_at is not None and mtime >= run_started_at:
+            still_wanted += 1
 
     if freed:
         logger.info(
             "Evicted %.1f MB from %s (budget %.1f MB)",
             freed / 1_000_000,
+            directory.name,
+            max_bytes / 1_000_000,
+        )
+    if still_wanted:
+        logger.warning(
+            "Evicted %d file(s) this run is still using from %s: the %.0f MB "
+            "budget is smaller than this run's working set, so cached work is "
+            "being deleted and re-fetched. Raise the budget for large runs.",
+            still_wanted,
             directory.name,
             max_bytes / 1_000_000,
         )

--- a/src/immich_memories/cache/thumbnail_cache.py
+++ b/src/immich_memories/cache/thumbnail_cache.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
+import time
 from pathlib import Path
 
 from immich_memories.cache.disk_budget import evict_to_budget
@@ -23,6 +25,10 @@ class ThumbnailCache:
         self.cache_dir = cache_dir
         self.max_size_mb = max_size_mb
         self._puts_since_check = 0
+        # A thumbnail written or read since the cache was opened belongs to the
+        # run holding it; evicting one means the budget cannot hold the working
+        # set, which the run should hear about instead of quietly re-fetching.
+        self._run_started_at = time.time()
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _path(self, asset_id: str, size: str) -> Path:
@@ -31,9 +37,16 @@ class ThumbnailCache:
 
     def get(self, asset_id: str, size: str) -> bytes | None:
         path = self._path(asset_id, size)
-        if path.exists():
-            return path.read_bytes()
-        return None
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return None
+        # Eviction is oldest-mtime-first. Without this a thumbnail the run keeps
+        # reading still looks as old as the moment it was written, so a working
+        # set larger than the budget evicts its own live entries (#512).
+        with contextlib.suppress(OSError):
+            os.utime(path)
+        return data
 
     def has(self, asset_id: str, size: str) -> bool:
         return self._path(asset_id, size).exists()
@@ -63,6 +76,7 @@ class ThumbnailCache:
             self.cache_dir,
             max_bytes=int(self.max_size_mb * 1_000_000),
             pattern="*.jpg",
+            run_started_at=self._run_started_at,
         )
 
     def clear(self) -> int:

--- a/tests/test_disk_budget.py
+++ b/tests/test_disk_budget.py
@@ -8,6 +8,7 @@ enforced.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
@@ -72,6 +73,19 @@ def test_only_matching_files_are_considered(tmp_path: Path):
     evict_to_budget(tmp_path, max_bytes=1000, pattern="*.jpg")
 
     assert manifest.exists()
+
+
+def test_a_caller_that_does_not_track_a_run_gets_no_self_eviction_warning(tmp_path: Path, caplog):
+    """The preview directories evict on their own schedule with no run to
+    speak of, so the warning is opt-in rather than "anything recent".
+    """
+    for name in ("a.bin", "b.bin"):
+        (tmp_path / name).write_bytes(b"x" * 4000)  # written now, so mtime is now
+
+    with caplog.at_level(logging.WARNING):
+        evict_to_budget(tmp_path, max_bytes=4000)
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
 
 def test_nested_files_count_toward_the_budget(tmp_path: Path):

--- a/tests/test_thumbnail_cache.py
+++ b/tests/test_thumbnail_cache.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import time
+from pathlib import Path
+
 import pytest
 
 from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+
+def _set_age(path: Path, seconds: float) -> None:
+    stamp = time.time() - seconds
+    os.utime(path, (stamp, stamp))
 
 
 @pytest.fixture
@@ -58,3 +68,57 @@ class TestThumbnailCache:
         stats = cache.get_stats()
         assert stats["file_count"] == 2
         assert stats["total_size_bytes"] == 1500
+
+
+class TestReadingAThumbnailKeepsItAlive:
+    """Eviction is oldest-mtime-first. Reading has to count as use, or a run
+    whose working set exceeds the budget evicts the thumbnails it is still
+    using and re-fetches them (#512).
+    """
+
+    def test_a_thumbnail_read_this_run_outlives_an_older_unread_one(self, tmp_path):
+        cache = ThumbnailCache(cache_dir=tmp_path / "thumbnails", max_size_mb=0.001)
+        payload = b"x" * 600  # two of these overflow the 1 KB budget by one file
+        read_again = cache.put("kept", "preview", payload)
+        never_read = cache.put("dropped", "preview", payload)
+        _set_age(read_again, seconds=300)
+        _set_age(never_read, seconds=100)
+
+        cache.get("kept", "preview")
+        cache.enforce_budget()
+
+        assert cache.has("kept", "preview")
+        assert not cache.has("dropped", "preview")
+
+
+class TestSelfEvictionIsAnnounced:
+    """A budget smaller than the run's working set degrades selection in
+    silence -- clustering skips, burst dedup skips hashless photos, photo
+    scores fall back to neutral. The run has to say it is happening (#512).
+    """
+
+    @staticmethod
+    def _warnings(caplog):
+        return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    def test_evicting_thumbnails_this_run_fetched_warns_once_per_pass(self, tmp_path, caplog):
+        cache = ThumbnailCache(cache_dir=tmp_path / "thumbnails", max_size_mb=0.001)
+        for i in range(4):  # 2.4 KB against a 1 KB budget: three files have to go
+            cache.put(f"asset-{i}", "preview", b"x" * 600)
+
+        with caplog.at_level(logging.WARNING):
+            cache.enforce_budget()
+
+        assert len(self._warnings(caplog)) == 1
+
+    def test_reclaiming_an_earlier_run_s_thumbnails_stays_quiet(self, tmp_path, caplog):
+        """Evicting a previous run's leftovers is the budget working, not failing."""
+        cache = ThumbnailCache(cache_dir=tmp_path / "thumbnails", max_size_mb=0.001)
+        for i in range(4):
+            _set_age(cache.put(f"asset-{i}", "preview", b"x" * 600), seconds=3600)
+
+        with caplog.at_level(logging.WARNING):
+            freed = cache.enforce_budget()
+
+        assert freed > 0  # eviction really happened; it just was not self-eviction
+        assert self._warnings(caplog) == []


### PR DESCRIPTION
Closes #512

## The bug

`ThumbnailCache.enforce_budget()` deletes oldest-mtime-first and its docstring calls that LRU. But `get()` was a bare `read_bytes()` — nothing ever refreshed mtime, so recency only recorded *writes*. That's write-FIFO wearing an LRU label.

The consequence only shows on big runs, which is the worst place for it. A yearly memory over a real library wants more thumbnails than the 500 MB default holds (the docs cite 3.5 GB observed on one library), so the budget pass starts deleting thumbnails the same run is still using. The prefetcher has already decided those assets are cached and won't re-fetch them, so the read comes back empty — and every consumer degrades in silence:

- `thumbnail_clustering.py` skips the asset, so duplicates ship un-clustered
- `burst_dedup.py` skips it for having no hash
- photo scoring falls back to a neutral 0.5

Nothing logs. Selection quality just gets quietly worse the larger the run.

## The fix

**1. Reads refresh recency.** `get()` now `os.utime`s the file after a successful read, so a thumbnail the run keeps coming back to keeps earning its place. `get()` also switched from `exists()` + `read_bytes()` to a plain `try/except OSError`, which drops a syscall and closes the TOCTOU window.

**2. Self-eviction is announced.** `evict_to_budget` takes an optional `run_started_at`; when a pass removes files last used after that timestamp, it logs **one WARNING for the pass** (not per file) naming how many went and saying the budget is smaller than the working set. `ThumbnailCache` stamps `run_started_at` at construction, which is once per CLI run.

The parameter is opt-in, so the two preview-directory callers (`preview_builder.py`, `step2_helpers.py`) are untouched — they have no run to speak of.

## On the measurement

The task asked me to check that per-read `utime` is negligible against `read_bytes`. Honest answer: **in relative terms it isn't, but it doesn't matter.** Measured on an 80 KB thumbnail with a warm page cache (macOS, APFS, median of 5×3000 reads):

| | per call |
|---|---|
| `read_bytes` alone | 11.96 µs |
| `os.utime` alone | 5.51 µs |
| both | 19.41 µs |

So `utime` adds ~62% to a *warm* read. The relative number is only that big because a cached 80 KB read is already very cheap. In absolute terms it's ~7.5 µs per read — about **0.15 s across a 20,000-thumbnail run**, against re-fetches over HTTP from Immich that cost milliseconds each. One avoided re-fetch pays for roughly a thousand `utime` calls.

I considered guarding the touch behind a `stat` (only touch if mtime predates the run, so repeat reads pay once). A `stat` is cheaper than a `utime`, but it saves ~4 µs on a path that costs 0.15 s total. Not worth the branch.

## On the default budget

**The default is unchanged at 500 MB, deliberately.**

That said — I think it genuinely should scale, and here's the argument for a follow-up. 500 MB holds roughly 5–10k thumbnails at 50–100 KB each. A yearly memory over a large library can want several times that; the config docs already cite a 3.5 GB thumbnails directory. So the default is undersized for exactly the run type where thumbnail quality signals matter most, and the honest fix is to derive the budget from the candidate count rather than ship a flat number.

I left it alone because silently changing a disk-usage default is the kind of thing a self-hoster should opt into, and because with this PR the failure is no longer silent: users who are over budget now get told, with a specific instruction to raise the limit. That makes a default change a separate, informed decision rather than a side effect of a bug fix.

## Tests

TDD, four behaviors, through the public API:

- `test_a_thumbnail_read_this_run_outlives_an_older_unread_one` — **true RED** against the old FIFO behavior: an older-but-read thumbnail survives while a newer unread one is evicted.
- `test_evicting_thumbnails_this_run_fetched_warns_once_per_pass` — **true RED**: three files evicted, exactly one WARNING.
- `test_reclaiming_an_earlier_run_s_thumbnails_stays_quiet` — guard test, green on arrival (eviction happens, no warning).
- `test_a_caller_that_does_not_track_a_run_gets_no_self_eviction_warning` — guard test, green on arrival; pins the opt-in contract for the preview callers.

The last two were green when written, so they weren't real RED→GREEN cycles. To confirm they aren't vacuous I mutated the guard to `if True:` and re-ran — **both fail against the mutant**, so they do pin the discrimination.

## Docs

`config-reference.md` claimed "a file you keep opening keeps earning its place" — which was simply false before this. That and `health-logs-cache.md` now describe the real behavior and what the new WARNING means. `make docs-build` passes.

## Adjacent findings (not fixed here, no issues filed)

1. **`has()` / `cached_ids()` don't touch mtime.** Existence checks aren't use, so I left them. But the prefetcher uses `has()` to decide *not* to fetch — a thumbnail skipped as "already cached" that isn't read before the next eviction pass can still be evicted. Touch-on-read covers the real consumers; this window remains.
2. **The run boundary is `ThumbnailCache` construction.** Per-run for the CLI and `generate_photos`. In the UI, `state.thumbnail_cache` is built per step-2 page load, so "this run" there means "since step 2 opened" — close enough, worth knowing.
3. **Warning cadence.** One per enforcement pass = one per 200 puts while over budget, so a badly undersized budget warns repeatedly through a run. That's what #512 asked for, but if it reads as noise the tweak is to latch it once per cache instance.
4. **The preview directories have the same blind spot.** `preview_builder.py` and `step2_helpers.py` can self-evict just as silently; they can opt into `run_started_at` whenever someone wants that signal.
5. **Cosmetic:** the warning renders budgets under 1 MB as "0 MB" (`%.0f`). Only reachable from tests.

## Verification

`make ci` — **passes, exit 0**, 5489 passed / 9 skipped. Note this branch is rebased onto #550; before that landed, `make ci` failed on the pre-existing `smart_pipeline.py` file-length breakage, which is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
