### PR TITLE
fix(live-photos): encode merged bursts under a resolved plan, not a hardcoded one

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2386,16 +2386,12 @@
       {
         "name": "_extract_clips",
         "complexity": 25,
-        "line_start": 95,
-        "line_end": 181,
+        "line_start": 96,
+        "line_end": 182,
         "line_complexities": [
           {
-            "line": 109,
+            "line": 110,
             "complexity": 2
-          },
-          {
-            "line": 112,
-            "complexity": 0
           },
           {
             "line": 113,
@@ -2407,74 +2403,78 @@
           },
           {
             "line": 115,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 116,
-            "complexity": 0
+            "complexity": 1
           },
           {
-            "line": 118,
-            "complexity": 1
+            "line": 117,
+            "complexity": 0
           },
           {
             "line": 119,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 120,
-            "complexity": 1
+            "complexity": 0
           },
           {
-            "line": 127,
-            "complexity": 4
+            "line": 121,
+            "complexity": 1
           },
           {
             "line": 128,
-            "complexity": 0
+            "complexity": 4
           },
           {
             "line": 129,
-            "complexity": 4
+            "complexity": 0
           },
           {
-            "line": 133,
-            "complexity": 0
+            "line": 130,
+            "complexity": 4
           },
           {
             "line": 134,
-            "complexity": 4
-          },
-          {
-            "line": 138,
-            "complexity": 1
-          },
-          {
-            "line": 143,
             "complexity": 0
           },
           {
-            "line": 152,
+            "line": 135,
+            "complexity": 4
+          },
+          {
+            "line": 139,
+            "complexity": 1
+          },
+          {
+            "line": 144,
             "complexity": 0
           },
           {
             "line": 153,
-            "complexity": 3
-          },
-          {
-            "line": 158,
-            "complexity": 3
-          },
-          {
-            "line": 162,
             "complexity": 0
           },
           {
-            "line": 177,
+            "line": 154,
+            "complexity": 3
+          },
+          {
+            "line": 159,
+            "complexity": 3
+          },
+          {
+            "line": 163,
+            "complexity": 0
+          },
+          {
+            "line": 178,
             "complexity": 1
           },
           {
-            "line": 181,
+            "line": 182,
             "complexity": 0
           }
         ]
@@ -2489,51 +2489,51 @@
       {
         "name": "_download_burst_clips",
         "complexity": 16,
-        "line_start": 157,
-        "line_end": 192,
+        "line_start": 164,
+        "line_end": 199,
         "line_complexities": [
           {
-            "line": 169,
+            "line": 176,
             "complexity": 0
-          },
-          {
-            "line": 170,
-            "complexity": 1
-          },
-          {
-            "line": 171,
-            "complexity": 2
-          },
-          {
-            "line": 172,
-            "complexity": 0
-          },
-          {
-            "line": 173,
-            "complexity": 3
           },
           {
             "line": 177,
-            "complexity": 2
-          },
-          {
-            "line": 178,
-            "complexity": 0
-          },
-          {
-            "line": 179,
-            "complexity": 3
-          },
-          {
-            "line": 185,
-            "complexity": 4
-          },
-          {
-            "line": 187,
             "complexity": 1
           },
           {
+            "line": 178,
+            "complexity": 2
+          },
+          {
+            "line": 179,
+            "complexity": 0
+          },
+          {
+            "line": 180,
+            "complexity": 3
+          },
+          {
+            "line": 184,
+            "complexity": 2
+          },
+          {
+            "line": 185,
+            "complexity": 0
+          },
+          {
+            "line": 186,
+            "complexity": 3
+          },
+          {
             "line": 192,
+            "complexity": 4
+          },
+          {
+            "line": 194,
+            "complexity": 1
+          },
+          {
+            "line": 199,
             "complexity": 0
           }
         ]
@@ -2651,101 +2651,101 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 815,
-        "line_end": 914,
+        "line_start": 634,
+        "line_end": 733,
         "line_complexities": [
           {
-            "line": 836,
+            "line": 655,
             "complexity": 0
           },
           {
-            "line": 837,
+            "line": 656,
             "complexity": 1
           },
           {
-            "line": 839,
+            "line": 658,
             "complexity": 1
           },
           {
-            "line": 840,
+            "line": 659,
             "complexity": 0
           },
           {
-            "line": 841,
+            "line": 660,
             "complexity": 2
           },
           {
-            "line": 842,
+            "line": 661,
             "complexity": 0
           },
           {
-            "line": 849,
+            "line": 668,
             "complexity": 1
           },
           {
-            "line": 853,
+            "line": 672,
             "complexity": 0
           },
           {
-            "line": 854,
+            "line": 673,
             "complexity": 0
           },
           {
-            "line": 855,
+            "line": 674,
             "complexity": 1
           },
           {
-            "line": 856,
+            "line": 675,
             "complexity": 0
           },
           {
-            "line": 857,
+            "line": 676,
             "complexity": 2
           },
           {
-            "line": 858,
+            "line": 677,
             "complexity": 0
           },
           {
-            "line": 865,
+            "line": 684,
             "complexity": 1
           },
           {
-            "line": 869,
+            "line": 688,
             "complexity": 0
           },
           {
-            "line": 872,
+            "line": 691,
             "complexity": 0
           },
           {
-            "line": 873,
+            "line": 692,
             "complexity": 2
           },
           {
-            "line": 874,
+            "line": 693,
             "complexity": 3
           },
           {
-            "line": 876,
+            "line": 695,
             "complexity": 1
           },
           {
-            "line": 879,
+            "line": 698,
             "complexity": 0
           },
           {
-            "line": 913,
+            "line": 732,
             "complexity": 1
           },
           {
-            "line": 914,
+            "line": 733,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 103
+    "complexity": 70
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/docs-site/docs/create/pipeline/live-photos.md
+++ b/docs-site/docs/create/pipeline/live-photos.md
@@ -51,6 +51,17 @@ If there aren't enough regular videos to fill the target, live photos get select
 
 When you rapid-fire photos, each Live Photo's video overlaps with the next. The merger uses **audio spectrogram fingerprinting** to find the exact overlap, then cuts at the midpoint between consecutive shutter presses.
 
+### How the merged file is encoded
+
+Bursts are merged while clips are still downloading, before the run has resolved the encoding plan
+for its final video. The merge resolves its own: your hardware encoder if `hardware.enabled` is on
+and a real test encode succeeded, software otherwise, at CRF 18.
+
+It deliberately does not adopt the run's output settings. The merged file is an intermediate that
+gets re-encoded during assembly, and an HLG burst in a memory you asked to output as SDR H.264 would
+be tone-mapped here — before anything had decided to. So HDR bursts stay H.265 10-bit with their
+transfer intact, and the assembler decides what to do with them later.
+
 ### Why audio alignment?
 
 Timestamps alone aren't precise enough: each clip's video doesn't start at exactly `shutter_time - 1.5s`. The actual start varies by up to 200ms. On rapid bursts, that's enough to cause audible clicks and gaps.

--- a/src/immich_memories/generate_clips.py
+++ b/src/immich_memories/generate_clips.py
@@ -81,6 +81,7 @@ def _download_video_path(
             clip,
             output_dir,
             prefetched_burst_results=burst_results,
+            hardware_enabled=params.config.hardware.enabled,
         )
 
     prefetched_result = prefetched.get(clip.asset.id) if prefetched is not None else None

--- a/src/immich_memories/generate_downloads.py
+++ b/src/immich_memories/generate_downloads.py
@@ -29,10 +29,14 @@ def download_clip(
     output_dir: Path,
     *,
     prefetched_burst_results: Mapping[str, DownloadResult] | None = None,
+    hardware_enabled: bool = True,
 ) -> Path | None:
     """Download a single clip, handling live photo bursts.
 
     If clip.local_path is already set and the file exists, skip downloading.
+
+    ``hardware_enabled`` reaches only the burst merge, which is the one place
+    this module encodes video (#504).
     """
     # Use pre-downloaded clip if available (e.g., from analysis cache)
     if clip.local_path and Path(clip.local_path).exists():
@@ -48,6 +52,7 @@ def download_clip(
             clip,
             output_dir,
             prefetched_burst_results=prefetched_burst_results,
+            hardware_enabled=hardware_enabled,
         )
 
     if video_cache is None:
@@ -62,6 +67,7 @@ def _download_and_merge_burst(
     output_dir: Path,
     *,
     prefetched_burst_results: Mapping[str, DownloadResult] | None = None,
+    hardware_enabled: bool = True,
 ) -> Path | None:
     """Download live photo burst videos and merge into one file."""
     burst_ids = clip.live_burst_video_ids or []
@@ -92,6 +98,7 @@ def _download_and_merge_burst(
         trim_points,
         merged_path,
         shutter_timestamps=clip.live_burst_shutter_timestamps,
+        hardware_enabled=hardware_enabled,
     )
     return merged or _download_fallback(client, video_cache, clip.asset, output_dir)
 
@@ -229,6 +236,8 @@ def _try_merge_burst(
     trim_points: list,
     merged_path: Path,
     shutter_timestamps: list[float] | None = None,
+    *,
+    hardware_enabled: bool = True,
 ) -> Path | None:
     """Try to merge burst clips with spectrogram-aligned audio/video.
 
@@ -284,7 +293,13 @@ def _try_merge_burst(
             logger.warning(f"Spectrogram alignment failed, using timestamp trims: {e}")
             audio_trims = None
 
-    cmd = build_merge_command(valid_paths, valid_trims, merged_path, audio_trim_points=audio_trims)
+    cmd = build_merge_command(
+        valid_paths,
+        valid_trims,
+        merged_path,
+        audio_trim_points=audio_trims,
+        hardware_enabled=hardware_enabled,
+    )
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)  # noqa: S603
         if result.returncode == 0 and merged_path.exists():

--- a/src/immich_memories/processing/live_photo_merger.py
+++ b/src/immich_memories/processing/live_photo_merger.py
@@ -19,9 +19,24 @@ if TYPE_CHECKING:
     import numpy as np
 
 from immich_memories.api.models import Asset
+from immich_memories.processing.encoding_plan import (
+    EncodingPlan,
+    EncodingRequest,
+    HdrMode,
+    OutputCodec,
+    resolve_encoding_plan,
+)
+from immich_memories.processing.hardware import HWAccelCapabilities
+from immich_memories.processing.hardware_detection import detect_hardware_acceleration
 
 # Default Live Photo clip duration (1.5s before + 1.5s after shutter)
 DEFAULT_CLIP_DURATION = 3.0
+
+# A merged burst is an intermediate: the assembler re-encodes it under the run's
+# own plan, so this only has to survive one more generation without visible
+# loss. 18 is the project's default CRF and is near-transparent; going lower
+# would only grow a file that is deleted at the end of the run.
+BURST_CRF = 18
 
 
 def estimate_clip_duration(asset: Asset) -> float:
@@ -540,6 +555,7 @@ def build_merge_command(
     output: Path,
     *,
     audio_trim_points: list[tuple[float, float]] | None = None,
+    hardware_enabled: bool = True,
 ) -> list[str]:
     """Build an FFmpeg command that trims and merges Live Photo clips.
 
@@ -550,8 +566,9 @@ def build_merge_command(
     (iPhone MOV containers have ~50ms audio/video offset). A 30ms fade at each
     audio boundary prevents crackling from waveform discontinuities.
 
-    HDR clips (iPhone HLG) are encoded with libx265 10-bit to preserve
-    color metadata. SDR clips use libx264.
+    HDR clips (iPhone HLG) are encoded as H.265 10-bit to preserve color
+    metadata; SDR clips use H.264. Which encoder implements that, and at what
+    quality, comes from ``burst_encoding_plan`` rather than being hardcoded.
     """
     is_hdr = bool(clip_paths) and _detect_clip_hdr(clip_paths[0])
     has_audio = all(probe_clip_has_audio(p) for p in clip_paths)
@@ -567,7 +584,8 @@ def build_merge_command(
     )
     _build_concat_and_map(cmd, parts, v_labels, a_labels, n, has_audio)
 
-    _append_encoding_args(cmd, is_hdr, has_audio, output)
+    plan = burst_encoding_plan(is_hdr=is_hdr, hardware_enabled=hardware_enabled)
+    _append_encoding_args(cmd, plan, has_audio, output)
     return cmd
 
 
@@ -637,27 +655,53 @@ def _build_concat_and_map(
             cmd.extend(["-map", f"[{a_labels[0].strip('[]')}]"])
 
 
-def _append_encoding_args(cmd: list[str], is_hdr: bool, has_audio: bool, output: Path) -> None:
+def burst_encoding_plan(*, is_hdr: bool, hardware_enabled: bool = True) -> EncodingPlan:
+    """The encoding contract for a merged burst.
+
+    Bursts merge at download time, before the run has resolved its own
+    ``EncodingPlan``, which is why this path used to hardcode an encoder. It
+    does not need the run's plan: the merged file is an intermediate that the
+    assembler re-encodes, and adopting an SDR output plan here would tone-map an
+    HDR burst before anything had chosen to. What it needs is the run's machine,
+    and ``detect_hardware_acceleration`` is ``lru_cache``d process-wide, so
+    asking for it here costs a dict lookup after the first probe.
+
+    The codec follows the source rather than the output: HLG bursts stay H.265
+    10-bit so the transfer survives to the assembler.
+    """
+    capabilities = detect_hardware_acceleration() if hardware_enabled else HWAccelCapabilities()
+    request = EncodingRequest(
+        codec=OutputCodec.H265 if is_hdr else OutputCodec.H264,
+        hdr_mode=HdrMode.HDR if is_hdr else HdrMode.SDR,
+        hardware_enabled=hardware_enabled,
+        # An intermediate is not worth a slow preset; the CRF carries the quality.
+        preset="fast",
+        crf=BURST_CRF,
+        container="mp4",
+    )
+    return resolve_encoding_plan(request, capabilities, input_has_hdr=is_hdr)
+
+
+def _append_encoding_args(
+    cmd: list[str], plan: EncodingPlan, has_audio: bool, output: Path
+) -> None:
     """Append video/audio codec arguments to the FFmpeg command."""
-    if is_hdr:
+    cmd.extend(["-c:v", plan.encoder, *plan.encoder_args, "-pix_fmt", plan.pixel_format])
+
+    if plan.hdr:
         cmd.extend(
             [
-                "-c:v",
-                "libx265",
-                "-pix_fmt",
-                "yuv420p10le",
                 "-color_primaries",
                 "bt2020",
                 "-color_trc",
                 "arib-std-b67",
                 "-colorspace",
                 "bt2020nc",
-                "-tag:v",
-                "hvc1",
             ]
         )
-    else:
-        cmd.extend(["-c:v", "libx264"])
+    if plan.codec is OutputCodec.H265:
+        # hev1 is the FFmpeg default in MP4 and will not play on Apple devices.
+        cmd.extend(["-tag:v", "hvc1"])
 
     if has_audio:
         cmd.extend(["-c:a", "aac"])

--- a/src/immich_memories/processing/live_photo_merger.py
+++ b/src/immich_memories/processing/live_photo_merger.py
@@ -685,23 +685,15 @@ def burst_encoding_plan(*, is_hdr: bool, hardware_enabled: bool = True) -> Encod
 def _append_encoding_args(
     cmd: list[str], plan: EncodingPlan, has_audio: bool, output: Path
 ) -> None:
-    """Append video/audio codec arguments to the FFmpeg command."""
-    cmd.extend(["-c:v", plan.encoder, *plan.encoder_args, "-pix_fmt", plan.pixel_format])
+    """Append video/audio codec arguments to the FFmpeg command.
 
-    if plan.hdr:
-        cmd.extend(
-            [
-                "-color_primaries",
-                "bt2020",
-                "-color_trc",
-                "arib-std-b67",
-                "-colorspace",
-                "bt2020nc",
-            ]
-        )
-    if plan.codec is OutputCodec.H265:
-        # hev1 is the FFmpeg default in MP4 and will not play on Apple devices.
-        cmd.extend(["-tag:v", "hvc1"])
+    Shares ``encoder_args_for_plan`` with the assembler rather than restating
+    the codec/pixel-format/colour-tag rules, which is how the two drifted apart
+    in the first place.
+    """
+    from immich_memories.processing.clip_encoder import encoder_args_for_plan
+
+    cmd.extend(encoder_args_for_plan(plan))
 
     if has_audio:
         cmd.extend(["-c:a", "aac"])

--- a/tests/test_burst_encoding_plan.py
+++ b/tests/test_burst_encoding_plan.py
@@ -1,0 +1,130 @@
+"""A merged Live Photo burst is encoded under a plan, not a hardcoded encoder (#504).
+
+The merge runs at download time, before the run's own EncodingPlan exists, so it
+used to hardcode libx264 (libx265 for HDR) with no quality setting and no
+hardware encoder. On a hardware-encode machine the bursts were the only
+software-encoded clips in the memory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from immich_memories.processing.hardware import HWAccelBackend, HWAccelCapabilities
+from immich_memories.processing.live_photo_merger import build_merge_command
+
+
+def _apple() -> HWAccelCapabilities:
+    return HWAccelCapabilities(
+        backend=HWAccelBackend.APPLE,
+        supports_h264_encode=True,
+        supports_h265_encode=True,
+    )
+
+
+def _merge_command(
+    *,
+    is_hdr: bool = False,
+    hardware_enabled: bool = True,
+    capabilities: HWAccelCapabilities | None = None,
+) -> list[str]:
+    caps = capabilities if capabilities is not None else HWAccelCapabilities()
+    with (
+        # WHY: the audio ffprobe boundary.
+        patch(
+            "immich_memories.processing.live_photo_merger.probe_clip_has_audio",
+            return_value=False,
+        ),
+        # WHY: the HDR ffprobe boundary.
+        patch(
+            "immich_memories.processing.live_photo_merger._detect_clip_hdr",
+            return_value=is_hdr,
+        ),
+        # WHY: the FFmpeg encoder probe, so the assertions do not depend on the
+        # machine running the tests.
+        patch(
+            "immich_memories.processing.live_photo_merger.detect_hardware_acceleration",
+            return_value=caps,
+        ),
+    ):
+        return build_merge_command(
+            [Path("a.mov")],
+            [(0.0, 1.0)],
+            Path("out.mp4"),
+            hardware_enabled=hardware_enabled,
+        )
+
+
+def _encoder(cmd: list[str]) -> str:
+    return cmd[cmd.index("-c:v") + 1]
+
+
+def test_the_burst_is_encoded_at_a_stated_quality() -> None:
+    """No CRF meant the encoder's own default, which is not the one the rest of
+    the run uses and is not written down anywhere."""
+    cmd = _merge_command()
+
+    assert "-crf" in cmd
+    assert cmd[cmd.index("-crf") + 1] == "18"
+
+
+def test_a_hardware_machine_encodes_the_burst_in_hardware() -> None:
+    """Bursts were the only software-encoded clips on a hardware-encode setup."""
+    assert _encoder(_merge_command(capabilities=_apple())) == "h264_videotoolbox"
+
+
+def test_disabling_hardware_is_still_honoured() -> None:
+    """The probe is process-wide, but the user's switch still decides."""
+    assert _encoder(_merge_command(capabilities=_apple(), hardware_enabled=False)) == "libx264"
+
+
+def test_no_hardware_available_falls_back_to_software() -> None:
+    assert _encoder(_merge_command()) == "libx264"
+
+
+@pytest.mark.parametrize("hardware_enabled", [True, False])
+def test_an_hdr_burst_keeps_its_hlg_metadata_and_ten_bits(hardware_enabled: bool) -> None:
+    """The merged file is an intermediate the assembler still has to read as HDR.
+    Losing the transfer here would tone-map the burst before anything chose to."""
+    cmd = _merge_command(is_hdr=True, capabilities=_apple(), hardware_enabled=hardware_enabled)
+
+    assert cmd[cmd.index("-color_trc") + 1] == "arib-std-b67"
+    assert cmd[cmd.index("-color_primaries") + 1] == "bt2020"
+    assert cmd[cmd.index("-colorspace") + 1] == "bt2020nc"
+    assert "10" in cmd[cmd.index("-pix_fmt") + 1]
+    # HEVC in MP4 needs hvc1 rather than hev1 to play on Apple devices.
+    assert cmd[cmd.index("-tag:v") + 1] == "hvc1"
+
+
+def test_an_hdr_burst_uses_the_hardware_hevc_encoder() -> None:
+    assert _encoder(_merge_command(is_hdr=True, capabilities=_apple())) == "hevc_videotoolbox"
+
+
+def test_the_download_path_carries_the_setting_into_the_merge() -> None:
+    """The plan is only worth resolving if the run's switch reaches it: the merge
+    happens under the downloader, several hops from where the config is read."""
+    from immich_memories.generate_downloads import _try_merge_burst
+
+    clips = [Path("a.mov"), Path("b.mov")]
+    trims = [(0.0, 1.0), (0.0, 1.0)]
+
+    with (
+        # WHY: the ffprobe validation of files that do not exist on disk.
+        patch(
+            "immich_memories.processing.live_photo_merger.filter_valid_clips",
+            return_value=(clips, trims),
+        ),
+        # WHY: the unit under test is what gets asked for, not the command itself.
+        patch(
+            "immich_memories.processing.live_photo_merger.build_merge_command",
+            return_value=["ffmpeg"],
+        ) as build,
+        # WHY: replaces the FFmpeg run.
+        patch("immich_memories.generate_downloads.subprocess.run"),
+    ):
+        _try_merge_burst(clips, trims, Path("out.mp4"), hardware_enabled=False)
+
+    assert build.call_args.kwargs["hardware_enabled"] is False


### PR DESCRIPTION
Closes #504.

## What

`live_photo_merger` ran the merge with `-c:v libx264` (`libx265` for HDR), **no CRF** and **no hardware encoder**. On a hardware-encode machine the merged Live Photos were the only software-encoded clips in the memory, at whatever quality the encoder happened to default to.

## Which option, and why

The issue offered two. I took **"resolve a minimal encoding plan before the merge"**.

Re-encoding merged bursts later under the run's plan would add a *second full generation of loss* and a second pass over every burst, to fix an encoder choice that costs nothing to make correctly the first time. The merge already encodes once; the fix is to encode once, well.

## Why the plan is resolved locally rather than threaded down

Two things made this cheap, and one made it necessary:

1. **The probe is free after the first call.** `detect_hardware_acceleration` is `@lru_cache(maxsize=1)`, so asking for capabilities at download time is a dict lookup. `cache/video_cache.py` already leans on exactly this for analysis decoding — same trick, same reason.
2. **The run's own output plan would be the *wrong* plan.** This is the part worth pausing on: a memory rendered as SDR H.264 would **tone-map an HLG burst here**, at download time, before the assembler had chosen to. That's a quality regression disguised as consistency. The codec follows the *source* instead — HDR bursts stay H.265 10-bit with the transfer intact — and the assembler decides later.

So "the run's EncodingPlan never reaches it" turns out to be correct behaviour for the codec, and a genuine bug only for the *encoder* and the *quality*. This PR fixes those two and leaves the codec source-driven.

`hardware.enabled` **is** threaded from the run, so the user's switch is still honoured. It reaches only the burst merge — the one place the download path encodes video.

CRF 18 matches the project default and is near-transparent. The merged file is an intermediate the assembler re-encodes, so a lower CRF would only grow a file that gets deleted at the end of the run.

## Tests

`tests/test_burst_encoding_plan.py`, all RED before the change. Capabilities are injected, so nothing depends on the machine running the suite:

- CRF is present and stated (`18`), rather than left to the encoder default.
- Apple caps produce `h264_videotoolbox`; `hardware_enabled=False` produces `libx264`; no caps produce `libx264`.
- HDR keeps `arib-std-b67` / `bt2020` / `bt2020nc`, 10-bit, and `hvc1` — parametrised over hardware on and off, because losing the transfer on either path tone-maps the burst early.
- HDR plus Apple caps produce `hevc_videotoolbox`.
- `_try_merge_burst` actually forwards the setting — the fix is worthless if the switch does not reach the merge.

`make ci` passes (5513 passed, 9 skipped). `make docs-build` passes.

## Test gap I want to be honest about

The final hop — `generate_clips` reading `params.config.hardware.enabled` into `download_clip` — has **no test**. Covering it needs a client, a cache batch, a burst-shaped clip and real downloads, which puts it over the 3-mock limit in `CLAUDE.md`. It is a one-line keyword pass and typed, but it is not verified by a test. An integration test under `tests/integration/live_photos/` would be the right home.

## Adjacent findings (not fixed here)

1. **The 30 fps hardcode the issue mentions is genuinely gone** — `burst_fps` measures the fastest clip. Confirmed while working here.
2. `_append_encoding_args` previously emitted no `-pix_fmt` at all for SDR, so the output format was whatever the filter chain produced. It is now explicit (`yuv420p`), which is a small behaviour change worth knowing on inputs that decoded to something else.
3. The merge has a real safety net: if the encoder fails, `_try_merge_burst` returns `None` and the caller falls back to downloading the single video component. So a broken hardware encoder degrades the burst rather than failing the run — worth remembering if a hardware path ever misbehaves in the wild.
4. **Second commit reuses the assembler's encoder args.** The first pass hand-rolled the codec / pixel-format / colour-tag block; `clip_encoder.encoder_args_for_plan` already owned exactly those rules, which is how the two drifted apart originally. Sharing it also picks up PQ handling — the hand-rolled version tagged every HDR burst as HLG.
5. **VAAPI/QSV need `-init_hw_device` + `hwupload` to accept software frames** (see `_PROBE_UPLOAD_ARGS` in `hardware.py`, which does this for the probe). Neither this merge nor `streaming_assembler`'s encode supplies it, so those two backends have the same gap on both paths. This PR does not introduce that — it adopts the project's existing encoder contract, which was the point of the issue — and the merge degrades safely if the encode fails (falls back to the single video component). Worth its own look for anyone on Intel/AMD Linux.
