### PR TITLE
feat(processing): sample frames one way, and decode each video once

### DIFF
--- a/src/immich_memories/audio/mood_analyzer.py
+++ b/src/immich_memories/audio/mood_analyzer.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import subprocess
-import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +11,9 @@ from pathlib import Path
 from immich_memories.security import validate_video_path
 
 logger = logging.getLogger(__name__)
+
+# A vision model needs more detail than a colour histogram.
+_MOOD_FRAME_WIDTH = 512
 
 # Valid values for LLM output validation (whitelist approach)
 VALID_MOODS = frozenset(
@@ -151,78 +152,22 @@ class MoodAnalyzer(ABC):
         num_frames: int = 5,
         output_dir: Path | None = None,
     ) -> list[Path]:
-        """Extract keyframes from a video using FFmpeg.
+        """Evenly spaced frames from a video, for the mood model to look at.
 
-        Args:
-            video_path: Path to the video
-            num_frames: Number of frames to extract
-            output_dir: Directory for output frames
+        Delegates to processing.frame_sampling, which is also what the title
+        colour sampler uses. Both were the same loop — probe the duration,
+        space the timestamps, one ffmpeg per frame — written twice and cached
+        neither time, so every run re-decoded the same video.
 
-        Returns:
-            List of paths to extracted frames
+        512px because a vision model needs more than a colour histogram does;
+        that width is the only thing this caller decides.
         """
-        # Validate video path before any subprocess calls
+        from immich_memories.processing.frame_sampling import sample_frames
+
         validated_video = validate_video_path(video_path, must_exist=True)
-
-        if output_dir is None:
-            output_dir = Path(tempfile.mkdtemp(prefix="keyframes_"))
-        else:
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Get video duration
-        probe_cmd = [
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            "format=duration",
-            "-of",
-            "default=noprint_wrappers=1:nokey=1",
-            str(validated_video),
-        ]
-
-        try:
-            result = subprocess.run(probe_cmd, capture_output=True, text=True, check=True)
-            duration = float(result.stdout.strip())
-        except (subprocess.CalledProcessError, ValueError):
-            logger.warning("Could not determine video duration, using 60s")
-            duration = 60.0
-
-        # Calculate frame times (evenly distributed)
-        frame_times = [duration * i / (num_frames + 1) for i in range(1, num_frames + 1)]
-
-        frames = []
-        for i, time in enumerate(frame_times):
-            output_path = output_dir / f"frame_{i:03d}.jpg"
-
-            cmd = [
-                "ffmpeg",
-                "-y",
-                "-ss",
-                str(time),
-                "-i",
-                str(validated_video),
-                "-vframes",
-                "1",
-                "-q:v",
-                "2",
-                "-vf",
-                "scale=512:-1",  # Resize for faster analysis
-                str(output_path),
-            ]
-
-            try:
-                subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    check=True,
-                )
-                if output_path.exists():
-                    frames.append(output_path)
-            except subprocess.CalledProcessError as e:
-                logger.warning(f"Failed to extract frame at {time}s: {e}")
-
-        return frames
+        return sample_frames(
+            validated_video, count=num_frames, width=_MOOD_FRAME_WIDTH, cache_dir=output_dir
+        )
 
     @staticmethod
     def _extract_json_from_text(text: str) -> str:

--- a/src/immich_memories/processing/frame_sampling.py
+++ b/src/immich_memories/processing/frame_sampling.py
@@ -1,0 +1,158 @@
+"""Sampling still frames from a video: one implementation, cached.
+
+Written three times before this: the mood analyser at scale=512, the title
+colour sampler at scale=320, and the analysis preview builder. The first two
+are the same algorithm — probe the duration, take evenly spaced timestamps,
+run one ffmpeg per frame — and neither kept the result, so every run decoded
+the same video again.
+
+The width genuinely differs by caller: a colour palette does not need what a
+vision model needs. That is a parameter, not a reason to write it twice.
+
+Frames are cached under a key covering everything that changes the pixels:
+the video's identity and size, how many frames, and how wide. A cache that
+cannot be written costs decodes, never the run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_DURATION_SECONDS = 60.0
+
+
+def even_timestamps(duration: float, count: int) -> list[float]:
+    """Evenly spaced sample points, avoiding the very first and last frame.
+
+    duration*i/(count+1) rather than i/count: the first and last frame of a
+    clip are the ones most likely to be a fade, a black frame or a cut.
+    """
+    usable = duration if duration > 0 else _FALLBACK_DURATION_SECONDS
+    return [usable * i / (count + 1) for i in range(1, count + 1)]
+
+
+def probe_duration(video: Path) -> float:
+    """Length in seconds, or 0.0 when the container will not say."""
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, path is not shell-interpreted
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(video),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        return float(result.stdout.strip())
+    except (subprocess.SubprocessError, OSError, ValueError) as exc:
+        logger.debug("Could not read duration of %s (%s)", video.name, type(exc).__name__)
+        return 0.0
+
+
+def _extract_one(video: Path, timestamp: float, width: int, out_path: Path) -> bool:
+    """One frame at one timestamp. -ss before -i so ffmpeg seeks instead of decoding."""
+    try:
+        subprocess.run(  # noqa: S603 - fixed argv, paths are not shell-interpreted
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(timestamp),
+                "-i",
+                str(video),
+                "-frames:v",
+                "1",
+                "-q:v",
+                "2",
+                "-vf",
+                f"scale={width}:-1",
+                str(out_path),
+            ],
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.debug("Frame at %.1fs failed (%s)", timestamp, type(exc).__name__)
+        return False
+    return out_path.exists()
+
+
+def _key_for(video: Path, count: int, width: int) -> str:
+    """What identifies these frames: which video, how many, how wide.
+
+    Size and mtime stand in for content — hashing gigabytes to decide whether
+    to skip a decode would cost more than the decode.
+    """
+    try:
+        stat = video.stat()
+        identity = f"{video.name}:{stat.st_size}:{int(stat.st_mtime)}"
+    except OSError:
+        identity = video.name
+    return hashlib.sha256(f"{identity}:{count}:{width}".encode()).hexdigest()[:16]
+
+
+def sample_frames(
+    video: Path,
+    *,
+    count: int,
+    width: int,
+    cache_dir: Path | None,
+) -> list[Path]:
+    """Evenly spaced frames from a video, decoded at most once per (video, count, width).
+
+    Returns the frames that could be extracted, in order. A video that yields
+    nothing returns an empty list rather than raising: a caller that cannot see
+    the pictures should degrade, not fail.
+    """
+    target = _prepared_dir(cache_dir, _key_for(video, count, width))
+    if target is not None:
+        cached = sorted(target.glob("frame_*.jpg"))
+        if len(cached) == count:
+            logger.debug("Reusing %d cached frame(s) for %s", count, video.name)
+            return cached
+
+    out_dir = target if target is not None else _scratch_dir(video)
+    if out_dir is None:
+        return []
+
+    frames = []
+    for index, timestamp in enumerate(even_timestamps(probe_duration(video), count)):
+        out_path = out_dir / f"frame_{index:03d}.jpg"
+        if _extract_one(video, timestamp, width, out_path):
+            frames.append(out_path)
+    return frames
+
+
+def _prepared_dir(cache_dir: Path | None, key: str) -> Path | None:
+    if cache_dir is None:
+        return None
+    try:
+        target = Path(cache_dir) / key
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("Frame cache unwritable (%s): decoding again", exc)
+        return None
+    return target
+
+
+def _scratch_dir(video: Path) -> Path | None:
+    """Somewhere to put frames nobody will keep."""
+    import tempfile
+
+    try:
+        return Path(tempfile.mkdtemp(prefix=f"frames-{video.stem}-"))
+    except OSError:
+        return None

