### PR TITLE
fix(music): align the tempo to the visible cut interval, not the clip length

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -99,12 +99,23 @@ lasts a whole number of beats. Photos hold the screen for a fixed time, so their
 cuts arrive at a steady rate; picking a tempo whose beat divides that rate makes
 the cuts land with the pulse instead of against it.
 
+The rate is the interval between visible cuts, not the photo's length. A
+crossfade starts the next clip before the current one ends, so at the default
+4 s photo duration and 0.5 s crossfade the cuts arrive every 3.5 s. Aligning to
+4 s instead put the pulse 0.21 beats away from the cut on average across the ten
+mood/style combinations, and 0.375 beats away at worst — most of a beat every
+few photos. Against the real 3.5 s interval that drops to 0.03 average, 0.2
+worst. Only 120 bpm divides 3.5 s exactly (the requested tempo is a whole
+number), so most combinations now land near-aligned rather than exactly aligned;
+near-aligned against the true interval beats exactly-aligned against the wrong
+one. With `transition: cut` there is no overlap and the cadence is the full
+photo duration.
+
 The nudge stays inside the genre's own tempo range — drum and bass at 70 bpm is
 not a thing — and within 15% of the mood's own tempo, so a run of short photos
 cannot drag a serene track up to dance tempo. Where neither holds, the mood wins
-and nothing changes. At the default 4 s photo duration all ten mood/style
-combinations land on whole beats, the largest shift being 132 → 120 bpm. Videos are never re-timed: they carry speech and laughter the pipeline
-protects, so only photo cadence drives this.
+and nothing changes. Videos are never re-timed: they carry speech and laughter
+the pipeline protects, so only photo cadence drives this.
 
 Measured on the 28 bundled tracks, ACE-Step honours a requested tempo to within
 0.4% (median), so asking for an aligned tempo is worth doing — but that residual

--- a/src/immich_memories/generate_music.py
+++ b/src/immich_memories/generate_music.py
@@ -138,8 +138,16 @@ def resolve_music(
     memory_type: str | None,
     report_fn: Callable[[str, float, str], None] | None = None,
     bundled_library: Path | None = None,
+    *,
+    transition_overlap: float,
 ) -> MusicSelection:
-    """Determine the music to use: provided path, generated, bundled, or none."""
+    """Determine the music to use: provided path, generated, bundled, or none.
+
+    ``transition_overlap`` is the run's effective crossfade, which both the
+    generated and the bundled branch need to read the photo cut cadence off the
+    clips (#514). It comes from the run rather than ``config.defaults`` because
+    ``--transition`` overrides the configured default.
+    """
     if no_music:
         return MusicSelection(None)
     if music_path and music_path.exists():
