### PR TITLE
docs: correct three claims the shipped pipeline no longer supports

### DIFF
--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -163,7 +163,46 @@ Videos, live photos, and regular photos all compete in a single selection pool. 
    c. Scale to target duration (sole monthly representatives protected)
    d. Temporal dedup (same-moment clips across ALL types), with the window measured against the memory's span
    e. Prefer variety, then progressively relax preferences when the timeline is short
+7. STABILISE: verify → judge → review, looping until the cut stops changing
 ```
+
+### Phase 5: the cut has to survive being looked at
+
+Selecting is not the last word. A clip can reach the final cut without anything having actually
+looked at it, and a cut that scores well can still be repetitive. Three stages run after
+selection, and every drop re-runs selection — which admits new clips that nothing has judged
+yet, which is why they loop.
+
+**Verify** catches clips nobody looked at. Two ways that happens: the clip carries a metadata
+guess instead of a real score, or it has a real visual score but no content analysis, so the
+review would be handed a bare line and — correctly — told never to drop a clip for missing
+information. Either way the clip is analysed for real and selection re-runs. Cold, that is a
+download and a full analysis; warm, it is a cache hit. Photographs are never queued here: their
+real look is the photo scorer, which has already run.
+
+**Judge** is mechanical and cheap — thresholds, no model. A non-favourite scoring below
+`judge_floor_score` (0.30) never ships. Separately, the chronologically last clip cannot be both
+the weakest in the cut and below `judge_boundary_ratio` (0.6) of the mean, because a video should
+not end on its worst shot. Favourites are exempt from both rules: the user chose them, and
+"start with all favourites" is the selection's oldest contract.
+
+**Review** is one LLM call over the whole cut — every clip's description, emotion, setting,
+subjects, audio categories, date and place, in timeline order. It is asked which clips are
+redundant, which subject is crowding out the rest, which clip clashes, and which is not a memory
+at all. It can drop at most 20% of the selection in one pass, never a favourite, and any failure
+or unparseable answer drops nothing. It is **optional by construction** — with no LLM configured
+it returns no drops and the selection is unchanged.
+
+`analysis.max_refinement_passes` (default 10) bounds each of these loops. It is the single
+largest multiplier on what a warm run costs, because each review pass is an uncached LLM call —
+the per-clip analysis is cached, but the review reads the current selection, which changes every
+round, so there is nothing to key a cache on. Lower it with
+`advanced.analysis.max_refinement_passes` or `--refinement-passes`; `preset: fast` uses 3.
+
+If the review is still dropping clips when the budget runs out, one final review runs that drops
+without refilling — a cut four seconds short beats a cut that ends on a photo of a shelf.
+
+See [Pipeline overview](./pipeline-overview.md) for how this sits in the run as a whole.
 
 The Step 2 checkboxes define the source pool. **Fast** means “deeply analyze fewer videos,” not
 “throw the rest away.” The completion summary reports eligible media, videos deeply analyzed, and

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -85,9 +85,33 @@ If Immich runs on the same Docker network, use the container name (`immich-serve
 - **Scheduling**: `immich-memories auto install` cannot install a cron job inside the container. Run it from the NAS host's scheduler instead: `docker exec immich-memories immich-memories auto run --quiet --cooldown 24` (daily is plenty)
 - **Photo support**: Ken Burns animations, face-aware pan, blur backgrounds
 
+### What still curates without an LLM
+
+Worth being precise about, because "no LLM" reads like "no curation" and that is not what
+happens. Only the final review is gated on a model — the rest of the loop is arithmetic over
+data Immich and the analyzer already produced:
+
+- **The verify pass.** A clip can reach the cut carrying a metadata *guess* for a score rather
+  than a real one. Verify finds those, analyses them properly, and re-runs selection. This runs
+  regardless of whether an LLM is configured.
+- **The mechanical judge.** A non-favourite scoring below the floor never ships, and the memory
+  cannot end on a clip that is both its weakest and well under the average — a video should not
+  end on its worst shot. Pure thresholds, no model.
+- **Event-vs-catalogue detection.** A dense day is only promoted as an event if Immich
+  recognised people in enough of it. This is what stops 130 photos of an empty apartment (a
+  property viewing) from beating the month's real days. It reads Immich's existing face
+  recognition, so it costs nothing extra.
+- **Favourites first.** Every favourite in range is taken before anything competes on score,
+  and favourites are exempt from the judge's floor.
+- **Adaptive coverage.** Every month or week in range is guaranteed at least one clip, and a
+  sole representative of a period is protected when the cut is scaled down to fit.
+
+What you actually give up is redundancy detection across the finished cut — two near-identical
+moments can both survive, because nothing read their descriptions side by side.
+
 ## What doesn't work
 
-- **LLM content analysis**: needs a separate LLM server (mlx-vlm, Ollama, vLLM). Without it, scoring uses motion + faces + audio only: still good, just not as context-aware.
+- **LLM content analysis**: needs a separate LLM server (mlx-vlm, Ollama, vLLM). Without it the pipeline loses the holistic review — the one pass that reads every clip's description together and spots the same birthday candles twice. Everything else in the curation loop still runs; see below.
 - **AI music generation**: MusicGen and ACE-Step need GPU servers. Use custom music upload instead.
 - **GPU encoding**: NAS CPUs (Celeron, Atom, low-end Xeon) don't have usable GPU encoders. Encoding is CPU-only via libx264.
 - **Taichi GPU title renderer**: falls back to PIL. Title screens still look good, just without particle effects and animated gradients.

