### PR TITLE
fix(audio): wire the generator fallback, and stop the CLI paying for stems

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2651,101 +2651,101 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 815,
-        "line_end": 914,
+        "line_start": 634,
+        "line_end": 733,
         "line_complexities": [
           {
-            "line": 836,
+            "line": 655,
             "complexity": 0
           },
           {
-            "line": 837,
+            "line": 656,
             "complexity": 1
           },
           {
-            "line": 839,
+            "line": 658,
             "complexity": 1
           },
           {
-            "line": 840,
+            "line": 659,
             "complexity": 0
           },
           {
-            "line": 841,
+            "line": 660,
             "complexity": 2
           },
           {
-            "line": 842,
+            "line": 661,
             "complexity": 0
           },
           {
-            "line": 849,
+            "line": 668,
             "complexity": 1
           },
           {
-            "line": 853,
+            "line": 672,
             "complexity": 0
           },
           {
-            "line": 854,
+            "line": 673,
             "complexity": 0
           },
           {
-            "line": 855,
+            "line": 674,
             "complexity": 1
           },
           {
-            "line": 856,
+            "line": 675,
             "complexity": 0
           },
           {
-            "line": 857,
+            "line": 676,
             "complexity": 2
           },
           {
-            "line": 858,
+            "line": 677,
             "complexity": 0
           },
           {
-            "line": 865,
+            "line": 684,
             "complexity": 1
           },
           {
-            "line": 869,
+            "line": 688,
             "complexity": 0
           },
           {
-            "line": 872,
+            "line": 691,
             "complexity": 0
           },
           {
-            "line": 873,
+            "line": 692,
             "complexity": 2
           },
           {
-            "line": 874,
+            "line": 693,
             "complexity": 3
           },
           {
-            "line": 876,
+            "line": 695,
             "complexity": 1
           },
           {
-            "line": 879,
+            "line": 698,
             "complexity": 0
           },
           {
-            "line": 913,
+            "line": 732,
             "complexity": 1
           },
           {
-            "line": 914,
+            "line": 733,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 103
+    "complexity": 70
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -143,11 +143,17 @@ musicgen:
 ### Local/API Fallback and Stem Separation
 
 ACE-Step `lib` mode automatically falls back to the configured ACE-Step REST API when the local
-package is not installed. It does not switch to MusicGen after an ACE generation failure.
+package is not installed.
 
-When both providers are enabled, ACE-Step generates the track and MusicGen supplies remote Demucs
-stem separation. With MusicGen disabled, an installed local Demucs handles stems instead. When
-ACE-Step is disabled, MusicGen handles both generation and stems.
+Generators are tried in order. With both enabled, ACE-Step goes first and MusicGen is the fallback:
+an ACE-Step failure costs the run its first choice, not its music. Only when every enabled generator
+fails does the run drop to a bundled track. With ACE-Step disabled, MusicGen handles generation on
+its own.
+
+MusicGen also supplies remote Demucs stem separation when it is enabled; with it disabled, an
+installed local Demucs handles stems instead. Stems are separated only for the web UI, whose mixer
+ducks the four stems independently. The CLI masters the full mix and ducks that, so it asks for no
+separation rather than paying for a Demucs run it would discard.
 
 ### Custom Music
 

--- a/src/immich_memories/audio/music_generator.py
+++ b/src/immich_memories/audio/music_generator.py
@@ -103,12 +103,16 @@ async def generate_music_for_video(
     app_config: object | None = None,
     memory_type: str | None = None,
     photo_cadence_seconds: float | None = None,
+    separate_stems: bool = True,
 ) -> MusicGenerationResult:
     """Generate multiple music versions for a video with per-clip moods.
 
     If app_config is provided and has ACE-Step/MusicGen enabled, uses the
     multi-provider pipeline (ACE-Step → MusicGen fallback). Otherwise falls
     back to direct MusicGen client for backwards compatibility.
+
+    Callers that cannot consume stems pass ``separate_stems=False`` rather than
+    paying for a Demucs run they will drop (#499).
 
     Args:
         timeline: Video timeline with per-clip mood information
@@ -126,7 +130,7 @@ async def generate_music_for_video(
     if app_config is not None and _has_pipeline_backends(app_config):
         from immich_memories.audio.music_pipeline import create_pipeline
 
-        pipeline = create_pipeline(app_config)
+        pipeline = create_pipeline(app_config, separate_stems=separate_stems)
         num_versions = getattr(config, "num_versions", 3) if config else 3
         async with pipeline:
             return await pipeline.generate_music_for_video(

--- a/src/immich_memories/audio/music_pipeline.py
+++ b/src/immich_memories/audio/music_pipeline.py
@@ -2,7 +2,8 @@
 
 Orchestrates music generation and optional stem separation:
 1. ACE-Step — generation in direct-library or API mode
-2. MusicGen — generation when ACE-Step is disabled, or remote Demucs stems
+2. MusicGen — generation behind ACE-Step in the fallback chain, and remote
+   Demucs stems
 
 Stem separation is decoupled from generation via the StemSeparator protocol:
 - DemucsLocalBackend: in-process, no server needed (Apple Silicon / CUDA / CPU)
@@ -35,9 +36,9 @@ logger = logging.getLogger(__name__)
 class MusicPipeline:
     """Music generation pipeline with ordered-backend fallback support.
 
-    Tries every configured generator in order. The application factory currently
-    configures ACE-Step alone when enabled, or MusicGen alone otherwise. Stem
-    separation remains decoupled via local Demucs or the MusicGen API.
+    Tries every configured generator in order, so a backend that is enabled but
+    failing costs the run its first choice rather than its music. Stem
+    separation is decoupled via local Demucs or the MusicGen API.
     """
 
     def __init__(
@@ -214,7 +215,7 @@ class MusicPipeline:
             return None
 
 
-def create_pipeline(app_config) -> MusicPipeline:
+def create_pipeline(app_config, *, separate_stems: bool = True) -> MusicPipeline:
     """Create a MusicPipeline from the application config.
 
     Reads musicgen and ace_step sections from the app config to build
@@ -223,6 +224,11 @@ def create_pipeline(app_config) -> MusicPipeline:
     Stem separation priority:
     1. MusicGen API (if enabled) — established, supports 2-stem and 4-stem
     2. Local Demucs (if demucs package installed) — zero-config fallback
+
+    ``separate_stems=False`` skips the separator entirely. Demucs is minutes of
+    CPU per version, and only the UI's 4-stem ducking consumes the result; the
+    CLI mix path masters the full mix instead, so it was paying for stems it
+    then dropped (#499).
     """
     from immich_memories.audio.generators.factory import create_generator
 
@@ -235,19 +241,25 @@ def create_pipeline(app_config) -> MusicPipeline:
         generators.append(create_generator("ace_step", app_config.ace_step))
         logger.info(f"Pipeline: ACE-Step enabled (mode={app_config.ace_step.mode})")
 
-    # MusicGen: stem separator always, generation fallback only if ACE-Step is off
+    # MusicGen: stem separator always, and generation behind ACE-Step in the chain.
+    # It used to be added as a generator only when ACE-Step was off, which left
+    # `generators` one element long in every configuration and made the fallback
+    # chain unreachable (#499).
     if getattr(app_config, "musicgen", None) and app_config.musicgen.enabled:
         musicgen = create_generator("musicgen", app_config.musicgen)
-        # MusicGenBackend satisfies StemSeparator (has separate_stems method)
-        stem_separator = musicgen  # type: ignore[assignment]
-        if ace_step_enabled:
-            logger.info("Pipeline: MusicGen enabled (Demucs stems only)")
-        else:
-            generators.append(musicgen)
-            logger.info("Pipeline: MusicGen enabled (generation + Demucs stems)")
+        if separate_stems:
+            # MusicGenBackend satisfies StemSeparator (has separate_stems method)
+            stem_separator = musicgen  # type: ignore[assignment]
+        generators.append(musicgen)
+        role = "fallback generation" if ace_step_enabled else "generation"
+        logger.info(
+            "Pipeline: MusicGen enabled (%s%s)",
+            role,
+            " + Demucs stems" if separate_stems else "",
+        )
 
     # Auto-detect local Demucs when no MusicGen configured
-    if stem_separator is None:
+    if separate_stems and stem_separator is None:
         stem_separator = _try_local_demucs()
 
     if not generators:

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -268,6 +268,9 @@ def auto_generate_music(
                 app_config=config,
                 memory_type=memory_type,
                 photo_cadence_seconds=photo_cadence_seconds(assembly_clips),
+                # This path masters the full mix and ducks that. It has no way to
+                # use stems, so it used to run Demucs and drop the result (#499).
+                separate_stems=False,
             )
         )
 

--- a/tests/test_music_pipeline.py
+++ b/tests/test_music_pipeline.py
@@ -385,6 +385,50 @@ class TestStemSeparatorProtocol:
         assert result.versions[0].stems is None
 
 
+class TestSeparationIsOptional:
+    """Demucs is minutes of CPU. Only ask for it where the stems get used (#499)."""
+
+    def test_the_cli_path_does_not_order_stems_it_cannot_use(self, tmp_path):
+        """`auto_generate_music` returns the full mix and the mix path masters it;
+        the stems it used to separate were dropped on the floor."""
+        from unittest.mock import AsyncMock
+
+        from immich_memories.config_loader import Config
+        from immich_memories.generate_music import auto_generate_music
+
+        config = Config()
+        config.ace_step.enabled = True
+
+        # WHY: replaces the ACE-Step/MusicGen generation call, which needs a GPU
+        # or a running server.
+        with patch(
+            "immich_memories.audio.music_generator.generate_music_for_video",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as generate:
+            auto_generate_music(config, [], tmp_path, None)
+
+        assert generate.await_args.kwargs["separate_stems"] is False
+
+    def test_a_caller_that_cannot_use_stems_gets_no_separator(self):
+        from immich_memories.audio.music_pipeline import create_pipeline
+
+        config = MagicMock()
+        config.ace_step.enabled = True
+        config.ace_step.mode = "api"
+        config.musicgen.enabled = True
+        config.musicgen.base_url = "http://gpu-server:8000"
+        config.musicgen.api_key = ""
+        config.musicgen.timeout_seconds = 3600
+        config.musicgen.num_versions = 1
+
+        pipeline = create_pipeline(config, separate_stems=False)
+
+        assert pipeline._stem_separator is None
+        # Turning stems off must not cost the generator behind ACE-Step.
+        assert len(pipeline._generators) == 2
+
+
 class TestCreatePipelineAutoDemucs:
     """Test that create_pipeline auto-detects local Demucs."""
 
@@ -427,7 +471,7 @@ class TestCreatePipelineAPIMode:
     """Test pipeline wiring for Linux/GPU deployments (external API servers)."""
 
     def test_musicgen_api_as_stem_separator(self):
-        """When musicgen enabled + ace_step enabled, MusicGen is stem separator only."""
+        """When musicgen enabled + ace_step enabled, MusicGen supplies the stems."""
         from immich_memories.audio.generators.musicgen_backend import MusicGenBackend
         from immich_memories.audio.music_pipeline import create_pipeline
 
@@ -446,9 +490,31 @@ class TestCreatePipelineAPIMode:
         ):
             pipeline = create_pipeline(config)
 
-        # MusicGen should be stem separator (not a generator — ACE-Step handles that)
         assert isinstance(pipeline._stem_separator, MusicGenBackend)
-        assert len(pipeline._generators) == 1  # Only ACE-Step
+        # ACE-Step leads; MusicGen sits behind it in the chain (see the fallback
+        # test below) as well as supplying stems.
+        assert len(pipeline._generators) == 2
+
+    def test_musicgen_is_also_the_generation_fallback_behind_ace_step(self):
+        """The chain existed but was never wired: with both enabled the factory
+        built a one-element list, so a failing ACE-Step fell straight through to
+        a bundled track instead of to the configured generator (#499)."""
+        from immich_memories.audio.generators.ace_step_backend import ACEStepBackend
+        from immich_memories.audio.generators.musicgen_backend import MusicGenBackend
+        from immich_memories.audio.music_pipeline import create_pipeline
+
+        config = MagicMock()
+        config.ace_step.enabled = True
+        config.ace_step.mode = "api"
+        config.musicgen.enabled = True
+        config.musicgen.base_url = "http://gpu-server:8000"
+        config.musicgen.api_key = ""
+        config.musicgen.timeout_seconds = 3600
+        config.musicgen.num_versions = 1
+
+        pipeline = create_pipeline(config)
+
+        assert [type(g) for g in pipeline._generators] == [ACEStepBackend, MusicGenBackend]
 
     def test_musicgen_api_preferred_over_local_demucs(self):
         """When musicgen is enabled, it takes priority for stems even if demucs is installed."""


### PR DESCRIPTION
Closes #499.

Two advertised behaviours never engaged. They pull in **opposite directions**, so each got the smaller honest fix rather than one uniform answer. The issue asked me to decide — here's the reasoning.

## 1. ACE-Step → MusicGen fallback: **implemented**

`create_pipeline` appended MusicGen as a generator only when ACE-Step was *off*, so `generators` was one element long in every configuration and `_try_generate`'s chain was unreachable. A failing ACE-Step fell straight through to a bundled track (#422 behaviour), never to the configured MusicGen.

**Why implement rather than delete:** the chain already works and is already tested. `MusicPipeline` has passing multi-generator tests (`test_fallback_on_failure`, `test_fallback_on_unavailable`, `test_all_backends_fail_raises`), and `_try_generate`'s broad-except carries a considered WHY about hosted backends raising `httpx.HTTPStatusError`. Only the *wiring* was missing. Enabling it is one line:

```diff
-        if ace_step_enabled: ... else: generators.append(musicgen)
+        generators.append(musicgen)
```

Deleting the branch would have meant unpicking the loop, the "all backends failed" path and its tests — a refactor that removes a working capability to make a docstring true. That's the larger and worse change.

**Behaviour change:** with both backends enabled and ACE-Step failing, the run now generates with MusicGen instead of dropping to a bundled track. Bundled remains the fallback when *every* enabled generator fails.

## 2. CLI Demucs stems: **deleted**

`auto_generate_music` returns the full mix only, so a CLI run with MusicGen enabled or local Demucs installed paid minutes of separation per version and dropped the result.

**Why delete rather than route** — the issue said route them "if the mixer supports it". It does support it (`mix_audio_with_4stem_ducking`, used by the UI), so I want to be explicit about why I didn't:

The two paths mix differently. The CLI **masters** the track first — `master_music_track` applies a tilt EQ, loudness normalisation and a ceiling — and it is the *only* caller of that function. The UI's stem path never masters. So routing stems into the CLI would silently trade a deliberate mastering step for a different ducking method, with no listening test to say which sounds better.

Mastering the four stems separately isn't a way out: independent `loudnorm` on drums vs vocals would normalise them to the same LUFS and destroy the balance between them.

So the honest small change is to stop buying what this path cannot use. `create_pipeline(..., separate_stems=False)` skips the separator entirely — it doesn't even probe for local Demucs. The UI is untouched (default `True`).

**Adopting 4-stem ducking in the CLI is a real capability gap and worth doing** — but it's an audio-quality decision that needs a listening comparison against the mastered mix, not a side effect of a wiring fix. Noting it here rather than opening an issue, per instructions.

## Tests

- `test_musicgen_is_also_the_generation_fallback_behind_ace_step` — asserts the chain is `[ACEStepBackend, MusicGenBackend]`. RED before.
- `test_a_caller_that_cannot_use_stems_gets_no_separator` — `separate_stems=False` yields no separator, and crucially does *not* cost the fallback generator. RED before.
- `test_the_cli_path_does_not_order_stems_it_cannot_use` — the CLI entry point actually passes the flag; this is the bug itself, so it needs a guard.
- Updated `test_musicgen_api_as_stem_separator`, which asserted `len(generators) == 1` — it was the test locking in the dishonest state.

`make ci` passes (5508 passed, 9 skipped). `make docs-build` passes.

## Docs

Corrected in **both** directions, which is the point of the issue:

- "It does not switch to MusicGen after an ACE generation failure" — no longer true, rewritten to describe the ordered chain.
- The stems-are-UI-only rule was never written down anywhere; now it is.
- Module and class docstrings in `music_pipeline.py` no longer claim a fallback the factory refused to build.

## Adjacent findings (not fixed here)

1. `MusicPipeline.__aenter__` already guarded against double-entering a backend that is both generator and separator (`sep not in self._generators`) — that guard was dead until this PR and is now load-bearing. Worth knowing if anyone refactors it.
2. `generate_music_for_video`'s legacy direct-MusicGen path (`app_config is None`) still separates stems unconditionally, but nothing in-tree reaches it with a stem-consuming caller.