### PR TITLE
fix(analysis): hold the category to its vocabulary on both parse paths

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2651,101 +2651,101 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 815,
-        "line_end": 914,
+        "line_start": 634,
+        "line_end": 733,
         "line_complexities": [
           {
-            "line": 836,
+            "line": 655,
             "complexity": 0
           },
           {
-            "line": 837,
+            "line": 656,
             "complexity": 1
           },
           {
-            "line": 839,
+            "line": 658,
             "complexity": 1
           },
           {
-            "line": 840,
+            "line": 659,
             "complexity": 0
           },
           {
-            "line": 841,
+            "line": 660,
             "complexity": 2
           },
           {
-            "line": 842,
+            "line": 661,
             "complexity": 0
           },
           {
-            "line": 849,
+            "line": 668,
             "complexity": 1
           },
           {
-            "line": 853,
+            "line": 672,
             "complexity": 0
           },
           {
-            "line": 854,
+            "line": 673,
             "complexity": 0
           },
           {
-            "line": 855,
+            "line": 674,
             "complexity": 1
           },
           {
-            "line": 856,
+            "line": 675,
             "complexity": 0
           },
           {
-            "line": 857,
+            "line": 676,
             "complexity": 2
           },
           {
-            "line": 858,
+            "line": 677,
             "complexity": 0
           },
           {
-            "line": 865,
+            "line": 684,
             "complexity": 1
           },
           {
-            "line": 869,
+            "line": 688,
             "complexity": 0
           },
           {
-            "line": 872,
+            "line": 691,
             "complexity": 0
           },
           {
-            "line": 873,
+            "line": 692,
             "complexity": 2
           },
           {
-            "line": 874,
+            "line": 693,
             "complexity": 3
           },
           {
-            "line": 876,
+            "line": 695,
             "complexity": 1
           },
           {
-            "line": 879,
+            "line": 698,
             "complexity": 0
           },
           {
-            "line": 913,
+            "line": 732,
             "complexity": 1
           },
           {
-            "line": 914,
+            "line": 733,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 103
+    "complexity": 70
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/src/immich_memories/analysis/llm_response_parser.py
+++ b/src/immich_memories/analysis/llm_response_parser.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import cv2
 
+from immich_memories.analysis.subject_policy import SubjectCategory
 from immich_memories.security import private_temp_dir
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,11 @@ SETTING_VALUES = (
     "vehicle",
     "water",
 )
+
+# Derived from the enum the subject policy resolves the label against, so the
+# prompt and the policy cannot drift apart. UNKNOWN is the policy's own name for
+# "no label" and is never a value the model is asked to return.
+CATEGORY_VALUES = tuple(c.value for c in SubjectCategory if c is not SubjectCategory.UNKNOWN)
 
 _PROMPT_TAIL = """Return JSON with these fields:
 - description: What is happening in this scene?
@@ -113,6 +119,18 @@ def _setting_in_vocabulary(raw: str) -> str:
     """
     value = raw.strip().lower()[:MAX_STR]
     return value if value in SETTING_VALUES else ""
+
+
+def _category_in_vocabulary(raw: str) -> str:
+    """One of CATEGORY_VALUES, or "" for anything else.
+
+    Shared by both parse paths like the setting vocabulary, and for a sharper
+    reason: the subject policy reads an unlisted value as UNKNOWN but still
+    counts any non-empty category as "the model labelled this clip", so free
+    text here does not merely leak — it votes (#539).
+    """
+    value = raw.strip().lower()[:MAX_STR]
+    return value if value in CATEGORY_VALUES else ""
 
 
 @dataclass
@@ -414,7 +432,7 @@ class ContentAnalyzer:
         """
         description = str(data.get("description", ""))[:MAX_STR]
         subjects = [str(s)[:MAX_STR] for s in data.get("subjects", [])[:MAX_LIST]]
-        category = str(data.get("category", ""))[:MAX_STR]
+        category = _category_in_vocabulary(str(data.get("category", "")))
         activities = [
             str(a).strip().lower()[:MAX_STR] for a in data.get("activities", [])[:MAX_LIST]
         ]
@@ -536,7 +554,7 @@ class ContentAnalyzer:
         # but the two fields it adds are the two the policy cannot work without.
         category_match = re.search(r'"category"\s*:\s*"([^"]+)"', text)
         if category_match:
-            result.category = category_match.group(1)
+            result.category = _category_in_vocabulary(category_match.group(1))
 
         subjects_match = re.search(r'"subjects"\s*:\s*\[([^\]]*)\]', text)
         if subjects_match:

--- a/tests/test_llm_category_parsing.py
+++ b/tests/test_llm_category_parsing.py
@@ -30,3 +30,25 @@ def test_category_survives_the_regex_fallback() -> None:
 def test_a_missing_category_stays_empty() -> None:
     result = _partial('{"description": "Kids on a beach", "emotion": "happy"')
     assert result.category == ""
+
+
+def test_an_off_vocabulary_category_is_dropped() -> None:
+    """The fallback is taken exactly when the model is ignoring the schema, so it
+    is the likeliest source of the free text the closed vocabulary keeps out (#539)."""
+    result = _partial('{"description": "x", "category": "a child holding a watch"')
+    assert result.category == ""
+
+
+def test_a_listed_category_survives_odd_casing() -> None:
+    """Dropping unlisted values only works if listed ones still get through: the
+    model returns "Screen" and "people " often enough to matter."""
+    assert _partial('{"description": "x", "category": "Screen "').category == "screen"
+
+
+def test_free_text_category_is_dropped_on_the_json_path_too() -> None:
+    """Well-formed JSON carrying an unlisted category was the wider door: it was
+    truncated to 500 chars and stored, where the subject policy read it as a label."""
+    build = ContentAnalyzer._build_content_analysis
+    assert build({"category": "a wide shot of a lawnmower"}, "").category == ""
+    assert build({"category": "l" * 600}, "").category == ""
+    assert build({"category": "landscape"}, "").category == "landscape"


### PR DESCRIPTION
Closes #539.

## What

#519 closed the free-text door for `setting`. The same door stood open for `category`:

- the malformed-JSON fallback stored the regex capture **verbatim** — uncapped, uncased, unvalidated;
- the JSON path only truncated it to `MAX_STR` (500 chars), with no vocabulary check at all.

## Why it matters more than a leak

`subject_policy` resolves an unlisted value to `UNKNOWN`, so at first glance free text looks harmless. It isn't: the same policy computes `labelled=bool(candidate.clip.llm_category)` (`subject_policy.py:244`). A garbage category therefore **votes** — it counts toward the described/labelled tallies that gate the people-quota rule — while carrying no usable category. Silence and noise were being counted the same way.

## The change

- `_category_in_vocabulary`, mirroring the `_setting_in_vocabulary` precedent: strip, lower, cap, then drop anything unlisted.
- Applied to **both** parse paths, exactly as the setting helper is.
- `CATEGORY_VALUES` is derived from the `SubjectCategory` enum the policy already resolves against, rather than retyped as a second literal tuple, so the prompt and the policy cannot drift. `UNKNOWN` is excluded — it is the policy's own name for "no label", never a value the model is asked to return.

## Scope note (deliberate, please sanity-check)

The issue names the fallback path. I closed the JSON path too, because leaving it would have made malformed responses *cleaner* than well-formed ones, and the JSON path is the one that actually carries most off-vocabulary answers — a model that returns `"category": "a wide shot of a lawnmower"` in valid JSON never reaches the fallback. Fixing only the fallback would have shipped the narrower half of the bug. Happy to split if you'd rather see them separately.

## Tests

Three behaviours, all in `tests/test_llm_category_parsing.py`:

- `test_an_off_vocabulary_category_is_dropped` — the fallback path with an off-vocabulary capture (the issue's ask). RED before the change.
- `test_free_text_category_is_dropped_on_the_json_path_too` — free text and a 600-char value dropped, `"landscape"` kept. RED before the change.
- `test_a_listed_category_survives_odd_casing` — `"Screen "` → `"screen"`. This one guards the *risk my change introduces*: strict matching must not start dropping valid labels over capitalisation.

`make ci` passes locally (5503 passed, 9 skipped).

## Adjacent finding (not fixed here)

`photos/scoring.py:104` runs its own prompt asking for the same closed category vocabulary ("people/animal/landscape/object/screen") with its own parsing. I did not touch it — different file, different issue — but if it parses that field the same way it has the same open door.