### PR TITLE
fix: two things that quietly did the wrong thing — swallowed bugs, and -o

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1080,136 +1080,124 @@
       {
         "name": "register_generate_commands",
         "complexity": 179,
-        "line_start": 169,
-        "line_end": 937,
+        "line_start": 170,
+        "line_end": 944,
         "line_complexities": [
           {
-            "line": 487,
-            "complexity": 0
-          },
-          {
-            "line": 488,
+            "line": 494,
             "complexity": 0
           },
           {
             "line": 495,
-            "complexity": 2
-          },
-          {
-            "line": 496,
             "complexity": 0
           },
           {
-            "line": 497,
-            "complexity": 0
-          },
-          {
-            "line": 499,
+            "line": 502,
             "complexity": 2
           },
           {
-            "line": 501,
-            "complexity": 3
+            "line": 503,
+            "complexity": 0
           },
           {
-            "line": 505,
-            "complexity": 3
+            "line": 504,
+            "complexity": 0
           },
           {
             "line": 506,
-            "complexity": 0
-          },
-          {
-            "line": 508,
-            "complexity": 0
-          },
-          {
-            "line": 509,
             "complexity": 2
           },
           {
-            "line": 510,
-            "complexity": 1
-          },
-          {
-            "line": 515,
+            "line": 508,
             "complexity": 3
           },
           {
+            "line": 512,
+            "complexity": 3
+          },
+          {
+            "line": 513,
+            "complexity": 0
+          },
+          {
+            "line": 515,
+            "complexity": 0
+          },
+          {
             "line": 516,
-            "complexity": 0
+            "complexity": 2
           },
           {
-            "line": 520,
-            "complexity": 0
-          },
-          {
-            "line": 521,
+            "line": 517,
             "complexity": 1
           },
           {
             "line": 522,
+            "complexity": 3
+          },
+          {
+            "line": 523,
             "complexity": 0
           },
           {
-            "line": 524,
+            "line": 527,
+            "complexity": 0
+          },
+          {
+            "line": 528,
+            "complexity": 1
+          },
+          {
+            "line": 529,
+            "complexity": 0
+          },
+          {
+            "line": 531,
             "complexity": 2
           },
           {
-            "line": 540,
+            "line": 547,
             "complexity": 0
           },
           {
-            "line": 551,
+            "line": 558,
             "complexity": 3
           },
           {
-            "line": 555,
+            "line": 562,
             "complexity": 3
           },
           {
-            "line": 559,
+            "line": 566,
             "complexity": 4
           },
           {
-            "line": 563,
+            "line": 570,
             "complexity": 3
           },
           {
-            "line": 567,
+            "line": 574,
             "complexity": 3
           },
           {
-            "line": 575,
-            "complexity": 0
-          },
-          {
-            "line": 592,
-            "complexity": 2
-          },
-          {
-            "line": 593,
-            "complexity": 0
-          },
-          {
-            "line": 594,
-            "complexity": 1
-          },
-          {
-            "line": 596,
-            "complexity": 0
-          },
-          {
-            "line": 597,
-            "complexity": 1
-          },
-          {
-            "line": 598,
+            "line": 582,
             "complexity": 0
           },
           {
             "line": 599,
-            "complexity": 3
+            "complexity": 2
+          },
+          {
+            "line": 600,
+            "complexity": 0
+          },
+          {
+            "line": 601,
+            "complexity": 1
+          },
+          {
+            "line": 603,
+            "complexity": 0
           },
           {
             "line": 604,
@@ -1217,278 +1205,290 @@
           },
           {
             "line": 605,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 606,
-            "complexity": 0
-          },
-          {
-            "line": 607,
-            "complexity": 1
-          },
-          {
-            "line": 608,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 611,
-            "complexity": 0
-          },
-          {
-            "line": 615,
-            "complexity": 2
-          },
-          {
-            "line": 620,
-            "complexity": 0
-          },
-          {
-            "line": 623,
-            "complexity": 0
-          },
-          {
-            "line": 624,
-            "complexity": 2
-          },
-          {
-            "line": 625,
-            "complexity": 0
-          },
-          {
-            "line": 628,
             "complexity": 1
           },
           {
-            "line": 631,
+            "line": 612,
             "complexity": 3
+          },
+          {
+            "line": 613,
+            "complexity": 0
+          },
+          {
+            "line": 614,
+            "complexity": 1
+          },
+          {
+            "line": 615,
+            "complexity": 0
+          },
+          {
+            "line": 618,
+            "complexity": 0
+          },
+          {
+            "line": 622,
+            "complexity": 2
+          },
+          {
+            "line": 627,
+            "complexity": 0
+          },
+          {
+            "line": 630,
+            "complexity": 0
+          },
+          {
+            "line": 631,
+            "complexity": 2
           },
           {
             "line": 632,
+            "complexity": 0
+          },
+          {
+            "line": 635,
+            "complexity": 1
+          },
+          {
+            "line": 638,
             "complexity": 3
           },
           {
-            "line": 634,
-            "complexity": 0
+            "line": 639,
+            "complexity": 3
           },
           {
             "line": 641,
             "complexity": 0
           },
           {
-            "line": 645,
-            "complexity": 3
-          },
-          {
-            "line": 646,
-            "complexity": 0
-          },
-          {
-            "line": 647,
-            "complexity": 3
-          },
-          {
             "line": 648,
             "complexity": 0
           },
           {
-            "line": 650,
-            "complexity": 0
-          },
-          {
-            "line": 674,
-            "complexity": 1
-          },
-          {
-            "line": 675,
-            "complexity": 2
-          },
-          {
-            "line": 679,
-            "complexity": 1
-          },
-          {
-            "line": 690,
+            "line": 652,
             "complexity": 3
           },
           {
-            "line": 691,
+            "line": 653,
             "complexity": 0
           },
           {
-            "line": 692,
+            "line": 654,
+            "complexity": 3
+          },
+          {
+            "line": 655,
             "complexity": 0
           },
           {
-            "line": 694,
+            "line": 657,
             "complexity": 0
           },
           {
-            "line": 696,
-            "complexity": 0
+            "line": 681,
+            "complexity": 1
+          },
+          {
+            "line": 682,
+            "complexity": 2
+          },
+          {
+            "line": 686,
+            "complexity": 1
+          },
+          {
+            "line": 697,
+            "complexity": 3
           },
           {
             "line": 698,
             "complexity": 0
           },
           {
+            "line": 699,
+            "complexity": 0
+          },
+          {
+            "line": 701,
+            "complexity": 0
+          },
+          {
+            "line": 703,
+            "complexity": 0
+          },
+          {
             "line": 705,
+            "complexity": 0
+          },
+          {
+            "line": 712,
             "complexity": 5
           },
           {
-            "line": 746,
+            "line": 753,
             "complexity": 6
           },
           {
-            "line": 789,
+            "line": 796,
             "complexity": 0
           },
           {
-            "line": 790,
+            "line": 797,
             "complexity": 5
           },
           {
-            "line": 791,
+            "line": 798,
             "complexity": 6
           },
           {
-            "line": 792,
+            "line": 799,
             "complexity": 0
           },
           {
-            "line": 793,
+            "line": 800,
             "complexity": 0
           },
           {
-            "line": 794,
+            "line": 801,
             "complexity": 7
           },
           {
-            "line": 802,
+            "line": 809,
             "complexity": 6
           },
           {
-            "line": 803,
+            "line": 810,
             "complexity": 0
           },
           {
-            "line": 804,
+            "line": 811,
             "complexity": 7
-          },
-          {
-            "line": 805,
-            "complexity": 0
-          },
-          {
-            "line": 807,
-            "complexity": 1
           },
           {
             "line": 812,
-            "complexity": 7
-          },
-          {
-            "line": 813,
             "complexity": 0
           },
           {
-            "line": 826,
-            "complexity": 7
-          },
-          {
-            "line": 827,
-            "complexity": 0
-          },
-          {
-            "line": 828,
-            "complexity": 0
-          },
-          {
-            "line": 831,
+            "line": 814,
             "complexity": 1
           },
           {
-            "line": 832,
+            "line": 819,
+            "complexity": 7
+          },
+          {
+            "line": 820,
             "complexity": 0
           },
           {
             "line": 833,
-            "complexity": 0
-          },
-          {
-            "line": 836,
-            "complexity": 0
-          },
-          {
-            "line": 846,
-            "complexity": 0
-          },
-          {
-            "line": 847,
-            "complexity": 5
-          },
-          {
-            "line": 848,
-            "complexity": 6
-          },
-          {
-            "line": 849,
             "complexity": 7
           },
           {
+            "line": 834,
+            "complexity": 0
+          },
+          {
+            "line": 835,
+            "complexity": 0
+          },
+          {
+            "line": 838,
+            "complexity": 1
+          },
+          {
+            "line": 839,
+            "complexity": 0
+          },
+          {
+            "line": 840,
+            "complexity": 0
+          },
+          {
+            "line": 843,
+            "complexity": 0
+          },
+          {
             "line": 853,
+            "complexity": 0
+          },
+          {
+            "line": 854,
+            "complexity": 5
+          },
+          {
+            "line": 855,
             "complexity": 6
           },
           {
             "line": 856,
+            "complexity": 7
+          },
+          {
+            "line": 860,
             "complexity": 6
           },
           {
-            "line": 861,
+            "line": 863,
+            "complexity": 6
+          },
+          {
+            "line": 868,
             "complexity": 0
           },
           {
-            "line": 863,
-            "complexity": 5
-          },
-          {
-            "line": 865,
-            "complexity": 5
-          },
-          {
-            "line": 869,
+            "line": 870,
             "complexity": 5
           },
           {
             "line": 872,
-            "complexity": 1
-          },
-          {
-            "line": 874,
-            "complexity": 0
+            "complexity": 5
           },
           {
             "line": 876,
+            "complexity": 5
+          },
+          {
+            "line": 879,
+            "complexity": 1
+          },
+          {
+            "line": 881,
             "complexity": 0
           },
           {
-            "line": 920,
-            "complexity": 1
-          },
-          {
-            "line": 923,
-            "complexity": 1
-          },
-          {
-            "line": 926,
-            "complexity": 1
+            "line": 883,
+            "complexity": 0
           },
           {
             "line": 927,
+            "complexity": 1
+          },
+          {
+            "line": 930,
+            "complexity": 1
+          },
+          {
+            "line": 933,
+            "complexity": 1
+          },
+          {
+            "line": 934,
             "complexity": 0
           },
           {
-            "line": 928,
+            "line": 935,
             "complexity": 1
           }
         ]
@@ -1932,39 +1932,39 @@
       {
         "name": "_print_title_test_params",
         "complexity": 18,
-        "line_start": 27,
-        "line_end": 75,
+        "line_start": 28,
+        "line_end": 76,
         "line_complexities": [
           {
-            "line": 42,
+            "line": 43,
             "complexity": 0
           },
           {
-            "line": 47,
-            "complexity": 1
-          },
-          {
             "line": 48,
-            "complexity": 2
+            "complexity": 1
           },
           {
             "line": 49,
+            "complexity": 2
+          },
+          {
+            "line": 50,
             "complexity": 9
           },
           {
-            "line": 59,
+            "line": 60,
             "complexity": 1
           },
           {
-            "line": 61,
+            "line": 62,
             "complexity": 2
           },
           {
-            "line": 63,
+            "line": 64,
             "complexity": 2
           },
           {
-            "line": 65,
+            "line": 66,
             "complexity": 1
           }
         ]
@@ -1972,135 +1972,135 @@
       {
         "name": "register_titles_commands",
         "complexity": 35,
-        "line_start": 112,
-        "line_end": 376,
+        "line_start": 113,
+        "line_end": 383,
         "line_complexities": [
-          {
-            "line": 226,
-            "complexity": 2
-          },
-          {
-            "line": 230,
-            "complexity": 2
-          },
           {
             "line": 233,
             "complexity": 2
           },
           {
-            "line": 234,
+            "line": 237,
+            "complexity": 2
+          },
+          {
+            "line": 240,
+            "complexity": 2
+          },
+          {
+            "line": 241,
             "complexity": 0
           },
           {
-            "line": 235,
+            "line": 242,
             "complexity": 1
           },
           {
-            "line": 236,
+            "line": 243,
             "complexity": 0
           },
           {
-            "line": 239,
+            "line": 246,
             "complexity": 0
           },
           {
-            "line": 248,
+            "line": 255,
             "complexity": 0
           },
           {
-            "line": 267,
+            "line": 274,
             "complexity": 2
           },
           {
-            "line": 268,
+            "line": 275,
             "complexity": 4
           },
           {
-            "line": 269,
+            "line": 276,
             "complexity": 0
-          },
-          {
-            "line": 271,
-            "complexity": 2
           },
           {
             "line": 278,
+            "complexity": 2
+          },
+          {
+            "line": 285,
             "complexity": 0
           },
           {
-            "line": 283,
+            "line": 290,
             "complexity": 0
           },
           {
-            "line": 286,
+            "line": 293,
             "complexity": 0
           },
           {
-            "line": 292,
+            "line": 299,
             "complexity": 0
           },
           {
-            "line": 304,
+            "line": 311,
             "complexity": 1
           },
           {
-            "line": 306,
+            "line": 313,
             "complexity": 0
           },
           {
-            "line": 330,
+            "line": 337,
             "complexity": 0
           },
           {
-            "line": 332,
+            "line": 339,
             "complexity": 2
-          },
-          {
-            "line": 338,
-            "complexity": 2
-          },
-          {
-            "line": 342,
-            "complexity": 0
-          },
-          {
-            "line": 344,
-            "complexity": 3
           },
           {
             "line": 345,
-            "complexity": 4
-          },
-          {
-            "line": 347,
-            "complexity": 1
-          },
-          {
-            "line": 355,
-            "complexity": 0
-          },
-          {
-            "line": 357,
-            "complexity": 0
-          },
-          {
-            "line": 362,
             "complexity": 2
           },
           {
-            "line": 363,
+            "line": 349,
+            "complexity": 0
+          },
+          {
+            "line": 351,
+            "complexity": 3
+          },
+          {
+            "line": 352,
+            "complexity": 4
+          },
+          {
+            "line": 354,
+            "complexity": 1
+          },
+          {
+            "line": 362,
             "complexity": 0
           },
           {
             "line": 364,
-            "complexity": 3
-          },
-          {
-            "line": 365,
             "complexity": 0
           },
           {
+            "line": 369,
+            "complexity": 2
+          },
+          {
+            "line": 370,
+            "complexity": 0
+          },
+          {
+            "line": 371,
+            "complexity": 3
+          },
+          {
             "line": 372,
+            "complexity": 0
+          },
+          {
+            "line": 379,
             "complexity": 2
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -44,13 +44,13 @@ immich-memories generate [OPTIONS]
 |------|-------|------|---------|-------------|
 | `--duration` | `-d` | int | — | Target duration in seconds |
 | `--short-form` | — | choice | — | `15`, `30`, `60`, or `90` — sets the duration and goes vertical |
-| `--orientation` | `-o` | choice | `landscape` | `landscape`, `portrait`, or `square` |
+| `--orientation` | — | choice | `landscape` | `landscape`, `portrait`, or `square` |
 | `--resolution` | `-r` | choice | config value; `auto` matches source clips | `auto`, `4k`, `1080p`, or `720p` |
 | `--scale-mode` | `-s` | choice | config/`blur` | `blur` (blurred background) or `fit` (black bars) |
 | `--transition` | `-t` | choice | `smart` | `smart`, `cut`, `crossfade`, or `none` |
 | `--quality` | `-q` | choice | config value | `high`, `medium`, or `low` |
 | `--format` | — | choice | config value | `mp4`, `h265`, or `prores` |
-| `--output` | `-O` | path | auto | Where to write — see [Output](#output); the file lands in a per-run folder beside it |
+| `--output` | `-o`, `-O` | path | auto | Where to write — see [Output](#output); the file lands in a per-run folder beside it |
 | `--title` | — | string | — | Override title screen text |
 | `--subtitle` | — | string | — | Override subtitle text |
 | `--add-date` | — | flag | — | Caption each clip with its capture date |

--- a/docs-site/docs/create/cli/titles.md
+++ b/docs-site/docs/create/cli/titles.md
@@ -22,11 +22,11 @@ immich-memories titles test [OPTIONS]
 | `--person` | `-p` | string | — | Person name for subtitle |
 | `--month` | `-m` | int | — | Month number 1-12 (for month divider) |
 | `--type` | — | choice | `title` | `title`, `month`, or `ending` |
-| `--orientation` | `-o` | choice | `landscape` | `landscape`, `portrait`, `square` |
+| `--orientation` | — | choice | `landscape` | `landscape`, `portrait`, `square` |
 | `--resolution` | `-r` | choice | `1080p` | `720p`, `1080p`, `4k` |
 | `--locale` | `-l` | choice | `en` | `en` or `fr` |
 | `--style` | `-s` | choice | `random` | `modern_warm`, `elegant_minimal`, `vintage_charm`, `playful_bright`, `soft_romantic`, `random` |
-| `--output` | `-O` | path | `./title_screen_preview.mp4` | Output file |
+| `--output` | `-o`, `-O` | path | `./title_screen_preview.mp4` | Output file |
 | `--download-fonts` | — | flag | — | Download fonts before generating |
 | `--no-animated-background` | — | flag | — | Use static gradient instead of animation |
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -270,14 +270,14 @@ immich-memories generate [OPTIONS]
 | `--hemisphere` | choice: `north` \| `south` | north | Hemisphere for season calculation |
 | `--duration`, `-d` | integer | - | Target duration in seconds (default: from memory type preset) |
 | `--short-form` | choice: `15` \| `30` \| `60` \| `90` | - | Short-form preset: sets the duration and makes the video vertical |
-| `--orientation`, `-o` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |
+| `--orientation` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |
 | `--scale-mode`, `-s` | choice: `fit` \| `blur` | - | How to fill an aspect mismatch: blurred background or black bars (default: from config, else blur) |
 | `--transition`, `-t` | choice: `smart` \| `cut` \| `crossfade` \| `none` | smart | Transition style (default: smart — mix of fades & cuts) |
 | `--resolution`, `-r` | choice: `auto` \| `4k` \| `1080p` \| `720p` | - | Output resolution (default: config value, 'auto' to match source clips) |
 | `--music-volume` | float | 0.5 | Music volume 0.0-1.0 (default: 0.5) |
 | `--format` | choice: `mp4` \| `h265` \| `prores` | - | Output format override (default: config value) |
 | `--quality`, `-q` | choice: `high` \| `medium` \| `low` | - | Output quality (default: from config, typically high) |
-| `--output`, `-O` | path | - | Output file path |
+| `--output`, `-o`, `-O` | path | - | Output file path |
 | `--music`, `-m` | text | - | Music: path to audio file, 'auto' to generate from config, or omit for default behavior |
 | `--no-music` | boolean | false | Disable all music (skip both provided files and AI generation) |
 | `--dry-run` | boolean | false | Show what would be done without generating |
@@ -605,11 +605,11 @@ immich-memories titles test [OPTIONS]
 | `--birthday-age` | integer | - | Age for birthday title (e.g., 1 for '1st Year') |
 | `--person`, `-p` | text | - | Person name for subtitle |
 | `--month`, `-m` | integer | - | Month for month divider (1-12) |
-| `--orientation`, `-o` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |
+| `--orientation` | choice: `landscape` \| `portrait` \| `square` | landscape | Output orientation |
 | `--resolution`, `-r` | choice: `720p` \| `1080p` \| `4k` | 1080p | Output resolution |
 | `--locale`, `-l` | choice: `en` \| `fr` | en | Language |
 | `--style`, `-s` | choice: `modern_warm` \| `elegant_minimal` \| `vintage_charm` \| `playful_bright` \| `soft_romantic` \| `random` | random | Visual style |
-| `--output`, `-O` | path | - | Output file path |
+| `--output`, `-o`, `-O` | path | - | Output file path |
 | `--type` | choice: `title` \| `month` \| `ending` | title | Screen type |
 | `--download-fonts` | boolean | false | Download fonts before generating |
 | `--no-animated-background` | boolean | false | Disable animated backgrounds (static gradient) |

--- a/src/immich_memories/analysis/llm_failures.py
+++ b/src/immich_memories/analysis/llm_failures.py
@@ -1,0 +1,42 @@
+"""Telling a model that could not answer from a bug in the code that asked.
+
+Both LLM judgement calls in selection catch broadly on purpose. The pass is
+fail-open by design: an unreachable model must not be able to gut a memory or
+turn every day of a library into an ordinary one.
+
+The cost of that catch is that it swallows our own mistakes with the same
+silence. A keyword argument that did not match a callee's signature raised
+TypeError inside the ask, the catch read it as "the model could not answer",
+and the caller carried on with a verdict nobody produced. Across a scan the
+visible result is zero special days found, or nothing ever dropped from a cut,
+with no error anywhere — a wrong answer that looks exactly like a right one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Named rather than inferred, and inverted on purpose: anything unrecognised
+# keeps failing open, so a transport error nobody anticipated stays quiet
+# instead of becoming a crash. Enumerating the transport side instead would
+# risk missing an httpx subclass and breaking the resilience these catches
+# exist to provide.
+_OUR_OWN_BUGS = (TypeError, AttributeError, NameError, KeyError, IndexError)
+
+
+def stop_if_this_is_our_bug(exc: Exception, doing: str) -> None:
+    """Let a bug in this code stop the run; let an unreachable model pass.
+
+    Raised as well as logged. A bug here is the same bug on every clip and
+    every day, so swallowing it does not degrade the result — it produces a
+    complete, confident, empty one. Failing at the first call costs seconds
+    and says why.
+
+    The ERROR line carries the traceback so the diagnosis survives a catch
+    added upstream later, which is exactly how this hid the first time.
+    """
+    if isinstance(exc, _OUR_OWN_BUGS):
+        logger.error("The %s hit a bug in our own code", doing, exc_info=exc)
+        raise exc

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
     from immich_memories.config_models_llm import LLMConfig
 
+from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
+
 logger = logging.getLogger(__name__)
 
 # An overeager model must not gut the video: at most this share of the
@@ -156,6 +158,7 @@ def review_selection(
     try:
         raw = _ask(prompt, llm_config, timeout_seconds)
     except Exception as e:  # WHY broad: the review is optional; never break selection
+        stop_if_this_is_our_bug(e, "selection review")
         logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
         return []
 

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -527,6 +527,33 @@ def _ask(
     )
 
 
+# A model that cannot answer is not a verdict — that fail-open is deliberate,
+# because an unreachable LLM must not turn every day of a library into an
+# ordinary one. It swallowed our own mistakes too: a keyword argument that did
+# not match a callee's signature came back as a quiet special=False, and across
+# a scan that shape means zero special days found, every day, with nothing in
+# the log to say why.
+#
+# Named rather than inferred, and inverted on purpose: anything unrecognised
+# keeps failing open, so a transport error nobody anticipated stays quiet
+# instead of becoming a crash.
+_OUR_OWN_BUGS = (TypeError, AttributeError, NameError, KeyError, IndexError)
+
+
+def _stop_if_this_is_our_bug(exc: Exception, doing: str) -> None:
+    """Let a bug in this code stop the scan; let an unreachable model pass.
+
+    Raised as well as logged. A bug here is the same on every candidate day, so
+    a scan that swallows it does not degrade — it runs for hours and finds
+    nothing, which costs more than failing on the first day. The ERROR line
+    carries the traceback so the diagnosis survives a catch added upstream
+    later.
+    """
+    if isinstance(exc, _OUR_OWN_BUGS):
+        logger.error("Special-day %s hit a bug in our own code", doing, exc_info=exc)
+        raise exc
+
+
 _LOOK_PROMPT = "One line per picture, in order, numbered: what is in it."
 
 # Reasoning about a judgement call costs 5-10x the latency of a fast answer, and
@@ -554,6 +581,7 @@ def _look_at(
     try:
         raw = _ask(_LOOK_PROMPT, llm_config, timeout_seconds, [image for _, image in thumbnails])
     except Exception as exc:  # noqa: BLE001 - a look that fails is not a verdict
+        _stop_if_this_is_our_bug(exc, "look")
         logger.debug("Special-day look failed: %s", type(exc).__name__)
         return []
     # A null content is documented mlx-vlm behaviour, and the rest of this
@@ -616,6 +644,7 @@ def ask_if_special(
     try:
         raw = _ask(prompt, llm_config, timeout_seconds, images, thinking=reasons)
     except Exception as exc:  # noqa: BLE001 - an unreachable model is not a verdict
+        _stop_if_this_is_our_bug(exc, "question")
         logger.debug("Special-day question failed: %s", type(exc).__name__)
         return SpecialDay(special=False)
 

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
     from immich_memories.config_models_llm import LLMConfig
 
+from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
+
 logger = logging.getLogger(__name__)
 
 # A day has to stay alive this long, and hold this much, to be worth asking
@@ -527,33 +529,6 @@ def _ask(
     )
 
 
-# A model that cannot answer is not a verdict — that fail-open is deliberate,
-# because an unreachable LLM must not turn every day of a library into an
-# ordinary one. It swallowed our own mistakes too: a keyword argument that did
-# not match a callee's signature came back as a quiet special=False, and across
-# a scan that shape means zero special days found, every day, with nothing in
-# the log to say why.
-#
-# Named rather than inferred, and inverted on purpose: anything unrecognised
-# keeps failing open, so a transport error nobody anticipated stays quiet
-# instead of becoming a crash.
-_OUR_OWN_BUGS = (TypeError, AttributeError, NameError, KeyError, IndexError)
-
-
-def _stop_if_this_is_our_bug(exc: Exception, doing: str) -> None:
-    """Let a bug in this code stop the scan; let an unreachable model pass.
-
-    Raised as well as logged. A bug here is the same on every candidate day, so
-    a scan that swallows it does not degrade — it runs for hours and finds
-    nothing, which costs more than failing on the first day. The ERROR line
-    carries the traceback so the diagnosis survives a catch added upstream
-    later.
-    """
-    if isinstance(exc, _OUR_OWN_BUGS):
-        logger.error("Special-day %s hit a bug in our own code", doing, exc_info=exc)
-        raise exc
-
-
 _LOOK_PROMPT = "One line per picture, in order, numbered: what is in it."
 
 # Reasoning about a judgement call costs 5-10x the latency of a fast answer, and
@@ -581,7 +556,7 @@ def _look_at(
     try:
         raw = _ask(_LOOK_PROMPT, llm_config, timeout_seconds, [image for _, image in thumbnails])
     except Exception as exc:  # noqa: BLE001 - a look that fails is not a verdict
-        _stop_if_this_is_our_bug(exc, "look")
+        stop_if_this_is_our_bug(exc, "special-day look")
         logger.debug("Special-day look failed: %s", type(exc).__name__)
         return []
     # A null content is documented mlx-vlm behaviour, and the rest of this
@@ -644,7 +619,7 @@ def ask_if_special(
     try:
         raw = _ask(prompt, llm_config, timeout_seconds, images, thinking=reasons)
     except Exception as exc:  # noqa: BLE001 - an unreachable model is not a verdict
-        _stop_if_this_is_our_bug(exc, "question")
+        stop_if_this_is_our_bug(exc, "special-day question")
         logger.debug("Special-day question failed: %s", type(exc).__name__)
         return SpecialDay(special=False)
 

--- a/src/immich_memories/cli/_flags.py
+++ b/src/immich_memories/cli/_flags.py
@@ -1,0 +1,24 @@
+"""Shared behaviour for command-line flags that more than one command takes."""
+
+from __future__ import annotations
+
+import click
+
+_ORIENTATIONS = ("landscape", "portrait", "square")
+
+
+def output_path(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
+    """Validate --output, catching the one mistake this flag used to cause.
+
+    -o meant --orientation here until it meant --output, which is what it means
+    in every other tool and in `analyze export`. Reassigning it silently turns
+    an old `-o landscape` into a file named "landscape" — a wrong result that
+    looks like a right one. Three words are never a filename, so say so.
+    """
+    del ctx, param
+    if value in _ORIENTATIONS:
+        raise click.UsageError(
+            f"'{value}' is an orientation, not a file path. "
+            f"-o is now the output file; use --orientation {value} instead."
+        )
+    return value

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -17,6 +17,7 @@ from immich_memories.cli._date_resolution import (
     infer_memory_type,
     resolve_date_range,
 )
+from immich_memories.cli._flags import output_path
 from immich_memories.cli._generate_display import (
     _build_params_table,
     _print_generation_result,
@@ -249,7 +250,6 @@ def register_generate_commands(main: click.Group) -> None:
     )
     @click.option(
         "--orientation",
-        "-o",
         type=click.Choice(["landscape", "portrait", "square"]),
         default="landscape",
         help="Output orientation",
@@ -296,7 +296,14 @@ def register_generate_commands(main: click.Group) -> None:
         default=None,
         help="Output quality (default: from config, typically high)",
     )
-    @click.option("--output", "-O", type=click.Path(), help="Output file path")
+    @click.option(
+        "--output",
+        "-o",
+        "-O",
+        type=click.Path(),
+        callback=output_path,
+        help="Output file path",
+    )
     @click.option(
         "--music",
         "-m",

--- a/src/immich_memories/cli/titles.py
+++ b/src/immich_memories/cli/titles.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import click
 from rich.table import Table
 
+from immich_memories.cli._flags import output_path
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
 
 
@@ -128,7 +129,6 @@ def register_titles_commands(main: click.Group) -> None:
     @click.option("--month", "-m", type=int, help="Month for month divider (1-12)")
     @click.option(
         "--orientation",
-        "-o",
         type=click.Choice(["landscape", "portrait", "square"]),
         default="landscape",
         help="Output orientation",
@@ -157,7 +157,14 @@ def register_titles_commands(main: click.Group) -> None:
         default="random",
         help="Visual style",
     )
-    @click.option("--output", "-O", type=click.Path(), help="Output file path")
+    @click.option(
+        "--output",
+        "-o",
+        "-O",
+        type=click.Path(),
+        callback=output_path,
+        help="Output file path",
+    )
     @click.option(
         "--type",
         "screen_type",

--- a/tests/test_output_flag.py
+++ b/tests/test_output_flag.py
@@ -1,0 +1,49 @@
+"""-o means output, the way it does in every other command line tool.
+
+It meant --orientation on `generate` and `titles`, and --output on
+`analyze export`, in the same CLI. Reaching for the obvious one wrote nothing
+and failed with a message about landscape and portrait.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from immich_memories.cli import main
+
+
+def _help(*command: str) -> str:
+    with patch("immich_memories.cli.init_config_dir"):
+        return CliRunner().invoke(main, [*command, "--help"], catch_exceptions=False).output
+
+
+def test_dash_o_is_the_output_file_on_generate() -> None:
+    assert "-o, -O, --output" in _help("generate")
+
+
+def test_dash_o_is_the_output_file_on_titles() -> None:
+    assert "-o, -O, --output" in _help("titles", "test")
+
+
+def test_orientation_keeps_its_long_form() -> None:
+    assert "--orientation" in _help("generate")
+
+
+def test_orientation_no_longer_answers_to_dash_o() -> None:
+    """Reassigned, not shared: a short flag that means two things is the bug."""
+    orientation_line = next(
+        line for line in _help("generate").splitlines() if "--orientation" in line
+    )
+
+    assert orientation_line.strip().startswith("--orientation"), orientation_line
+
+
+def test_an_orientation_word_as_an_output_path_says_so() -> None:
+    """`-o landscape` used to be valid. Now it must not quietly write a file
+    called "landscape" — the whole point is that reaching for -o stops being
+    a way to get something you did not ask for."""
+    with patch("immich_memories.cli.init_config_dir"):
+        result = CliRunner().invoke(main, ["generate", "-o", "landscape"], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "--orientation" in result.output

--- a/tests/test_special_day_taxonomy.py
+++ b/tests/test_special_day_taxonomy.py
@@ -1,0 +1,87 @@
+"""A model that cannot answer is not a verdict. A bug in our code is not a model.
+
+The fail-open catch is load-bearing — an unreachable LLM must not turn every
+day into "ordinary". But it swallowed our own mistakes too: a keyword argument
+that did not match a callee's signature came back as a quiet special=False, and
+in a real scan that shape means zero special days found, for every day, with
+nothing in the log to say why.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from immich_memories.analysis.special_day import ask_if_special
+
+_VERDICT = '{"special": true, "title": "Pace and Light", "subtitle": "", "what": ""}'
+
+
+def _asset(hour: int = 10) -> SimpleNamespace:
+    return SimpleNamespace(
+        file_created_at=datetime(2021, 4, 4, hour, tzinfo=UTC),
+        exif_info=SimpleNamespace(city="Someplace", country="Belgium"),
+        people=[],
+    )
+
+
+def test_a_bug_in_our_own_code_stops_the_scan_loudly() -> None:
+    """The exact incident: a signature mismatch read as "not special"."""
+    # WHY: the ask path is the boundary; here our own call into it is wrong.
+    with (
+        patch(
+            "immich_memories.analysis.special_day._ask",
+            side_effect=TypeError("_capture() got an unexpected keyword argument 'thinking'"),
+        ),
+        pytest.raises(TypeError, match="unexpected keyword argument"),
+    ):
+        ask_if_special([_asset()], llm_config=SimpleNamespace())
+
+
+def test_a_model_that_cannot_be_reached_is_still_quietly_not_a_verdict() -> None:
+    """The fail-open path stays exactly as it was for transport failures."""
+    # WHY: the LLM server is the external boundary; here it is unreachable.
+    with patch(
+        "immich_memories.analysis.special_day._ask", side_effect=OSError("no route to host")
+    ):
+        verdict = ask_if_special([_asset()], llm_config=SimpleNamespace())
+
+    assert verdict.special is False
+
+
+def test_a_bug_during_the_look_stops_the_scan_too() -> None:
+    """Step one is our code as much as step two is."""
+    asset = _asset()
+
+    async def _broken(_prompt, _config, **kwargs):
+        if kwargs.get("images"):
+            raise AttributeError("'NoneType' object has no attribute 'name'")
+        return _VERDICT
+
+    # WHY: the LLM server is the external boundary; the bug is on our side of it.
+    with (
+        patch("immich_memories.analysis.llm_query.query_llm", new=_broken),
+        pytest.raises(AttributeError, match="has no attribute"),
+    ):
+        ask_if_special(
+            [asset],
+            llm_config=SimpleNamespace(thinking=True),
+            thumbnails=[(asset, b"jpeg-bytes")],
+        )
+
+
+def test_the_bug_is_logged_before_it_is_raised(caplog) -> None:
+    """Loud in the log as well as loud in the traceback: an upstream catch
+    somewhere later must not be able to erase the diagnosis."""
+    import logging
+
+    with (
+        # WHY: the ask path is the boundary; here our own call into it is wrong.
+        patch("immich_memories.analysis.special_day._ask", side_effect=TypeError("boom")),
+        caplog.at_level(logging.ERROR, logger="immich_memories.analysis.special_day"),
+        pytest.raises(TypeError),
+    ):
+        ask_if_special([_asset()], llm_config=SimpleNamespace())
+
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)

--- a/tests/test_special_day_taxonomy.py
+++ b/tests/test_special_day_taxonomy.py
@@ -85,3 +85,62 @@ def test_the_bug_is_logged_before_it_is_raised(caplog) -> None:
         ask_if_special([_asset()], llm_config=SimpleNamespace())
 
     assert any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+def test_the_selection_review_also_stops_on_our_own_bug() -> None:
+    """The same fail-open catch, the same swallowed mistake, the same fix.
+
+    Found live: changing _ask's signature made every review return "nothing to
+    drop" instead of raising. A cut that nothing was dropped from reads as a
+    cut nothing was wrong with.
+    """
+    from immich_memories.analysis.selection_review import review_selection
+
+    members = [_asset() for _ in range(4)]
+    selection = [
+        SimpleNamespace(
+            clip=SimpleNamespace(
+                asset=SimpleNamespace(id=f"a{i}", is_favorite=False, **vars(m)),
+                llm_description="something",
+            ),
+            start_time=0.0,
+            end_time=4.0,
+            score=0.5,
+            analyzed=True,
+        )
+        for i, m in enumerate(members)
+    ]
+
+    # WHY: the ask path is the boundary; here our own call into it is wrong.
+    with (
+        patch(
+            "immich_memories.analysis.selection_review._ask",
+            side_effect=TypeError("unexpected keyword argument"),
+        ),
+        pytest.raises(TypeError, match="unexpected keyword"),
+    ):
+        review_selection(selection, SimpleNamespace(model="m", thinking=True))
+
+
+def test_the_selection_review_still_survives_an_unreachable_model() -> None:
+    """And the fail-open it exists for is untouched."""
+    from immich_memories.analysis.selection_review import review_selection
+
+    members = [_asset() for _ in range(4)]
+    selection = [
+        SimpleNamespace(
+            clip=SimpleNamespace(
+                asset=SimpleNamespace(id=f"a{i}", is_favorite=False, **vars(m)),
+                llm_description="something",
+            ),
+            start_time=0.0,
+            end_time=4.0,
+            score=0.5,
+            analyzed=True,
+        )
+        for i, m in enumerate(members)
+    ]
+
+    # WHY: the LLM server is the external boundary; here it is unreachable.
+    with patch("immich_memories.analysis.selection_review._ask", side_effect=OSError("no route")):
+        assert review_selection(selection, SimpleNamespace(model="m", thinking=True)) == []


### PR DESCRIPTION
**Stacked on #564.** Two fixes made in one pass at the owner's request. They are separable — say so and I'll split them — but they are the same failure: *something that reports success while doing the wrong thing.*

---

## 1. Fail-open catches swallowed our own bugs

`ask_if_special` and `review_selection` both catch broadly on purpose. An unreachable LLM must not turn every day of a library into an ordinary one, or gut a cut. **That fail-open stays.**

What they also caught was *us*, twice, live, during this session:

- Building #538, a keyword argument didn't match a callee's signature. `TypeError` → caught → the day came back `special=False`.
- Building the judgment cache, changing `_ask`'s signature did the same to the review → **every review returned "nothing to drop"**.

A bug here is the same bug on every clip and every day, so swallowing it doesn't degrade the result — it produces a complete, confident, empty one. Zero special days found. Nothing ever dropped from a cut. No error anywhere.

### Raise, not log-and-continue

The worry is that propagation kills a long scan mid-flight. It inverts: **a scan that hits this was already dead and hadn't noticed.** It would have run to the end and found nothing. Failing at the first call costs seconds and says why. There is no broad catch around the call site in `automation/special_day_scan.py`, so raising genuinely stops it — which is the point.

### The taxonomy is inverted

```python
_OUR_OWN_BUGS = (TypeError, AttributeError, NameError, KeyError, IndexError)
```

Everything unrecognised **keeps failing open**. Enumerating the *transport* side instead risks missing an httpx subclass and converting a connection failure into a crash — the opposite mistake and the worse one, since it breaks the resilience these catches exist to provide.

Logged at ERROR with `exc_info` **and** raised, so the diagnosis survives a catch someone adds upstream later. That is exactly how it hid.

It lives in `analysis/llm_failures.py` so both callers share one rule rather than two copies that drift.

---

## 2. `-o` writes a file, the way it does everywhere else

`-o` meant `--orientation` on `generate` and `titles`, and `--output` on `analyze export` — in the same CLI. Reaching for the obvious one wrote nothing and failed with a message about landscape and portrait.

`-o` and `-O` now both mean `--output`. `--orientation` keeps its long form only: a short flag that means two things is the bug, so it is reassigned rather than shared.

**Reassigning it has a trap.** An old `-o landscape` would stop being an error and start writing a file called `landscape` — a wrong result that looks like a right one. So `--output` rejects the three orientation words and points at `--orientation`.

Nothing used the old spelling: verified against every docs page, every script, and all 35 sweep-spec entries.

---

## Tests

Strict TDD throughout. RED failures were `DID NOT RAISE` (×3) and a missing flag, each verified for the right reason before implementing.

The incidents are the acceptance tests: a signature-mismatch `TypeError` must surface from *both* the special-day ask and the selection review, while a connection failure still yields the quiet not-a-verdict in both.

One test caught my own sloppiness: `assert "-o" not in orientation_line` passed for the wrong reason, because `-o` is a substring of `--orientation`.

`make ci` exit 0.
