### PR TITLE
feat(cli): run the real selection without producing a video

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -921,46 +921,26 @@
         "name": "register_generate_commands",
         "complexity": 177,
         "line_start": 182,
-        "line_end": 962,
+        "line_end": 973,
         "line_complexities": [
-          {
-            "line": 511,
-            "complexity": 0
-          },
-          {
-            "line": 512,
-            "complexity": 0
-          },
-          {
-            "line": 519,
-            "complexity": 2
-          },
-          {
-            "line": 520,
-            "complexity": 0
-          },
           {
             "line": 521,
             "complexity": 0
           },
           {
-            "line": 523,
-            "complexity": 2
-          },
-          {
-            "line": 525,
-            "complexity": 3
+            "line": 522,
+            "complexity": 0
           },
           {
             "line": 529,
-            "complexity": 3
+            "complexity": 2
           },
           {
             "line": 530,
             "complexity": 0
           },
           {
-            "line": 532,
+            "line": 531,
             "complexity": 0
           },
           {
@@ -968,8 +948,8 @@
             "complexity": 2
           },
           {
-            "line": 534,
-            "complexity": 1
+            "line": 535,
+            "complexity": 3
           },
           {
             "line": 539,
@@ -980,84 +960,80 @@
             "complexity": 0
           },
           {
-            "line": 544,
+            "line": 542,
             "complexity": 0
           },
           {
-            "line": 545,
-            "complexity": 1
-          },
-          {
-            "line": 546,
-            "complexity": 0
-          },
-          {
-            "line": 548,
+            "line": 543,
             "complexity": 2
           },
           {
-            "line": 564,
+            "line": 544,
+            "complexity": 1
+          },
+          {
+            "line": 549,
+            "complexity": 3
+          },
+          {
+            "line": 550,
             "complexity": 0
           },
           {
-            "line": 575,
+            "line": 554,
+            "complexity": 0
+          },
+          {
+            "line": 555,
+            "complexity": 1
+          },
+          {
+            "line": 556,
+            "complexity": 0
+          },
+          {
+            "line": 558,
+            "complexity": 2
+          },
+          {
+            "line": 574,
+            "complexity": 0
+          },
+          {
+            "line": 585,
             "complexity": 3
           },
           {
-            "line": 579,
+            "line": 589,
             "complexity": 3
           },
           {
-            "line": 583,
+            "line": 593,
             "complexity": 4
           },
           {
-            "line": 587,
+            "line": 597,
             "complexity": 3
           },
           {
-            "line": 591,
+            "line": 601,
             "complexity": 3
           },
           {
-            "line": 599,
+            "line": 609,
             "complexity": 0
           },
           {
-            "line": 616,
+            "line": 626,
             "complexity": 2
           },
           {
-            "line": 617,
+            "line": 627,
             "complexity": 0
-          },
-          {
-            "line": 618,
-            "complexity": 1
-          },
-          {
-            "line": 620,
-            "complexity": 0
-          },
-          {
-            "line": 621,
-            "complexity": 1
-          },
-          {
-            "line": 622,
-            "complexity": 0
-          },
-          {
-            "line": 623,
-            "complexity": 3
           },
           {
             "line": 628,
             "complexity": 1
-          },
-          {
-            "line": 629,
-            "complexity": 3
           },
           {
             "line": 630,
@@ -1072,132 +1048,144 @@
             "complexity": 0
           },
           {
-            "line": 635,
-            "complexity": 0
+            "line": 633,
+            "complexity": 3
+          },
+          {
+            "line": 638,
+            "complexity": 1
           },
           {
             "line": 639,
-            "complexity": 2
+            "complexity": 3
           },
           {
-            "line": 644,
+            "line": 640,
             "complexity": 0
           },
           {
-            "line": 647,
-            "complexity": 0
-          },
-          {
-            "line": 653,
+            "line": 641,
             "complexity": 1
           },
           {
-            "line": 656,
-            "complexity": 3
+            "line": 642,
+            "complexity": 0
+          },
+          {
+            "line": 645,
+            "complexity": 0
+          },
+          {
+            "line": 649,
+            "complexity": 2
+          },
+          {
+            "line": 654,
+            "complexity": 0
           },
           {
             "line": 657,
-            "complexity": 3
+            "complexity": 0
           },
           {
-            "line": 659,
-            "complexity": 0
+            "line": 663,
+            "complexity": 1
           },
           {
             "line": 666,
-            "complexity": 0
-          },
-          {
-            "line": 670,
             "complexity": 3
           },
           {
-            "line": 671,
-            "complexity": 0
-          },
-          {
-            "line": 672,
+            "line": 667,
             "complexity": 3
           },
           {
-            "line": 673,
+            "line": 669,
             "complexity": 0
           },
           {
-            "line": 675,
+            "line": 676,
             "complexity": 0
           },
           {
-            "line": 699,
+            "line": 680,
+            "complexity": 3
+          },
+          {
+            "line": 681,
+            "complexity": 0
+          },
+          {
+            "line": 682,
+            "complexity": 3
+          },
+          {
+            "line": 683,
+            "complexity": 0
+          },
+          {
+            "line": 685,
+            "complexity": 0
+          },
+          {
+            "line": 709,
             "complexity": 1
           },
           {
-            "line": 700,
+            "line": 710,
             "complexity": 2
           },
           {
-            "line": 704,
+            "line": 714,
             "complexity": 1
           },
           {
-            "line": 715,
+            "line": 725,
             "complexity": 3
           },
           {
-            "line": 716,
+            "line": 726,
             "complexity": 0
           },
           {
-            "line": 717,
+            "line": 727,
             "complexity": 0
           },
           {
-            "line": 719,
+            "line": 729,
             "complexity": 0
           },
           {
-            "line": 721,
+            "line": 731,
             "complexity": 0
           },
           {
-            "line": 723,
+            "line": 733,
             "complexity": 0
           },
           {
-            "line": 730,
+            "line": 740,
             "complexity": 5
           },
           {
-            "line": 771,
+            "line": 781,
             "complexity": 6
           },
           {
-            "line": 814,
+            "line": 824,
             "complexity": 0
           },
           {
-            "line": 815,
+            "line": 825,
             "complexity": 5
           },
           {
-            "line": 816,
+            "line": 826,
             "complexity": 6
-          },
-          {
-            "line": 817,
-            "complexity": 0
-          },
-          {
-            "line": 818,
-            "complexity": 0
-          },
-          {
-            "line": 819,
-            "complexity": 7
           },
           {
             "line": 827,
-            "complexity": 6
+            "complexity": 0
           },
           {
             "line": 828,
@@ -1208,47 +1196,55 @@
             "complexity": 7
           },
           {
-            "line": 830,
-            "complexity": 0
-          },
-          {
-            "line": 832,
-            "complexity": 1
-          },
-          {
             "line": 837,
-            "complexity": 7
+            "complexity": 6
           },
           {
             "line": 838,
             "complexity": 0
           },
           {
-            "line": 851,
+            "line": 839,
             "complexity": 7
           },
           {
-            "line": 852,
+            "line": 840,
             "complexity": 0
           },
           {
-            "line": 853,
-            "complexity": 0
-          },
-          {
-            "line": 856,
+            "line": 842,
             "complexity": 1
           },
           {
-            "line": 857,
-            "complexity": 0
+            "line": 847,
+            "complexity": 7
           },
           {
-            "line": 858,
+            "line": 848,
             "complexity": 0
           },
           {
             "line": 861,
+            "complexity": 7
+          },
+          {
+            "line": 862,
+            "complexity": 0
+          },
+          {
+            "line": 863,
+            "complexity": 0
+          },
+          {
+            "line": 866,
+            "complexity": 1
+          },
+          {
+            "line": 867,
+            "complexity": 0
+          },
+          {
+            "line": 868,
             "complexity": 0
           },
           {
@@ -1256,71 +1252,75 @@
             "complexity": 0
           },
           {
-            "line": 872,
+            "line": 881,
+            "complexity": 0
+          },
+          {
+            "line": 882,
             "complexity": 5
           },
           {
-            "line": 873,
+            "line": 883,
             "complexity": 6
           },
           {
-            "line": 874,
+            "line": 884,
             "complexity": 7
           },
           {
-            "line": 878,
-            "complexity": 6
-          },
-          {
-            "line": 881,
-            "complexity": 6
-          },
-          {
-            "line": 886,
-            "complexity": 0
-          },
-          {
             "line": 888,
-            "complexity": 5
+            "complexity": 6
           },
           {
-            "line": 890,
-            "complexity": 5
+            "line": 891,
+            "complexity": 6
           },
           {
-            "line": 894,
-            "complexity": 5
-          },
-          {
-            "line": 897,
-            "complexity": 1
-          },
-          {
-            "line": 899,
+            "line": 896,
             "complexity": 0
           },
           {
-            "line": 901,
+            "line": 898,
+            "complexity": 5
+          },
+          {
+            "line": 900,
+            "complexity": 5
+          },
+          {
+            "line": 904,
+            "complexity": 5
+          },
+          {
+            "line": 907,
+            "complexity": 1
+          },
+          {
+            "line": 909,
             "complexity": 0
           },
           {
-            "line": 945,
-            "complexity": 1
-          },
-          {
-            "line": 948,
-            "complexity": 1
-          },
-          {
-            "line": 951,
-            "complexity": 1
-          },
-          {
-            "line": 952,
+            "line": 911,
             "complexity": 0
           },
           {
-            "line": 953,
+            "line": 956,
+            "complexity": 1
+          },
+          {
+            "line": 959,
+            "complexity": 1
+          },
+          {
+            "line": 962,
+            "complexity": 1
+          },
+          {
+            "line": 963,
+            "complexity": 0
+          },
+          {
+            "line": 964,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -141,7 +141,8 @@ have not set explicitly; the flags below still win. Persistent form: `preset: fa
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--dry-run` | — | flag | — | Show what would be done, don't generate |
+| `--dry-run` | — | flag | — | Cheap preview: cached analysis only, verify pass skipped, no video |
+| `--no-render` | — | flag | — | The real selection — analysis, verify, judge, review — stopping before the encode |
 | `--privacy-mode` | — | flag | — | Blur all video and mute speech |
 | `--include-live-photos` | — | flag | — | Include Live Photo video clips (merged when burst-captured) |
 | `--keep-intermediates` | — | flag | — | Keep intermediate files for debugging |
@@ -388,8 +389,24 @@ of guessing. This answers it directly.
 :::warning Do not combine this with `--dry-run`
 `--dry-run` skips work, and some of the work it skips is selection. Photo scoring falls back to
 metadata only — the VLM scorer never runs — so a trace taken under `--dry-run` describes a
-different, cheaper pipeline than the one that makes your videos. Trace a real run.
+different, cheaper pipeline than the one that makes your videos. Trace a real run —
+`--no-render` gives you one without the encode. See below.
 :::
+
+### Two ways to skip the video
+
+They are not the same, and the difference decides which one you want.
+
+`--dry-run` is the cheap preview. It analyses nothing it has not already
+cached and skips the verify pass, so the clips it lists are an approximation
+of the real selection. Use it to check that your criteria match the assets you
+expect.
+
+`--no-render` runs the pipeline for real — full analysis, the verify pass, the
+judge and the review — and stops at the encode. The clips it lists are the
+clips it would have shipped. Use it when you care about the selection itself:
+tuning scoring, comparing settings, or measuring how long selection takes
+without paying several minutes to encode a file you are going to delete.
 
 Use `--dry-run` to see how many videos match your criteria without actually generating anything:
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -281,6 +281,7 @@ immich-memories generate [OPTIONS]
 | `--music`, `-m` | text | - | Music: path to audio file, 'auto' to generate from config, or omit for default behavior |
 | `--no-music` | boolean | false | Disable all music (skip both provided files and AI generation) |
 | `--dry-run` | boolean | false | Show what would be done without generating |
+| `--no-render` | boolean | false | Run the real selection — analysis, verify, judge, review — and stop before encoding. Unlike --dry-run, which uses cached analysis only and skips the verify pass, this picks the clips it would actually ship |
 | `--trace-selection` | file | - | Write a stage-by-stage report of how the clips were chosen |
 | `--upload-to-immich` | boolean | false | Upload generated video back to Immich |
 | `--album` | text | - | Immich album name for uploaded video |

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -158,7 +158,17 @@ def _configure_output_canvas(
     return canvas
 
 
-def _finish_dry_run(
+def _stops_before_rendering(*, dry_run: bool, no_render: bool) -> bool:
+    """Whether this run ends at the plan instead of producing a file.
+
+    Two callers, one boundary. --dry-run has always stopped here as a side
+    effect of being cheap; --no-render asks for the same stop directly, having
+    run the real analysis and the verify pass on the way.
+    """
+    return dry_run or no_render
+
+
+def _finish_without_rendering(
     *,
     pipeline_result: PipelineResult,
     timeline_plan: TimelinePlan,
@@ -177,7 +187,13 @@ def _finish_dry_run(
     progress,
     task,
 ) -> tuple[Path, bool, str | None]:
-    """Print the resolved plan and return without crossing the render boundary."""
+    """Print the resolved plan and return without crossing the render boundary.
+
+    Reached two ways, and the difference matters. --dry-run gets here having
+    used only cached analysis and skipped the verify pass, so its selection is
+    a cheap approximation. --no-render gets here having run the real thing;
+    only the encode is missing.
+    """
     from immich_memories.api.models import AssetType
     from immich_memories.cli._generation_preview import (
         GenerationPreview,
@@ -272,6 +288,7 @@ def run_pipeline_and_generate(
     memory_category: str | None = None,
     automation_attempt_id: str | None = None,
     dry_run: bool = False,
+    no_render: bool = False,
 ) -> tuple[Path, bool, str | None]:
     """Run smart pipeline analysis + video generation.
 
@@ -469,8 +486,8 @@ def run_pipeline_and_generate(
     album_name = album or config.upload.album_name
     person_name = person_names[0] if person_names else None
 
-    if dry_run:
-        return _finish_dry_run(
+    if _stops_before_rendering(dry_run=dry_run, no_render=no_render):
+        return _finish_without_rendering(
             pipeline_result=pipeline_result,
             timeline_plan=timeline_plan,
             assets=assets,

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -326,6 +326,15 @@ def register_generate_commands(main: click.Group) -> None:
     )
     @click.option("--dry-run", is_flag=True, help="Show what would be done without generating")
     @click.option(
+        "--no-render",
+        is_flag=True,
+        help=(
+            "Run the real selection — analysis, verify, judge, review — and stop "
+            "before encoding. Unlike --dry-run, which uses cached analysis only and "
+            "skips the verify pass, this picks the clips it would actually ship"
+        ),
+    )
+    @click.option(
         "--trace-selection",
         type=click.Path(dir_okay=False, path_type=Path),
         help="Write a stage-by-stage report of how the clips were chosen",
@@ -461,6 +470,7 @@ def register_generate_commands(main: click.Group) -> None:
         music: str | None,
         no_music: bool,
         dry_run: bool,
+        no_render: bool,
         trace_selection: Path | None,
         upload_to_immich: bool,
         album: str | None,
@@ -933,6 +943,7 @@ def register_generate_commands(main: click.Group) -> None:
                         memory_category=memory_category,
                         automation_attempt_id=automation_attempt_id,
                         dry_run=dry_run,
+                        no_render=no_render,
                     )
 
                 _print_generation_result(

--- a/tests/test_no_render.py
+++ b/tests/test_no_render.py
@@ -1,0 +1,104 @@
+"""Running the real selection without producing a video.
+
+--dry-run cannot do this. It welds three separate decisions together: use only
+cached analysis, skip the verify pass, and stop before rendering. So the cheap
+mode runs a *different* selection than the real one, and there was no way to
+exercise the real one without also spending minutes encoding an mp4 nobody
+wanted.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from immich_memories.config_loader import Config
+from immich_memories.timeperiod import DateRange
+
+
+def _run(**kwargs):
+    from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
+
+    clip = MagicMock()
+    clip.asset.id = "asset-1"
+    clip.width, clip.height = 1920, 1080
+    config = Config()
+
+    with (
+        # WHY: Immich is the external boundary — no live server in a unit test.
+        patch("immich_memories.generate.assets_to_clips", return_value=[clip]),
+        # WHY: the pipeline is the collaborator under inspection.
+        patch("immich_memories.analysis.smart_pipeline.SmartPipeline") as pipeline_type,
+    ):
+        pipeline = pipeline_type.return_value
+        pipeline.run_analysis.return_value = []
+        pipeline.run_planning_analysis.return_value = []
+        # Stop at the call under inspection: everything past it is rendering,
+        # which is the whole thing this flag exists to avoid.
+        pipeline.run_selection.side_effect = RuntimeError("stop at selection")
+        try:
+            run_pipeline_and_generate(
+                assets=[clip.asset],
+                client=MagicMock(),
+                config=config,
+                progress=MagicMock(),
+                duration=60,
+                transition="cut",
+                music=None,
+                output_path=Path("/tmp/never-written.mp4"),
+                memory_type="trip",
+                person_names=[],
+                date_range=DateRange(start=datetime(2026, 1, 1), end=datetime(2026, 1, 2)),
+                upload_to_immich=False,
+                album=None,
+                source="auto",
+                **kwargs,
+            )
+        except RuntimeError as exc:
+            if "stop at selection" not in str(exc):
+                raise
+        return pipeline
+
+
+def test_no_render_runs_the_real_selection() -> None:
+    """The verify pass is what makes it the real one, so it has to stay on."""
+    pipeline = _run(no_render=True)
+
+    assert pipeline.run_selection.call_args.kwargs["verify"] is True
+    pipeline.run_analysis.assert_called()
+    pipeline.run_planning_analysis.assert_not_called()
+
+
+def test_dry_run_still_means_the_cheap_plan() -> None:
+    """Unchanged: --dry-run stays the cached-only, unverified preview."""
+    pipeline = _run(dry_run=True)
+
+    assert pipeline.run_selection.call_args.kwargs["verify"] is False
+    pipeline.run_planning_analysis.assert_called()
+
+
+def test_the_flag_exists_and_says_what_it_does() -> None:
+    """A flag nobody can find is a flag nobody uses."""
+    from click.testing import CliRunner
+
+    from immich_memories.cli import main
+
+    with patch("immich_memories.cli.init_config_dir"):
+        help_text = CliRunner().invoke(main, ["generate", "--help"]).output
+
+    assert "--no-render" in help_text
+
+
+def test_no_render_is_not_dry_run() -> None:
+    """The two must not be the same switch wearing two names.
+
+    --dry-run uses cached analysis only and skips verify; --no-render runs
+    both for real. If they ever collapse into one, the cheap preview silently
+    becomes the expensive path or the real one silently becomes approximate.
+    """
+    real = _run(no_render=True)
+    cheap = _run(dry_run=True)
+
+    assert real.run_selection.call_args.kwargs["verify"] is True
+    assert cheap.run_selection.call_args.kwargs["verify"] is False
+    real.run_analysis.assert_called()
+    cheap.run_planning_analysis.assert_called()

--- a/tests/test_no_render.py
+++ b/tests/test_no_render.py
@@ -23,8 +23,8 @@ def _run(**kwargs):
     clip.width, clip.height = 1920, 1080
     config = Config()
 
+    # WHY: Immich is the external boundary — no live server in a unit test.
     with (
-        # WHY: Immich is the external boundary — no live server in a unit test.
         patch("immich_memories.generate.assets_to_clips", return_value=[clip]),
         # WHY: the pipeline is the collaborator under inspection.
         patch("immich_memories.analysis.smart_pipeline.SmartPipeline") as pipeline_type,
@@ -82,6 +82,7 @@ def test_the_flag_exists_and_says_what_it_does() -> None:
 
     from immich_memories.cli import main
 
+    # WHY: config-dir creation is a filesystem boundary; --help must not touch it.
     with patch("immich_memories.cli.init_config_dir"):
         help_text = CliRunner().invoke(main, ["generate", "--help"]).output
 


### PR DESCRIPTION
## The problem

`--dry-run` welds **three** independent decisions into one flag:

1. use only cached analysis (`run_planning_analysis`)
2. skip the verify pass (`verify=not dry_run`)
3. stop before rendering (`_finish_dry_run`)

So the cheap mode runs a **different selection algorithm** than the real one, and there is no way to ask for (3) without also accepting (1) and (2).

Anyone tuning selection had two bad options: `--dry-run`, whose clips are an approximation, or a full `generate` that spends minutes encoding a file they were going to delete. Measured on a real month: **~375s of every run is assembly and encoding.**

## The change

`--no-render` runs analysis, the verify pass, the judge and the review for real, then stops at the render boundary. The clips it prints are the clips it would have shipped.

Barely any new machinery. `_finish_dry_run` was **already written as a general render boundary** — its docstring said *"return without crossing the render boundary"* — and had simply been hard-wired to one caller. It becomes `_finish_without_rendering` and is reached by either flag.

| Flag | Analysis | Verify pass | Renders |
|---|---|---|---|
| `--dry-run` | cached only | ❌ skipped | ❌ |
| `--no-render` | real | ✅ runs | ❌ |
| *(neither)* | real | ✅ runs | ✅ |

## They are pinned apart

A test asserts `--no-render` runs with `verify=True` while `--dry-run` runs with `verify=False`. If they ever collapse into one switch that test fails — the cheap preview must not silently become the expensive path, and the real one must not silently become approximate.

## One note on the complexity gate

`run_pipeline_and_generate` was already at the edge and one more inline condition tipped it to rank D. The decision became `_stops_before_rendering(dry_run=..., no_render=...)` instead, which is better regardless of the gate: *"does this run end at the plan?"* is a concept, and now it has a name and says why two callers share one boundary for different reasons.

`make ci` exit 0.