### PR TITLE
chore(deps): drop four unused dependencies and raise three stale floors

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ Runs on every push to `main` and on pull requests. All jobs use `make` targets a
 - **file-length**: Runs `make file-length` (all `.py` files must be ≤800 lines)
 - **complexity**: Runs `make complexity` (Xenon grade C max)
 - **test**: Runs `make test` on Python 3.11, 3.12, and 3.13, on Ubuntu and macOS
-- **test-extras**: Tests optional extras (face, audio, audio-ml, gpu, mac) on Python 3.13
+- **test-extras**: Tests optional extras (audio, audio-ml, gpu, mac) on Python 3.13
 - **build**: Builds the package with version from git tags
 
 Run the full CI pipeline locally with `make ci`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,11 +296,11 @@ jobs:
         include:
           # speech (onnxruntime/kaldi-native-fbank, the default and only
           # engine) runs in the main `test` job -- it doesn't need torch.
-          # This job now only covers the torch-heavy face/audio-ml extras.
+          # This job now only covers the torch-heavy audio-ml extras.
           - os: ubuntu-latest
-            extras: "dev,face,audio,audio-ml,gpu"
+            extras: "dev,audio,audio-ml,gpu"
           - os: macos-latest
-            extras: "dev,mac,audio,audio-ml,face,gpu"
+            extras: "dev,mac,audio,audio-ml,gpu"
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Create LFS cache key

--- a/docs-site/docs/contribute/development-setup.md
+++ b/docs-site/docs/contribute/development-setup.md
@@ -21,7 +21,7 @@ cd immich-video-memory-generator
 make dev-test
 ```
 
-`make dev-test` installs the dev tools (pytest, ruff, mypy and the other CI gates) plus the `gpu` and `speech` extras — the same set the CI test jobs use. It is the fast path: no torch, no CUDA, no dlib compile. Run it before any other make target.
+`make dev-test` installs the dev tools (pytest, ruff, mypy and the other CI gates) plus the `gpu` and `speech` extras — the same set the CI test jobs use. It is the fast path: no torch, no CUDA. Run it before any other make target.
 
 Other install targets, when you need them:
 
@@ -30,7 +30,7 @@ Other install targets, when you need them:
 | `make dev-ci` | dev tools only | Lint/typecheck-only work |
 | `make dev-test` | dev + `gpu` + `speech` | Default for contributors (what CI tests with) |
 | `make dev-mac` | dev + `all-mac` (Apple Vision, Metal, ACE-Step MLX) | Apple Silicon, full feature set |
-| `make dev` | every extra, including `face` (compiles dlib, slow) | Only if you work on face recognition |
+| `make dev` | every extra (torch, ACE-Step, demucs — slow) | Only if you work across all optional backends |
 
 ## Verify everything works
 

--- a/docs-site/docs/deploy/installation/uv-pip.md
+++ b/docs-site/docs/deploy/installation/uv-pip.md
@@ -114,9 +114,6 @@ Quote the package spec — zsh (the macOS default shell) treats `[...]` as a glo
 `no matches found` otherwise.
 
 ```bash
-# Face recognition
-pip install "immich-memories[face]"
-
 # macOS Apple Vision framework
 pip install "immich-memories[mac]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,18 +32,15 @@ dependencies = [
     "httpx>=0.27",
     "pydantic>=2.0",
     "pydantic-settings>=2.14.2",
-    "nicegui>=3.12.0",
-    "moviepy>=1.0.3",
-    "scenedetect>=0.6",  # OpenCV is already a direct dependency below
+    "nicegui>=3.16.0",  # 3.16 fixes GHSA-46f2 (unauth memory exhaustion) + GHSA-955g (XSS)
+    "scenedetect>=0.7,<0.8",  # OpenCV is already a direct dependency below; 0.7 = VFR-correct (iPhone)
     "opencv-python>=4.9,<5",  # OpenCV 5 dropped cv2.CascadeClassifier (face scoring, #339)
-    "videohash>=3.0",
     "pyyaml>=6.0",
     "click>=8.3.3",
     "rich>=13.0",
     "pillow>=12.3.0",
     "pillow-heif>=1.0",
     "numpy>=1.24",
-    "imagehash>=4.3",
     "watchdog>=3.0",
     "croniter>=1.3",
     "geopy>=2.4",