@@ -151,7 +159,12 @@ def resolve_music(
             report_fn("music", 0.85, "Generating AI music...")
         try:
             generated = auto_generate_music(
-                config, assembly_clips, run_output_dir, memory_type, report_fn
+                config,
+                assembly_clips,
+                run_output_dir,
+                memory_type,
+                report_fn,
+                transition_overlap=transition_overlap,
             )
         except Exception as exc:  # WHY: optional music must not invalidate the base artifact
             # A configured generator that fails used to be worse than no generator
@@ -182,7 +195,9 @@ def resolve_music(
     bundled = bundled_track_for_mood(
         aggregate_mood_from_clips(assembly_clips),
         library=bundled_library,
-        cadence_seconds=photo_cadence_seconds(assembly_clips),
+        cadence_seconds=photo_cadence_seconds(
+            assembly_clips, transition_overlap=transition_overlap
+        ),
     )
     if not bundled:
         return MusicSelection(None, warning)
@@ -197,17 +212,40 @@ def _master(track: Path, run_output_dir: Path) -> Path:
     return master_music_track(track, run_output_dir / f"mastered_{track.stem}.wav")
 
 
-def photo_cadence_seconds(assembly_clips: list[AssemblyClip]) -> float | None:
+def transition_overlap_seconds(transition: str, transition_duration: float) -> float:
+    """How much a transition shortens the interval between two visible cuts.
+
+    Only a crossfade overlaps: "smart" resolves to a fade at every boundary the
+    assembler builds (``assembly_engine.get_transition_types``), so it costs the
+    same as "crossfade". A hard cut leaves the clips end to end.
+    """
+    return 0.0 if transition in ("cut", "none") else transition_duration
+
+
+def photo_cadence_seconds(
+    assembly_clips: list[AssemblyClip], *, transition_overlap: float
+) -> float | None:
     """How often a photo cut lands, or None when there is no rhythm to sync to.
 
     Read off the clips rather than ``config.photos.duration`` because the final
     budget trim rescales every clip: by the time music is chosen, a photo the
     config called 4 s may be 3.7 s on screen.
+
+    ``transition_overlap`` is not optional on purpose. The cut lands before the
+    clip ends: a crossfade starts the next clip at ``duration - fade``, which is
+    the clock ``_estimate_total_frames`` and ``music_mute_windows`` already keep.
+    Aligning tempo to the raw duration instead drifted 0.75 beats per photo at
+    90 bpm with the default 0.5 s fade (#514), so a caller that has not thought
+    about the overlap should not be able to ask for a cadence at all.
     """
     durations = sorted(clip.duration for clip in assembly_clips if clip.is_photo)
     if len(durations) < 2:
         return None
-    return durations[len(durations) // 2]
+    cadence = durations[len(durations) // 2] - transition_overlap
+    # A fade wider than the photos themselves leaves no interval to sync to.
+    # The assembler downgrades those boundaries to cuts, and the tempo search
+    # divides by the cadence, so a zero or negative one is "no rhythm", not 0.
+    return cadence if cadence > 0 else None
 
 
 def auto_generate_music(
@@ -216,6 +254,8 @@ def auto_generate_music(
     run_output_dir: Path,
     memory_type: str | None,
     report_fn: Callable[[str, float, str], None] | None = None,
+    *,
+    transition_overlap: float,
 ) -> Path | None:
     """Auto-generate music using configured AI backends.
 
@@ -267,7 +307,9 @@ def auto_generate_music(
                 progress_callback=music_progress,
                 app_config=config,
                 memory_type=memory_type,
-                photo_cadence_seconds=photo_cadence_seconds(assembly_clips),
+                photo_cadence_seconds=photo_cadence_seconds(
+                    assembly_clips, transition_overlap=transition_overlap
+                ),
                 # This path masters the full mix and ducks that. It has no way to
                 # use stems, so it used to run Demucs and drop the result (#499).
                 separate_stems=False,

--- a/src/immich_memories/generate_settings.py
+++ b/src/immich_memories/generate_settings.py
@@ -255,6 +255,7 @@ def _run_music_phase(
         MusicPhaseResult,
         apply_music_file,
         resolve_music,
+        transition_overlap_seconds,
     )
 
     def _report_fn(phase: str, progress: float, msg: str) -> None:
@@ -275,6 +276,9 @@ def _run_music_phase(
             run_output_dir=run_output_dir,
             memory_type=params.memory_type,
             report_fn=_report_fn,
+            transition_overlap=transition_overlap_seconds(
+                params.transition, params.transition_duration
+            ),
         )
         if not selection.path:
             if phase_started and selection.warning:

--- a/tests/test_beat_grid.py
+++ b/tests/test_beat_grid.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from immich_memories.audio.beat_grid import beat_aligned_bpm
-from immich_memories.generate_music import photo_cadence_seconds
+from immich_memories.generate_music import photo_cadence_seconds, transition_overlap_seconds
 from immich_memories.processing.assembly_config import AssemblyClip
 
 
@@ -48,13 +48,39 @@ class TestPhotoCadence:
         """The final budget trim scales every clip, so config.photos.duration lies."""
         clips = [_clip(3.7, is_photo=True), _clip(3.7, is_photo=True), _clip(9.1, is_photo=False)]
 
-        assert photo_cadence_seconds(clips) == 3.7
+        assert photo_cadence_seconds(clips, transition_overlap=0.0) == 3.7
 
     def test_a_single_photo_has_no_cadence(self):
         """One photo is not a rhythm; syncing tempo to it would be arbitrary."""
         clips = [_clip(4.0, is_photo=True), _clip(9.1, is_photo=False)]
 
-        assert photo_cadence_seconds(clips) is None
+        assert photo_cadence_seconds(clips, transition_overlap=0.0) is None
+
+    def test_a_crossfade_makes_the_cut_land_before_the_clip_ends(self):
+        """The assembler starts the next clip at duration - fade, so 4.0s photos
+        under the default 0.5s crossfade are visibly cut every 3.5s (#514)."""
+        clips = [_clip(4.0, is_photo=True), _clip(4.0, is_photo=True)]
+
+        assert photo_cadence_seconds(clips, transition_overlap=0.5) == 3.5
+
+    def test_a_fade_wider_than_the_photos_is_not_a_rhythm(self):
+        """The tempo search divides by the cadence, so a non-positive one has to
+        read as "nothing to sync to" rather than as an interval of zero."""
+        clips = [_clip(0.4, is_photo=True), _clip(0.4, is_photo=True)]
+
+        assert photo_cadence_seconds(clips, transition_overlap=0.5) is None
+
+
+class TestTransitionOverlap:
+    def test_a_hard_cut_leaves_the_clips_end_to_end(self):
+        assert transition_overlap_seconds("cut", 0.5) == 0.0
+        assert transition_overlap_seconds("none", 0.5) == 0.0
+
+    def test_smart_costs_the_same_as_crossfade(self):
+        """ "smart" is not a middle ground: get_transition_types resolves it to a
+        fade at every boundary, so it overlaps exactly like an explicit crossfade."""
+        assert transition_overlap_seconds("smart", 0.5) == 0.5
+        assert transition_overlap_seconds("crossfade", 0.5) == 0.5
 
 
 class TestCaptionTempoFollowsTheCadence:

--- a/tests/test_bundled_music_fallback.py
+++ b/tests/test_bundled_music_fallback.py
@@ -64,6 +64,7 @@ def test_resolve_music_uses_the_bundle_when_no_backend_is_configured(library):
         run_output_dir=library,
         memory_type=None,
         bundled_library=library,
+        transition_overlap=0.0,
     )
 
     assert chosen.path is not None
@@ -80,6 +81,7 @@ def test_no_music_still_means_no_music(library):
         run_output_dir=library,
         memory_type=None,
         bundled_library=library,
+        transition_overlap=0.0,
     )
 
     assert chosen.path is None
@@ -97,6 +99,7 @@ def test_a_missing_explicit_track_is_not_silently_replaced(library, tmp_path):
         run_output_dir=library,
         memory_type=None,
         bundled_library=library,
+        transition_overlap=0.0,
     )
 
     assert chosen.path is None
@@ -129,6 +132,7 @@ def test_bundled_music_is_mastered_before_use(library, tmp_path):
             run_output_dir=tmp_path,
             memory_type=None,
             bundled_library=library,
+            transition_overlap=0.0,
         )
     finally:
         mastering.master_music_track = original
@@ -163,6 +167,7 @@ def _bundled_choice(clips, library, tmp_path, monkeypatch):
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=library,
+        transition_overlap=0.0,
     ).path
 
 
@@ -237,6 +242,7 @@ def test_a_user_supplied_track_is_left_alone(library, tmp_path):
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=library,
+        transition_overlap=0.0,
     )
 
     assert chosen.path == theirs

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -806,7 +806,11 @@ class TestAutoMusicGeneration:
             )
 
             result = auto_generate_music(
-                params.config, assembly_clips, tmp_path / "run_output", params.memory_type
+                params.config,
+                assembly_clips,
+                tmp_path / "run_output",
+                params.memory_type,
+                transition_overlap=0.0,
             )
             assert result is not None
             assert result == fake_music_path
