### PR TITLE
feat(config): expose the refinement pass budget as a dial

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1079,65 +1079,21 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 179,
-        "line_start": 169,
-        "line_end": 937,
+        "complexity": 177,
+        "line_start": 182,
+        "line_end": 962,
         "line_complexities": [
           {
-            "line": 487,
+            "line": 511,
             "complexity": 0
           },
           {
-            "line": 488,
+            "line": 512,
             "complexity": 0
           },
           {
-            "line": 495,
+            "line": 519,
             "complexity": 2
-          },
-          {
-            "line": 496,
-            "complexity": 0
-          },
-          {
-            "line": 497,
-            "complexity": 0
-          },
-          {
-            "line": 499,
-            "complexity": 2
-          },
-          {
-            "line": 501,
-            "complexity": 3
-          },
-          {
-            "line": 505,
-            "complexity": 3
-          },
-          {
-            "line": 506,
-            "complexity": 0
-          },
-          {
-            "line": 508,
-            "complexity": 0
-          },
-          {
-            "line": 509,
-            "complexity": 2
-          },
-          {
-            "line": 510,
-            "complexity": 1
-          },
-          {
-            "line": 515,
-            "complexity": 3
-          },
-          {
-            "line": 516,
-            "complexity": 0
           },
           {
             "line": 520,
@@ -1145,350 +1101,386 @@
           },
           {
             "line": 521,
-            "complexity": 1
-          },
-          {
-            "line": 522,
             "complexity": 0
           },
           {
-            "line": 524,
+            "line": 523,
             "complexity": 2
+          },
+          {
+            "line": 525,
+            "complexity": 3
+          },
+          {
+            "line": 529,
+            "complexity": 3
+          },
+          {
+            "line": 530,
+            "complexity": 0
+          },
+          {
+            "line": 532,
+            "complexity": 0
+          },
+          {
+            "line": 533,
+            "complexity": 2
+          },
+          {
+            "line": 534,
+            "complexity": 1
+          },
+          {
+            "line": 539,
+            "complexity": 3
           },
           {
             "line": 540,
             "complexity": 0
           },
           {
-            "line": 551,
-            "complexity": 3
+            "line": 544,
+            "complexity": 0
           },
           {
-            "line": 555,
-            "complexity": 3
+            "line": 545,
+            "complexity": 1
           },
           {
-            "line": 559,
-            "complexity": 4
+            "line": 546,
+            "complexity": 0
           },
           {
-            "line": 563,
-            "complexity": 3
+            "line": 548,
+            "complexity": 2
           },
           {
-            "line": 567,
-            "complexity": 3
+            "line": 564,
+            "complexity": 0
           },
           {
             "line": 575,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 592,
-            "complexity": 2
+            "line": 579,
+            "complexity": 3
           },
           {
-            "line": 593,
-            "complexity": 0
+            "line": 583,
+            "complexity": 4
           },
           {
-            "line": 594,
-            "complexity": 1
+            "line": 587,
+            "complexity": 3
           },
           {
-            "line": 596,
-            "complexity": 0
-          },
-          {
-            "line": 597,
-            "complexity": 1
-          },
-          {
-            "line": 598,
-            "complexity": 0
+            "line": 591,
+            "complexity": 3
           },
           {
             "line": 599,
-            "complexity": 3
-          },
-          {
-            "line": 604,
-            "complexity": 1
-          },
-          {
-            "line": 605,
-            "complexity": 3
-          },
-          {
-            "line": 606,
             "complexity": 0
           },
           {
-            "line": 607,
-            "complexity": 1
-          },
-          {
-            "line": 608,
-            "complexity": 0
-          },
-          {
-            "line": 611,
-            "complexity": 0
-          },
-          {
-            "line": 615,
+            "line": 616,
             "complexity": 2
+          },
+          {
+            "line": 617,
+            "complexity": 0
+          },
+          {
+            "line": 618,
+            "complexity": 1
           },
           {
             "line": 620,
             "complexity": 0
           },
           {
+            "line": 621,
+            "complexity": 1
+          },
+          {
+            "line": 622,
+            "complexity": 0
+          },
+          {
             "line": 623,
-            "complexity": 0
-          },
-          {
-            "line": 624,
-            "complexity": 2
-          },
-          {
-            "line": 625,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 628,
             "complexity": 1
           },
           {
-            "line": 631,
+            "line": 629,
             "complexity": 3
+          },
+          {
+            "line": 630,
+            "complexity": 0
+          },
+          {
+            "line": 631,
+            "complexity": 1
           },
           {
             "line": 632,
-            "complexity": 3
-          },
-          {
-            "line": 634,
             "complexity": 0
           },
           {
-            "line": 641,
+            "line": 635,
             "complexity": 0
           },
           {
-            "line": 645,
-            "complexity": 3
+            "line": 639,
+            "complexity": 2
           },
           {
-            "line": 646,
+            "line": 644,
             "complexity": 0
           },
           {
             "line": 647,
+            "complexity": 0
+          },
+          {
+            "line": 653,
+            "complexity": 1
+          },
+          {
+            "line": 656,
             "complexity": 3
           },
           {
-            "line": 648,
+            "line": 657,
+            "complexity": 3
+          },
+          {
+            "line": 659,
             "complexity": 0
           },
           {
-            "line": 650,
+            "line": 666,
             "complexity": 0
           },
           {
-            "line": 674,
-            "complexity": 1
+            "line": 670,
+            "complexity": 3
+          },
+          {
+            "line": 671,
+            "complexity": 0
+          },
+          {
+            "line": 672,
+            "complexity": 3
+          },
+          {
+            "line": 673,
+            "complexity": 0
           },
           {
             "line": 675,
+            "complexity": 0
+          },
+          {
+            "line": 699,
+            "complexity": 1
+          },
+          {
+            "line": 700,
             "complexity": 2
           },
           {
-            "line": 679,
+            "line": 704,
             "complexity": 1
           },
           {
-            "line": 690,
+            "line": 715,
             "complexity": 3
           },
           {
-            "line": 691,
+            "line": 716,
             "complexity": 0
           },
           {
-            "line": 692,
+            "line": 717,
             "complexity": 0
           },
           {
-            "line": 694,
+            "line": 719,
             "complexity": 0
           },
           {
-            "line": 696,
+            "line": 721,
             "complexity": 0
           },
           {
-            "line": 698,
+            "line": 723,
             "complexity": 0
           },
           {
-            "line": 705,
+            "line": 730,
             "complexity": 5
           },
           {
-            "line": 746,
+            "line": 771,
             "complexity": 6
           },
           {
-            "line": 789,
+            "line": 814,
             "complexity": 0
           },
           {
-            "line": 790,
+            "line": 815,
             "complexity": 5
           },
           {
-            "line": 791,
+            "line": 816,
             "complexity": 6
           },
           {
-            "line": 792,
+            "line": 817,
             "complexity": 0
           },
           {
-            "line": 793,
+            "line": 818,
             "complexity": 0
           },
           {
-            "line": 794,
-            "complexity": 7
-          },
-          {
-            "line": 802,
-            "complexity": 6
-          },
-          {
-            "line": 803,
-            "complexity": 0
-          },
-          {
-            "line": 804,
-            "complexity": 7
-          },
-          {
-            "line": 805,
-            "complexity": 0
-          },
-          {
-            "line": 807,
-            "complexity": 1
-          },
-          {
-            "line": 812,
-            "complexity": 7
-          },
-          {
-            "line": 813,
-            "complexity": 0
-          },
-          {
-            "line": 826,
+            "line": 819,
             "complexity": 7
           },
           {
             "line": 827,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 828,
             "complexity": 0
           },
           {
-            "line": 831,
-            "complexity": 1
-          },
-          {
-            "line": 832,
-            "complexity": 0
-          },
-          {
-            "line": 833,
-            "complexity": 0
-          },
-          {
-            "line": 836,
-            "complexity": 0
-          },
-          {
-            "line": 846,
-            "complexity": 0
-          },
-          {
-            "line": 847,
-            "complexity": 5
-          },
-          {
-            "line": 848,
-            "complexity": 6
-          },
-          {
-            "line": 849,
+            "line": 829,
             "complexity": 7
           },
           {
+            "line": 830,
+            "complexity": 0
+          },
+          {
+            "line": 832,
+            "complexity": 1
+          },
+          {
+            "line": 837,
+            "complexity": 7
+          },
+          {
+            "line": 838,
+            "complexity": 0
+          },
+          {
+            "line": 851,
+            "complexity": 7
+          },
+          {
+            "line": 852,
+            "complexity": 0
+          },
+          {
             "line": 853,
-            "complexity": 6
+            "complexity": 0
           },
           {
             "line": 856,
-            "complexity": 6
+            "complexity": 1
+          },
+          {
+            "line": 857,
+            "complexity": 0
+          },
+          {
+            "line": 858,
+            "complexity": 0
           },
           {
             "line": 861,
             "complexity": 0
           },
           {
-            "line": 863,
-            "complexity": 5
-          },
-          {
-            "line": 865,
-            "complexity": 5
-          },
-          {
-            "line": 869,
-            "complexity": 5
+            "line": 871,
+            "complexity": 0
           },
           {
             "line": 872,
-            "complexity": 1
+            "complexity": 5
+          },
+          {
+            "line": 873,
+            "complexity": 6
           },
           {
             "line": 874,
+            "complexity": 7
+          },
+          {
+            "line": 878,
+            "complexity": 6
+          },
+          {
+            "line": 881,
+            "complexity": 6
+          },
+          {
+            "line": 886,
             "complexity": 0
           },
           {
-            "line": 876,
+            "line": 888,
+            "complexity": 5
+          },
+          {
+            "line": 890,
+            "complexity": 5
+          },
+          {
+            "line": 894,
+            "complexity": 5
+          },
+          {
+            "line": 897,
+            "complexity": 1
+          },
+          {
+            "line": 899,
             "complexity": 0
           },
           {
-            "line": 920,
-            "complexity": 1
-          },
-          {
-            "line": 923,
-            "complexity": 1
-          },
-          {
-            "line": 926,
-            "complexity": 1
-          },
-          {
-            "line": 927,
+            "line": 901,
             "complexity": 0
           },
           {
-            "line": 928,
+            "line": 945,
+            "complexity": 1
+          },
+          {
+            "line": 948,
+            "complexity": 1
+          },
+          {
+            "line": 951,
+            "complexity": 1
+          },
+          {
+            "line": 952,
+            "complexity": 0
+          },
+          {
+            "line": 953,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -124,6 +124,7 @@ have not set explicitly; the flags below still win. Persistent form: `preset: fa
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
+| `--refinement-passes` | — | integer | `10` | How many times selection may verify, judge and review before it settles. Three loops run up to this many times, so it is the largest multiplier on a warm run — and on the bill if `llm.base_url` is a paid API. `preset: fast` uses 3 |
 | `--analysis-depth` | — | choice | `auto` | `auto` (all manageable cache misses, shortlist large pools), `fast` (favorites first), or `thorough` (every eligible clip). Under `preset: fast`, `auto` runs as `fast` |
 | `--include-photos` | — | flag | — | Include photos alongside videos |
 | `--photo-duration` | — | float | `4.0` | Seconds per photo clip (use with `--include-photos`) |

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -97,9 +97,31 @@ If Immich runs on the same Docker network, use the container name (`immich-serve
 Add `IMMICH_MEMORIES_PRESET=fast` to the compose `environment:` (or `preset: fast` at the top of
 `config.yaml`) and the CPU-only profile is on: 1080p H.264 with the fast encoder preset and
 medium quality, static title backgrounds instead of animated ones, no per-clip speech analysis,
-photos capped at a quarter of the cut, and analysis depth `auto` running as `fast` (favorites
-first). Every value you set explicitly still wins, and the web UI's Step 3 shows a banner when
-the preset is active. `immich-memories --preset fast generate …` does the same for one CLI run.
+photos capped at a quarter of the cut, three refinement passes instead of ten, and analysis depth
+`auto` running as `fast` (favorites first). Every value you set explicitly still wins, and the web
+UI's Step 3 shows a banner when the preset is active. `immich-memories --preset fast generate …`
+does the same for one CLI run.
+
+### `max_refinement_passes` is a bill, not just a clock
+
+Selection verifies, judges and reviews in a loop, up to `analysis.max_refinement_passes` times
+(default 10). Three loops share that budget, and each round that changes the cut sends the
+descriptions back to the model. On a NAS that is time. If `llm.base_url` points at a hosted API
+rather than a box you own, it is money, and it is the largest single multiplier on what a run
+costs you.
+
+`preset: fast` sets it to 3. Set it yourself to override that either way:
+
+```yaml
+advanced:
+  analysis:
+    max_refinement_passes: 3     # or 1 to stop after the first pass
+```
+
+or per run: `immich-memories generate --refinement-passes 3 …`
+
+Lower is cheaper and faster. The cost of lowering it is that a clip admitted by the last refill
+may ship with less scrutiny than the ones before it.
 
 ```yaml
     environment:

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -293,6 +293,7 @@ immich-memories generate [OPTIONS]
 | `--include-live-photos` | boolean | - | Include Live Photo video clips (3s iPhone clips, merged when burst-captured) |
 | `--include-photos` | boolean | - | Include photos as animated Ken Burns clips (blur background, face-aware pan) |
 | `--photo-duration` | float | - | Duration per photo clip in seconds (default: 4.0) |
+| `--refinement-passes` | integer range | - | How many times selection may verify, judge and review before settling (default: 10). The biggest dial on warm-run time, and on the bill when llm.base_url points at a paid API |
 | `--analysis-depth` | choice: `auto` \| `fast` \| `thorough` | - | Analysis depth: auto (full analysis for manageable pools), fast (favorites first), or thorough (every eligible clip) |
 | `--trip-index` | integer | - | Select a specific trip by index (use with --memory-type trip) |
 | `--all-trips` | boolean | false | Generate a video for every detected trip (use with --memory-type trip) |

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -111,6 +111,7 @@ analysis:
   max_object_ratio: 0.05         # Share that may be object clips (must also score well)
 
   # Performance
+  max_refinement_passes: 10      # Verify/judge/review rounds before selection settles (1-20)
   download_workers: 3            # Parallel download clients for video and thumbnail prefetching (1-8)
   enable_downscaling: true       # Downscale for analysis (~3-5x faster)
   analysis_resolution: 480       # Target height for analysis (240-1080)

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -126,7 +126,11 @@ class PipelineConfig:
         enforced cap was the dataclass default whatever the YAML said.
         Anything the caller decides instead arrives as an override.
         """
-        return cls(photo_max_ratio=config.photos.max_ratio, **overrides)
+        return cls(
+            photo_max_ratio=config.photos.max_ratio,
+            max_refinement_passes=config.analysis.max_refinement_passes,
+            **overrides,
+        )
 
     @property
     def duration_target(self) -> float:

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -32,7 +32,7 @@ from immich_memories.processing.encoding_plan import resolve_output_selection
 from immich_memories.timeperiod import DateRange, parse_date
 
 if TYPE_CHECKING:
-    pass
+    from immich_memories.config_loader import Config
 
 
 def _resolve_generation_scope(
@@ -146,6 +146,19 @@ def resolve_short_form(
         duration=duration if duration is not None else int(short_form),
         orientation=orientation if orientation_was_given else "portrait",
     )
+
+
+def _apply_scalar_overrides(
+    config: Config,
+    *,
+    photo_duration: float | None,
+    refinement_passes: int | None,
+) -> None:
+    """Let a flag outrank the config file for the dials that have both."""
+    if photo_duration is not None:
+        config.photos.duration = photo_duration
+    if refinement_passes is not None:
+        config.analysis.max_refinement_passes = refinement_passes
 
 
 def resolve_inclusion(flag: bool | None, *, config_enabled: bool) -> bool:
@@ -368,6 +381,16 @@ def register_generate_commands(main: click.Group) -> None:
         help="Duration per photo clip in seconds (default: 4.0)",
     )
     @click.option(
+        "--refinement-passes",
+        type=click.IntRange(1, 20),
+        default=None,
+        help=(
+            "How many times selection may verify, judge and review before settling "
+            "(default: 10). The biggest dial on warm-run time, and on the bill when "
+            "llm.base_url points at a paid API"
+        ),
+    )
+    @click.option(
         "--analysis-depth",
         type=click.Choice(["auto", "fast", "thorough"]),
         default=None,
@@ -451,6 +474,7 @@ def register_generate_commands(main: click.Group) -> None:
         include_live_photos: bool | None,
         include_photos: bool | None,
         photo_duration: float | None,
+        refinement_passes: int | None,
         analysis_depth: str | None,
         trip_index: int | None,
         all_trips: bool,
@@ -621,8 +645,9 @@ def register_generate_commands(main: click.Group) -> None:
             include_live_photos, config_enabled=config.analysis.include_live_photos
         )
         use_photos = resolve_inclusion(include_photos, config_enabled=config.photos.enabled)
-        if photo_duration is not None:
-            config.photos.duration = photo_duration
+        _apply_scalar_overrides(
+            config, photo_duration=photo_duration, refinement_passes=refinement_passes
+        )
 
         # Analysis depth: CLI override → stored for PipelineConfig
         effective_analysis_depth = analysis_depth or "auto"

--- a/src/immich_memories/config_models.py
+++ b/src/immich_memories/config_models.py
@@ -155,6 +155,16 @@ class AnalysisConfig(BaseModel):
         le=8,
         description="Concurrent isolated clients used for video and thumbnail prefetching",
     )
+    max_refinement_passes: int = Field(
+        default=10,
+        ge=1,
+        le=20,
+        description="How many times selection may verify, judge and review before "
+        "settling (#503). Three refinement loops run up to this many times, so it "
+        "is the largest multiplier on warm-run time — and on the bill for anyone "
+        "pointing llm.base_url at a paid API. Lower it to spend less per run; the "
+        "cost is that a late refill may ship less scrutinised.",
+    )
     max_album_assets: int = Field(
         default=10000,
         ge=1,

--- a/src/immich_memories/config_presets.py
+++ b/src/immich_memories/config_presets.py
@@ -2,7 +2,7 @@
 
 `preset: fast` is the CPU-only / NAS profile: no per-clip speech analysis, static title
 backgrounds, the fast software encoder preset, medium quality at 1080p, fewer photos, and
-`analysis_depth: auto` resolving to `fast` (favorites first). Anything the user has set
+`analysis_depth: auto` resolving to `fast` (favorites first), and three refinement passes rather than ten. Anything the user has set
 explicitly (config file key, env var, CLI flag) wins over the preset, like `clip_style`.
 """
 
@@ -22,6 +22,7 @@ PRESETS: dict[str, dict[str, dict[str, Any]]] = {
         "speech": {"enabled": False},
         "title_screens": {"animated_background": False},
         "photos": {"max_ratio": 0.25},
+        "analysis": {"max_refinement_passes": 3},
     },
 }
 

--- a/tests/test_refinement_passes_config.py
+++ b/tests/test_refinement_passes_config.py
@@ -1,0 +1,92 @@
+"""max_refinement_passes is the biggest warm-run cost dial; it needs a knob."""
+
+from immich_memories.analysis.smart_pipeline import PipelineConfig
+from immich_memories.config_loader import Config
+
+
+def test_the_configured_pass_budget_reaches_the_pipeline() -> None:
+    """Three refinement loops run up to this many times, each costing LLM calls.
+
+    Anyone pointing llm.base_url at a paid API pays this multiplier, so it has
+    to be settable rather than fixed at the dataclass default.
+    """
+    config = Config()
+    config.analysis.max_refinement_passes = 3
+
+    assert PipelineConfig.from_app_config(config).max_refinement_passes == 3
+
+
+def test_the_default_pass_budget_is_unchanged() -> None:
+    """A dial nobody sets must not change what anybody already gets."""
+    assert PipelineConfig.from_app_config(Config()).max_refinement_passes == 10
+
+
+def _generate_with(args: list[str], config: Config):
+    """Run the CLI down to the point of generation, replacing only live boundaries."""
+    from pathlib import Path
+    from unittest.mock import MagicMock, patch
+
+    from click.testing import CliRunner
+
+    from immich_memories.cli import main
+
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    client.get_photos_for_date_range.return_value = []
+    asset = MagicMock(duration_seconds=10.0)
+    with (
+        # WHY: Immich is the external boundary — no live server in a unit test.
+        patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
+        patch(
+            "immich_memories.cli.generate.fetch_videos_and_live_photos",
+            return_value=([asset], []),
+        ),
+        # WHY: generation is the boundary past the flag resolution under test.
+        patch(
+            "immich_memories.cli.generate.run_pipeline_and_generate",
+            return_value=(Path("plan.mp4"), False, None),
+        ),
+        patch("immich_memories.cli.init_config_dir"),
+        patch("immich_memories.cli.get_config", return_value=config),
+    ):
+        return CliRunner().invoke(main, args, catch_exceptions=False)
+
+
+def test_the_flag_overrides_the_configured_pass_budget() -> None:
+    """A per-run cost dial is worth a flag; the YAML value is the default, not the law."""
+    config = Config()
+    config.immich.url = "http://immich:2283"
+    config.immich.api_key = "test-key"
+    config.analysis.max_refinement_passes = 10
+
+    result = _generate_with(
+        [
+            "generate",
+            "--memory-type",
+            "monthly_highlights",
+            "--month",
+            "7",
+            "--year",
+            "2024",
+            "--refinement-passes",
+            "3",
+            "--dry-run",
+        ],
+        config,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert config.analysis.max_refinement_passes == 3
+
+
+def test_the_fast_preset_spends_fewer_passes() -> None:
+    """preset: fast is the CPU-only/NAS profile — the cost dial belongs in it."""
+    assert Config(preset="fast").analysis.max_refinement_passes == 3
+
+
+def test_the_fast_preset_yields_to_an_explicit_setting() -> None:
+    """Anything the user set explicitly outranks the preset, as with every other knob."""
+    config = Config(preset="fast", analysis={"max_refinement_passes": 8})
+
+    assert config.analysis.max_refinement_passes == 8


### PR DESCRIPTION
Closes #503. **Stacked on #559** (`fix/495-photo-max-ratio`) — merge that first; this PR targets it, so GitHub will retarget to `main` automatically once it lands.

## What

`max_refinement_passes` drives three refinement loops and is the largest multiplier on what a warm run costs — in time on a NAS, in **money** for anyone pointing `llm.base_url` at a hosted API. It had no YAML key, no flag, and no mention in the docs. The only way to change it was to edit a dataclass default.

| | |
|---|---|
| Config | `advanced.analysis.max_refinement_passes` (tier 2, default **10**, range 1–20) |
| CLI | `--refinement-passes` |
| Preset | `preset: fast` now takes **3** |
| Docs | config-reference, cli-reference (generated), generate.md, and the NAS page |

**The default does not move**, so nobody's existing runs change.

## The docs say what it costs, not what it does

Per the issue, this is a cost dial and not just a speed dial. The NAS page gets a section saying so plainly, including the honest downside: lowering it means a clip admitted by the last refill may ship with less scrutiny than the ones before it.

`preset: fast` taking 3 follows the same reasoning as the rest of that preset — a box without a GPU should not spend ten rounds of LLM calls settling a cut.

## Two implementation notes

**It rides in via `PipelineConfig.from_app_config`**, added in #495 — the constructor that exists precisely so a new dial reaches both the CLI and the wizard instead of neither. This PR is the first test of that: the plumbing was two lines in one place rather than two easily-forgotten call sites.

**`register_generate_commands` is at cognitive complexity 179** against a project limit of 15, grandfathered as a watermark. One added `if` took it to 181 and CI refused. The two scalar CLI overrides moved into `_apply_scalar_overrides`, beside the existing `resolve_inclusion` helper, which takes the function down rather than up.

## Tests

Five, strict TDD, each RED verified for the right reason first:

- the configured budget reaches the pipeline
- the default is unchanged (nobody's run changes)
- `--refinement-passes` overrides the config, exercised through the real CLI
- `preset: fast` uses 3
- an explicit setting outranks the preset

One honest caveat: the last test cannot fail before the preset contains the key, so it's a precedence guard rather than a driver.

`make ci` exit 0. `make docs-build` exit 0.