@@ -57,10 +54,6 @@ dependencies = [
 # can require it.
 music = [
     "immich-memories-music>=0.1.0",
-]
-face = [
-    "face-recognition>=1.3",
-    "dlib>=19.24",
 ]
 # Mac-specific dependencies for GPU-accelerated processing
 mac = [
@@ -89,7 +82,7 @@ audio-ml = [
 # nothing. `pip install transformers huggingface-hub` re-enables it; without
 # them SmartTurnDetector returns a neutral 0.5.
 speech = [
-    "onnxruntime>=1.17",
+    "onnxruntime>=1.28",
     "kaldi-native-fbank>=1.20",
 ]
 # Speech transcription (whisper.cpp via pywhispercpp)
@@ -122,7 +115,6 @@ gpu = [
 ]
 # All cross-platform optional features
 all = [
-    "immich-memories[face]",
     "immich-memories[music]",
     "immich-memories[audio]",
     "immich-memories[audio-ml]",
@@ -134,7 +126,6 @@ all = [
 ]
 # All features for macOS (includes Apple Vision framework)
 all-mac = [
-    "immich-memories[face]",
     "immich-memories[music]",
     "immich-memories[audio]",
     "immich-memories[audio-ml]",
@@ -353,11 +344,7 @@ warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 module = [
-    "moviepy.*",
     "scenedetect.*",
-    "videohash.*",
-    "face_recognition.*",
-    "imagehash.*",
     "mutagen.*",
     # macOS frameworks (PyObjC)
     "Vision.*",
@@ -538,11 +525,7 @@ DEP002 = [
     "opencv-python",                                    # imported as cv2
     "pyyaml",                                           # imported as yaml
     "pillow",                                           # imported as PIL
-    "imagehash",                                        # imported via videohash
-    "videohash",                                        # used via subprocess
     "watchdog",                                         # runtime scheduler
-    "face-recognition",                                 # imported as face_recognition
-    "dlib",                                             # face-recognition backend
     "pyobjc-core", "pyobjc-framework-Vision",           # macOS-only, runtime
     "pyobjc-framework-Quartz", "pyobjc-framework-Metal", # macOS GPU
     "torch",                                            # PANNs inference backend
@@ -615,7 +598,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "integration: requires FFmpeg (deselect with '-m not integration')",
-    "extras: needs the torch-family optional dependencies (face/audio-ml/demucs)",
+    "extras: needs the torch-family optional dependencies (audio-ml/demucs)",
     "e2e: Playwright E2E browser tests (deselect with '-m not e2e')",
     "slow: long-running tests (full generation pipeline, ~10min)",
     "perf: performance benchmarks (run with: make benchmark-perf)",

--- a/src/immich_memories/analysis/silence_detection.py
+++ b/src/immich_memories/analysis/silence_detection.py
@@ -88,8 +88,10 @@ def detect_silence_gaps(
 ) -> list[tuple[float, float]]:
     """Detect silence gaps in a video's audio track.
 
-    Uses ffmpeg with explicit stream selection to handle iPhone videos
-    with spatial audio (apac codec) that moviepy can't process.
+    Uses ffmpeg with explicit stream selection so iPhone videos carrying
+    spatial audio (apac codec) resolve to the right stream. Audio that
+    cannot be extracted yields no gaps, which callers treat as "make no
+    silence-based boundary adjustment".
 
     Args:
         video_path: Path to video file.
@@ -109,9 +111,7 @@ def detect_silence_gaps(
             audio_array, sample_rate, threshold_db, min_silence_duration, window_size
         )
 
-    # Fall back to moviepy if ffmpeg extraction fails
-    logger.debug("Falling back to moviepy for audio extraction")
-    return _detect_silence_gaps_moviepy(video_path, threshold_db, min_silence_duration, window_size)
+    return []
 
 
 def _collect_silence_gaps(
@@ -199,57 +199,6 @@ def _analyze_audio_for_silence(
 
     logger.debug(f"Found {len(silence_gaps)} silence gaps")
     return silence_gaps
-
-
-def _detect_silence_gaps_moviepy(
-    video_path: Path,
-    threshold_db: float,
-    min_silence_duration: float,
-    window_size: float,
-) -> list[tuple[float, float]]:
-    """Detect silence gaps using moviepy (legacy fallback).
-
-    Args:
-        video_path: Path to video file.
-        threshold_db: Volume threshold in dB.
-        min_silence_duration: Minimum silence duration.
-        window_size: Analysis window size.
-
-    Returns:
-        List of (start, end) tuples for silence gaps.
-    """
-    try:
-        try:
-            from moviepy.editor import VideoFileClip
-        except ImportError:
-            from moviepy import VideoFileClip
-    except ImportError:
-        logger.debug("moviepy not available for silence detection")
-        return []
-
-    try:
-        with VideoFileClip(str(video_path)) as video:
-            if video.audio is None:
-                logger.debug(f"No audio track in {video_path}")
-                return []
-
-            # Get audio parameters
-            fps = video.audio.fps
-
-            # Extract audio as numpy array
-            audio_array = video.audio.to_soundarray(fps=fps)
-
-            # Convert to mono if stereo
-            if len(audio_array.shape) > 1:
-                audio_array = np.mean(audio_array, axis=1)
-
-            return _analyze_audio_for_silence(
-                audio_array, int(fps), threshold_db, min_silence_duration, window_size
-            )
-
-    except (OSError, RuntimeError, ValueError) as e:
-        logger.debug(f"moviepy silence detection failed: {e}")
-        return []
 
 
 def find_nearest_silence(

--- a/tests/test_silence_detection.py
+++ b/tests/test_silence_detection.py
@@ -6,12 +6,15 @@ numpy audio arrays — no FFmpeg, no video files needed.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from immich_memories.analysis.silence_detection import (
     _analyze_audio_for_silence,
     _collect_silence_gaps,
+    detect_silence_gaps,
     find_nearest_silence,
 )
 
@@ -344,3 +347,29 @@ class TestFindNearestSilence:
 # ---------------------------------------------------------------------------
 # TestAdjustSegmentToSilence
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# TestDetectSilenceGapsDegradation
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSilenceGapsDegradation:
+    """What `detect_silence_gaps` promises when it cannot read the audio.
+
+    Segment generation treats an empty gap list as "no silence-based boundary
+    adjustment" and keeps its original cuts, so returning nothing is the safe
+    degradation. These pin that contract through the public function with a
+    real unreadable file — no mocks, no fixture video.
+    """
+
+    def test_unreadable_file_yields_no_gaps(self, tmp_path: Path) -> None:
+        """A file FFmpeg cannot decode yields no gaps rather than raising."""
+        not_a_video = tmp_path / "not_a_video.mp4"
+        not_a_video.write_bytes(b"this is not a video container")
+
+        assert detect_silence_gaps(not_a_video) == []
+
+    def test_missing_file_yields_no_gaps(self, tmp_path: Path) -> None:
+        """A path that does not exist yields no gaps rather than raising."""
+        assert detect_silence_gaps(tmp_path / "absent.mp4") == []

--- a/uv.lock
+++ b/uv.lock
@@ -1060,12 +1060,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dlib"
-version = "20.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/28/f4/f8949b18ec1df2ef05fc2ea1d1dd82ff2d050b8704b7d0d088017315c221/dlib-20.0.0.tar.gz", hash = "sha256:9ab6a6fe113cc36a20c3f611c57fa6a07f18d1169bd04efb85c32e21b23b7d2b", size = 3310015, upload-time = "2025-05-28T01:22:16.141Z" }
-
-[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,28 +1107,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e712
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
-
-[[package]]
-name = "face-recognition"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "dlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "face-recognition-models", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/49/75dda409b94841f01cbbc34114c9b67ec618265084e4d12d37ab838f4fd3/face_recognition-1.3.0.tar.gz", hash = "sha256:5e5efdd1686aa566af0d3cc1313b131e4b197657a8ffd03669e6d3fad92705ec", size = 3182249, upload-time = "2020-02-20T14:26:05.903Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/95/f6c9330f54ab07bfa032bf3715c12455a381083125d8880c43cbe76bb3d0/face_recognition-1.3.0-py2.py3-none-any.whl", hash = "sha256:c543e91c8cfbf24d19db04e511ebbddcb23894bcee510133729ee78e9f4b5e83", size = 15508, upload-time = "2020-02-20T14:26:01.282Z" },
-]
-
-[[package]]
-name = "face-recognition-models"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/3b/4fd8c534f6c0d1b80ce0973d01331525538045084c73c153ee6df20224cf/face_recognition_models-0.3.0.tar.gz", hash = "sha256:b79bd200a88c87c9a9d446c990ae71c5a626d1f3730174e6d570157ff1d896cf", size = 100149358, upload-time = "2017-09-28T22:53:52.516Z" }
 
 [[package]]
 name = "fastapi"
@@ -1692,60 +1664,6 @@ wheels = [
 ]
 
 [[package]]
-name = "imagedominantcolor"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/504aa527e9a3eb287a5d0d382fcff9b2580af91b45a9fe21dff95be96651/imagedominantcolor-1.0.1.tar.gz", hash = "sha256:f37790dfb52402a636231e8e0a1148f241990d4ff75f6b6e7f838885ffef7079", size = 5375, upload-time = "2022-01-31T18:38:05.098Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/cf/92931dbe2151fc92db9827dd12da43fc97e6579e3658e847f10e2f5bce67/imagedominantcolor-1.0.1-py3-none-any.whl", hash = "sha256:d890d61f78637f718f5eb6afbd60919317b889c45c5c4133d6bf8e670b18ff6c", size = 5925, upload-time = "2022-01-31T18:38:03.56Z" },
-]
-
-[[package]]
-name = "imagehash"
-version = "4.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pywavelets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "scipy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/de/5c0189b0582e21583c2a213081c35a2501c0f9e51f21f6a52f55fbb9a4ff/ImageHash-4.3.2.tar.gz", hash = "sha256:e54a79805afb82a34acde4746a16540503a9636fd1ffb31d8e099b29bbbf8156", size = 303190, upload-time = "2025-02-01T08:45:39.328Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/2c/5f0903a53a62029875aaa3884c38070cc388248a2c1b9aa935632669e5a7/ImageHash-4.3.2-py2.py3-none-any.whl", hash = "sha256:02b0f965f8c77cd813f61d7d39031ea27d4780e7ebcad56c6cd6a709acc06e5f", size = 296657, upload-time = "2025-02-01T08:45:36.102Z" },
-]
-
-[[package]]
-name = "imageio"
-version = "2.37.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/606be632e37bf8d05b253e8626c2291d74c691ddc7bcdf7d6aaf33b32f6a/imageio-2.37.2.tar.gz", hash = "sha256:0212ef2727ac9caa5ca4b2c75ae89454312f440a756fcfc8ef1993e718f50f8a", size = 389600, upload-time = "2025-11-04T14:29:39.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl", hash = "sha256:ad9adfb20335d718c03de457358ed69f141021a333c40a53e57273d8a5bd0b9b", size = 317646, upload-time = "2025-11-04T14:29:37.948Z" },
-]
-
-[[package]]
-name = "imageio-ffmpeg"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
-]
-
-[[package]]
 name = "immich-memories"
 source = { editable = "." }
 dependencies = [
@@ -1754,8 +1672,6 @@ dependencies = [
     { name = "croniter", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "geopy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "imagehash", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "moviepy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "nicegui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opencv-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1767,7 +1683,6 @@ dependencies = [
     { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "scenedetect", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "staticmap", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "videohash", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
@@ -1775,8 +1690,6 @@ dependencies = [
 all = [
     { name = "authlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "demucs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "dlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "face-recognition", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "freetype-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "immich-memories-music", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "kaldi-native-fbank", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1789,8 +1702,6 @@ all = [
 ]
 all-mac = [
     { name = "demucs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "dlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "face-recognition", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "freetype-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "immich-memories-music", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "kaldi-native-fbank", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1840,10 +1751,6 @@ dev = [
     { name = "types-croniter", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "types-pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-face = [
-    { name = "dlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "face-recognition", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
 gpu = [
     { name = "freetype-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "taichi", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'linux') or sys_platform == 'darwin' or sys_platform == 'win32'" },
@@ -1878,19 +1785,12 @@ requires-dist = [
     { name = "demucs", marker = "extra == 'demucs'", specifier = ">=4.0" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.20" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
-    { name = "dlib", marker = "extra == 'all'", specifier = ">=19.24" },
-    { name = "dlib", marker = "extra == 'all-mac'", specifier = ">=19.24" },
-    { name = "dlib", marker = "extra == 'face'", specifier = ">=19.24" },
-    { name = "face-recognition", marker = "extra == 'all'", specifier = ">=1.3" },
-    { name = "face-recognition", marker = "extra == 'all-mac'", specifier = ">=1.3" },
-    { name = "face-recognition", marker = "extra == 'face'", specifier = ">=1.3" },
     { name = "freetype-py", marker = "extra == 'all'", specifier = ">=2.4" },
     { name = "freetype-py", marker = "extra == 'all-mac'", specifier = ">=2.4" },
     { name = "freetype-py", marker = "extra == 'gpu'", specifier = ">=2.4" },
     { name = "geopy", specifier = ">=2.4" },
     { name = "grimp", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "imagehash", specifier = ">=4.3" },
     { name = "immich-memories-music", marker = "extra == 'all'", directory = "packages/immich-memories-music" },
     { name = "immich-memories-music", marker = "extra == 'all-mac'", directory = "packages/immich-memories-music" },
     { name = "immich-memories-music", marker = "extra == 'music'", directory = "packages/immich-memories-music" },
@@ -1898,17 +1798,16 @@ requires-dist = [
     { name = "kaldi-native-fbank", marker = "extra == 'all'", specifier = ">=1.20" },
     { name = "kaldi-native-fbank", marker = "extra == 'all-mac'", specifier = ">=1.20" },
     { name = "kaldi-native-fbank", marker = "extra == 'speech'", specifier = ">=1.20" },
-    { name = "moviepy", specifier = ">=1.0.3" },
     { name = "mutagen", marker = "extra == 'all'", specifier = ">=1.47" },
     { name = "mutagen", marker = "extra == 'all-mac'", specifier = ">=1.47" },
     { name = "mutagen", marker = "extra == 'audio'", specifier = ">=1.47" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "nicegui", specifier = ">=3.12.0" },
+    { name = "nicegui", specifier = ">=3.16.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "oidc-provider-mock", marker = "extra == 'dev'", specifier = ">=0.3" },
-    { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.17" },
-    { name = "onnxruntime", marker = "extra == 'all-mac'", specifier = ">=1.17" },
-    { name = "onnxruntime", marker = "extra == 'speech'", specifier = ">=1.17" },
+    { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.28" },
+    { name = "onnxruntime", marker = "extra == 'all-mac'", specifier = ">=1.28" },
+    { name = "onnxruntime", marker = "extra == 'speech'", specifier = ">=1.28" },
     { name = "opencv-python", specifier = ">=4.9,<5" },
     { name = "panns-inference", marker = "extra == 'all'", specifier = ">=0.1" },
     { name = "panns-inference", marker = "extra == 'all-mac'", specifier = ">=0.1" },
@@ -1940,7 +1839,7 @@ requires-dist = [
     { name = "refurb", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
-    { name = "scenedetect", specifier = ">=0.6" },
+    { name = "scenedetect", specifier = ">=0.7,<0.8" },
     { name = "soundfile", marker = "extra == 'dev'", specifier = ">=0.12" },
     { name = "staticmap", specifier = ">=0.5" },
     { name = "taichi", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'all') or (sys_platform != 'linux' and extra == 'all')", specifier = ">=1.7.0" },
@@ -1951,10 +1850,9 @@ requires-dist = [
     { name = "torch", marker = "extra == 'audio-ml'", specifier = ">=2.0" },
     { name = "types-croniter", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "videohash", specifier = ">=3.0" },
     { name = "watchdog", specifier = ">=3.0" },
 ]
-provides-extras = ["all", "all-mac", "audio", "audio-ml", "auth", "demucs", "dev", "face", "gpu", "mac", "music", "speech", "transcribe"]
+provides-extras = ["all", "all-mac", "audio", "audio-ml", "auth", "demucs", "dev", "gpu", "mac", "music", "speech", "transcribe"]
 
 [[package]]
 name = "immich-memories-music"
@@ -2592,21 +2490,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
-
-[[package]]
-name = "moviepy"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "imageio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "imageio-ffmpeg", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "proglog", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/54/01a8c4e35c75ca9724d19a7e4de9dc23f0ceb8769102c7de056113af61c3/moviepy-1.0.3.tar.gz", hash = "sha256:2884e35d1788077db3ff89e763c5ba7bfddbd7ae9108c9bc809e7ba58fa433f5", size = 388311, upload-time = "2020-05-07T16:27:46.856Z" }
 
 [[package]]
 name = "mpmath"
@@ -3555,18 +3438,6 @@ wheels = [
 ]
 
 [[package]]
-name = "proglog"
-version = "0.1.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/af/c108866c452eda1132f3d6b3cb6be2ae8430c97e9309f38ca9dbd430af37/proglog-0.1.12.tar.gz", hash = "sha256:361ee074721c277b89b75c061336cb8c5f287c92b043efa562ccf7866cda931c", size = 8794, upload-time = "2025-05-09T14:36:18.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl", hash = "sha256:ccaafce51e80a81c65dc907a460c07ccb8ec1f78dc660cfd8f9ec3a22f01b84c", size = 6337, upload-time = "2025-05-09T14:36:16.798Z" },
-]
-
-[[package]]
 name = "prompt-toolkit"
 version = "3.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -4198,65 +4069,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
-]
-
-[[package]]
-name = "pywavelets"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/8b/ca700d0c174c3a4eec1fbb603f04374d1fed84255c2a9f487cfaa749c865/pywavelets-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54662cce4d56f0d6beaa6ebd34b2960f3aa4a43c83c9098a24729e9dc20a4be2", size = 4323640, upload-time = "2025-08-04T16:18:51.683Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f3/0fa57b6407ea9c4452b0bc182141256b9481b479ffbfc9d7fdb73afe193b/pywavelets-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d8ed4b4d1eab9347e8fe0c5b45008ce5a67225ce5b05766b8b1fa923a5f8b34", size = 4294938, upload-time = "2025-08-04T16:18:53.818Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/95/a998313c8459a57e488ff2b18e24be9e836aedda3aa3a1673197deeaa59a/pywavelets-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:862be65481fdfecfd84c6b0ca132ba571c12697a082068921bca5b5e039f1371", size = 4472829, upload-time = "2025-08-04T16:18:55.508Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/8c/f316a153f7f89d2753df8a7371d15d0faab87e709fe02715dbc297c79385/pywavelets-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d76b7fa8fc500b09201d689b4f15bf5887e30ffbe2e1f338eb8470590eb4521a", size = 4524936, upload-time = "2025-08-04T16:18:57.146Z" },
-    { url = "https://files.pythonhosted.org/packages/24/f7/89fdc1caef4b384a341a8e149253e23f36c1702bbb986a26123348624854/pywavelets-1.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:aa859d0b686a697c87a47e29319aebe44125f114a4f8c7e444832b921f52de5a", size = 4481475, upload-time = "2025-08-04T16:18:58.725Z" },
-    { url = "https://files.pythonhosted.org/packages/82/53/b733fbfb71853e4a5c430da56e325a763562d65241dd785f0fadb67aed6a/pywavelets-1.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20e97b84a263003e2c7348bcf72beba96edda1a6169f072dc4e4d4ee3a6c7368", size = 4527994, upload-time = "2025-08-04T16:18:59.917Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/15/5f6a6e9fdad8341e42642ed622a5f3033da4ea9d426cc3e574ae418b4726/pywavelets-1.9.0-cp311-cp311-win32.whl", hash = "sha256:f8330cdbfa506000e63e79525716df888998a76414c5cd6ecd9a7e371191fb05", size = 4136109, upload-time = "2025-08-04T16:19:01.511Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/33/62dbb4aea86ec9d79b283127c42cc896f4d4ff265a9aeb1337a7836dd550/pywavelets-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:ed10959a17df294ef55948dcc76367d59ec7b6aad67e38dd4e313d2fe3ad47b2", size = 4228321, upload-time = "2025-08-04T16:19:03.164Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/37/3fda13fb2518fdd306528382d6b18c116ceafefff0a7dccd28f1034f4dd2/pywavelets-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30baa0788317d3c938560c83fe4fc43817342d06e6c9662a440f73ba3fb25c9b", size = 4320835, upload-time = "2025-08-04T16:19:04.855Z" },
-    { url = "https://files.pythonhosted.org/packages/36/65/a5549325daafc3eae4b52de076798839eaf529a07218f8fb18cccefe76a1/pywavelets-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:df7436a728339696a7aa955c020ae65c85b0d9d2b5ff5b4cf4551f5d4c50f2c7", size = 4290469, upload-time = "2025-08-04T16:19:06.178Z" },
-    { url = "https://files.pythonhosted.org/packages/05/85/901bb756d37dfa56baa26ef4a3577aecfe9c55f50f51366fede322f8c91d/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07b26526db2476974581274c43a9c2447c917418c6bd03c8d305ad2a5cd9fac3", size = 4437717, upload-time = "2025-08-04T16:19:07.514Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/34/0f54dd9c288941294898877008bcb5c07012340cc9c5db9cff1bd185d449/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:573b650805d2f3c981a0e5ae95191c781a722022c37a0f6eba3fa7eae8e0ee17", size = 4483843, upload-time = "2025-08-04T16:19:08.857Z" },
-    { url = "https://files.pythonhosted.org/packages/48/1f/cff6bb4ea64ff508d8cac3fe113c0aa95310a7446d9efa6829027cc2afdf/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3747ec804492436de6e99a7b6130480e53406d047e87dc7095ab40078a515a23", size = 4442236, upload-time = "2025-08-04T16:19:11.061Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/53/a3846eeefe0fb7ca63ae045f038457aa274989a15af793c1b824138caf98/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5163665686219c3f43fd5bbfef2391e87146813961dad0f86c62d4aed561f547", size = 4488077, upload-time = "2025-08-04T16:19:12.333Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/98/44852d2fe94455b72dece2db23562145179d63186a1c971125279a1c381f/pywavelets-1.9.0-cp312-cp312-win32.whl", hash = "sha256:80b8ab99f5326a3e724f71f23ba8b0a5b03e333fa79f66e965ea7bed21d42a2f", size = 4134094, upload-time = "2025-08-04T16:19:13.564Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a7/0d9ee3fe454d606e0f5c8e3aebf99d2ecddbfb681826a29397729538c8f1/pywavelets-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:92bfb8a117b8c8d3b72f2757a85395346fcbf37f50598880879ae72bd8e1c4b9", size = 4213900, upload-time = "2025-08-04T16:19:14.939Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a7/dec4e450675d62946ad975f5b4d924437df42d2fae46e91dfddda2de0f5a/pywavelets-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:74f8455c143818e4b026fc67b27fd82f38e522701b94b8a6d1aaf3a45fcc1a25", size = 4316201, upload-time = "2025-08-04T16:19:16.259Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/0c/b54b86596c0df68027e48c09210e907e628435003e77048384a2dd6767e3/pywavelets-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c50320fe0a4a23ddd8835b3dc9b53b09ee05c7cc6c56b81d0916f04fc1649070", size = 4286838, upload-time = "2025-08-04T16:19:17.92Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/9c/333969c3baad8af2e7999e83addcb7bb1d1fd48e2d812fb27e2e89582cb1/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6e059265223ed659e5214ab52a84883c88ddf3decbf08d7ec6abb8e4c5ed7be", size = 4430753, upload-time = "2025-08-04T16:19:19.529Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/1b/a24c6ff03b026b826ad7b9267bd63cd34ce026795a0302f8a5403840b8e7/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae10ed46c139c7ddb8b1249cfe0989f8ccb610d93f2899507b1b1573a0e424b5", size = 4491315, upload-time = "2025-08-04T16:19:20.717Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/c7/e3fbb502fca3469e51ced4f1e1326364c338be91edc5db5a8ddd26b303fa/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c8f8b1cc2df012401cb837ee6fa2f59607c7b4fe0ff409d9a4f6906daf40dc86", size = 4437654, upload-time = "2025-08-04T16:19:22.359Z" },
-    { url = "https://files.pythonhosted.org/packages/92/44/c9b25084048d9324881a19b88e0969a4141bcfdc1d218f1b4b680b7af1c1/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db43969c7a8fbb17693ecfd14f21616edc3b29f0e47a49b32fa4127c01312a67", size = 4496435, upload-time = "2025-08-04T16:19:23.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/b6/b27ec18c72b1dee3314e297af39c5f8136d43cc130dd93cb6c178ca820e5/pywavelets-1.9.0-cp313-cp313-win32.whl", hash = "sha256:9e7d60819d87dcd6c68a2d1bc1d37deb1f4d96607799ab6a25633ea484dcda41", size = 4132709, upload-time = "2025-08-04T16:19:25.415Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/87/78ef3f9fb36cdb16ee82371d22c3a7c89eeb79ec8c9daef6222060da6c79/pywavelets-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:0d70da9d7858c869e24dc254f16a61dc09d8a224cad85a10c393b2eccddeb126", size = 4213377, upload-time = "2025-08-04T16:19:26.875Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cd/ca0d9db0ff29e3843f6af60c2f5eb588794e05ca8eeb872a595867b1f3f5/pywavelets-1.9.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4dc85f44c38d76a184a1aa2cb038f802c3740428c9bb877525f4be83a223b134", size = 4354336, upload-time = "2025-08-04T16:19:28.745Z" },
-    { url = "https://files.pythonhosted.org/packages/82/d6/70afefcc1139f37d02018a3b1dba3b8fc87601bb7707d9616b7f7a76e269/pywavelets-1.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7acf6f950c6deaecd210fbff44421f234a8ca81eb6f4da945228e498361afa9d", size = 4335721, upload-time = "2025-08-04T16:19:30.371Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/3a/713f731b9ed6df0c36269c8fb62be8bb28eb343b9e26b13d6abda37bce38/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:144d4fc15c98da56654d0dca2d391b812b8d04127b194a37ad4a497f8e887141", size = 4418702, upload-time = "2025-08-04T16:19:31.743Z" },
-    { url = "https://files.pythonhosted.org/packages/44/e8/f801eb4b5f7a316ba20054948c5d6b27b879c77fab2674942e779974bd86/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1aa3729585408a979d655736f74b995b511c86b9be1544f95d4a3142f8f4b8b5", size = 4470023, upload-time = "2025-08-04T16:19:32.963Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/cc/44b002cb16f2a392f2082308dd470b3f033fa4925d3efa7c46f790ce895a/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e0e24ad6b8eb399c49606dd1fcdcbf9749ad7f6d638be3fe6f59c1f3098821e2", size = 4426498, upload-time = "2025-08-04T16:19:34.151Z" },
-    { url = "https://files.pythonhosted.org/packages/91/fe/2b70276ede7878c5fe8356ca07574db5da63e222ce39a463e84bfad135e8/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3830e6657236b53a3aae20c735cccead942bb97c54bbca9e7d07bae01645fe9c", size = 4477528, upload-time = "2025-08-04T16:19:35.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ed/d58b540c15e36508cfeded7b0d39493e811b0dce18d9d4e6787fb2e89685/pywavelets-1.9.0-cp313-cp313t-win32.whl", hash = "sha256:81bb65facfbd7b50dec50450516e72cdc51376ecfdd46f2e945bb89d39bfb783", size = 4186493, upload-time = "2025-08-04T16:19:37.198Z" },
-    { url = "https://files.pythonhosted.org/packages/84/b2/12a849650d618a86bbe4d8876c7e20a7afe59a8cad6f49c57eca9af26dfa/pywavelets-1.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:47d52cf35e2afded8cfe1133663f6f67106a3220b77645476ae660ad34922cb4", size = 4274821, upload-time = "2025-08-04T16:19:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/1f/18c82122547c9eec2232d800b02ada1fbd30ce2136137b5738acca9d653e/pywavelets-1.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:53043d2f3f4e55a576f51ac594fe33181e1d096d958e01524db5070eb3825306", size = 4314440, upload-time = "2025-08-04T16:19:39.701Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e1/1c92ac6b538ef5388caf1a74af61cf6af16ea6d14115bb53357469cb38d6/pywavelets-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bc36b42b1b125fd9cb56e7956b22f8d0f83c1093f49c77fc042135e588c799", size = 4290162, upload-time = "2025-08-04T16:19:41.322Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d3/d856a2cac8069c20144598fa30a43ca40b5df2e633230848a9a942faf04a/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08076eb9a182ddc6054ac86868fb71df6267c341635036dc63d20bdbacd9ad7e", size = 4437162, upload-time = "2025-08-04T16:19:42.556Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/54/777e0495acd4fb008791e84889be33d6e7fc8af095b441d939390b7d2491/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ee1ee7d80f88c64b8ec3b5021dd1e94545cc97f0cd479fb51aa7b10f6def08e", size = 4498169, upload-time = "2025-08-04T16:19:43.791Z" },
-    { url = "https://files.pythonhosted.org/packages/76/68/81b97f4d18491a18fbe17e06e2eee80a591ce445942f7b6f522de07813c5/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3226b6f62838a6ccd7782cb7449ee5d8b9d61999506c1d9b03b2baf41b01b6fd", size = 4443318, upload-time = "2025-08-04T16:19:45.368Z" },
-    { url = "https://files.pythonhosted.org/packages/92/74/5147f2f0436f7aa131cb1bc13dba32ef5f3862748ae1c7366b4cde380362/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9fb7f4b11d18e2db6dd8deee7b3ce8343d45f195f3f278c2af6e3724b1b93a24", size = 4503294, upload-time = "2025-08-04T16:19:46.632Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d4/af998cc71e869919e0ab45471bd43e91d055ac7bc3ce6f56cc792c9b6bc8/pywavelets-1.9.0-cp314-cp314-win32.whl", hash = "sha256:9902d9fc9812588ab2dce359a1307d8e7f002b53a835640e2c9388fe62a82fd4", size = 4144478, upload-time = "2025-08-04T16:19:47.974Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/66/1d071eae5cc3e3ad0e45334462f8ce526a79767ccb759eb851aa5b78a73a/pywavelets-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:7e57792bde40e331d6cc65458e5970fd814dba18cfc4e9add9d051e901a7b7c7", size = 4227186, upload-time = "2025-08-04T16:19:49.57Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1f/da0c03ac99bd9d20409c0acf6417806d4cf333d70621da9f535dd0cf27fa/pywavelets-1.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b47c72fb4b76d665c4c598a5b621b505944e5b761bf03df9d169029aafcb652f", size = 4354391, upload-time = "2025-08-04T16:19:51.221Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/de9e225d8cc307fbb4fda88aefa79442775d5e27c58ee4d3c8a8580ceba6/pywavelets-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:969e369899e7eab546ea5d77074e4125082e6f9dad71966499bf5dee3758be55", size = 4335810, upload-time = "2025-08-04T16:19:52.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/3b/336761359d07cd44a4233ca854704ff2a9e78d285879ccc82d254b9daa57/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8aeffd4f35036c1fade972a61454de5709a7a8fc9a7d177eefe3ac34d76962e5", size = 4422220, upload-time = "2025-08-04T16:19:54.068Z" },
-    { url = "https://files.pythonhosted.org/packages/98/61/76ccc7ada127f14f65eda40e37407b344fd3713acfca7a94d7f0f67fe57d/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f63f400fcd4e7007529bd06a5886009760da35cd7e76bb6adb5a5fbee4ffeb8c", size = 4470156, upload-time = "2025-08-04T16:19:55.379Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/de/142ca27ee729cf64113c2560748fcf2bd45b899ff282d6f6f3c0e7f177bb/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a63bcb6b5759a7eb187aeb5e8cd316b7adab7de1f4b5a0446c9a6bcebdfc22fb", size = 4430167, upload-time = "2025-08-04T16:19:56.566Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/5e/90b39adff710d698c00ba9c3125e2bec99dad7c5f1a3ba37c73a78a6689f/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9950eb7c8b942e9bfa53d87c7e45a420dcddbd835c4c5f1aca045a3f775c6113", size = 4477378, upload-time = "2025-08-04T16:19:58.162Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/1a/89f5f4ebcb9d34d9b7b2ac0a868c8b6d8c78d699a36f54407a060cea0566/pywavelets-1.9.0-cp314-cp314t-win32.whl", hash = "sha256:097f157e07858a1eb370e0d9c1bd11185acdece5cca10756d6c3c7b35b52771a", size = 4209132, upload-time = "2025-08-04T16:20:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d2/a8065103f5e2e613b916489e6c85af6402a1ec64f346d1429e2d32cb8d03/pywavelets-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b6ff6ba4f625d8c955f68c2c39b0a913776d406ab31ee4057f34ad4019fb33b", size = 4306793, upload-time = "2025-08-04T16:20:02.934Z" },
 ]
 
 [[package]]
@@ -5219,21 +5031,6 @@ wheels = [
 ]
 
 [[package]]
-name = "videohash"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "imagedominantcolor", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "imagehash", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "yt-dlp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/97/aa964ed2a1a626201a4bff2a3cfa2d665c535894df3fda34c095d399297f/videohash-3.0.1.tar.gz", hash = "sha256:64ba3876804c584a4ae22c70d4708eea08e559c2ea9ce8a7926a2894b4f38c2f", size = 24321, upload-time = "2022-05-29T07:38:02.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/e5/3fa06f6fc3c7b31cccaa2222c12d459332d2e419cebf238c31bd07cb3e60/videohash-3.0.1-py3-none-any.whl", hash = "sha256:9a230d9cdef4d5b677c7377ddf477662b03feefd52ff675457e0aef3e19ba4d6", size = 23743, upload-time = "2022-05-29T07:38:00.748Z" },
-]
-
-[[package]]
 name = "virtualenv"
 version = "21.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5658,13 +5455,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
-]
-
-[[package]]
-name = "yt-dlp"
-version = "2026.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
 ]


### PR DESCRIPTION
Closes #556.

Four dependencies with no consumer, and three pins that had stopped meaning anything.

## The dead four

| Dep | Claimed use | Actual |
|---|---|---|
| `videohash` | deptry ignore: "used via subprocess" | zero references in `src/` |
| `imagehash` | deptry ignore: "imported via videohash" | zero imports; hashing is hand-rolled on cv2+numpy in `analysis/duplicate_hashing.py` |
| `face` extra (`face-recognition` + `dlib`) | face scoring | zero usage — faces come from Apple Vision, OpenCV and Immich |
| `moviepy` | silence-detection fallback | see below |

They passed `make dep-check` because the `per_rule_ignores` entries excusing them were stale. Removing the deps **and** the ignores together leaves deptry green, which is the proof the justifications were dead text.

## The moviepy fallback was a fallback from ffmpeg to ffmpeg

`detect_silence_gaps` tries `_extract_audio_with_ffmpeg` (system ffmpeg, explicit `-map` stream selection). On failure it called moviepy — which shells out to **imageio-ffmpeg's bundled ffmpeg binary**. Same tool, second copy.

It was also strictly weaker: the primary path exists precisely to select the right stream on iPhone spatial audio (apac), which the fallback's own docstring admitted it could not process. A fallback earns its weight by failing *differently*; this one failed the same way, slower.

Measured on the two new tests, before vs after — identical assertions, identical results:

```
before (fallback present):  2 passed in 27.29s
after  (fallback deleted):  2 passed in  0.09s
```

Extraction failure now returns no gaps. `segment_generation.py` already treats an empty gap list as "make no silence-based boundary adjustment" and keeps its original cuts, so the degradation path is unchanged in effect.

## What comes off the install

`uv lock` drops **12 packages, 184 MB**:

```
dlib, face-recognition, face-recognition-models (125 MB of model data),
imagedominantcolor, imagehash, imageio, imageio-ffmpeg (47 MB — a second
ffmpeg binary), moviepy, proglog, pywavelets, videohash, yt-dlp
```

`yt-dlp` was arriving transitively through `videohash`. `make dev` is `uv sync --all-extras`, so **every contributor following the documented setup was compiling dlib from source for an extra nothing imports** — and that compile is the step that scares NAS users off installs.

## Floors raised while in the file

- **`nicegui>=3.16.0`** — the `>=3.12` floor permitted installs missing 3.16's fixes for an unauthenticated memory exhaustion (GHSA-46f2-xhpw-8vh3) and an XSS (GHSA-955g-h32v-mvrr).
- **`scenedetect>=0.7,<0.8`** — the unbounded `>=0.6` already absorbed the 0.7 major silently. It happened to be safe (and its VFR overhaul is a correctness win for iPhone video), but the next major should not land unannounced.
- **`onnxruntime>=1.28`** — `>=1.17` was meaningless; 1.28+ has the `ORT_*_OP_NUM_THREADS` env controls worth having against thread oversubscription.

## Tests

Two, added **before** the deletion and run against the old code first to pin the contract — `detect_silence_gaps` returns `[]` for an unreadable file and for a missing one. No mocks, no fixture video: a real junk file that ffmpeg genuinely cannot decode.

They pass identically before and after, which is the point — this is a characterization pair, not a red-green cycle, because the PR removes a redundant path rather than adding behavior. Stating that plainly rather than manufacturing a fake RED.

## Also updated

CI's `test-extras` matrix (both legs referenced the now-absent `face` extra, which would have failed the install step), the workflows README, the `extras` pytest marker description, and the two docs pages that advertised the extra.

`make ci` green: 5537 passed, 9 skipped. Diff coverage 100% on changed lines.

## One caveat

`make docs-build` could not be verified locally — this machine's `docs-site/node_modules` predates `@docusaurus/theme-mermaid` being added to `package.json`, so the build fails identically on `main`. The docs change is 5 lines (one removed bash snippet, one table row, one clause) with no new pages, no sidebar change, and a grep confirming nothing links to the removed section. CI's docs job is the real check.
