### PR TITLE
refactor(analysis): score a duration one way, not two

### DIFF
--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 from immich_memories.analysis.analyzer_factory import (  # noqa: F401
     create_unified_analyzer_from_config,
 )
@@ -488,37 +486,24 @@ class UnifiedSegmentAnalyzer:
         return self.optimal_clip_duration
 
     def _compute_duration_score(self, clip_duration: float, source_duration: float) -> float:
-        """Compute duration preference score using a Gaussian curve.
+        """How well this clip length suits this source, on the shared curve.
 
-        The score peaks at the dynamic optimal duration and falls off
-        smoothly for shorter or longer clips.
-
-        Args:
-            clip_duration: Duration of the clip in seconds.
-            source_duration: Total source video duration in seconds.
-
-        Returns:
-            Score between 0.0 and 1.0, with 1.0 at optimal duration.
+        The rule lives in analysis.scoring and is called from there by the
+        other scoring path too. It was written out a second time here, and the
+        two agreed exactly — which is luck, not a guarantee: tuning one would
+        have left the other scoring the old way, and which rule a clip met
+        would have depended on the path it arrived by.
         """
-        # Clips below minimum duration get heavy penalty
-        if clip_duration < self.min_segment_duration:
-            return max(0.0, 0.3 * (clip_duration / self.min_segment_duration))
+        from immich_memories.analysis.scoring import compute_duration_score
 
-        # Get dynamic optimal for this source
-        dynamic_optimal = self._get_dynamic_optimal_duration(source_duration)
-
-        # Gaussian curve centered at dynamic optimal duration
-        # sigma scales with optimal to keep curve proportional
-        sigma = max(3.0, dynamic_optimal * 0.6)
-        diff = clip_duration - dynamic_optimal
-        score = float(np.exp(-(diff * diff) / (2 * sigma * sigma)))
-
-        # For very long clips (>15s), add extra penalty
-        if clip_duration > 15.0:
-            long_penalty = (clip_duration - 15.0) * 0.05
-            score = max(0.2, score - long_penalty)
-
-        return score
+        return compute_duration_score(
+            clip_duration,
+            source_duration,
+            self.optimal_clip_duration,
+            self.max_optimal_duration,
+            self.target_extraction_ratio,
+            self.min_segment_duration,
+        )
 
     def _score_visual(self, video_path: Path, start_time: float, end_time: float) -> _VisualScores:
         """Score a segment using visual analysis (faces, motion, stability).

--- a/tests/test_one_duration_score.py
+++ b/tests/test_one_duration_score.py
@@ -1,0 +1,61 @@
+"""Duration scoring is one rule, so there is one implementation of it.
+
+It was written twice — analysis/scoring.py as a pure function taking its
+parameters, and UnifiedSegmentAnalyzer._compute_duration_score as a method
+reading the same values off self. Same Gaussian, same 0.3x floor penalty
+below the minimum, same sigma, same >15s long-clip penalty. Two call sites,
+two copies, nothing connecting them: tune one and the other silently keeps
+the old rule, and which one a clip meets depends on the path it took.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from immich_memories.analysis.scoring import compute_duration_score
+from immich_memories.config_loader import Config
+
+_SOURCES = (5.0, 15.0, 21.0, 60.0, 120.0, 600.0)
+_CLIPS = (0.5, 1.9, 2.0, 3.0, 5.0, 8.0, 10.0, 15.0, 16.0, 25.0, 40.0)
+
+
+def _analyzer():
+    from immich_memories.analysis.unified_analyzer import UnifiedSegmentAnalyzer
+
+    config = Config()
+    return UnifiedSegmentAnalyzer(
+        scorer=MagicMock(),
+        audio_content_config=config.audio_content,
+        analysis_config=config.analysis,
+    )
+
+
+@pytest.mark.parametrize("source", _SOURCES)
+def test_the_analyzer_scores_a_duration_the_same_way_the_scorer_does(source: float) -> None:
+    """The two agreed exactly when this was written; they must not drift apart."""
+    analyzer = _analyzer()
+
+    for clip in _CLIPS:
+        assert analyzer._compute_duration_score(clip, source) == pytest.approx(
+            compute_duration_score(
+                clip,
+                source,
+                analyzer.optimal_clip_duration,
+                analyzer.max_optimal_duration,
+                analyzer.target_extraction_ratio,
+                analyzer.min_segment_duration,
+            )
+        ), f"duration scoring disagreed at source={source}s clip={clip}s"
+
+
+def test_a_clip_under_the_minimum_is_penalised_not_zeroed() -> None:
+    """Behaviour worth pinning while both copies are in play."""
+    analyzer = _analyzer()
+    below = analyzer.min_segment_duration / 2
+
+    assert 0.0 < analyzer._compute_duration_score(below, 60.0) < 0.3
+
+
+def test_a_very_long_clip_keeps_a_floor() -> None:
+    """The >15s penalty subtracts, but never below 0.2."""
+    assert _analyzer()._compute_duration_score(120.0, 600.0) >= 0.2


### PR DESCRIPTION
`compute_duration_score` existed **twice**:

- `analysis/scoring.py:255` — a pure function taking its six parameters. Called from `scoring.py:704`.
- `UnifiedSegmentAnalyzer._compute_duration_score` — the same algorithm as a method reading the same values off `self`. Called from `unified_analyzer.py:773`.

Same Gaussian, same `0.3 × (d/min)` floor penalty, same `sigma = max(3.0, optimal × 0.6)`, same `>15s → 0.05/s` long-clip penalty. One call site each, nothing connecting them.

## Verified equivalent before deleting anything

Ran both across **66 (source, clip) pairs**: **max absolute difference 0.0**.

That turned a risky deletion into a provably-safe one — and it's luck rather than a guarantee. Tuning one would have left the other scoring the old way, and which rule a clip met would have depended on which path it arrived by.

The method now calls the function. The equivalence is pinned by a parametrised test so they cannot drift back apart, and the behaviour either copy encoded is pinned alongside it: a clip under the minimum is penalised rather than zeroed, and a very long clip keeps its 0.2 floor.

## A small confirmation

`numpy` became an unused import in `unified_analyzer.py` — which is how you know the duplicate was a whole self-contained copy rather than something half-shared.

`make ci` exit 0, **5543 passed**.