### PR TITLE
fix(ui): hand the photo merge its thumbnail cache so bursts collapse

### DIFF
--- a/src/immich_memories/ui/pages/clip_pipeline.py
+++ b/src/immich_memories/ui/pages/clip_pipeline.py
@@ -325,6 +325,7 @@ def _run_pipeline_blocking(
                     config=app_config,
                     client=client,
                     work_dir=Path(app_config.cache.cache_path) / "photo_scoring",
+                    thumbnail_cache=tc,
                 )
 
             result = pipeline.run_selection(all_candidates)

--- a/tests/test_clip_pipeline_ui.py
+++ b/tests/test_clip_pipeline_ui.py
@@ -160,3 +160,48 @@ def test_blocking_pipeline_cannot_reintroduce_unchecked_photos() -> None:
     assert state.pipeline_result["stats"]["eligible_count"] == 1
     assert state.pipeline_result["stats"]["deeply_analyzed_count"] == 0
     assert state.pipeline_result["stats"]["planned_count"] == 0
+
+
+def test_blocking_pipeline_hands_the_photo_merge_its_thumbnail_cache() -> None:
+    """Burst de-duplication is switched on by the thumbnail cache, not by config.
+
+    `_drop_burst_duplicates` returns the pool untouched when the cache is None
+    — unlike its siblings, it has no `thumbnail_fn` fallback — so a merge call
+    that omits the cache silently ships every frame of a held shutter. On a real
+    June pool that was 21% of the photos (`photos/photo_pipeline.py`).
+    """
+    photo = _photo("burst-frame")
+    state = AppState(
+        config=Config(),
+        immich_url="http://immich.test",
+        immich_api_key="test-key",
+        include_photos=True,
+        photo_assets=[photo],
+        thumbnail_cache=MagicMock(),
+        analysis_cache=MagicMock(),
+    )
+    pipeline = MagicMock()
+    pipeline.last_deep_analysis_count = 0
+    pipeline.run_analysis.return_value = []
+    pipeline.run_selection.return_value = MagicMock(
+        selected_clips=[], clip_segments={}, errors=[], stats={}
+    )
+    progress_state = {"cancelled": False, "done": False, "error": None}
+
+    with (
+        # WHY: Immich is the external boundary — the wizard's library read.
+        patch("immich_memories.ui.pages.clip_pipeline.SyncImmichClient") as client_cls,
+        # WHY: the pipeline is not under test here; only what the merge is handed.
+        patch("immich_memories.analysis.smart_pipeline.SmartPipeline", return_value=pipeline),
+        patch("immich_memories.config.get_config", return_value=state.config),
+        # WHY: the seam under inspection — captures the arguments, runs nothing.
+        patch(
+            "immich_memories.cli._pipeline_runner._merge_photos_into_pool",
+            return_value=[],
+        ) as merge_photos,
+    ):
+        client_cls.return_value.__enter__.return_value = MagicMock()
+        _run_pipeline_blocking(state, PipelineConfig(), [], [photo], progress_state)
+
+    assert progress_state["error"] is None
+    assert merge_photos.call_args.kwargs.get("thumbnail_cache") is state.thumbnail_cache


### PR DESCRIPTION
Refs #505 — one row of that issue's asymmetry list. It stays open; seven rows remain.

## What was wrong

`ui/pages/clip_pipeline.py` called `_merge_photos_into_pool` without `thumbnail_cache`. The parameter defaults to `None`, so there was no error, no crash, and no log line — the UI simply ran photo scoring with no cache.

That argument feeds three things. Two of them degrade gracefully:

| consumer | without a cache |
|---|---|
| `_thumbnail_hash_resolver` (moment suppression) | falls back to `thumbnail_fn` — works, just refetches |
| `_apply_frame_quality` | `if (thumbnail_cache is thumbnail_fn is None)` — works via `thumbnail_fn` |
| **`_drop_burst_duplicates`** | **`if thumbnail_cache is None: return scored`** — no fallback, silently does nothing |

So burst de-duplication never ran in the UI. Every frame of a held shutter arrived at selection as a separate photo, competing on its own metadata score. The comment above the call in `photos/photo_pipeline.py` measures that at **21% of a real June pool**, and notes that collapsing bursts before scoring means each one dropped is also an LLM call saved — so the UI was paying for those calls too.

## Why it stayed hidden

Inconsistent degradation. Two of the three consumers kept working, so nothing about the UI looked broken — only the silent one stopped. Combined with a keyword argument that defaults to `None`, there was no signal at all: no exception, no type error, nothing in the logs.

## The fix

The cache was already in scope as `tc` three lines above the call, already guarded against `None` (`_run_pipeline_blocking` raises if it is missing). One line forwards it.

## Test

Genuine RED → GREEN, following the plumbing-test pattern #495 established here yesterday (`test_photo_cap_plumbing.py`): assert the value reaches the consumer, because a dial that never arrives is indistinguishable from a dial set to its default.

The existing `test_blocking_pipeline_cannot_reintroduce_unchecked_photos` already patches `_merge_photos_into_pool` and asserts on `call_args.kwargs` — the bug survived only because no one asserted on *this* kwarg. The new test is a sibling that does.

RED verified for the right reason before the fix:

```
assert merge_photos.call_args.kwargs.get("thumbnail_cache") is state.thumbnail_cache
E  AssertionError: assert None is <MagicMock id='4488327872'>
```

`make ci` green: 5552 passed, 9 skipped. Diff coverage passed.

## One thing I did not fix, deliberately

The root asymmetry is still there: `_drop_burst_duplicates` is the only one of the three consumers that no-ops silently instead of falling back to `thumbnail_fn`. Any future caller that forgets the cache gets the same invisible behaviour — the UI was just the first to find out.

Giving it the same fallback its siblings have would fix the class rather than the instance, but it changes shared CLI behaviour (more thumbnail fetches when no cache is present, which is why `_apply_frame_quality` carries a fetch budget). That is a design call, not a wiring fix, and the standing order is settle down — so it is flagged here rather than done unilaterally.