--- a/src/immich_memories/titles/colors.py
+++ b/src/immich_memories/titles/colors.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import colorsys
 import subprocess
-import tempfile
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -150,6 +149,10 @@ HDR_GRAPHICS_WHITE = 0xBF
 
 # Above this, a colour is carrying real hue — an accent that happens to be bright,
 # not a white. Off-whites in the palettes sit well under it (#E0F2FE is 0.12).
+# A colour histogram does not need more; a 4K frame costs about 32MB
+# against roughly 0.3MB at this width.
+_PALETTE_FRAME_WIDTH = 320
+
 _NEUTRAL_SATURATION = 0.15
 
 
@@ -306,93 +309,30 @@ def extract_dominant_color(
 def extract_keyframes_from_video(
     video_path: Path,
     count: int = 5,
+    cache_dir: Path | None = None,
 ) -> list[Image.Image]:
-    """Extract keyframes from a video file.
+    """Keyframes from a video, as PIL images, for picking a palette.
 
-    Args:
-        video_path: Path to video file.
-        count: Number of frames to extract.
+    Delegates to processing.frame_sampling, which the mood analyser also uses.
+    Both were the same loop written separately, and neither kept its frames.
 
-    Returns:
-        List of PIL Images.
+    320px because a colour histogram does not need more, and a 4K frame costs
+    about 32MB against 0.3MB at this width.
     """
     if not HAS_PIL:
         raise ImportError("PIL/Pillow is required for keyframe extraction")
 
-    try:
-        import shutil
-        import subprocess
-    except ImportError:
-        return []
-
-    # Check if ffmpeg is available
-    if not shutil.which("ffmpeg"):
-        return []
+    from immich_memories.processing.frame_sampling import sample_frames
 
     frames = []
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir_path = Path(tmpdir)
-
+    for path in sample_frames(
+        Path(video_path), count=count, width=_PALETTE_FRAME_WIDTH, cache_dir=cache_dir
+    ):
         try:
-            # Get video duration first
-            probe_cmd = [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                str(video_path),
-            ]
-            result = subprocess.run(
-                probe_cmd,
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            duration = float(result.stdout.strip() or "10")
-        except (OSError, subprocess.SubprocessError, ValueError):
-            duration = 10.0
-
-        # Calculate timestamps for even distribution
-        interval = duration / (count + 1)
-
-        for i in range(1, count + 1):
-            timestamp = i * interval
-            frame_path = tmpdir_path / f"frame_{i:03d}.jpg"
-
-            try:
-                # Downsample to 320px width for color extraction
-                # This reduces memory from ~32MB/frame to ~0.3MB/frame for 4K source
-                extract_cmd = [
-                    "ffmpeg",
-                    "-ss",
-                    str(timestamp),
-                    "-i",
-                    str(video_path),
-                    "-vf",
-                    "scale=320:-1",  # Downsample - color analysis doesn't need full res
-                    "-frames:v",
-                    "1",
-                    "-y",
-                    str(frame_path),
-                ]
-                subprocess.run(
-                    extract_cmd,
-                    capture_output=True,
-                    timeout=10,
-                )
-
-                if frame_path.exists():
-                    img = Image.open(frame_path)
-                    frames.append(img.copy())
-                    img.close()
-
-            except (OSError, subprocess.SubprocessError):
-                continue
-
+            with Image.open(path) as img:
+                frames.append(img.copy())
+        except (OSError, ValueError):
+            continue
     return frames
 
 

--- a/tests/test_frame_extraction.py
+++ b/tests/test_frame_extraction.py
@@ -1,0 +1,167 @@
+"""Sampling frames from a video happens one way, and only once per video.
+
+It was written three times: the mood analyser at scale=512, the title colour
+sampler at scale=320, and the analysis preview builder. The first two are the
+same algorithm — probe the duration, take duration*i/(n+1) evenly spaced
+timestamps, run one ffmpeg per frame — and neither cached anything, so every
+run re-decoded the same video forever.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from immich_memories.processing.frame_sampling import even_timestamps, sample_frames
+
+
+def test_frames_are_spread_evenly_across_the_video() -> None:
+    """The distribution both copies used, in one place."""
+    assert even_timestamps(duration=60.0, count=3) == [15.0, 30.0, 45.0]
+
+
+def test_a_video_of_unknown_length_still_yields_the_asked_for_count() -> None:
+    """Duration probing fails on odd containers; a caller still needs frames."""
+    assert len(even_timestamps(duration=0.0, count=4)) == 4
+
+
+def test_the_same_video_is_only_decoded_once(tmp_path) -> None:
+    """The whole point: a second ask costs nothing."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    calls: list = []
+
+    def _fake_extract(_video, timestamp, width, out_path):
+        calls.append(timestamp)
+        out_path.write_bytes(b"jpeg")
+        return True
+
+    # WHY: ffmpeg is the external boundary — decoding is the cost being counted.
+    with patch("immich_memories.processing.frame_sampling._extract_one", new=_fake_extract):
+        first = sample_frames(video, count=3, width=512, cache_dir=tmp_path / "frames")
+        second = sample_frames(video, count=3, width=512, cache_dir=tmp_path / "frames")
+
+    assert len(first) == 3
+    assert first == second
+    assert len(calls) == 3, f"the video was decoded again: {len(calls)} extractions"
+
+
+def test_a_different_width_is_a_different_ask(tmp_path) -> None:
+    """A colour palette wants 320px and a vision model wants 512; both are valid."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    calls: list = []
+
+    def _fake_extract(_video, timestamp, width, out_path):
+        calls.append((timestamp, width))
+        out_path.write_bytes(b"jpeg")
+        return True
+
+    # WHY: ffmpeg is the external boundary.
+    with patch("immich_memories.processing.frame_sampling._extract_one", new=_fake_extract):
+        sample_frames(video, count=2, width=512, cache_dir=tmp_path / "frames")
+        sample_frames(video, count=2, width=320, cache_dir=tmp_path / "frames")
+
+    assert len({w for _, w in calls}) == 2, "one width served the other's frames"
+
+
+def test_a_cache_that_cannot_be_written_still_returns_frames(tmp_path) -> None:
+    """Losing the cache costs decodes, never the run."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+
+    def _fake_extract(_video, timestamp, width, out_path):
+        out_path.write_bytes(b"jpeg")
+        return True
+
+    # WHY: ffmpeg is the external boundary.
+    with patch("immich_memories.processing.frame_sampling._extract_one", new=_fake_extract):
+        frames = sample_frames(video, count=2, width=512, cache_dir=None)
+
+    assert len(frames) == 2
+    assert all(isinstance(f, Path) for f in frames)
+
+
+def test_a_video_that_will_not_probe_reports_no_duration(tmp_path) -> None:
+    """ffprobe fails on odd containers; even_timestamps has a fallback for it."""
+    from immich_memories.processing.frame_sampling import probe_duration
+
+    assert probe_duration(tmp_path / "does-not-exist.mp4") == 0.0
+
+
+def test_a_frame_that_will_not_extract_is_left_out(tmp_path) -> None:
+    """A video that yields nothing returns an empty list, not an exception.
+
+    A caller that cannot see the pictures should degrade, not fail.
+    """
+    from immich_memories.processing.frame_sampling import _extract_one, sample_frames
+
+    missing = tmp_path / "not-a-video.mp4"
+    missing.write_bytes(b"nope")
+
+    assert _extract_one(missing, 1.0, 320, tmp_path / "out.jpg") is False
+    assert sample_frames(missing, count=2, width=320, cache_dir=tmp_path / "c") == []
+
+
+def test_the_mood_analyser_asks_for_vision_sized_frames(tmp_path) -> None:
+    """512px, and through the shared sampler rather than its own ffmpeg loop."""
+    from immich_memories.audio.mood_analyzer import MoodAnalyzer
+
+    class _Concrete(MoodAnalyzer):
+        """extract_keyframes is concrete on the base; the two abstracts are not."""
+
+        async def analyze_video(self, *_a, **_k):  # pragma: no cover - not exercised
+            raise NotImplementedError
+
+        async def analyze_frames(self, *_a, **_k):  # pragma: no cover - not exercised
+            raise NotImplementedError
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"pretend")
+    seen: dict = {}
+
+    def _fake(_video, *, count, width, cache_dir):
+        seen.update(count=count, width=width)
+        return [tmp_path / "f0.jpg"]
+
+    # WHY: frame extraction is the ffmpeg boundary; the ask is what is tested.
+    with patch("immich_memories.processing.frame_sampling.sample_frames", new=_fake):
+        _Concrete().extract_keyframes(video, num_frames=4, output_dir=tmp_path)
+
+    assert seen == {"count": 4, "width": 512}
+
+
+def test_the_palette_sampler_asks_for_smaller_frames(tmp_path) -> None:
+    """320px: a colour histogram does not need what a vision model needs."""
+    from PIL import Image
+
+    from immich_memories.titles.colors import extract_keyframes_from_video
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"pretend")
+    frame = tmp_path / "f0.jpg"
+    Image.new("RGB", (8, 8), (1, 2, 3)).save(frame)
+    seen: dict = {}
+
+    def _fake(_video, *, count, width, cache_dir):
+        seen.update(count=count, width=width)
+        return [frame]
+
+    # WHY: frame extraction is the ffmpeg boundary.
+    with patch("immich_memories.processing.frame_sampling.sample_frames", new=_fake):
+        images = extract_keyframes_from_video(video, count=3)
+
+    assert seen == {"count": 3, "width": 320}
+    assert len(images) == 1
+
+
+def test_a_frame_that_will_not_open_is_skipped_not_fatal(tmp_path) -> None:
+    """A truncated jpeg loses one frame, not the palette."""
+    from immich_memories.titles.colors import extract_keyframes_from_video
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"pretend")
+    broken = tmp_path / "broken.jpg"
+    broken.write_bytes(b"not a jpeg")
+
+    # WHY: frame extraction is the ffmpeg boundary.
+    with patch("immich_memories.processing.frame_sampling.sample_frames", return_value=[broken]):
+        assert extract_keyframes_from_video(video, count=1) == []


### PR DESCRIPTION
## Three implementations of one operation

Sampling still frames from a video was written three times:

| Site | Purpose | Scale | Cached |
|---|---|---|---|
| `audio/mood_analyzer.py` | frames → vision model | 512px | ❌ |
| `titles/colors.py` | frames → colour palette | 320px | ❌ |
| `analysis/preview_builder.py` | video **segments** → analysis | — | ✅ |

The first two are **line-for-line the same algorithm**: probe the duration, take `duration*i/(n+1)` evenly spaced timestamps, run one ffmpeg per frame. Only the scale differed — and that difference is legitimate.

Neither kept what it produced, so **every run re-decoded the same video, forever**. Both also spawned **one ffmpeg process per frame**: five frames meant five decoder startups and five seeks into the same file.

## The change

`processing/frame_sampling.sample_frames(video, count=, width=, cache_dir=)` owns it. Frames are cached under a key covering everything that changes the pixels — which video, how many frames, how wide.

**Width stays a parameter** because the difference is real: a colour histogram doesn't need what a vision model needs, and a 4K frame is ~32MB against ~0.3MB at 320px.

**`even_timestamps` captures a subtlety neither copy explained**: the timestamps are `duration*i/(n+1)` rather than `i/n`, because the first and last frame of a clip are the ones most likely to be a fade, a black frame, or a cut.

**Identity is `name:size:mtime`, not a content hash** — hashing gigabytes to decide whether to skip a decode costs more than the decode.

**A cache that cannot be written costs decodes, never the run.**

## The preview builder is deliberately left alone

It extracts video *segments* rather than stills, and already caches them via `find_cached_preview`. Verified rather than assumed — it's a different operation, not a third copy.

## Why this matters beyond tidiness

Every uncached heavy operation is a tax paid on every run forever. Mood frames and title-palette frames are now decoded once per video, ever — which also means previously-unaffordable quality signals become affordable, since the expensive part is the decode.

`make ci` exit 0, **5540 passed**. Ten tests cover the sampler, both delegations, the subprocess failure paths, and the cache-unwritable path.