--- a/docs-site/docs/deploy/hardware/cpu-only.md
+++ b/docs-site/docs/deploy/hardware/cpu-only.md
@@ -60,10 +60,26 @@ On a modern CPU (4+ cores), expect roughly:
 
 - **Encoding**: 0.2-0.5x realtime for 1080p H.264 (a 3-minute video takes 6-15 minutes)
 - **Analysis**: Similar speed (most analysis is CPU-bound regardless of GPU)
-- **Title rendering**: Near-instant with PIL (no GPU kernel compilation)
+- **Title rendering**: the dominant cost — see below
 - **Transitions**: Negligible difference for typical clip counts
 
-The biggest slowdown without a GPU is video encoding. If encoding speed matters, consider a machine with hardware encoding support.
+### Title rendering is the bottleneck, not encoding
+
+This page used to say title rendering was near-instant on CPU. It is the opposite, and the
+number is worth knowing before you size a box.
+
+Measured 2026-08-23 in the container with `--cpus=2`, generating 18 seconds of output:
+**title rendering took ~263 s of a ~339 s assembly**, and assembly was ~94% of the whole run.
+Titles are seconds of video, but every frame of them is composed pixel by pixel on the CPU,
+while the clips around them are a decode-and-encode the CPU is comparatively good at.
+
+The practical consequences:
+
+- A **shorter or simpler title** is the cheapest large win available on a CPU-only box.
+- Rendering cost scales with title **duration and resolution**, not with how many clips the
+  memory has — a 12-clip memory and a 40-clip memory pay nearly the same title bill.
+- Hardware encoding helps the encode, which is the smaller half. Buy a GPU for the titles
+  before you buy one for the encoder.
 
 ## Preflight check
 


### PR DESCRIPTION
Refs #520 — three of its items. The issue stays open; the missing pages and nice-to-haves remain.

One concern: **three places where the docs describe a product older than the one that ships.** Each claim was checked against code or a measurement rather than against the issue text.

## 1. `cpu-only.md` had the bottleneck backwards

The page said:

> **Title rendering**: Near-instant with PIL (no GPU kernel compilation)
> […] The biggest slowdown without a GPU is video encoding.

Title rendering is the **dominant** cost on a CPU-only box. Measured 2026-08-23 in the container with `--cpus=2`, generating 18 seconds of output:

| | |
|---|---|
| Title render | **~263 s** |
| Full assembly | ~339 s |
| Assembly share of the run | ~94% |

Titles are a few seconds of video, but every frame is composed pixel by pixel on the CPU, while the clips around them are a decode-and-encode the CPU is comparatively good at.

This mattered practically: a reader sizing a NAS was being pointed at the encoder, which is the smaller half. The replacement gives the number and what follows from it — cost scales with title **duration and resolution**, not clip count, so a 12-clip and a 40-clip memory pay nearly the same title bill, and shortening the title is the cheapest large win available.

## 2. `nas-only.md` undersold the no-LLM pipeline

The page said scoring without an LLM "uses motion + faces + audio only: still good, just not as context-aware."

Only the **holistic review** is gated on a model — `SelectionQuality.review` returns no drops when `content_analysis.enabled` is false, and its docstring says so: *"Optional by construction — no LLM, no drops, selection unchanged."* Verified in code, everything else in the curation loop still runs:

- **verify pass** — `_needs_a_real_look` returns `True` for any clip carrying a metadata guess rather than a real score, independent of LLM config
- **mechanical judge** — `judge_offenders` is pure thresholds; no model anywhere in it
- **event-vs-catalogue detection** — `_people_share` reads Immich's *existing* face recognition ("Free: Immich has already run face recognition over the library"). This is what stops 130 photos of an empty apartment beating the month's real days
- **favourites first** and **adaptive coverage**

This is the NAS pitch page, and it was underselling what a NAS user actually gets. The new section also states plainly what *is* lost — cross-cut redundancy detection, because nothing reads the descriptions side by side — rather than replacing an understatement with an overstatement.

## 3. `clip-selection-scoring.md` stopped at Phase 4

The flagship mechanism's own page ended its process list before verify, judge and review — the stages that make a cut survive being looked at.

Now documented: all three stages, **why they loop** (every drop re-runs selection, and a re-selection admits clips nothing has judged yet), the judge's two rules with the favourite exemption and the reason for it, the review's 20% cap and fail-open behaviour, the final drop-without-refill pass, and why `max_refinement_passes` is a bill rather than a clock — the per-clip analysis is cached, the review is not, because it reads a selection that changes every round.

## Verification

`make docs-build` **exit 0**, with a clean `npm ci` in the worktree. `make ci` green: 5551 passed.

Worth recording: verifying via a **symlinked** `docs-site/node_modules` does not work — Docusaurus fails 62 static paths with `Cannot read properties of undefined (reading 'id')`, and it fails **identically on clean `main`**, so the symlink route can neither confirm nor deny a docs change. I checked the baseline before blaming my own edits.