@@ -827,7 +831,11 @@ class TestAutoMusicGeneration:
             config=config,
         )
         result = auto_generate_music(
-            params.config, assembly_clips, tmp_path / "run_output", params.memory_type
+            params.config,
+            assembly_clips,
+            tmp_path / "run_output",
+            params.memory_type,
+            transition_overlap=0.0,
         )
         assert result is None
 
@@ -858,7 +866,11 @@ class TestAutoMusicGeneration:
             pytest.raises(RuntimeError, match="API unreachable"),
         ):
             auto_generate_music(
-                params.config, assembly_clips, tmp_path / "run_output", params.memory_type
+                params.config,
+                assembly_clips,
+                tmp_path / "run_output",
+                params.memory_type,
+                transition_overlap=0.0,
             )
 
 

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -2260,6 +2260,7 @@ class TestResolveMusic:
             assembly_clips=[],
             run_output_dir=tmp_path,
             memory_type=None,
+            transition_overlap=0.0,
         )
         assert result.path is None
 
@@ -2275,6 +2276,7 @@ class TestResolveMusic:
             assembly_clips=[],
             run_output_dir=tmp_path,
             memory_type=None,
+            transition_overlap=0.0,
         )
         assert result.path == music
 
@@ -2288,6 +2290,7 @@ class TestResolveMusic:
             assembly_clips=[],
             run_output_dir=tmp_path,
             memory_type=None,
