### PR TITLE
fix(ci): give each Docker platform its own cache scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,8 +386,11 @@ jobs:
             INSTALL_EXTRAS=all
             VCS_REF=${{ github.sha }}
             SOURCE_URL=https://github.com/${{ github.repository }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # WHY scoped: both platform jobs wrote the same default cache scope
+          # and clobbered each other — measured ZERO cached layers on every PR
+          # build, a full image rebuild each time.
+          cache-from: type=gha,scope=docker-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.platform }}
 
   docs:
     name: Docs Build


### PR DESCRIPTION
Both PR Docker jobs wrote the default GHA cache scope and clobbered each other — the latest amd64 build log shows literally zero CACHED layers, a full-image rebuild on every PR (the 20-minute tail that paced every merge today). release.yml already uses per-slug scopes; ci.yml now matches. No behavior change to the image itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f