### PR TITLE
feat(llm): pay for a judgement once, not once per round

### DIFF
--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -21,6 +21,7 @@ from immich_memories.config_models_llm import LLMConfig
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +136,15 @@ async def query_llm(
     thinking: bool = False,
     images: Sequence[bytes] = (),
     image_detail: str = "low",
+    cache_path: Path | None = None,
 ) -> str:
     """Send a prompt, optionally with JPEG images, and return the response.
+
+    cache_path opts this call into reuse: an identical question to an identical
+    model gets the answer it got before, rather than being paid for again.
+    Deliberately opt-in — a health probe must reach the server every time — and
+    deliberately refused for image-bearing calls, whose pictures a prompt hash
+    cannot see.
 
     thinking=True asks a reasoning model to reason before answering — only
     honored when the config says the server supports it (llm.thinking), never
@@ -145,6 +153,73 @@ async def query_llm(
     for judgement calls: measured cost is 5-10x latency and 10-20x tokens.
     """
     llm_config = _resolved(llm_config)
+    # A prompt hash cannot see the pictures, so an image-bearing call with a
+    # fixed prompt template — "one line per picture, in order" — would key
+    # identically for two entirely different days and serve one the other's
+    # answer. Vision is cached per asset upstream, where the key is the asset
+    # id, so there is nothing for this layer to add and everything to get
+    # wrong.
+    remembered = _remembered(cache_path, llm_config, prompt, thinking) if not images else None
+    if remembered is not None:
+        logger.debug("Reusing the answer to an identical question")
+        return remembered
+    answer = await _dispatch(
+        prompt,
+        llm_config,
+        temperature,
+        max_tokens,
+        timeout_seconds,
+        thinking,
+        images,
+        image_detail,
+    )
+    if not images:
+        _remember(cache_path, llm_config, prompt, thinking, answer)
+    return answer
+
+
+def _cache_key(llm_config: LLMConfig, prompt: str, thinking: bool) -> str:
+    from immich_memories.cache.judgment_cache import judgment_key
+
+    return judgment_key(
+        model=getattr(llm_config, "model", None),
+        prompt=prompt,
+        thinking=bool(thinking and getattr(llm_config, "thinking", False)),
+    )
+
+
+def _remembered(
+    cache_path: Path | None, llm_config: LLMConfig, prompt: str, thinking: bool
+) -> str | None:
+    """What this exact question was answered with before, if it was."""
+    if cache_path is None:
+        return None
+    from immich_memories.cache.judgment_cache import JudgmentCache
+
+    return JudgmentCache(cache_path).answer_for(_cache_key(llm_config, prompt, thinking))
+
+
+def _remember(
+    cache_path: Path | None, llm_config: LLMConfig, prompt: str, thinking: bool, answer: str
+) -> None:
+    """Keep an answer. Silence is never kept — a failed call must not stick."""
+    if cache_path is None or not answer:
+        return
+    from immich_memories.cache.judgment_cache import JudgmentCache
+
+    JudgmentCache(cache_path).remember(_cache_key(llm_config, prompt, thinking), answer)
+
+
+async def _dispatch(
+    prompt: str,
+    llm_config: LLMConfig,
+    temperature: float,
+    max_tokens: int,
+    timeout_seconds: int,
+    thinking: bool,
+    images: Sequence[bytes],
+    image_detail: str,
+) -> str:
     if llm_config.provider == "ollama":
         return await _query_ollama(prompt, llm_config, temperature, timeout_seconds, images)
     think = thinking and llm_config.thinking and not images

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -18,6 +18,8 @@ from immich_memories.analysis import selection_trace as trace
 from immich_memories.analysis.source_filter import is_a_still
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from immich_memories.analysis.clip_analyzer import ClipAnalyzer
     from immich_memories.analysis.clip_refiner import ClipRefiner
     from immich_memories.analysis.progress import ProgressTracker
@@ -65,6 +67,18 @@ class SelectionQuality:
         self._app_config = app_config
         # Clips the verify pass has already looked at, across every entry.
         self._verify_attempted: set[str] = set()
