### PR TITLE
fix(ui): the wizard keeps every window a memory spans, not just the first

### DIFF
--- a/src/immich_memories/ui/pages/step1_config.py
+++ b/src/immich_memories/ui/pages/step1_config.py
@@ -193,7 +193,7 @@ def _make_date_range_updater(
             if dr is None:
                 date_range_label.set_text("")
                 return
-            state.date_range = dr
+            state.date_ranges = [dr]
             date_range_label.set_text(f"{dr.description} ({dr.days} days)")
             auto_duration = max(1, min(60, round(dr.days / 365 * 10)))
             state.target_duration = auto_duration

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -347,7 +347,7 @@ def _render_album_picker() -> None:
         state.album_id = album_id
         state.album_name = albums.get(album_id)
         # Album mode discovers its own span from the assets, so nothing to set here.
-        state.date_range = None
+        state.date_ranges = []
         state.duration_mode = "auto"
 
     async def _load_albums() -> None:
@@ -535,7 +535,7 @@ def _render_trip_params() -> None:
         for k in ("trip_index", "trip_start", "trip_end", "location_name"):
             state.memory_preset_params.pop(k, None)
         state.detected_trips = []
-        state.date_range = None
+        state.date_ranges = []
         await _detect_trips_for_year(e.value)
 
     ui.select(
@@ -560,14 +560,13 @@ def _apply_preset_to_state(memory_type: MemoryType) -> None:
     if params.get("year") == 0:
         from datetime import date
 
-        state.date_range = custom_range(date(2000, 1, 1), date.today())
+        state.date_ranges = [custom_range(date(2000, 1, 1), date.today())]
         state.target_duration = 10
         return
 
     try:
         preset = create_preset(memory_type, **params)
-        if preset.date_ranges:
-            state.date_range = preset.date_ranges[0]
+        state.date_ranges = preset.date_ranges.copy()
         if preset.default_duration_seconds:
             state.target_duration = preset.default_duration_seconds / 60
             state.duration_mode = "auto"
@@ -576,6 +575,6 @@ def _apply_preset_to_state(memory_type: MemoryType) -> None:
             days = preset.date_ranges[0].days
             state.target_duration = max(1, min(10, round(days / 45)))
     except (ValueError, TypeError) as exc:
-        # Preset not fully configured yet (e.g. no person selected) — clear stale date range
-        state.date_range = None
+        # Preset not fully configured yet (e.g. no person selected) — clear stale ranges
+        state.date_ranges = []
         logger.debug("Preset not ready yet: %s", exc)

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -67,27 +67,51 @@ def _fetch_album(state) -> tuple[list[VideoClipInfo], list]:
             use_photos=state.include_photos,
         )
     if media.date_range is not None:
-        state.date_range = media.date_range
+        state.date_ranges = [media.date_range]
     clips, photos = album_media_as_clips(media)
     if state.duration_mode == "auto":
         state.target_duration = album_target_minutes(clips, photos)
     return clips, photos
 
 
+def _dedup_by_id(assets: list) -> list:
+    """First occurrence wins, order preserved.
+
+    Windows can overlap — a holiday window two days either side of the date
+    collides with itself when two requested years are consecutive leap-adjusted
+    neighbours, and On This Day windows overlap outright if years_back exceeds
+    the gap. The same asset must not be analysed twice.
+    """
+    seen: set[str] = set()
+    unique = []
+    for asset in assets:
+        if asset.id not in seen:
+            seen.add(asset.id)
+            unique.append(asset)
+    return unique
+
+
 def _fetch_assets(state) -> list:
-    """Blocking: fetch video assets from Immich API."""
-    date_range = state.date_range
+    """Blocking: fetch video assets from Immich API, one query per window."""
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as client:
         multi_ids = state.memory_preset_params.get("person_ids", [])
-        if len(multi_ids) >= 2:
-            return client.get_videos_for_all_persons(multi_ids, date_range)
-        if state.selected_person:
-            return client.get_videos_for_person_and_date_range(state.selected_person.id, date_range)
-        return client.get_videos_for_date_range(date_range)
+        assets: list = []
+        for date_range in state.date_ranges:
+            if len(multi_ids) >= 2:
+                assets.extend(client.get_videos_for_all_persons(multi_ids, date_range))
+            elif state.selected_person:
+                assets.extend(
+                    client.get_videos_for_person_and_date_range(
+                        state.selected_person.id, date_range
+                    )
+                )
+            else:
+                assets.extend(client.get_videos_for_date_range(date_range))
+        return _dedup_by_id(assets)
 
 
 def _filter_near_home(assets: list, state) -> list:
@@ -122,19 +146,22 @@ def _build_clips(assets: list) -> tuple[list[VideoClipInfo], int]:
     return clips, skipped
 
 
-def _fetch_photos(state, date_range) -> list:
-    """Fetch photo assets (blocking)."""
+def _fetch_photos(state) -> list:
+    """Fetch photo assets (blocking), one query per window."""
     person_id = state.selected_person.id if state.selected_person else None
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as client:
-        return client.get_photos_for_date_range(date_range, person_id=person_id)
+        photos: list = []
+        for date_range in state.date_ranges:
+            photos.extend(client.get_photos_for_date_range(date_range, person_id=person_id))
+        return _dedup_by_id(photos)
 
 
-def _fetch_live_photos(state, date_range) -> tuple[list[VideoClipInfo], set[str]]:
-    """Fetch live photo clips (blocking)."""
+def _fetch_live_photos(state) -> tuple[list[VideoClipInfo], set[str]]:
+    """Fetch live photo clips (blocking), one query per window."""
     lp_person_id = state.selected_person.id if state.selected_person else None
     multi_ids = state.memory_preset_params.get("person_ids", [])
 
@@ -143,13 +170,25 @@ def _fetch_live_photos(state, date_range) -> tuple[list[VideoClipInfo], set[str]
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as lp_client:
-        return fetch_live_photo_clips(
-            lp_client,
-            date_range,
-            person_id=lp_person_id,
-            person_ids=multi_ids if len(multi_ids) >= 2 else None,
-            config=state.config,
-        )
+        clips: list[VideoClipInfo] = []
+        video_ids: set[str] = set()
+        for date_range in state.date_ranges:
+            window_clips, window_video_ids = fetch_live_photo_clips(
+                lp_client,
+                date_range,
+                person_id=lp_person_id,
+                person_ids=multi_ids if len(multi_ids) >= 2 else None,
+                config=state.config,
+            )
+            clips.extend(window_clips)
+            video_ids |= window_video_ids
+        seen: set[str] = set()
+        unique_clips = []
+        for clip in clips:
+            if clip.asset.id not in seen:
+                seen.add(clip.asset.id)
+                unique_clips.append(clip)
+        return unique_clips, video_ids
 
 
 def _merge_live_photos(
@@ -198,8 +237,7 @@ async def _finish_load(state, clips, photo_assets, status_label, progress_bar) -
 
 async def _collect_date_range_media(state, status_label, progress_bar):
     """Discover the clip and photo pools for a date-range memory."""
-    date_range = state.date_range
-    if date_range is None:
+    if not state.date_ranges:
         raise ValueError("No date range configured")
 
     assets = _filter_near_home(await io_bound_result(_fetch_assets, state), state)
@@ -217,13 +255,13 @@ async def _collect_date_range_media(state, status_label, progress_bar):
     clips, _ = _build_clips(assets)
     if state.include_live_photos:
         status_label.set_text("Fetching Live Photos...")
-        live_clips, live_video_ids = await io_bound_result(_fetch_live_photos, state, date_range)
+        live_clips, live_video_ids = await io_bound_result(_fetch_live_photos, state)
         clips = _merge_live_photos(clips, live_clips, live_video_ids)
 
     photo_assets = []
     if state.include_photos:
         status_label.set_text("Fetching photos...")
-        photo_assets = await io_bound_result(_fetch_photos, state, date_range)
+        photo_assets = await io_bound_result(_fetch_photos, state)
         logger.info(f"Found {len(photo_assets)} photos")
 
     clips.sort(key=lambda c: c.asset.file_created_at)

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from immich_memories.api.compatibility import ApiVersionPolicy
+from immich_memories.timeperiod import DateRange
 from immich_memories.tracking.models import DeliveryStatus
 
 if TYPE_CHECKING:
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
     from immich_memories.cache.thumbnail_cache import ThumbnailCache
     from immich_memories.config_loader import Config
     from immich_memories.processing.timeline_budget import TimelinePlan
-    from immich_memories.timeperiod import DateRange
 
 
 @dataclass
@@ -52,7 +52,9 @@ class AppState:
     period_unit: str = "years"  # "months" or "years"
     custom_start: date | None = None
     custom_end: date | None = None
-    date_range: DateRange | None = None
+    # Every window the memory covers. On This Day and Holiday build one per
+    # year, Then and Now builds two far apart; the rest build exactly one.
+    date_ranges: list[DateRange] = field(default_factory=list)
 
     # Person selection
     selected_person: Person | None = None
@@ -157,6 +159,23 @@ class AppState:
     # file does not.
     thumbnail_hashes: dict[str, str] = field(default_factory=dict)
     analysis_cache: Any = None  # AnalysisCache
+
+    @property
+    def date_range(self) -> DateRange | None:
+        """The whole period the memory covers — for titles, filenames and labels.
+
+        Anything that *fetches* must use `date_ranges` instead. The span of a
+        Then and Now is a decade it has no interest in, and the span of an On
+        This Day is years it wants three days out of.
+        """
+        if not self.date_ranges:
+            return None
+        if len(self.date_ranges) == 1:
+            return self.date_ranges[0]
+        return DateRange(
+            start=min(r.start for r in self.date_ranges),
+            end=max(r.end for r in self.date_ranges),
+        )
 
     @property
     def scope_is_selected(self) -> bool:

--- a/tests/test_album_ui_support.py
+++ b/tests/test_album_ui_support.py
@@ -119,7 +119,7 @@ class TestAlbumModeState:
         state.memory_type = "album"
         state.album_id = "a-1"
         state.album_name = "Trip 2025"
-        state.date_range = None
+        state.date_ranges = []
 
         assert state.memory_type == "album"
         assert state.album_id == "a-1"
@@ -173,7 +173,7 @@ class TestScopeReadiness:
 
     def test_a_date_range_is_a_complete_scope(self):
         state = AppState()
-        state.date_range = object()
+        state.date_ranges = [object()]
 
         assert state.scope_is_selected
 

--- a/tests/test_pipeline_title.py
+++ b/tests/test_pipeline_title.py
@@ -116,9 +116,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.config = _make_config(llm_model="")  # No LLM
 
@@ -134,9 +134,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -159,9 +159,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -186,9 +186,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -265,7 +265,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.config = _make_config(llm_model="")
 
         with patch(
@@ -283,7 +283,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = None
+        state.date_ranges = []
         state.config = _make_config(llm_model="omlx")
 
         with patch(
@@ -300,7 +300,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "year"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -330,7 +330,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "year"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -353,7 +353,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "person"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -381,7 +381,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "trip"
         state.clips = []
         state.analysis_cache = None

--- a/tests/test_sidebar_completion.py
+++ b/tests/test_sidebar_completion.py
@@ -26,7 +26,7 @@ class TestIsStepComplete:
     def test_step1_complete_when_config_and_date_range_set(self) -> None:
         state = AppState()
         state.config = object()  # type: ignore[assignment]
-        state.date_range = object()  # type: ignore[assignment]
+        state.date_ranges = [object()]  # type: ignore[assignment]
         assert _is_step_complete(state, 1) is True
 
     def test_step2_incomplete_when_no_clips_selected(self) -> None:

--- a/tests/test_ui_multi_range_state.py
+++ b/tests/test_ui_multi_range_state.py
@@ -1,0 +1,87 @@
+"""The wizard has to hold every window a memory spans, not just the first.
+
+Three memory types build more than one date range — On This Day and Holiday
+build one window per year, Then and Now builds two years far apart. The wizard
+stored a single `date_range`, so it kept `date_ranges[0]` and silently dropped
+the rest. Since the builders order their windows most-recent-first, that made
+"This day through the years" a memory about this year.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from immich_memories.memory_types.registry import MemoryType
+from immich_memories.timeperiod import DateRange
+from immich_memories.ui.pages.step1_presets import _apply_preset_to_state
+from immich_memories.ui.state import AppState
+
+
+def _apply(memory_type: MemoryType, **params) -> AppState:
+    state = AppState(memory_preset_params=dict(params))
+    # WHY: the wizard reads its state through a per-session accessor; this is
+    # the seam that hands the function a state object instead of a live session.
+    with patch("immich_memories.ui.pages.step1_presets.get_app_state", return_value=state):
+        _apply_preset_to_state(memory_type)
+    return state
+
+
+def test_on_this_day_keeps_every_year_the_card_promises() -> None:
+    """The card says "This day through the years"; five years must survive."""
+    state = _apply(MemoryType.ON_THIS_DAY)
+
+    assert len(state.date_ranges) == 5
+
+
+def _year(y: int) -> DateRange:
+    return DateRange(start=datetime(y, 1, 1), end=datetime(y, 12, 31, 23, 59, 59))
+
+
+def _state_with_ranges(*years: int) -> AppState:
+    return AppState(
+        immich_url="http://immich.test",
+        immich_api_key="k",
+        date_ranges=[_year(y) for y in years],
+    )
+
+
+def test_the_wizard_fetches_each_window_not_the_span_between_them() -> None:
+    """Three windows means three queries.
+
+    Querying the span instead would pull every asset between the oldest and
+    newest window — for a Then and Now, a decade of library it has no interest
+    in, at Immich's expense and then the analyzer's.
+    """
+    from immich_memories.ui.pages.step2_loading import _fetch_assets
+
+    state = _state_with_ranges(2020, 2023, 2026)
+    client = MagicMock()
+    client.get_videos_for_date_range.return_value = []
+
+    # WHY: Immich is the external boundary — this stands in for the library read.
+    with patch("immich_memories.ui.pages.step2_loading.SyncImmichClient") as client_cls:
+        client_cls.return_value.__enter__.return_value = client
+        _fetch_assets(state)
+
+    queried = [c.args[0] for c in client.get_videos_for_date_range.call_args_list]
+    assert queried == [_year(2020), _year(2023), _year(2026)]
+
+
+def test_an_asset_in_two_overlapping_windows_is_fetched_once() -> None:
+    """Holiday windows two days either side can collide on consecutive years."""
+    from immich_memories.ui.pages.step2_loading import _fetch_assets
+
+    state = _state_with_ranges(2025, 2026)
+    shared = MagicMock()
+    shared.id = "in-both-windows"
+    client = MagicMock()
+    client.get_videos_for_date_range.return_value = [shared]
+
+    # WHY: Immich is the external boundary — this stands in for the library read.
+    with patch("immich_memories.ui.pages.step2_loading.SyncImmichClient") as client_cls:
+        client_cls.return_value.__enter__.return_value = client
+        assets = _fetch_assets(state)
+
+    assert client.get_videos_for_date_range.call_count == 2
+    assert [a.id for a in assets] == ["in-both-windows"]


### PR DESCRIPTION
Refs #461 — **PR A of two**. This ships no new preset cards. It makes the wizard's state able to carry them, because wiring THEN_AND_NOW onto single-range state would ship a "then and now" containing only the now.

## The issue says this is presentation-only. It isn't.

#461 reads *"the gap is small — the UI already routes through the same `create_preset`/`MemoryType` factory, so it's presentation only."* That's true of the factory and false of the state behind it.

`MemoryPreset.date_ranges` is a **list**. Three types return more than one:

| Type | Windows |
|---|---|
| `ON_THIS_DAY` | `build_on_this_day(target_date, years_back)` — one ±1-day window per year |
| `HOLIDAY` | `build_holiday(...)` — one window per year |
| `THEN_AND_NOW` | exactly two, a decade apart by design |

The wizard did this (`step1_presets.py:570`):

```python
if preset.date_ranges:
    state.date_range = preset.date_ranges[0]
```

## Which means On This Day has been broken, not just unwired

Both builders document their output as **"most recent year first"**. So `[0]` is always the newest window, and everything older was dropped without a warning.

The card reads **"This day through the years"**. The label under it reads **"Automatically uses today's date across previous years."** It passes no params, so the factory default `years_back=5` applies, five windows are built — and the wizard keeps one. It has been a memory about this year.

The CLI has always looped over every range (`fetch_videos_and_live_photos`), so the two surfaces have been producing different memories from the same request. Fixed here in the same PR rather than filed separately, per the audit.

## What changed

**`AppState.date_ranges: list[DateRange]`** is now the source of truth, and **`date_range` becomes a read-only property returning the enclosing span.**

The split is deliberate and the docstring says so. Titles, filenames and the step-2 label want *the whole period the memory covers*. Anything that **fetches** must use the windows — fetching by the span is the same bug pointed the other way: for a Then and Now the span is a decade of library the memory has no interest in, at Immich's expense and then the analyzer's.

Making it **read-only** rather than renaming the field turned this into a checked refactor: all thirteen stale assignment sites failed loudly with `property 'date_range' has no setter` instead of storing a value the fetch path would quietly ignore.

**All three fetch paths** — videos, photos, live photos — now issue one query per window and de-duplicate by asset id, mirroring the CLI. De-duplication is not theoretical: a holiday window two days either side of the date overlaps itself on consecutive years, and On This Day windows overlap outright when `years_back` exceeds the gap.

## Tests

Three, strict TDD, each RED first for the right reason:

1. **On This Day keeps all five years** — RED was `AttributeError: 'AppState' object has no attribute 'date_ranges'`.
2. **Each window is queried, not the span between them** — RED showed a single query for `2020-01-01 → 2026-12-31` where three per-year queries were expected. This is the over-fetch, caught rather than reasoned about.
3. **An asset in two overlapping windows is fetched once.**

`make ci` green: **5560 passed**, 9 skipped.

## Two notes

**A type-only import bit me and is worth knowing.** `DateRange` lived under `if TYPE_CHECKING:`, which is fine while it is only an annotation — but the new span property *constructs* one. `from __future__ import annotations` erases annotations, not constructor calls, so it raised `NameError` at runtime. Promoted to a real import. Test 2 caught it.

**One thing I deliberately left alone:** the auto-duration branch still reads `preset.date_ranges[0].days`. All three multi-range presets set `default_duration_seconds`, so that branch cannot fire for them — changing it would be speculative.

## Next

PR B adds the two preset cards, their param pickers, the `pipeline_title.py` per-type branches, and the `docs-site/docs/create/web-ui/` update.

---
**Correction (from #586's review of this PR's rationale):** the claim above that holiday/on-this-day windows can overlap on consecutive years is wrong — a ±2-day annual window leaves ~360 days between occurrences, so cross-window duplicates cannot occur in practice. The per-window de-dup STAYS because it mirrors fetch_videos_and_live_photos' long-standing CLI behavior and is sound defensive practice — but it is defensive, not evidence of observed overlap.