+            transition_overlap=0.0,
         )
         assert result.path is None
 
@@ -2317,6 +2320,7 @@ class TestResolveMusic:
                 run_output_dir=tmp_path,
                 memory_type="month",
                 report_fn=report_fn,
+                transition_overlap=0.0,
             )
 
         mock_gen.assert_called_once()
@@ -2337,6 +2341,7 @@ class TestResolveMusic:
                 run_output_dir=tmp_path,
                 memory_type=None,
                 bundled_library=tmp_path / "no-bundle",
+                transition_overlap=0.0,
             )
         # Silent only when there is no bundled music to fall back to (#308).
         assert result.path is None
@@ -2371,7 +2376,7 @@ class TestAutoGenerateMusic:
         config = Config()
         # WHY: music_config_available checks MusicGen/ACE-Step service configs
         with patch("immich_memories.generate_music.music_config_available", return_value=False):
-            result = auto_generate_music(config, [], tmp_path, None)
+            result = auto_generate_music(config, [], tmp_path, None, transition_overlap=0.0)
         assert result is None
 
     def test_generation_exception_reaches_optional_phase_boundary(self, tmp_path):
@@ -2387,7 +2392,7 @@ class TestAutoGenerateMusic:
             ),
             pytest.raises(RuntimeError, match="API down"),
         ):
-            auto_generate_music(config, [], tmp_path, "month")
+            auto_generate_music(config, [], tmp_path, "month", transition_overlap=0.0)
 
 
 class TestMusicConfigAvailable:

--- a/tests/test_music_bundled_fallback.py
+++ b/tests/test_music_bundled_fallback.py
@@ -68,6 +68,7 @@ def test_a_failing_generator_falls_back_to_the_bundled_track(
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=_library(tmp_path),
+        transition_overlap=0.0,
     )
 
     assert result.path is not None, "a failed generator must not produce silence"
@@ -93,6 +94,7 @@ def test_the_bundled_substitution_is_reported_not_swallowed(
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=_library(tmp_path),
+        transition_overlap=0.0,
     )
 
     assert result.warning is not None
@@ -146,6 +148,7 @@ def test_an_explicit_missing_track_is_still_a_user_error(
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=_library(tmp_path),
+        transition_overlap=0.0,
     )
 
     assert result.path is None
@@ -160,6 +163,7 @@ def test_no_music_still_means_no_music(tmp_path: Path, generator_enabled: Config
         run_output_dir=tmp_path,
         memory_type=None,
         bundled_library=_library(tmp_path),
+        transition_overlap=0.0,
     )
 
     assert result.path is None