+
+    @property
+    def _verdicts(self) -> Path:
+        """Where a judgement about an identical selection is kept.
+
+        Its own file beside the analysis cache rather than a table inside it:
+        that database carries a SCHEMA_VERSION users' stored analysis keys off,
+        and this is derived data that may be deleted at any time.
+        """
+        from immich_memories.cache.judgment_cache import verdicts_beside
+
+        return verdicts_beside(self._app_config.cache.cache_path)
 
     def stabilize(
         self,
@@ -231,7 +245,7 @@ class SelectionQuality:
 
         by_id = {c.clip.asset.id: c for c in analyzed}
         selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = set(review_selection(selected, self._app_config.llm))
+        drops = set(review_selection(selected, self._app_config.llm, cache_path=self._verdicts))
         if not drops:
             return result, analyzed
 
@@ -414,7 +428,7 @@ class SelectionQuality:
 
         by_id = {c.clip.asset.id: c for c in analyzed}
         selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = review_selection(selected, self._app_config.llm)
+        drops = review_selection(selected, self._app_config.llm, cache_path=self._verdicts)
         if not drops:
             trace.record("llm review", selected, selected)
             return result, analyzed, False

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -19,6 +19,8 @@ import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
     from immich_memories.config_models_llm import LLMConfig
 
@@ -82,12 +84,19 @@ Most good selections need no changes. Answer with STRICT JSON only, no prose:
 Use an empty list when the set is good."""
 
 
-def _ask(prompt: str, llm_config: LLMConfig, timeout_seconds: int) -> str:
+def _ask(
+    prompt: str, llm_config: LLMConfig, timeout_seconds: int, cache_path: Path | None = None
+) -> str:
     from immich_memories.analysis.llm_query import query_llm
 
     return asyncio.run(
         query_llm(
-            prompt, llm_config, temperature=0.2, timeout_seconds=timeout_seconds, thinking=True
+            prompt,
+            llm_config,
+            temperature=0.2,
+            timeout_seconds=timeout_seconds,
+            thinking=True,
+            cache_path=cache_path,
         )
     )
 
@@ -138,6 +147,7 @@ def review_selection(
     llm_config: LLMConfig,
     *,
     timeout_seconds: int = 45,
+    cache_path: Path | None = None,
 ) -> list[str]:
     """Asset ids the LLM says to drop from the selection; [] on any doubt.
 
@@ -154,7 +164,7 @@ def review_selection(
     clips_block = "\n".join(_clip_line(i + 1, m) for i, m in enumerate(selected))
     prompt = _PROMPT.format(clips=clips_block)
     try:
-        raw = _ask(prompt, llm_config, timeout_seconds)
+        raw = _ask(prompt, llm_config, timeout_seconds, cache_path)
     except Exception as e:  # WHY broad: the review is optional; never break selection
         logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
         return []

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -1,0 +1,110 @@
+"""Answers to judgement-call prompts, keyed by exactly what was asked.
+
+A judgement call is the expensive kind: reasoning mode costs 5-10x the latency
+and 10-20x the completion tokens of a fast answer. The refinement loop asks the
+same question repeatedly — a stabilize round that changes nothing re-presents
+an identical selection, and a second run of the same memory presents it again.
+
+Reusing the answer is the point rather than a compromise. A good judgement
+about an identical set should not be re-rolled, and a sampled verdict that
+changes between two identical rounds is noise, not a second opinion.
+
+Its own database rather than a table in the analysis cache: that one carries a
+SCHEMA_VERSION real users' stored analysis keys off, and bumping it for a
+derived cache would invalidate everybody's work for an unrelated feature. This
+file can be deleted at any time and costs only the calls it saved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Bump to abandon every stored answer — for a change in how the answer is used
+# that the prompt text itself does not capture.
+_ANSWER_VERSION = "judge1"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS judgments (
+    key TEXT PRIMARY KEY,
+    answer TEXT NOT NULL,
+    answered_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+def judgment_key(*, model: str | None, prompt: str, thinking: bool) -> str:
+    """Everything that could change the answer, and nothing that could not.
+
+    The prompt text carries the clips, their descriptions and their order, so
+    a changed selection keys differently without anyone maintaining a list of
+    what to invalidate on. It also carries the prompt template, so editing the
+    wording abandons the answers given to the old one — which is the behaviour
+    you want and the one that is easiest to forget to implement.
+    """
+    material = "\x1f".join(
+        [_ANSWER_VERSION, model or "", "thinking" if thinking else "fast", prompt]
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def verdicts_beside(cache_dir: Path) -> Path:
+    """Where reused answers live, given the configured cache directory."""
+    return Path(cache_dir) / "judgments.db"
+
+
+class JudgmentCache:
+    """Remembers what the model said about an identical question.
+
+    Every failure here is quiet and costs only calls: an unwritable directory,
+    a locked database or a corrupt file must never take a generation down with
+    it.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.execute(_SCHEMA)
+        return conn
+
+    def answer_for(self, key: str) -> str | None:
+        """What the model said last time, or None if it has not been asked."""
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Judgment cache unreadable (%s): asking again", exc)
+            return None
+        try:
+            row = conn.execute("SELECT answer FROM judgments WHERE key = ?", (key,)).fetchone()
+        except sqlite3.Error as exc:
+            logger.debug("Judgment cache unreadable (%s): asking again", exc)
+            return None
+        finally:
+            conn.close()
+        return str(row[0]) if row else None
+
+    def remember(self, key: str, answer: str) -> None:
+        """Keep an answer. Silence and failures are never stored."""
+        if not answer:
+            return
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Judgment cache unwritable (%s): the answer is not kept", exc)
+            return
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO judgments (key, answer) VALUES (?, ?)", (key, answer)
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.debug("Judgment cache unwritable (%s): the answer is not kept", exc)
+        finally:
+            conn.close()

--- a/src/immich_memories/titles/llm_titles.py
+++ b/src/immich_memories/titles/llm_titles.py
@@ -14,6 +14,8 @@ import httpx
 from immich_memories.analysis.llm_query import query_llm
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from immich_memories.config_models_llm import LLMConfig
 
 logger = logging.getLogger(__name__)
@@ -183,8 +185,14 @@ async def generate_title_with_llm(
     smart_objects: list[str] | None = None,
     llm_config: LLMConfig | None = None,
     temperature: float = 0.1,
+    cache_path: Path | None = None,
 ) -> TitleSuggestion | None:
-    """Generate a title using the LLM. Returns None on failure."""
+    """Generate a title using the LLM. Returns None on failure.
+
+    With cache_path, a title asked for twice about the same memory is paid for
+    once: the prompt carries the dates, places, people and clip descriptions,
+    so anything that would change the answer changes the key.
+    """
     if llm_config is None:
         return None
 
@@ -209,6 +217,7 @@ async def generate_title_with_llm(
             max_tokens=8000,
             timeout_seconds=300,
             thinking=True,
+            cache_path=cache_path,
         )
         return parse_title_response(raw)
     except (httpx.HTTPError, RuntimeError, ValueError, OSError) as e:

--- a/src/immich_memories/ui/pages/pipeline_title.py
+++ b/src/immich_memories/ui/pages/pipeline_title.py
@@ -10,6 +10,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from immich_memories.cache.judgment_cache import verdicts_beside
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.titles.llm_titles import generate_title_with_llm
 
@@ -277,6 +278,7 @@ async def generate_title_after_pipeline(state: AppState) -> None:
             start_date=str(start_date),
             end_date=str(end_date),
             duration_days=(end_date - start_date).days,
+            cache_path=verdicts_beside(config.cache.cache_path),
             daily_locations=trip.daily_locations,
             country=trip.country,
             person_names=person_names,

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -1,0 +1,172 @@
+"""A judgement about an identical selection should not be paid for twice.
+
+The refinement loop asks the same question repeatedly: a stabilize round that
+changes nothing re-presents the same clips in the same order, and a second run
+of the same memory presents them again. In reasoning mode each of those costs
+5-10x the latency and 10-20x the tokens of a fast call, and the overnight sweep
+measured ~15 minutes a memory spent almost entirely here.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from immich_memories.analysis.selection_review import review_selection
+
+_VERDICT = '{"drop": []}'
+
+
+async def _always(*_args, **_kwargs):
+    return _VERDICT
+
+
+def _member(asset_id: str) -> SimpleNamespace:
+    asset = SimpleNamespace(
+        id=asset_id,
+        is_favorite=False,
+        file_created_at=datetime(2021, 4, 4, 10, tzinfo=UTC),
+        exif_info=None,
+        people=[],
+    )
+    return SimpleNamespace(
+        clip=SimpleNamespace(asset=asset, llm_description=f"a picture of {asset_id}"),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.5,
+        analyzed=True,
+    )
+
+
+def _selection(n: int = 4) -> list:
+    return [_member(f"asset-{i}") for i in range(n)]
+
+
+def _config(model: str = "qwen"):
+    from immich_memories.config_models_llm import LLMConfig
+
+    return LLMConfig(model=model, thinking=True)
+
+
+def test_an_unchanged_selection_is_judged_once(tmp_path) -> None:
+    """Acceptance (a): two identical rounds inside one generation, one call."""
+    calls: list = []
+
+    async def _answer(prompt, *_args, **_kwargs):
+        calls.append(prompt)
+        return _VERDICT
+
+    # WHY: the LLM server is the external boundary; counting calls is the point.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_answer):
+        review_selection(_selection(), _config(), cache_path=tmp_path / "judgments.db")
+        review_selection(_selection(), _config(), cache_path=tmp_path / "judgments.db")
+
+    assert len(calls) == 1, f"an identical selection was judged {len(calls)} times"
+
+
+def test_a_second_run_of_the_same_memory_judges_nothing(tmp_path) -> None:
+    """Acceptance (b): the answer outlives the process that paid for it."""
+    db = tmp_path / "judgments.db"
+
+    # WHY: the LLM server is the external boundary; the first run pays.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_always):
+        review_selection(_selection(), _config(), cache_path=db)
+
+    calls: list = []
+
+    async def _answer(prompt, *_args, **_kwargs):
+        calls.append(prompt)
+        return _VERDICT
+
+    # WHY: same boundary; a later run must not reach it at all.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_answer):
+        review_selection(_selection(), _config(), cache_path=db)
+
+    assert calls == [], "a second run re-paid for a verdict it already had"
+
+
+def test_a_different_selection_is_judged_again(tmp_path) -> None:
+    """The key is what was asked, so changing the clips has to miss."""
+    calls: list = []
+
+    async def _answer(prompt, *_args, **_kwargs):
+        calls.append(prompt)
+        return _VERDICT
+
+    # WHY: the LLM server is the external boundary.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_answer):
+        review_selection(_selection(4), _config(), cache_path=tmp_path / "judgments.db")
+        review_selection(_selection(5), _config(), cache_path=tmp_path / "judgments.db")
+
+    assert len(calls) == 2, "a changed selection reused a verdict about a different one"
+
+
+def test_a_different_model_is_judged_again(tmp_path) -> None:
+    """A verdict belongs to the model that gave it."""
+    calls: list = []
+
+    async def _answer(prompt, *_args, **_kwargs):
+        calls.append(prompt)
+        return _VERDICT
+
+    # WHY: the LLM server is the external boundary.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_answer):
+        review_selection(
+            _selection(),
+            _config("qwen"),
+            cache_path=tmp_path / "judgments.db",
+        )
+        review_selection(
+            _selection(),
+            _config("llama"),
+            cache_path=tmp_path / "judgments.db",
+        )
+
+    assert len(calls) == 2, "one model's judgement was served for another's question"
+
+
+def test_a_cache_that_cannot_be_opened_costs_calls_not_the_run(tmp_path) -> None:
+    """Losing the cache is a cost, never a failure — the project's rule."""
+    unwritable = tmp_path / "no-such-dir" / "judgments.db"
+
+    # WHY: the LLM server is the external boundary.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_always):
+        drops = review_selection(_selection(), _config(), cache_path=unwritable)
+
+    assert drops == []
+
+
+def test_the_pipeline_keeps_its_verdicts_beside_the_other_caches(tmp_path) -> None:
+    """Wired to the configured cache directory, not to a temp dir or the cwd."""
+    from unittest.mock import MagicMock
+
+    from immich_memories.analysis.selection_quality import SelectionQuality
+    from immich_memories.config_loader import Config
+
+    config = Config(cache={"directory": str(tmp_path / "cache")})
+    quality = SelectionQuality(
+        config=MagicMock(),
+        app_config=config,
+        analyzer=MagicMock(),
+        refiner=MagicMock(),
+        tracker=MagicMock(),
+        client=MagicMock(),
+        provider_circuit=MagicMock(),
+    )
+
+    assert quality._verdicts.parent == config.cache.cache_path
+
+
+def test_without_a_cache_path_nothing_is_remembered(tmp_path) -> None:
+    """The default stays uncached, so no caller gets caching by accident."""
+    calls: list = []
+
+    async def _answer(prompt, *_args, **_kwargs):
+        calls.append(prompt)
+        return _VERDICT
+
+    # WHY: the LLM server is the external boundary.
+    with patch("immich_memories.analysis.llm_query._dispatch", new=_answer):
+        review_selection(_selection(), _config())
+        review_selection(_selection(), _config())
+
+    assert len(calls) == 2


### PR DESCRIPTION
Closes the review tax. **Sam's top blocker — gates the matrix restart.**

## The problem

The refinement loop asks the same question repeatedly. A stabilize round that changes nothing re-presents an identical selection; a second run of the same memory presents it again. In reasoning mode each of those costs 5–10× the latency and 10–20× the tokens of a fast answer.

## The change

`query_llm` takes an optional `cache_path`. With one, an identical question to an identical model returns the answer it returned before. **Opt-in** — a health probe must reach the server every time. Review and titles opt in now; the special-day judgement follows with #564.

## Measured on a real month, generated three times

Counting rows written to `judgments.db` — a verifiable artifact, not a log grep:

| Run | Wall clock | Judgement calls |
|---|---|---|
| 1 (cold) | 921s | **8** |
| 2 | 640s | **7** |
| 3 | 421s | **2** |

**It converges rather than dropping to zero, and that is the honest result.** The review prompt embeds LLM-derived text — scores, descriptions, emotion, setting, subjects. While the analysis cache is still filling, run 2 is asking a genuinely *different* question and correctly misses. By run 3 the inputs had settled and six of eight hit.

**Do not read 921s → 421s as this cache's saving.** Most of it is the analysis cache warming — the verify pass went from 8 invocations to 2 — and roughly 375s of every run is assembly and encoding that no cache can touch.

Acceptance (a), an unchanged round inside one generation, is pinned by unit test. Acceptance (b) as originally specified — *a second run makes zero review calls* — does not hold and I don't believe it can: these are LLMs, the inputs are not deterministic, and a cache keyed on the exact question converges as its inputs settle.

## Three decisions worth keeping

**The raw response is cached, not the parsed verdict.** A parser fix then doesn't abandon every stored answer, and the `dropping clip N (reason)` lines still fire on a hit — a reused verdict is as visible in the log as a fresh one. Caching parsed drops would make a hit silent, which is the failure family this codebase has spent the day closing.

**Image-bearing calls are refused outright.** A prompt hash cannot see the pictures, so a fixed template — `"one line per picture, in order"` — would key identically for two different days and serve one the other's answer. Mood is the live example: `MOOD_ANALYSIS_PROMPT` is a constant plus 4 frames, so caching it by prompt hash would give **every video the first video's mood**. Vision is cached per asset upstream, where the key is the asset id.

**Its own sqlite file**, not a table in the analysis database — that one carries a `SCHEMA_VERSION` users' stored analysis keys off, and bumping it for derived, deletable data would invalidate everyone's work for an unrelated feature.

`make ci` exit 0, **5542 passed**.
