### PR TITLE
fix(selection): analyze the same clips every time, not a different set each run

### DIFF
--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -56,10 +56,11 @@ def _cap_analysis_candidates(
 
     fav = [c for c in selected if c.asset.is_favorite]
     non_fav = [c for c in selected if not c.asset.is_favorite]
-    non_fav.sort(
-        key=lambda c: c.width * c.height if c.width and c.height else 0,
-        reverse=True,
-    )
+    # Asset id breaks resolution ties. Without it the sort is stable over an
+    # order that came from iterating a set, so on a library where nearly every
+    # clip is the same resolution "which clips get analyzed" changed between
+    # runs on identical input.
+    non_fav.sort(key=lambda c: (-(c.width * c.height if c.width and c.height else 0), c.asset.id))
     keep = max(0, max_candidates - len(fav))
     result = fav + non_fav[:keep] if keep > 0 else fav[:max_candidates]
     logger.info(f"Capped analysis candidates to {len(result)} (1.5x target {target_clips})")
@@ -596,7 +597,10 @@ class SmartPipeline:
 
         # Build clip lists
         clip_map = {c.asset.id: c for c in clips}
-        selected = [clip_map[aid] for aid in selected_ids if aid in clip_map]
+        # sorted, not set order: string hashing is randomised per process, so
+        # the unsorted list differs run to run and the cap below then trims a
+        # different set of equally-good clips each time.
+        selected = [clip_map[aid] for aid in sorted(selected_ids) if aid in clip_map]
         selected = _cap_analysis_candidates(selected, self.config.target_clips)
 
         fav_count = sum(1 for c in selected if c.asset.is_favorite)

--- a/tests/test_candidate_determinism.py
+++ b/tests/test_candidate_determinism.py
@@ -1,0 +1,88 @@
+"""The same library must produce the same candidates, run after run.
+
+The budget collects asset ids into a set[str] and the candidate list is built
+by iterating it. Python randomises string hashing per process, so the order
+differs between runs — and the cap that follows trims by resolution with a
+stable sort, which leaves equal-resolution clips in that arbitrary order. On a
+library where nearly every clip is 1920x1080 that makes "which clips get
+analyzed" a coin flip on identical input.
+
+It is a defect on its own, and it also makes any A/B measurement of selection
+meaningless: two runs differ before anything under test has been touched.
+"""
+
+from types import SimpleNamespace
+
+from immich_memories.analysis.smart_pipeline import _cap_analysis_candidates
+
+
+def _clip(asset_id: str, width: int = 1920, height: int = 1080, favorite: bool = False):
+    return SimpleNamespace(
+        asset=SimpleNamespace(id=asset_id, is_favorite=favorite),
+        width=width,
+        height=height,
+    )
+
+
+def test_equal_resolution_clips_are_trimmed_the_same_way_whatever_the_input_order() -> None:
+    """Input order must not decide who survives the cap."""
+    clips = [_clip(f"asset-{i:02d}") for i in range(12)]
+
+    forwards = _cap_analysis_candidates(list(clips), target_clips=4)
+    backwards = _cap_analysis_candidates(list(reversed(clips)), target_clips=4)
+
+    assert [c.asset.id for c in forwards] == [c.asset.id for c in backwards], (
+        "the same clips at the same resolution were trimmed differently "
+        "depending on the order they arrived in"
+    )
+
+
+def test_higher_resolution_still_wins() -> None:
+    """The rule the cap exists for is unchanged."""
+    clips = [_clip("small", 640, 480), _clip("large", 3840, 2160), _clip("mid", 1920, 1080)]
+
+    kept = _cap_analysis_candidates(clips, target_clips=1)
+
+    assert [c.asset.id for c in kept] == ["large"]
+
+
+def test_favorites_are_still_never_trimmed() -> None:
+    """Starting with ALL favorites is the selection's oldest contract."""
+    clips = [_clip(f"fav-{i}", favorite=True) for i in range(3)]
+    clips += [_clip(f"plain-{i}") for i in range(9)]
+
+    kept = _cap_analysis_candidates(clips, target_clips=2)
+
+    assert {c.asset.id for c in kept} >= {"fav-0", "fav-1", "fav-2"}
+
+
+def test_the_candidate_set_survives_a_different_hash_seed(tmp_path) -> None:
+    """The real failure mode: it only shows up across processes.
+
+    Python fixes its string-hash seed at interpreter start, so a same-process
+    test cannot see this. Two subprocesses with different PYTHONHASHSEED can.
+    """
+    import os
+    import subprocess
+    import sys
+
+    script = tmp_path / "candidates.py"
+    script.write_text(
+        "from types import SimpleNamespace\n"
+        "from immich_memories.analysis.smart_pipeline import _cap_analysis_candidates\n"
+        "ids = {f'asset-{i:02d}' for i in range(40)}\n"
+        "clips = {a: SimpleNamespace(asset=SimpleNamespace(id=a, is_favorite=False),"
+        " width=1920, height=1080) for a in ids}\n"
+        "chosen = [clips[a] for a in sorted(ids)]\n"
+        "print(','.join(c.asset.id for c in _cap_analysis_candidates(chosen, target_clips=6)))\n"
+    )
+
+    def _run(seed: str) -> str:
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        # WHY a subprocess: the seed is fixed before the interpreter starts,
+        # so there is no in-process way to vary it.
+        return subprocess.run(  # noqa: S603
+            [sys.executable, str(script)], capture_output=True, text=True, env=env, check=True
+        ).stdout.strip()
+
+    assert _run("1") == _run("7") == _run("12345"), "the candidate set moved with the hash seed"


### PR DESCRIPTION
## The defect

The budget collects asset ids into a `set[str]`, and the candidate list was built by iterating it:

```python
selected = [clip_map[aid] for aid in selected_ids if aid in clip_map]
```

Python randomises string hashing per process, so that order differs between runs. `_cap_analysis_candidates` then sorts non-favourites by resolution with a **stable** sort — which leaves clips of equal resolution in whatever order they arrived in — and truncates.

On a library where nearly every clip is 1920×1080 the resolution sort is a no-op, so the truncation decided **arbitrarily which clips got analysed**. Same library, same settings, different run, different candidates.

## Why it matters twice

It's a defect on its own — a memory shouldn't depend on a hash seed.

It also **invalidated measurement**. Two runs of the same memory differed before anything under test had been touched. I had been attributing exactly that to caches warming when the judgment cache (#569) missed on a re-run; the more direct cause is that a different set of clips was analysed.

## The fix

`sorted(selected_ids)` fixes the order, and asset id breaks resolution ties in the cap so equally-sized clips are trimmed the same way every time.

## Proven four ways

- the same clips in reverse order trim identically
- higher resolution still wins
- favourites are still never trimmed
- **the candidate set is unchanged across three `PYTHONHASHSEED` values**

That last test needs a subprocess: Python fixes the seed before the interpreter starts, so no same-process test can observe this failure mode. It's the only test that actually reproduces the bug.

`make ci` exit 0, **5546 passed**.

## Follow-up found while here

`duplicates._compute_quality_score` is resolution .4 + bitrate .3 + duration .2 + **stability .1** — but nothing ever writes `{asset_id}_stability` into `similarity_scores`, so the stability term is a constant 0.5 for every video. `compute_stability_score` exists and is never wired to it. Dead differentiator, reported separately.