### PR TITLE
docs(config): gate the config reference against the pydantic schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: CLI reference drift
         if: '!cancelled()'
         run: make docs-cli-check
+      - name: Config reference drift
+        if: '!cancelled()'
+        run: make docs-config-check
       - name: Type Check (mypy)
         if: '!cancelled()'
         run: make typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ make refurb
 # Dependency hygiene (deptry: hallucinated/unused/transitive deps)
 make dep-check
 
+# Regenerate the CLI reference from the Click tree, and fail on drift
+make docs-cli
+make docs-cli-check
+
+# Config reference key parity with the pydantic schema
+make docs-config-check
+
 
 # Architectural boundary enforcement (import-linter)
 make arch-check
@@ -111,6 +118,8 @@ make critique
 - **Security (cross-file)**: Semgrep must pass with no ERROR findings (`make semgrep`)
 - **Modernization**: refurb must pass (`make refurb`)
 - **Dependency hygiene**: deptry must pass (`make dep-check`)
+- **CLI reference drift**: the generated page must match the Click tree (`make docs-cli-check`)
+- **Config reference drift**: the config reference must list exactly the schema's keys (`make docs-config-check`)
 - **Tests**: all tests must pass (`make test`)
 - **Commit messages**: must follow [Conventional Commits](https://www.conventionalcommits.org/) (`make commitlint`)
   - Format: `type(scope): description` — e.g., `fix(api): handle timeout errors`

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams capability-matrix
+.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check docs-config-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams capability-matrix
 
 # Default target
 help:
@@ -580,7 +580,7 @@ launch-check-ci: ensure-dev e2e
 	@echo "Hermetic launch check passed!"
 
 # Full CI-equivalent pipeline (locally)
-ci: ensure-dev lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint semgrep refurb dep-check arch-check duplication critique docs-cli-check test
+ci: ensure-dev lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint semgrep refurb dep-check arch-check duplication critique docs-cli-check docs-config-check test
 	@echo "Full CI pipeline passed!"
 
 # Self-critique for AI code smells
@@ -750,6 +750,10 @@ docs-cli-check:
 		exit 1; \
 	fi; \
 	echo "CLI reference is up to date"
+
+# Fail when the hand-written config reference and the pydantic schema disagree on keys
+docs-config-check:
+	uv run python scripts/check_config_docs.py
 
 docs-install:
 	cd docs-site && npm ci

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -110,6 +110,9 @@ analysis:
   max_animal_ratio: 0.10         # Share of the video that may be animal clips
   max_object_ratio: 0.05         # Share that may be object clips (must also score well)
 
+  # Album source
+  max_album_assets: 10000        # Most assets read from one album, per media type (min 1)
+
   # Performance
   download_workers: 3            # Parallel download clients for video and thumbnail prefetching (1-8)
   enable_downscaling: true       # Downscale for analysis (~3-5x faster)
@@ -129,6 +132,11 @@ analysis:
 Presets: `fast-cuts` = 3–6 s clips, 30% extraction; `balanced` = 5–10 s, 40%; `long-cuts` =
 8–15 s, 50%. With no preset the defaults above apply (5–10 s, 15%). Any Live Photo cluster of two
 or more within the merge window is treated as a burst — the count is not configurable.
+
+`max_album_assets` applies per media type, so the default reads up to 10,000 videos and 10,000
+photos from one album. Smart albums reach tens of thousands; Immich returns newest first, so a
+bigger album is truncated to its most recent assets and you get a warning naming it. Narrow the
+album, raise the cap, or use a date range instead.
 
 ## Generation defaults
 
@@ -191,10 +199,16 @@ photos:
   moment_gap_seconds: 120        # Window for "same moment as a video" (0-3600)
   moment_hash_threshold: 10      # Hash bits allowed between photo and that video (0-64)
   score_penalty: 0.2             # Photos score 80% of equivalent videos (0-1)
+  burst_window_seconds: 300      # Near-identical photos this close apart are one burst (0-3600)
+  burst_hash_threshold: 8        # Hash bits two photos may differ by and still be one burst (0-64)
 ```
 
 The animation per photo (Ken Burns, face pan, blurred background) is picked automatically from the
 photo's content; it is not configurable.
+
+Burst de-duplication keeps only the best-scored frame of a run of near-identical photos, so the
+fifteen shots of the same jump do not become fifteen clips. `burst_window_seconds: 0` turns it off.
+It is separate from `moment_gap_seconds`, which is about a photo and a *video* of the same moment.
 
 ## Hardware acceleration
 
@@ -492,14 +506,17 @@ title_screens:
   ending_duration: 7.0           # seconds (2-15)
   locale: "auto"                 # en, fr, or auto-detect
   style_mode: "auto"             # auto (mood-based) or random
+  animated_background: true      # Gradient shift and colour pulse behind the text
+  show_decorative_lines: false   # Line accents around the title text
   show_month_dividers: true      # When the video spans several months (all-or-none)
   month_divider_threshold: 2     # Min clips in a month to show its divider (1-10)
   use_first_name_only: true      # "Alice" instead of "Alice Smith" in titles
 ```
 
-Look-and-feel (animated backgrounds, decorative lines, colour palette, custom fonts) is not
-configurable from the config file today. The `immich-memories titles` command exposes some of these
-as flags for previewing.
+Those two switches are all the look-and-feel the config file exposes; the colour palette and
+custom fonts are not configurable today. `animated_background: false` keeps the gradient still
+— no rotation, colour pulse or vignette pulse — which is what `preset: fast` selects. The
+`immich-memories titles` command exposes more of the look as flags for previewing.
 
 ## Trip detection
 

--- a/scripts/check_config_docs.py
+++ b/scripts/check_config_docs.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail when the config reference page and the pydantic schema disagree.
+
+The page is hand-written on purpose -- the prose around each YAML block is worth
+more than anything a generator would emit -- so this checks the key lists instead
+of regenerating them: every field of every section model must appear in a YAML
+block, and every key in a YAML block must be a real field.
+
+Usage:
+    python scripts/check_config_docs.py
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple, get_args
+
+from pydantic import BaseModel
+
+from immich_memories.config_loader import Config
+
+PAGE = "docs-site/docs/reference/config-reference.md"
+
+_FIX_HINT = "Document the missing keys, or drop the ones the schema no longer accepts."
+
+_YAML_BLOCK = re.compile(r"^```yaml$(.*?)^```$", re.DOTALL | re.MULTILINE)
+_KEY = re.compile(r"^(?P<indent> *)(?:# )?(?P<key>[a-z_][a-z0-9_]*):(?: |$)")
+
+
+def _read_block(block: str, documented: dict[str, set[str]]) -> None:
+    # `advanced:` is where the app writes tier-2 sections, so a block that opens
+    # with it documents the sections one level in, not a section called advanced.
+    section_indent = 0
+    section: str | None = None
+    for line in block.splitlines():
+        match = _KEY.match(line)
+        if match is None:
+            continue
+        indent = len(match.group("indent"))
+        key = match.group("key")
+        if indent == 0 and key == "advanced":
+            section_indent = 2
+            section = None
+        elif indent == section_indent:
+            section = key
+            documented.setdefault(key, set())
+        elif indent == section_indent + 2 and section is not None:
+            documented[section].add(key)
+
+
+def documented_keys(page: str) -> dict[str, set[str]]:
+    """Map each section documented in a YAML block to the field names shown under it."""
+    documented: dict[str, set[str]] = {}
+    for block in _YAML_BLOCK.findall(page):
+        _read_block(block, documented)
+    return documented
+
+
+class SectionSchema(NamedTuple):
+    """One `Config` field: the model behind the section and the keys it accepts.
+
+    A plain switch such as `preset` has no model of its own, so it groups under
+    its own name and shares its documentation with nothing.
+    """
+
+    model: str
+    fields: frozenset[str]
+
+
+def _section_model(annotation: object) -> type[BaseModel] | None:
+    for candidate in (annotation, *get_args(annotation)):
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+            return candidate
+    return None
+
+
+def schema_sections() -> dict[str, SectionSchema]:
+    """Enumerate the config sections by walking `Config`, whatever module each model lives in."""
+    sections = {}
+    for name, field in Config.model_fields.items():
+        model = _section_model(field.annotation)
+        if model is None:
+            # A plain top-level switch (`preset`) still has to appear on the page.
+            sections[name] = SectionSchema(name, frozenset())
+        else:
+            sections[name] = SectionSchema(model.__name__, frozenset(model.model_fields))
+    return sections
+
+
+def _section_drift(
+    section: str, entry: SectionSchema, shown: set[str] | None, shown_for_model: set[str]
+) -> list[str]:
+    if shown is None:
+        return [f"{section}: section is missing from the page"]
+    drift = []
+    if undocumented := entry.fields - shown_for_model:
+        drift.append(
+            f"{section}: in the schema but not on the page: {', '.join(sorted(undocumented))}"
+        )
+    if invented := shown - entry.fields:
+        drift.append(f"{section}: on the page but not in the schema: {', '.join(sorted(invented))}")
+    return drift
+
+
+def find_drift(schema: dict[str, SectionSchema], documented: dict[str, set[str]]) -> list[str]:
+    """Report every schema field the page omits and every key it invents.
+
+    Two sections built from one model (`llm` and `title_llm`) need the field list
+    written out once: whichever block carries it documents both.
+    """
+    shown_by_model: dict[str, set[str]] = {}
+    for section, entry in schema.items():
+        shown_by_model.setdefault(entry.model, set()).update(documented.get(section, set()))
+
+    drift = []
+    for section, entry in sorted(schema.items()):
+        drift.extend(
+            _section_drift(section, entry, documented.get(section), shown_by_model[entry.model])
+        )
+    drift.extend(
+        f"{section}: on the page but not a section of Config"
+        for section in sorted(documented.keys() - schema.keys())
+    )
+    return drift
+
+
+def main() -> int:
+    """Print the drift between the config reference page and the schema."""
+    drift = find_drift(schema_sections(), documented_keys(Path(PAGE).read_text()))
+    if not drift:
+        print(f"{PAGE} matches the config schema")  # noqa: T201
+        return 0
+    report = "\n  ".join([f"{PAGE} has drifted from the config schema:", *drift])
+    print(f"{report}\n{_FIX_HINT}")  # noqa: T201
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_config_docs_gate.py
+++ b/tests/test_config_docs_gate.py
@@ -1,0 +1,124 @@
+"""The config reference page must list exactly the keys the schema accepts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_config_docs import (  # noqa: E402
+    PAGE,
+    SectionSchema,
+    documented_keys,
+    find_drift,
+    schema_sections,
+)
+
+from immich_memories.config_loader import Config  # noqa: E402
+
+
+def test_yaml_block_keys_are_read_as_section_and_field_names() -> None:
+    page = """
+# Cache
+
+```yaml
+cache:
+  directory: "~/.immich-memories/cache"
+  max_age_days: 30               # Analysis cache expiry (1-365)
+```
+"""
+
+    assert documented_keys(page) == {"cache": {"directory", "max_age_days"}}
+
+
+def test_sections_shown_under_the_advanced_wrapper_count_as_documented() -> None:
+    """`advanced:` is the YAML layout of tier-2 sections, not a section of its own."""
+    page = """
+```yaml
+advanced:
+  analysis:
+    scene_threshold: 25.0
+  hardware:
+    encoder_preset: "quality"
+```
+"""
+
+    assert documented_keys(page) == {
+        "analysis": {"scene_threshold"},
+        "hardware": {"encoder_preset"},
+    }
+
+
+def test_key_shown_commented_out_still_counts_as_documented() -> None:
+    """`thinking_params` is documented as a commented example; its contents are not keys."""
+    page = """
+```yaml
+llm:
+  thinking: false                # server has a reasoning switch
+  # thinking_params:             # what the switch looks like on your server
+  #   chat_template_kwargs:      # (default: the Qwen dialect, vLLM/mlx)
+  #     enable_thinking: true
+```
+"""
+
+    assert documented_keys(page) == {"llm": {"thinking", "thinking_params"}}
+
+
+def test_field_missing_from_the_page_is_reported() -> None:
+    schema = {
+        "photos": SectionSchema("PhotoConfig", frozenset({"enabled", "burst_window_seconds"}))
+    }
+
+    drift = find_drift(schema, {"photos": {"enabled"}})
+
+    assert drift == ["photos: in the schema but not on the page: burst_window_seconds"]
+
+
+def test_key_the_schema_would_reject_is_reported() -> None:
+    schema = {"photos": SectionSchema("PhotoConfig", frozenset({"enabled"}))}
+
+    drift = find_drift(schema, {"photos": {"enabled", "renamed_last_year"}})
+
+    assert drift == ["photos: on the page but not in the schema: renamed_last_year"]
+
+
+def test_two_sections_of_one_model_are_documented_once() -> None:
+    """`llm` carries the full field list; `title_llm` is the same model, shown short."""
+    llm = SectionSchema("LLMConfig", frozenset({"model", "thinking"}))
+    schema = {"llm": llm, "title_llm": llm}
+
+    drift = find_drift(schema, {"llm": {"model", "thinking"}, "title_llm": {"model"}})
+
+    assert drift == []
+
+
+def test_section_with_no_yaml_block_at_all_is_reported() -> None:
+    schema = {"trips": SectionSchema("TripsConfig", frozenset({"max_gap_days"}))}
+
+    drift = find_drift(schema, {})
+
+    assert drift == ["trips: section is missing from the page"]
+
+
+def test_section_the_config_dropped_is_reported() -> None:
+    drift = find_drift({}, {"scoring_priority": {"faces"}})
+
+    assert drift == ["scoring_priority: on the page but not a section of Config"]
+
+
+def test_sections_come_from_config_itself_not_a_hand_kept_list() -> None:
+    """Splitting the models across more modules must not shrink what is checked."""
+    sections = schema_sections()
+
+    assert sections.keys() == set(Config.model_fields)
+    assert sections["photos"].model == "PhotoConfig"
+    assert "burst_window_seconds" in sections["photos"].fields
+    assert sections["llm"].model == sections["title_llm"].model
+    assert sections["preset"].fields == frozenset()
+
+
+def test_the_published_page_lists_exactly_the_keys_the_schema_accepts() -> None:
+    page = (Path(__file__).resolve().parents[1] / PAGE).read_text()
+
+    assert find_drift(schema_sections(), documented_keys(page)) == []


### PR DESCRIPTION
Closes #319

`docs-site/docs/reference/config-reference.md` had no drift protection — the CLI reference has `make docs-cli-check`, this page had nothing. The 2026-08-18 launch review flagged it.

## What this does

The page stays hand-written. The prose around each YAML block (why `min_confidence` defaults to 0.0, what `host` does when you never set it, the 30-second whisper window) is worth more than anything a generator would emit, so `make docs-config-check` checks the **key lists** instead of regenerating the page:

- every field of every section model must appear in a YAML block on the page
- every key in a YAML block must be a real field

Sections are enumerated by walking `Config.model_fields` and following each annotation to its `BaseModel`, so the models moving between `config_models*.py` modules — or a new module arriving — needs no edit in the checker. `llm` and `title_llm` are the same model, so whichever block spells the field list out documents both; `title_llm` stays the short example it is today.

## Drift it found

Five live knobs nobody had written down:

| Key | Read by |
|---|---|
| `analysis.max_album_assets` | `analysis/album_source.py` (per-type album cap, #270) |
| `photos.burst_window_seconds` | `photos/photo_pipeline.py` (burst de-dup) |
| `photos.burst_hash_threshold` | same |
| `title_screens.animated_background` | `generate_settings.py` → title renderer |
| `title_screens.show_decorative_lines` | same |

The last two are the interesting ones: the page claimed animated backgrounds and decorative lines were *not configurable from the config file*, while `preset: fast` has been turning `animated_background` off all along. All five are now documented, with the prose corrected.

## Wiring

- `make docs-config-check`, next to `docs-cli-check`
- added to the `ci` make target and to the CI workflow's quality job ("Config reference drift")
- Quality Gates list in `CLAUDE.md` (both `docs-cli-check` and the new one, which was also missing)
- `tests/test_config_docs_gate.py` covers the parsing rules and both drift directions, plus one test asserting the published page is in sync — so `make test` catches it too

`make ci` passes (5509 tests). `make docs-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f