--- a/tests/test_music_pipeline.py
+++ b/tests/test_music_pipeline.py
@@ -406,7 +406,7 @@ class TestSeparationIsOptional:
             new_callable=AsyncMock,
             return_value=None,
         ) as generate:
-            auto_generate_music(config, [], tmp_path, None)
+            auto_generate_music(config, [], tmp_path, None, transition_overlap=0.0)
 
         assert generate.await_args.kwargs["separate_stems"] is False
 


### PR DESCRIPTION
Closes #514.

## What

`photo_cadence_seconds` returned the median **raw photo duration**. A crossfade starts the next clip at `duration - fade`, so at the default 4.0 s photo and 0.5 s crossfade the viewer sees a cut every **3.5 s** — while both the ACE-Step tempo request and the bundled-track pick were aligned to 4.0 s.

The assembler already keeps that clock in two places (`_estimate_total_frames`, `music_mute_windows`). The cadence path was the one that didn't.

## Does it actually help?

Measured across all ten mood/style combinations, scoring each against the **real** 3.5 s interval (script run against the shipped profiles, not estimated):

| | mean drift | worst |
|---|---|---|
| before (aligned to 4.0 s) | 0.212 beats/photo | 0.375 |
| after (aligned to 3.5 s) | **0.030** | **0.200** |

Per-combination, before → after bpm: calm/acoustic 75→69, nostalgic/acoustic 75→86, energetic/electronic 150→137, happy/electronic 120→120 (already right).

## An honest wrinkle worth knowing

Only **120 bpm divides 3.5 s exactly**, because the requested tempo is rounded to a whole number (`60n/3.5 = 120n/7`). So after this change 2/10 combinations are *exactly* aligned where 10/10 were before — but they were exactly aligned to the wrong interval. Near-aligned against the true interval (0.03 beats) beats exactly-aligned against an interval the viewer never sees (0.212 beats). I've written this into the docs rather than quietly dropping the old claim.

This also sharpens #312: true beat-locked cuts will need the tempo search to stop rounding to integer bpm, or the cut interval to be chosen to suit the tempo.

## Design note

`transition_overlap` is a **required** keyword argument, not one defaulting to `0.0`. Forgetting the overlap is precisely this bug; a caller that hasn't thought about it shouldn't be able to ask for a cadence at all. That cost ~10 one-line updates at existing call sites, which I think is the right trade.

It's resolved from the run's **effective** transition (`params.transition`), not `config.defaults.transition`, because `--transition cut` overrides the configured default — reading config there would have subtracted a fade that the run isn't applying.

## Tests

- `test_a_crossfade_makes_the_cut_land_before_the_clip_ends` — the issue's ask: 4.0 s photos at the default 0.5 s crossfade give 3.5 s. RED before.
- `test_a_fade_wider_than_the_photos_is_not_a_rhythm` — a non-positive cadence must read as "nothing to sync to"; the tempo search divides by it.
- `TestTransitionOverlap` — `cut`/`none` → 0.0, and `smart` costs the same as `crossfade` (it resolves to a fade at every boundary, which is not obvious from the name).

`make ci` passes (5504 passed, 9 skipped). `make docs-build` passes.

## Adjacent findings (not fixed here)

1. **The overlap is modelled, not observed.** `assembly_engine._validate_fade_transitions` downgrades a fade to a cut when either clip is shorter than `2 * fade`, and per-clip `outgoing_transition` can override. The real transition list exists at assembly time and is already surfaced to the music phase as `music_mute_windows`; a follow-up could surface the true mean photo interval the same way instead of deriving it. For default-shaped runs (4 s photos, 0.5 s fade) the two agree.
2. `photos/scoring.py` and this path both encode "default photo duration" assumptions independently — worth a look if photo durations ever become variable.

---
Successor to #563: identical change rebased flat onto current main. The old branch carried a hand-written merge commit whose message fails the commitlint gate, and branch history rewrites are not permitted, so the branch was replaced instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f