### PR TITLE
fix(automation): schedule a launcher, not a point-in-time binary path

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -351,203 +351,203 @@
       {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 462,
-        "line_end": 603,
+        "line_start": 467,
+        "line_end": 608,
         "line_complexities": [
           {
-            "line": 472,
-            "complexity": 0
-          },
-          {
-            "line": 476,
-            "complexity": 0
-          },
-          {
             "line": 477,
-            "complexity": 2
-          },
-          {
-            "line": 478,
-            "complexity": 0
-          },
-          {
-            "line": 480,
             "complexity": 0
           },
           {
             "line": 481,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 482,
+            "complexity": 2
+          },
+          {
+            "line": 483,
             "complexity": 0
           },
           {
-            "line": 484,
+            "line": 485,
             "complexity": 0
           },
           {
-            "line": 488,
-            "complexity": 3
+            "line": 486,
+            "complexity": 2
+          },
+          {
+            "line": 487,
+            "complexity": 0
           },
           {
             "line": 489,
             "complexity": 0
           },
           {
-            "line": 491,
-            "complexity": 0
-          },
-          {
-            "line": 492,
-            "complexity": 2
-          },
-          {
             "line": 493,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 494,
             "complexity": 0
           },
           {
-            "line": 495,
-            "complexity": 1
-          },
-          {
             "line": 496,
             "complexity": 0
           },
           {
-            "line": 504,
+            "line": 497,
             "complexity": 2
           },
           {
-            "line": 506,
+            "line": 498,
             "complexity": 0
           },
           {
-            "line": 516,
+            "line": 499,
             "complexity": 0
           },
           {
-            "line": 517,
+            "line": 500,
             "complexity": 1
           },
           {
-            "line": 518,
+            "line": 501,
             "complexity": 0
           },
           {
-            "line": 519,
+            "line": 509,
+            "complexity": 2
+          },
+          {
+            "line": 511,
             "complexity": 0
+          },
+          {
+            "line": 521,
+            "complexity": 0
+          },
+          {
+            "line": 522,
+            "complexity": 1
           },
           {
             "line": 523,
             "complexity": 0
           },
           {
-            "line": 529,
+            "line": 524,
+            "complexity": 0
+          },
+          {
+            "line": 528,
+            "complexity": 0
+          },
+          {
+            "line": 534,
             "complexity": 1
           },
           {
-            "line": 530,
+            "line": 535,
             "complexity": 1
           },
           {
-            "line": 531,
+            "line": 536,
             "complexity": 0
           },
           {
-            "line": 533,
+            "line": 538,
             "complexity": 0
           },
           {
-            "line": 540,
+            "line": 545,
             "complexity": 2
           },
           {
-            "line": 541,
+            "line": 546,
             "complexity": 0
           },
           {
-            "line": 542,
+            "line": 547,
             "complexity": 0
           },
           {
-            "line": 544,
+            "line": 549,
             "complexity": 0
-          },
-          {
-            "line": 551,
-            "complexity": 0
-          },
-          {
-            "line": 555,
-            "complexity": 2
           },
           {
             "line": 556,
             "complexity": 0
           },
           {
-            "line": 557,
-            "complexity": 0
-          },
-          {
-            "line": 563,
+            "line": 560,
             "complexity": 2
           },
           {
-            "line": 564,
+            "line": 561,
             "complexity": 0
           },
           {
-            "line": 565,
+            "line": 562,
             "complexity": 0
           },
           {
-            "line": 572,
-            "complexity": 0
-          },
-          {
-            "line": 573,
+            "line": 568,
             "complexity": 2
           },
           {
-            "line": 574,
+            "line": 569,
             "complexity": 0
           },
           {
-            "line": 575,
+            "line": 570,
             "complexity": 0
           },
           {
-            "line": 583,
+            "line": 577,
             "complexity": 0
           },
           {
-            "line": 591,
+            "line": 578,
+            "complexity": 2
+          },
+          {
+            "line": 579,
+            "complexity": 0
+          },
+          {
+            "line": 580,
+            "complexity": 0
+          },
+          {
+            "line": 588,
+            "complexity": 0
+          },
+          {
+            "line": 596,
             "complexity": 1
           },
           {
-            "line": 592,
+            "line": 597,
             "complexity": 0
           },
           {
-            "line": 593,
+            "line": 598,
             "complexity": 1
           },
           {
-            "line": 595,
+            "line": 600,
             "complexity": 0
           },
           {
-            "line": 602,
+            "line": 607,
             "complexity": 0
           },
           {
-            "line": 603,
+            "line": 608,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -219,28 +219,65 @@ once a day itself. See [automated generation](../recipes/automated-generation.md
 | `--cooldown` | int | `24` | Cooldown hours between runs |
 | `--uninstall` | flag | `false` | Remove installed scheduler |
 | `--show` | flag | `false` | Print config without installing |
-| `--force` | flag | `false` | Install even from a linked git worktree |
+| `--force` | flag | `false` | Install even when the checkout is a worktree or behind its upstream |
 
 | Platform | What gets created | How to activate |
 |----------|-------------------|-----------------|
-| **macOS** | `~/Library/LaunchAgents/com.immich-memories.auto.plist` | `launchctl load <path>` |
-| **Linux** | systemd user service + timer in `~/.config/systemd/user/` | `systemctl --user enable --now immich-memories-auto.timer` |
-| **Other** | Prints a crontab entry | `crontab -e` |
+| **macOS** | launcher in `~/.immich-memories/bin/` + `~/Library/LaunchAgents/com.immich-memories.auto.plist` | `launchctl load <path>` |
+| **Linux** | launcher in `~/.immich-memories/bin/` + systemd user service and timer in `~/.config/systemd/user/` | `systemctl --user enable --now immich-memories-auto.timer` |
+| **Other** | launcher in `~/.immich-memories/bin/` + prints a crontab entry | `crontab -e` |
 
 On macOS the plist uses `StartCalendarInterval`; launchd runs a missed job the next time the Mac wakes rather than waking it from sleep. If the Mac is asleep at the scheduled time, expect the run once it wakes.
 
 ### Which binary gets scheduled
 
-The installer writes the absolute path of the `immich-memories` on your `PATH` into the plist,
-unit, or crontab line. The OS never re-resolves it, so whichever environment you install from is
-the one the nightly job runs forever.
+The OS never re-resolves the command it was given, so `auto install` does not hand it a path that
+can go stale. It writes a small launcher at `~/.immich-memories/bin/immich-memories-auto` and
+schedules *that*. The launcher re-runs the `immich-memories` lookup on every fire, with the
+directory you installed from first on its `PATH`. Upgrade or reinstall the package in place and the
+nightly job picks it up; no reinstall of the scheduler is needed.
 
-That is fine for a system install, a venv, or a plain clone. It is a trap inside a **linked git
-worktree** (`git worktree add`): a worktree stays frozen on the commit it was left at, or gets
-pruned, and the scheduled job keeps quietly running that stale code. `auto install` detects this
-(a linked worktree's root holds a `.git` *file* rather than a directory) and refuses, naming the
-worktree. Re-run it from your canonical checkout. `--force` schedules the worktree path anyway if
-you really mean it.
+`auto install --uninstall` removes the launcher along with the plist or unit files.
+
+### Refusing to schedule stale code
+
+Nothing updates a checkout on your behalf, and a scheduled job re-runs whatever that checkout holds
+every night while the logs look completely normal. `auto install` refuses two cases:
+
+- **A linked git worktree** (`git worktree add`) — its root holds a `.git` *file* rather than a
+  directory. A worktree stays frozen on the commit it was left at, or gets pruned.
+- **A checkout already behind its tracking branch** — measured with `git rev-list HEAD..@{upstream}`
+  against refs you have already fetched. `auto install` never fetches, so this only sees drift your
+  own `git pull` or `git fetch` recorded.
+
+Both name the offending path and the drift. Update the checkout and re-run, or pass `--force` to
+schedule it as it is.
+
+Every `auto run` also states which code it is executing, and `auto status` shows the same thing —
+see [auto status](#auto-status).
+
+### What environment the scheduled job sees
+
+A scheduled job does **not** inherit your interactive shell. launchd and cron start it from a
+login-less environment, so anything you `export` in `.zshrc` is absent at 03:00 — which is how a
+scheduled ACE-Step render ends up tuned differently from the one you tested by hand.
+
+`auto install` captures these variables from the shell you install from and writes them into the
+plist or unit alongside `PATH`:
+
+| Variable | Why it is carried |
+|----------|-------------------|
+| `PATH` | So FFmpeg and the launcher's own lookup work |
+| `ACESTEP_CHECKPOINTS_DIR` | Model cache location |
+| `ACESTEP_MLX_VAE_CHUNK` | ACE-Step MLX VAE decode chunk |
+| `IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32` | ACE-Step MLX decoder precision |
+| `PYTORCH_MPS_HIGH_WATERMARK_RATIO` | torch MPS allocator ceiling |
+
+Nothing else is copied. `IMMICH_MEMORIES_*` also holds the Immich API key and the UI password, and
+a plist in `~/Library` is not a secret store — put credentials in your config file or a `.env` the
+app reads, not in the scheduler. Change any of these and re-run `auto install` to update the job.
+
+Crontab entries carry no environment; set what you need in the crontab itself.
 
 ### Installing with a custom config
 
@@ -273,9 +310,36 @@ Shows recent auto-generated memories: date, type, date range, output file.
 immich-memories auto status [--json]
 ```
 
-Shows the external scheduler state, last automation attempt, last completed automatic run, cooldown, the last six categories, current variety rejection rules, and the live suggestion status. It is diagnostic: it does not generate a video or install, load, unload, or rewrite a scheduler.
+Shows which code is running, the external scheduler state, last automation attempt, last completed automatic run, cooldown, the last six categories, current variety rejection rules, and the live suggestion status. It is diagnostic: it does not generate a video or install, load, unload, or rewrite a scheduler.
 
 Use `--json` for the full machine-readable object. If Immich discovery is temporarily unavailable, durable attempt and run history still appears and `suggestion.outcome` explains the discovery failure.
+
+### Knowing which code is running
+
+The `Running code:` line names the version, the short commit, the checkout it came from, and how
+many commits that checkout is behind its tracking branch. When it is behind, the line is printed as
+an error rather than as info.
+
+The same object is in `--json` under `runtime`:
+
+```json
+{
+  "runtime": {
+    "version": "0.54.0",
+    "checkout": "/home/me/immich-video-memory-generator",
+    "commit": "08e4cd3",
+    "upstream": "origin/main",
+    "commits_behind": 32,
+    "stale": true
+  }
+}
+```
+
+`auto run` reports the same object. Under `--quiet` it is the `runtime` key of the single JSON line
+it prints, so a scheduled run records which code produced it in `auto.log`; if the checkout is
+behind, `auto run` additionally writes a `warning: scheduled code is stale` line to stderr, which
+`--quiet` cannot suppress. `commit`, `upstream`, and `commits_behind` are `null` for an install that
+is not a git checkout (pip, pipx, Docker); `version` is always present.
 
 ## auto test-notification
 

--- a/docs-site/docs/deploy/configuration/environment-variables.md
+++ b/docs-site/docs/deploy/configuration/environment-variables.md
@@ -143,6 +143,15 @@ Not config fields, but read by the app:
 
 There is no environment variable for the log *level*.
 
+:::caution Scheduled jobs do not inherit your shell
+A launchd or cron job starts from a login-less environment, so nothing you `export` interactively
+reaches it. `auto install` copies `PATH`, `ACESTEP_CHECKPOINTS_DIR`, `ACESTEP_MLX_VAE_CHUNK`,
+`IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32`, and `PYTORCH_MPS_HIGH_WATERMARK_RATIO` from the shell you
+install from into the plist or unit — and nothing else, since `IMMICH_MEMORIES_*` also holds
+credentials. Change one of them and re-run `auto install`. See
+[`auto install`](../../create/cli/auto.md#what-environment-the-scheduled-job-sees).
+:::
+
 ## Precedence
 
 Highest wins:

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -56,7 +56,7 @@ immich-memories auto install [OPTIONS]
 | `--cooldown` | integer | 24 | Cooldown hours between runs |
 | `--uninstall` | boolean | false | Remove installed scheduler |
 | `--show` | boolean | false | Show config without installing |
-| `--force` | boolean | false | Schedule the resolved binary even when it lives in a linked git worktree |
+| `--force` | boolean | false | Schedule this install even when its checkout is a worktree or behind its upstream |
 
 ### `auto run`
 

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -133,6 +134,10 @@ def _execute_generate(cmd: list[str]) -> ProcessResult:
         capture_output=True,
         text=True,
         timeout=_GENERATION_TIMEOUT_SECONDS,
+        # WHY: a scheduled run's environment is whatever launchd/systemd handed this
+        # process, not the shell's. Passing it explicitly makes what the child sees a
+        # stated fact and gives `auto install`'s captured tuning a path through (#573).
+        env=os.environ.copy(),
     )
     return ProcessResult(
         returncode=result.returncode,

--- a/src/immich_memories/automation/runtime_provenance.py
+++ b/src/immich_memories/automation/runtime_provenance.py
@@ -1,0 +1,131 @@
+"""Which code is actually running: version, commit, and how stale the checkout is.
+
+A scheduled job stores a command once and re-runs it for months. When that command
+resolves to a checkout nobody updates, every run silently executes old code and the logs
+look completely normal (#573). Nothing here changes behaviour — it only makes the answer
+to "which code just ran?" printable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from immich_memories import __version__
+
+_GIT_TIMEOUT_SECONDS = 5
+
+
+def _git_free_environment() -> dict[str, str]:
+    """Environment with git's own overrides removed.
+
+    `GIT_DIR` and friends beat `-C` — inside a git hook (pre-commit, for one) every
+    `git -C <path>` below would silently answer about the hook's repository instead.
+    """
+    return {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+
+
+@dataclass(frozen=True)
+class CheckoutDrift:
+    """How far a git checkout has fallen behind the branch it tracks."""
+
+    upstream: str
+    commits_behind: int
+
+
+@dataclass(frozen=True)
+class RuntimeProvenance:
+    """Identity of the code executing in this process."""
+
+    version: str
+    checkout: Path | None = None
+    commit: str | None = None
+    drift: CheckoutDrift | None = None
+
+    @property
+    def is_stale(self) -> bool:
+        """True when this checkout is behind a tracking branch it already fetched."""
+        return self.drift is not None
+
+    def describe(self) -> str:
+        """One log line naming exactly which code is running."""
+        parts = [f"immich-memories {self.version}"]
+        if self.commit:
+            parts.append(f"commit {self.commit}")
+        if self.checkout:
+            parts.append(f"checkout {self.checkout}")
+        if self.drift:
+            parts.append(f"BEHIND {self.drift.upstream} by {self.drift.commits_behind} commit(s)")
+        return ", ".join(parts)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Machine-facing provenance for `auto status --json`."""
+        return {
+            "version": self.version,
+            "checkout": str(self.checkout) if self.checkout else None,
+            "commit": self.commit,
+            "upstream": self.drift.upstream if self.drift else None,
+            "commits_behind": self.drift.commits_behind if self.drift else None,
+            "stale": self.is_stale,
+        }
+
+
+def _git(checkout: Path, *args: str) -> str | None:
+    """Run one read-only git command, returning None for any inconclusive result."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(checkout), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=_git_free_environment(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def git_checkout_root(start: Path) -> Path | None:
+    """Return the checkout holding `start` — clone, linked worktree, or submodule alike."""
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            return directory
+    return None
+
+
+def checkout_drift(checkout: Path) -> CheckoutDrift | None:
+    """Commits this checkout trails its tracking branch by, from already-fetched refs.
+
+    Deliberately never fetches: neither `auto install` nor a 03:00 run should reach the
+    network, so this reports only drift the user's own fetch or pull already recorded.
+    """
+    upstream = _git(checkout, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+    if not upstream:
+        return None
+    behind = _git(checkout, "rev-list", "--count", "HEAD..@{upstream}")
+    if behind is None or not behind.isdigit() or int(behind) == 0:
+        return None
+    return CheckoutDrift(upstream=upstream, commits_behind=int(behind))
+
+
+def runtime_provenance(package_file: Path | None = None) -> RuntimeProvenance:
+    """Identify the code this process is executing, for logs and `auto status`."""
+    if package_file is None:
+        import immich_memories
+
+        located = getattr(immich_memories, "__file__", None)
+        package_file = Path(located).resolve() if located else None
+
+    checkout = git_checkout_root(package_file) if package_file else None
+    if checkout is None:
+        return RuntimeProvenance(version=__version__)
+    return RuntimeProvenance(
+        version=__version__,
+        checkout=checkout,
+        commit=_git(checkout, "rev-parse", "--short", "HEAD"),
+        drift=checkout_drift(checkout),
+    )

--- a/src/immich_memories/automation/system_scheduler.py
+++ b/src/immich_memories/automation/system_scheduler.py
@@ -12,6 +12,12 @@ import textwrap
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from immich_memories.automation.runtime_provenance import (
+    CheckoutDrift,
+    checkout_drift,
+    git_checkout_root,
+)
+
 
 @dataclass
 class SchedulerInstallResult:
@@ -36,9 +42,23 @@ class SchedulerStatus:
 _LAUNCHD_LABEL = "com.immich-memories.auto"
 _SYSTEMD_SERVICE = "immich-memories-auto.service"
 _SYSTEMD_TIMER = "immich-memories-auto.timer"
+_LAUNCHER_SHIM_NAME = "immich-memories-auto"
+
+# Non-secret tuning knobs documented on the environment-variables page. Anything that can
+# hold a credential is deliberately excluded — see `_scheduled_environment`.
+_SCHEDULED_TUNING_VARS = (
+    "ACESTEP_CHECKPOINTS_DIR",
+    "ACESTEP_MLX_VAE_CHUNK",
+    "IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32",
+    "PYTORCH_MPS_HIGH_WATERMARK_RATIO",
+)
 
 
-class WorktreePinnedBinaryError(RuntimeError):
+class StaleScheduledCodeError(RuntimeError):
+    """The code this install would schedule is already frozen or already behind."""
+
+
+class WorktreePinnedBinaryError(StaleScheduledCodeError):
     """The binary that would be persisted into the scheduler lives in a linked git worktree."""
 
     def __init__(self, binary: str, worktree: Path) -> None:
@@ -48,6 +68,19 @@ class WorktreePinnedBinaryError(RuntimeError):
             "gets pruned — so the scheduled job would silently keep running stale code. "
             "Install from your canonical checkout (or a system/user install) instead, "
             "or pass --force to schedule this exact path anyway."
+        )
+
+
+class StaleCheckoutError(StaleScheduledCodeError):
+    """The checkout backing this binary is already behind the branch it tracks."""
+
+    def __init__(self, binary: str, checkout: Path, drift: CheckoutDrift) -> None:
+        super().__init__(
+            f"Refusing to schedule {binary}: its checkout {checkout} is "
+            f"{drift.commits_behind} commit(s) behind {drift.upstream}. Nothing updates a "
+            "checkout on your behalf, so the scheduled job would re-run this exact code every "
+            "night while the logs look normal. Update it (git pull) and reinstall, or pass "
+            "--force to schedule it as it is."
         )
 
 
@@ -87,8 +120,96 @@ def _linked_worktree_root(binary: str) -> Path | None:
     return None
 
 
+def _guard_scheduled_code_freshness(binary: str) -> None:
+    """Refuse to schedule code that is already frozen, or already behind its upstream.
+
+    Both refusals describe the same #573 failure: a scheduled job re-runs one checkout
+    forever, so anything already stale at install time stays stale silently for months.
+    """
+    worktree = _linked_worktree_root(binary)
+    if worktree is not None:
+        raise WorktreePinnedBinaryError(binary, worktree)
+
+    checkout = git_checkout_root(Path(binary))
+    if checkout is None:
+        return
+    drift = checkout_drift(checkout)
+    if drift is not None:
+        raise StaleCheckoutError(binary, checkout, drift)
+
+
 def _default_log_dir() -> Path:
     return Path.home() / ".immich-memories" / "logs"
+
+
+def _install_time_path() -> str:
+    return os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+
+def _scheduled_environment() -> dict[str, str]:
+    """Environment the scheduled job gets, captured from the shell that installed it.
+
+    launchd and cron start a job from a login-less environment, so ACE-Step tuning
+    exported in an interactive shell is simply absent at 03:00 — the scheduled and manual
+    runs in #573 were tuned differently for exactly this reason. Only the documented
+    tuning knobs are copied: `IMMICH_MEMORIES_*` also carries the Immich API key and the
+    UI password, and a plist under ~/Library is no place for either.
+    """
+    env = {"PATH": _install_time_path()}
+    env.update({name: os.environ[name] for name in _SCHEDULED_TUNING_VARS if name in os.environ})
+    return env
+
+
+def _launcher_shim_path() -> Path:
+    return Path.home() / ".immich-memories" / "bin" / _LAUNCHER_SHIM_NAME
+
+
+def _launcher_search_path(binary: str) -> str:
+    """Put the install's own bin directory first, then the rest of the install-time PATH."""
+    own_bin = str(Path(binary).parent)
+    entries = [
+        own_bin,
+        *(part for part in _install_time_path().split(os.pathsep) if part != own_bin),
+    ]
+    return os.pathsep.join(entries)
+
+
+def render_launcher_shim(path_env: str) -> str:
+    """Render the launcher that schedulers store in place of a resolved binary path.
+
+    launchd, systemd, and cron keep the path they were handed forever and never re-resolve
+    it, so a `shutil.which()` result frozen at install time keeps executing whichever
+    checkout happened to be first on PATH that day (#573). This shim is the durable address
+    instead: it re-runs the lookup on every fire, so upgrading or reinstalling the package
+    is enough to change what the scheduled job executes.
+    """
+    return textwrap.dedent(f"""\
+        #!/bin/sh
+        # Managed by `immich-memories auto install`; rewritten on every reinstall.
+        PATH={shlex.quote(path_env)}
+        export PATH
+        if ! command -v immich-memories >/dev/null 2>&1; then
+            echo "immich-memories is not on the scheduled job's PATH: $PATH" >&2
+            exit 127
+        fi
+        exec immich-memories "$@"
+    """)
+
+
+def _write_launcher_shim(binary: str) -> Path:
+    shim = _launcher_shim_path()
+    shim.parent.mkdir(parents=True, exist_ok=True)
+    shim.write_text(render_launcher_shim(_launcher_search_path(binary)))
+    shim.chmod(0o755)
+    return shim
+
+
+def _remove_launcher_shim() -> bool:
+    shim = _launcher_shim_path()
+    if not shim.exists():
+        return False
+    shim.unlink()
+    return True
 
 
 def _auto_command(binary_path: str, cooldown_hours: int, config_path: Path | None) -> list[str]:
@@ -119,8 +240,6 @@ def generate_launchd_plist(
 ) -> str:
     """Generate a macOS launchd plist XML string for scheduled auto-generation."""
     log_dir = log_dir or _default_log_dir()
-    # PATH from current env so FFmpeg, etc. are discoverable
-    env_path = os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
 
     payload = {
         "Label": _LAUNCHD_LABEL,
@@ -129,7 +248,7 @@ def generate_launchd_plist(
         "StandardOutPath": str(log_dir / "auto.log"),
         "StandardErrorPath": str(log_dir / "auto-error.log"),
         "WorkingDirectory": str(Path.home()),
-        "EnvironmentVariables": {"PATH": env_path},
+        "EnvironmentVariables": _scheduled_environment(),
     }
     return plistlib.dumps(payload, sort_keys=False).decode()
 
@@ -145,19 +264,26 @@ def generate_systemd_units(
     command = " ".join(
         _systemd_quote_arg(arg) for arg in _auto_command(binary_path, cooldown_hours, config_path)
     )
-    service = textwrap.dedent(f"""\
-        [Unit]
-        Description=Immich Memories auto-generation
-        After=network-online.target
-        Wants=network-online.target
-
-        [Service]
-        Type=oneshot
-        ExecStart={command}
-
-        [Install]
-        WantedBy=default.target
-    """)
+    service = "\n".join(
+        [
+            "[Unit]",
+            "Description=Immich Memories auto-generation",
+            "After=network-online.target",
+            "Wants=network-online.target",
+            "",
+            "[Service]",
+            "Type=oneshot",
+            *(
+                f"Environment={_systemd_quote_arg(f'{key}={value}')}"
+                for key, value in _scheduled_environment().items()
+            ),
+            f"ExecStart={command}",
+            "",
+            "[Install]",
+            "WantedBy=default.target",
+            "",
+        ]
+    )
 
     timer = textwrap.dedent(f"""\
         [Unit]
@@ -297,26 +423,29 @@ def install_scheduler(
 ) -> SchedulerInstallResult:
     """Detect platform, generate scheduler files, write them, and return result.
 
-    Raises WorktreePinnedBinaryError when the resolved binary sits inside a linked git worktree,
-    unless `force` is set — the OS never re-resolves the absolute path persisted here.
+    Raises StaleScheduledCodeError when the resolved binary is backed by a linked git
+    worktree or by a checkout already behind its tracking branch, unless `force` is set.
     """
     platform = detect_platform()
     binary = _resolve_binary()
-    worktree = None if force else _linked_worktree_root(binary)
-    if worktree is not None:
-        raise WorktreePinnedBinaryError(binary, worktree)
+    if not force:
+        _guard_scheduled_code_freshness(binary)
 
+    launcher = _write_launcher_shim(binary)
     if platform == "launchd":
-        return _install_launchd(
-            binary, schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
+        result = _install_launchd(
+            str(launcher), schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
         )
-    if platform == "systemd":
-        return _install_systemd(
-            binary, schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
+    elif platform == "systemd":
+        result = _install_systemd(
+            str(launcher), schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
         )
-    return _install_crontab(
-        binary, schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
-    )
+    else:
+        result = _install_crontab(
+            str(launcher), schedule_hour, schedule_minute, cooldown_hours, config_path=config_path
+        )
+    result.files_written.insert(0, launcher)
+    return result
 
 
 def _install_launchd(
@@ -390,17 +519,17 @@ def _install_crontab(
 def uninstall_scheduler() -> bool:
     """Remove installed scheduler files. Returns True if something was removed."""
     platform = detect_platform()
+    removed = _remove_launcher_shim()
 
     if platform == "launchd":
         plist = _launchd_plist_path()
         if plist.exists():
             plist.unlink()
-            return True
-        return False
+            removed = True
+        return removed
 
     if platform == "systemd":
         user_dir = _systemd_user_dir()
-        removed = False
         for name in (_SYSTEMD_SERVICE, _SYSTEMD_TIMER):
             path = user_dir / name
             if path.exists():
@@ -408,8 +537,8 @@ def uninstall_scheduler() -> bool:
                 removed = True
         return removed
 
-    # crontab: nothing to remove on disk
-    return False
+    # crontab: the launcher is the only thing this app put on disk
+    return removed
 
 
 def show_scheduler_config(
@@ -419,10 +548,11 @@ def show_scheduler_config(
     config_path: Path | None = None,
 ) -> str | None:
     """Generate scheduler config for current platform without writing files."""
-    binary = shutil.which("immich-memories")
-    if not binary:
+    if not shutil.which("immich-memories"):
         return None
 
+    # Preview the launcher `install_scheduler` would write, not today's resolved path.
+    binary = str(_launcher_shim_path())
     platform = detect_platform()
 
     if platform == "launchd":

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -14,6 +14,8 @@ from immich_memories.automation.models import AutoOutcome, AutoRunResult
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
 from immich_memories.config_loader import Config
 
+logger = logging.getLogger(__name__)
+
 
 def _print_candidates_table(candidates: list) -> None:
     table = Table(title="Memory Candidates")
@@ -59,10 +61,11 @@ def _candidates_to_json(candidates: list) -> str:
     return json_mod.dumps(rows, indent=2)
 
 
-def _auto_result_to_json(result: AutoRunResult) -> str:
+def _auto_result_to_json(result: AutoRunResult, runtime: dict[str, Any]) -> str:
     """Serialize the stable machine-facing automation result contract."""
     return json_mod.dumps(
         {
+            "runtime": runtime,
             "outcome": result.outcome.value,
             "action": result.action.value if result.action is not None else None,
             "reason": result.reason,
@@ -84,6 +87,21 @@ def _auto_result_to_json(result: AutoRunResult) -> str:
             ],
         }
     )
+
+
+def _print_auto_run_result(result: AutoRunResult) -> None:
+    """Render one auto run for a human; failures are reported by the caller on stderr."""
+    if result.outcome is AutoOutcome.COMPLETED:
+        print_success(f"{result.outcome.value}: {result.reason} ({result.output_path})")
+    elif result.outcome is not AutoOutcome.FAILED:
+        print_info(f"{result.outcome.value}: {result.reason}")
+
+    if result.candidate is not None:
+        print_info(f"Candidate: {result.candidate.category.value} ({result.candidate.memory_key})")
+    if result.recent_categories:
+        print_info(f"Recent auto categories: {', '.join(result.recent_categories)}")
+    for rejection in result.rejections:
+        print_info(f"Rejected {rejection.category} ({rejection.memory_key}): {rejection.rule}")
 
 
 def _print_pending_delivery_status(payload: dict[str, Any]) -> None:
@@ -196,13 +214,20 @@ def run_cmd(
     quiet: bool,
 ) -> None:
     """Generate the top-scoring memory candidate."""
+    from immich_memories.automation import runtime_provenance as provenance_module
     from immich_memories.automation.runner import AutoRunner
 
     config: Config = ctx.obj["config"]
+    provenance = provenance_module.runtime_provenance()
     previous_logging_disable = logging.root.manager.disable
     if quiet:
         logging.disable(logging.CRITICAL)
     try:
+        logger.info("auto run starting — %s", provenance.describe())
+        if provenance.is_stale:
+            # WHY: --quiet turns logging off entirely, and a scheduled job is exactly
+            # where nobody is watching. Staleness must reach the error log by itself.
+            click.echo(f"warning: scheduled code is stale — {provenance.describe()}", err=True)
         result = AutoRunner(config, config_path=ctx.obj["config_path"]).run_one(
             force=force, cooldown_hours=cooldown, upload=upload, dry_run=dry_run
         )
@@ -211,21 +236,9 @@ def run_cmd(
             logging.disable(previous_logging_disable)
 
     if quiet:
-        click.echo(_auto_result_to_json(result))
-    elif result.outcome is AutoOutcome.COMPLETED:
-        print_success(f"{result.outcome.value}: {result.reason} ({result.output_path})")
-    elif result.outcome is not AutoOutcome.FAILED:
-        print_info(f"{result.outcome.value}: {result.reason}")
-
-    if not quiet:
-        if result.candidate is not None:
-            print_info(
-                f"Candidate: {result.candidate.category.value} ({result.candidate.memory_key})"
-            )
-        if result.recent_categories:
-            print_info(f"Recent auto categories: {', '.join(result.recent_categories)}")
-        for rejection in result.rejections:
-            print_info(f"Rejected {rejection.category} ({rejection.memory_key}): {rejection.rule}")
+        click.echo(_auto_result_to_json(result, provenance.to_dict()))
+    else:
+        _print_auto_run_result(result)
 
     if result.outcome is AutoOutcome.FAILED:
         click.echo(f"{result.outcome.value}: {result.reason}: {result.error}", err=True)
@@ -255,10 +268,12 @@ def history(ctx: click.Context, limit: int) -> None:
 @click.pass_context
 def status(ctx: click.Context, as_json: bool) -> None:
     """Show durable automation and external scheduler state."""
+    from immich_memories.automation import runtime_provenance as provenance_module
     from immich_memories.automation.runner import AutoRunner
     from immich_memories.automation.system_scheduler import get_scheduler_status
 
     config: Config = ctx.obj["config"]
+    provenance = provenance_module.runtime_provenance()
     previous_logging_disable = logging.root.manager.disable
     if as_json:
         logging.disable(logging.CRITICAL)
@@ -279,6 +294,7 @@ def status(ctx: click.Context, as_json: bool) -> None:
             "state": scheduler_state,
             "paths": [str(path) for path in scheduler.paths],
         }
+        payload["runtime"] = provenance.to_dict()
     finally:
         if as_json:
             logging.disable(previous_logging_disable)
@@ -298,6 +314,10 @@ def status(ctx: click.Context, as_json: bool) -> None:
         else "not installed"
     )
     print_info(f"Scheduler: {scheduler.platform}, {scheduler_installation}, {scheduler_state}")
+    if provenance.is_stale:
+        print_error(f"Running code: {provenance.describe()}")
+    else:
+        print_info(f"Running code: {provenance.describe()}")
     print_info(
         "Last attempt: "
         + (
@@ -335,7 +355,7 @@ def status(ctx: click.Context, as_json: bool) -> None:
 @click.option(
     "--force",
     is_flag=True,
-    help="Schedule the resolved binary even when it lives in a linked git worktree",
+    help="Schedule this install even when its checkout is a worktree or behind its upstream",
 )
 @click.pass_context
 def install(
@@ -349,7 +369,7 @@ def install(
 ) -> None:
     """Install system-level scheduler (launchd/systemd/cron)."""
     from immich_memories.automation.system_scheduler import (
-        WorktreePinnedBinaryError,
+        StaleScheduledCodeError,
         install_scheduler,
         show_scheduler_config,
         uninstall_scheduler,
@@ -377,7 +397,7 @@ def install(
     except FileNotFoundError:
         print_info("immich-memories binary not found in PATH")
         return
-    except WorktreePinnedBinaryError as exc:
+    except StaleScheduledCodeError as exc:
         print_error(str(exc))
         ctx.exit(1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import tempfile
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -85,6 +86,49 @@ def isolated_user_paths() -> Iterator[Path]:
         config.output.output_path,
     }
     assert not resolved_paths & normal_user_paths
+
+
+@pytest.fixture()
+def git_checkout_factory() -> Callable[[Path, int], Path]:
+    """Build a real checkout whose HEAD trails an already-fetched tracking branch.
+
+    Real git rather than a mocked one: the staleness guard's whole job is reading refs
+    that only git can produce, and a faked `rev-list` would prove nothing about it.
+    """
+
+    # GIT_DIR and friends beat `-C`, so under a git hook (pre-commit runs the suite as
+    # one) every command below would target the real repository instead of tmp_path.
+    env = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
+
+    def run(root: Path, *args: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+            env=env,
+        )
+        return result.stdout.strip()
+
+    def build(root: Path, commits_behind: int = 0) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        run(root, "init", "-b", "main", "-q")
+        run(root, "config", "user.email", "test@example.invalid")
+        run(root, "config", "user.name", "Test")
+        # The upstream needs a registered remote for its fetch refspec to resolve.
+        run(root, "remote", "add", "origin", "https://example.invalid/repo.git")
+        run(root, "commit", "--allow-empty", "-q", "-m", "base")
+        base = run(root, "rev-parse", "HEAD")
+        for index in range(commits_behind):
+            run(root, "commit", "--allow-empty", "-q", "-m", f"upstream-{index}")
+        run(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+        run(root, "reset", "--hard", "-q", base)
+        run(root, "config", "branch.main.remote", "origin")
+        run(root, "config", "branch.main.merge", "refs/heads/main")
+        return root
+
+    return build
 
 
 def make_asset(

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -1545,12 +1545,26 @@ class TestRunOneOutcomes:
             result = _execute_generate(["immich-memories", "generate"])
 
         assert result == ProcessResult(0, "stdout", "stderr")
-        run.assert_called_once_with(
-            ["immich-memories", "generate"],
-            capture_output=True,
-            text=True,
-            timeout=7200,
-        )
+        assert run.call_args.args[0] == ["immich-memories", "generate"]
+        assert run.call_args.kwargs["capture_output"] is True
+        assert run.call_args.kwargs["text"] is True
+        assert run.call_args.kwargs["timeout"] == 7200
+
+    def test_execute_adapter_states_the_child_environment_instead_of_inheriting_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under launchd the parent's environment is the whole story — spell it out."""
+        monkeypatch.setenv("ACESTEP_MLX_VAE_CHUNK", "384")
+        completed = subprocess.CompletedProcess(["generate"], 0, "", "")
+
+        # WHY: subprocess.run would fork a real generation
+        with patch(
+            "immich_memories.automation.runner.subprocess.run", return_value=completed
+        ) as run:
+            _execute_generate(["immich-memories", "generate"])
+
+        assert run.call_args.kwargs["env"]["ACESTEP_MLX_VAE_CHUNK"] == "384"
+        assert "PATH" in run.call_args.kwargs["env"]
 
 
 class TestBuildGenerateCommand:

--- a/tests/test_auto_status.py
+++ b/tests/test_auto_status.py
@@ -15,6 +15,7 @@ from immich_memories.automation.candidate_discovery import ImmichDiscoveryError
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoOutcome
 from immich_memories.automation.runner import AutoRunner
+from immich_memories.automation.runtime_provenance import CheckoutDrift, RuntimeProvenance
 from immich_memories.automation.state_store import AutomationStateStore
 from immich_memories.automation.status import SuggestOutcome, SuggestStatus
 from immich_memories.automation.system_scheduler import SchedulerStatus
@@ -148,6 +149,7 @@ def test_status_json_reports_durable_attempt_rotation_and_scheduler(tmp_path: Pa
         "pending_delivery_count",
         "oldest_pending_delivery",
         "notification_health",
+        "runtime",
     }
     assert payload["last_attempt"]["outcome"] == "failed"
     assert payload["last_attempt"]["error"] == "connection refused"
@@ -289,6 +291,45 @@ def test_status_refreshes_and_reports_current_rejection_reasons(tmp_path: Path) 
     assert payload["suggestion"] == {"outcome": "ready", "error": None}
     assert payload["rejection_reasons"] == ["same_category_as_previous"]
     suggest.assert_called_once()
+
+
+def test_status_names_the_code_that_would_run_and_flags_it_when_stale(tmp_path: Path) -> None:
+    """#573 stayed invisible for a week because no surface said which code was running."""
+    config = _config(tmp_path)
+    scheduler = SchedulerStatus(platform="launchd", installed=True, active=True)
+    stale = RuntimeProvenance(
+        version="1.2.3",
+        checkout=Path("/home/me/.immich-memories/runtime"),
+        commit="ea892ad",
+        drift=CheckoutDrift(upstream="origin/main", commits_behind=32),
+    )
+    with (
+        patch.object(AutoRunner, "suggest", return_value=[]),
+        patch(
+            "immich_memories.automation.system_scheduler.get_scheduler_status",
+            return_value=scheduler,
+        ),
+        # WHY: runtime_provenance shells out to git against the real checkout
+        patch(
+            "immich_memories.automation.runtime_provenance.runtime_provenance",
+            return_value=stale,
+        ),
+    ):
+        json_result = _invoke(config, ["auto", "status", "--json"])
+        human_result = _invoke(config, ["auto", "status"])
+
+    assert json_result.exit_code == 0
+    assert json.loads(json_result.output)["runtime"] == {
+        "version": "1.2.3",
+        "checkout": "/home/me/.immich-memories/runtime",
+        "commit": "ea892ad",
+        "upstream": "origin/main",
+        "commits_behind": 32,
+        "stale": True,
+    }
+    assert human_result.exit_code == 0
+    assert "ea892ad" in human_result.output
+    assert "32 commit(s)" in human_result.output
 
 
 def test_status_json_is_one_document_on_a_fresh_database(tmp_path: Path) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner, Result
 import immich_memories
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoAction, AutoOutcome, AutoRejection, AutoRunResult
+from immich_memories.automation.runtime_provenance import CheckoutDrift, RuntimeProvenance
 from immich_memories.automation.system_scheduler import (
     SchedulerInstallResult,
     WorktreePinnedBinaryError,
@@ -407,7 +408,9 @@ class TestAutoRunOutput:
 
         assert result.exit_code == 0
         assert result.stdout.count("\n") == 1
-        assert json.loads(result.stdout) == {
+        payload = json.loads(result.stdout)
+        assert payload.pop("runtime")["version"] == immich_memories.__version__
+        assert payload == {
             "outcome": "completed",
             "action": "generation",
             "reason": "generation completed",
@@ -419,6 +422,34 @@ class TestAutoRunOutput:
             "recent_categories": [],
             "rejections": [],
         }
+
+    def test_stale_checkout_warns_on_stderr_even_when_quiet(self) -> None:
+        """--quiet silences logging, so the one thing #573 needed must not go through it."""
+        auto_runner = MagicMock()
+        auto_runner.run_one.return_value = AutoRunResult(
+            outcome=AutoOutcome.SKIPPED, reason="cooldown active"
+        )
+        stale = RuntimeProvenance(
+            version="1.2.3",
+            checkout=Path("/home/me/.immich-memories/runtime"),
+            commit="ea892ad",
+            drift=CheckoutDrift(upstream="origin/main", commits_behind=32),
+        )
+
+        with (
+            patch("immich_memories.automation.runner.AutoRunner", return_value=auto_runner),
+            # WHY: runtime_provenance shells out to git against the real checkout
+            patch(
+                "immich_memories.automation.runtime_provenance.runtime_provenance",
+                return_value=stale,
+            ),
+        ):
+            result = _invoke(["auto", "run", "--quiet"])
+
+        assert result.exit_code == 0
+        assert "32 commit(s)" in result.stderr
+        assert "origin/main" in result.stderr
+        assert json.loads(result.stdout)["runtime"]["stale"] is True
 
     def test_human_completed_states_outcome_and_reason(self, tmp_path: Path) -> None:
         output = tmp_path / "memory.mp4"
@@ -450,7 +481,9 @@ class TestAutoRunOutput:
             result = _invoke(["auto", "run", "--quiet"])
 
         assert result.exit_code == 0
-        assert json.loads(result.stdout) == {
+        payload = json.loads(result.stdout)
+        assert payload.pop("runtime")["version"] == immich_memories.__version__
+        assert payload == {
             "outcome": "skipped",
             "action": "generation",
             "reason": "cooldown active",
@@ -500,7 +533,9 @@ class TestAutoRunOutput:
             result = _invoke(["auto", "run", "--quiet", "--dry-run"])
 
         assert result.exit_code == 0
-        assert json.loads(result.stdout) == {
+        payload = json.loads(result.stdout)
+        assert payload.pop("runtime")["version"] == immich_memories.__version__
+        assert payload == {
             "outcome": "skipped",
             "action": "generation",
             "reason": "no eligible candidates",
@@ -557,7 +592,9 @@ class TestAutoRunOutput:
             result = _invoke(["auto", "run", "--quiet"])
 
         assert result.exit_code == 1
-        assert json.loads(result.stdout) == {
+        payload = json.loads(result.stdout)
+        assert payload.pop("runtime")["version"] == immich_memories.__version__
+        assert payload == {
             "outcome": "failed",
             "action": "generation",
             "reason": "generation subprocess exited with code 7",

--- a/tests/test_daemon_failure_reporting.py
+++ b/tests/test_daemon_failure_reporting.py
@@ -115,7 +115,8 @@ class TestTheMachineReadableResult:
 
         return json.loads(
             _auto_result_to_json(
-                AutoRunResult(outcome=AutoOutcome.FAILED, reason="generation failed", **kwargs)
+                AutoRunResult(outcome=AutoOutcome.FAILED, reason="generation failed", **kwargs),
+                {"version": "0.0.0"},
             )
         )
 

--- a/tests/test_runtime_provenance.py
+++ b/tests/test_runtime_provenance.py
@@ -1,0 +1,82 @@
+"""Tests for identifying which code a run is actually executing."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from immich_memories.automation.runtime_provenance import (
+    checkout_drift,
+    git_checkout_root,
+    runtime_provenance,
+)
+
+BuildCheckout = Callable[..., Path]
+
+
+class TestCheckoutDrift:
+    def test_reports_how_far_behind_the_tracking_branch_the_checkout_is(
+        self, tmp_path: Path, git_checkout_factory: BuildCheckout
+    ) -> None:
+        checkout = git_checkout_factory(tmp_path / "runtime", 3)
+
+        drift = checkout_drift(checkout)
+
+        assert drift is not None
+        assert drift.commits_behind == 3
+        assert drift.upstream == "origin/main"
+
+    def test_checkout_level_with_its_upstream_has_no_drift(
+        self, tmp_path: Path, git_checkout_factory: BuildCheckout
+    ) -> None:
+        assert checkout_drift(git_checkout_factory(tmp_path / "runtime", 0)) is None
+
+    def test_non_git_directory_has_no_drift(self, tmp_path: Path) -> None:
+        assert checkout_drift(tmp_path) is None
+
+
+class TestGitCheckoutRoot:
+    def test_finds_the_checkout_holding_a_nested_path(
+        self, tmp_path: Path, git_checkout_factory: BuildCheckout
+    ) -> None:
+        checkout = git_checkout_factory(tmp_path / "runtime", 1)
+        nested = checkout / "src" / "immich_memories"
+        nested.mkdir(parents=True)
+
+        assert git_checkout_root(nested) == checkout
+
+    def test_returns_none_outside_any_checkout(self, tmp_path: Path) -> None:
+        assert git_checkout_root(tmp_path / "nowhere") is None
+
+
+class TestRuntimeProvenance:
+    def test_always_reports_the_installed_version(self) -> None:
+        from immich_memories import __version__
+
+        assert runtime_provenance().version == __version__
+
+    def test_describes_drift_so_a_scheduled_run_says_it_is_stale(
+        self, tmp_path: Path, git_checkout_factory: BuildCheckout
+    ) -> None:
+        checkout = git_checkout_factory(tmp_path / "runtime", 32)
+        package = checkout / "src" / "immich_memories" / "__init__.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("")
+
+        provenance = runtime_provenance(package_file=package)
+
+        assert provenance.is_stale is True
+        assert "32" in provenance.describe()
+        assert "origin/main" in provenance.describe()
+        assert provenance.to_dict()["commits_behind"] == 32
+
+    def test_a_checkout_free_install_still_describes_itself(self, tmp_path: Path) -> None:
+        package = tmp_path / "site-packages" / "immich_memories" / "__init__.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("")
+
+        provenance = runtime_provenance(package_file=package)
+
+        assert provenance.is_stale is False
+        assert provenance.commit is None
+        assert provenance.version in provenance.describe()

--- a/tests/test_system_scheduler.py
+++ b/tests/test_system_scheduler.py
@@ -11,8 +11,10 @@ from unittest.mock import patch
 
 import pytest
 
+from immich_memories.automation import system_scheduler
 from immich_memories.automation.system_scheduler import (
     SchedulerInstallResult,
+    StaleCheckoutError,
     WorktreePinnedBinaryError,
     detect_platform,
     generate_crontab_entry,
@@ -23,6 +25,16 @@ from immich_memories.automation.system_scheduler import (
     show_scheduler_config,
     uninstall_scheduler,
 )
+
+
+@pytest.fixture(autouse=True)
+def launcher_shim(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Keep install/uninstall away from the developer's real ~/.immich-memories/bin."""
+    shim = tmp_path_factory.mktemp("launcher") / "immich-memories-auto"
+    monkeypatch.setattr(system_scheduler, "_launcher_shim_path", lambda: shim)
+    return shim
 
 
 def _checkout_binary(checkout: Path) -> str:
@@ -116,6 +128,38 @@ class TestGenerateLaunchdPlist:
             "--cooldown",
             "24",
         ]
+
+
+class TestScheduledEnvironment:
+    """launchd and cron start from a login-less environment; shell tuning is not there."""
+
+    def test_launchd_plist_carries_ace_step_tuning_from_the_install_shell(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ACESTEP_MLX_VAE_CHUNK", "384")
+        monkeypatch.setenv("IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32", "1")
+
+        parsed = plistlib.loads(generate_launchd_plist("/bin/im").encode())
+
+        assert parsed["EnvironmentVariables"]["ACESTEP_MLX_VAE_CHUNK"] == "384"
+        assert parsed["EnvironmentVariables"]["IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32"] == "1"
+        assert "PATH" in parsed["EnvironmentVariables"]
+
+    def test_launchd_plist_never_carries_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The plist is a plain file in ~/Library — an API key does not belong in it."""
+        monkeypatch.setenv("IMMICH_MEMORIES_IMMICH__API_KEY", "not-a-real-key-573")
+        monkeypatch.setenv("IMMICH_MEMORIES_AUTH_PASSWORD", "not-a-real-password-573")
+
+        assert "not-a-real-key-573" not in generate_launchd_plist("/bin/im")
+        assert "not-a-real-password-573" not in generate_launchd_plist("/bin/im")
+
+    def test_systemd_service_carries_ace_step_tuning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ACESTEP_MLX_VAE_CHUNK", "384")
+
+        service, _ = generate_systemd_units("/bin/im")
+
+        assert 'Environment="ACESTEP_MLX_VAE_CHUNK=384"' in service
+        assert service.index("Environment=") < service.index("ExecStart=")
 
 
 class TestGenerateSystemdUnits:
@@ -244,18 +288,20 @@ class TestInstallScheduler:
             result = install_scheduler()
 
         assert result.platform == "systemd"
-        assert len(result.files_written) == 2
+        assert len(result.files_written) == 3
         assert (tmp_path / "immich-memories-auto.service").exists()
         assert (tmp_path / "immich-memories-auto.timer").exists()
         assert "systemctl --user enable" in result.activate_command
 
     @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
     @patch("immich_memories.automation.system_scheduler._resolve_binary", return_value="/bin/im")
-    def test_crontab_returns_command(self, _bin: object, _plat: object) -> None:
+    def test_crontab_returns_command(
+        self, _bin: object, _plat: object, launcher_shim: Path
+    ) -> None:
         # WHY: _resolve_binary checks PATH, detect_platform checks OS
         result = install_scheduler()
         assert result.platform == "crontab"
-        assert result.files_written == []
+        assert result.files_written == [launcher_shim]
         assert "crontab" in result.activate_command
 
     @patch(
@@ -291,7 +337,9 @@ class TestEphemeralBinaryRefusal:
 
     # WHY: detect_platform reads the host OS
     @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
-    def test_binary_inside_plain_clone_is_installed(self, _plat: object, tmp_path: Path) -> None:
+    def test_binary_inside_plain_clone_is_installed(
+        self, _plat: object, tmp_path: Path, launcher_shim: Path
+    ) -> None:
         """Self-hosters deploy by cloning — only the ephemeral worktree case is rejected."""
         clone = tmp_path / "immich-video-memory-generator"
         (clone / ".git").mkdir(parents=True)
@@ -301,12 +349,12 @@ class TestEphemeralBinaryRefusal:
         with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
             result = install_scheduler()
 
-        assert binary in result.activate_command
+        assert str(launcher_shim) in result.activate_command
 
     # WHY: detect_platform reads the host OS
     @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
     def test_force_schedules_the_worktree_binary_anyway(
-        self, _plat: object, tmp_path: Path
+        self, _plat: object, tmp_path: Path, launcher_shim: Path
     ) -> None:
         worktree = tmp_path / "agent-branch"
         worktree.mkdir()
@@ -319,7 +367,144 @@ class TestEphemeralBinaryRefusal:
         with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
             result = install_scheduler(force=True)
 
-        assert binary in result.activate_command
+        assert str(launcher_shim) in result.activate_command
+        assert str(worktree) in launcher_shim.read_text()
+
+
+class TestStableLauncher:
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_scheduled_command_is_not_the_install_time_binary(
+        self, _plat: object, tmp_path: Path, launcher_shim: Path
+    ) -> None:
+        """The OS never re-resolves what it stores, so store a launcher, not today's path."""
+        clone = tmp_path / "checkout"
+        (clone / ".git").mkdir(parents=True)
+        binary = _checkout_binary(clone)
+
+        # WHY: shutil.which reads the real PATH
+        with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
+            result = install_scheduler()
+
+        assert binary not in result.activate_command
+        assert str(launcher_shim) in result.activate_command
+        assert launcher_shim in result.files_written
+
+    def test_launcher_re_resolves_the_binary_on_every_run(self, launcher_shim: Path) -> None:
+        clone_bin = "/opt/frozen-checkout/.venv/bin/immich-memories"
+
+        # WHY: shutil.which reads the real PATH
+        with (
+            patch(
+                "immich_memories.automation.system_scheduler.shutil.which", return_value=clone_bin
+            ),
+            patch(
+                "immich_memories.automation.system_scheduler.detect_platform",
+                return_value="crontab",
+            ),
+        ):
+            install_scheduler()
+
+        shim = launcher_shim.read_text()
+        assert clone_bin not in shim
+        assert "exec immich-memories" in shim
+        assert launcher_shim.stat().st_mode & 0o111
+
+    def test_launcher_carries_the_install_time_path_so_a_venv_stays_findable(
+        self, launcher_shim: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PATH", "/home/me/venvs/immich/bin:/usr/bin")
+
+        # WHY: shutil.which reads the real PATH
+        with (
+            patch(
+                "immich_memories.automation.system_scheduler.shutil.which",
+                return_value="/home/me/venvs/immich/bin/immich-memories",
+            ),
+            patch(
+                "immich_memories.automation.system_scheduler.detect_platform",
+                return_value="crontab",
+            ),
+        ):
+            install_scheduler()
+
+        assert "/home/me/venvs/immich/bin:/usr/bin" in launcher_shim.read_text()
+
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_uninstall_removes_the_launcher(self, _plat: object, launcher_shim: Path) -> None:
+        # WHY: shutil.which reads the real PATH
+        with patch(
+            "immich_memories.automation.system_scheduler.shutil.which", return_value="/bin/im"
+        ):
+            install_scheduler()
+        assert launcher_shim.exists()
+
+        assert uninstall_scheduler() is True
+        assert not launcher_shim.exists()
+
+    # WHY: shutil.which checks PATH, detect_platform checks OS
+    @patch("immich_memories.automation.system_scheduler.shutil.which", return_value="/bin/im")
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="launchd")
+    def test_show_previews_the_launcher_without_writing_it(
+        self, _plat: object, _which: object, launcher_shim: Path
+    ) -> None:
+        preview = show_scheduler_config()
+
+        assert preview is not None
+        assert str(launcher_shim) in preview
+        assert not launcher_shim.exists()
+
+
+class TestStaleCheckoutRefusal:
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_checkout_behind_its_tracking_branch_is_refused(
+        self, _plat: object, tmp_path: Path, git_checkout_factory: object
+    ) -> None:
+        """A plain clone nobody pulls is the same failure class as a frozen worktree."""
+        clone = git_checkout_factory(tmp_path / "runtime", 32)  # type: ignore[operator]
+        binary = _checkout_binary(clone)
+
+        # WHY: shutil.which reads the real PATH
+        with (
+            patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary),
+            pytest.raises(StaleCheckoutError) as excinfo,
+        ):
+            install_scheduler()
+
+        message = str(excinfo.value)
+        assert "32" in message
+        assert "origin/main" in message
+        assert "--force" in message
+
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_force_installs_a_behind_checkout_anyway(
+        self, _plat: object, tmp_path: Path, git_checkout_factory: object, launcher_shim: Path
+    ) -> None:
+        clone = git_checkout_factory(tmp_path / "runtime", 5)  # type: ignore[operator]
+        binary = _checkout_binary(clone)
+
+        # WHY: shutil.which reads the real PATH
+        with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
+            result = install_scheduler(force=True)
+
+        assert str(launcher_shim) in result.activate_command
+
+    # WHY: detect_platform reads the host OS
+    @patch("immich_memories.automation.system_scheduler.detect_platform", return_value="crontab")
+    def test_checkout_level_with_its_upstream_installs(
+        self, _plat: object, tmp_path: Path, git_checkout_factory: object, launcher_shim: Path
+    ) -> None:
+        clone = git_checkout_factory(tmp_path / "runtime", 0)  # type: ignore[operator]
+        binary = _checkout_binary(clone)
+
+        # WHY: shutil.which reads the real PATH
+        with patch("immich_memories.automation.system_scheduler.shutil.which", return_value=binary):
+            result = install_scheduler()
+
+        assert str(launcher_shim) in result.activate_command
 
 
 class TestUninstallScheduler:


### PR DESCRIPTION
## The problem

`_resolve_binary()` handed launchd, systemd, and cron the absolute path `shutil.which()`
returned at install time. The OS never re-resolves that path, so whichever environment you
install from is the one the nightly job executes forever.

In #573 that meant the 03:00 job ran a nine-day-old linked worktree — re-executing the
unbounded MLX VAE decode path weeks after it was fixed, until jetsam SIGKILLed it. The
interim repair (point the install at a hand-made clone) reproduced the same class within
days: that clone went 32 commits behind `main` and nothing noticed, because a plain clone
has a `.git` *directory* and sails straight through the existing worktree-only guard.

Both failures were invisible for a week because no surface ever said which code was running.

## What changed

**1. The scheduler stores a launcher, not a path.**
`auto install` writes `~/.immich-memories/bin/immich-memories-auto` and schedules that. The
launcher re-runs the `immich-memories` lookup on every fire, with the install's own bin
directory first on `PATH` — so upgrading or reinstalling the package in place changes what
the nightly job executes, with no scheduler reinstall. `--uninstall` removes it too.

**2. The staleness guard widens past linked worktrees.**
A checkout already behind its tracking branch is now refused as well, measured with
`git rev-list HEAD..@{upstream}` against refs that were **already fetched** — install never
reaches the network, so this only reports drift your own `git pull`/`fetch` recorded. Both
refusals name the path and the drift; `--force` still overrides.

**3. Version skew is observable.**
`auto run` states which code it is executing and `auto status` shows the same — version,
short commit, checkout, commits behind. Under `--quiet` it is the `runtime` key of the single
JSON line (so it lands in `auto.log`); a stale checkout *also* writes a
`warning: scheduled code is stale` line to stderr, which `--quiet` cannot suppress. That
detail matters: the scheduled job runs `--quiet`, which disables logging entirely.

**4. The scheduled job gets a stated environment.**
launchd and cron start a job from a login-less environment, so shell-exported ACE-Step tuning
is simply absent at 03:00 — which is why scheduled and manual renders were tuned differently.
`auto install` now captures `ACESTEP_CHECKPOINTS_DIR`, `ACESTEP_MLX_VAE_CHUNK`,
`IMMICH_MEMORIES_ACESTEP_MLX_DIT_FP32`, and `PYTORCH_MPS_HIGH_WATERMARK_RATIO` into the plist
or unit alongside `PATH`. Deliberately an allow-list, not an `IMMICH_MEMORIES_*` sweep: that
prefix also carries the Immich API key and the UI password, and a plist in `~/Library` is not
a secret store. The generate subprocess is launched with an explicit `env`.

## Tests

New `tests/test_runtime_provenance.py` (8) — drift counting, checkout-root walking, and
provenance description, all against **real** temporary git repositories rather than a mocked
`rev-list`, since reading refs correctly is the entire behaviour under test.

`tests/test_system_scheduler.py` (+9) — the launcher replaces the resolved path; the launcher
re-resolves and is executable; it carries the install-time `PATH`; uninstall removes it;
`--show` previews it without writing; a behind checkout is refused, `--force` installs it, a
level checkout installs; plist/unit carry ACE-Step tuning; the plist never carries credentials.

`tests/test_cli_smoke.py` (+1), `tests/test_auto_status.py` (+1), `tests/test_auto_runner.py`
(+1) — the stale-checkout stderr warning survives `--quiet`; `auto status` names the running
code in both JSON and human output; the generate subprocess receives an explicit environment.

An autouse fixture keeps install/uninstall away from the developer's real
`~/.immich-memories/bin`.

## Note on a trap this hit

The git-backed tests failed under `pre-commit` but passed standalone: git exports `GIT_DIR`
into hook processes, and `GIT_DIR` beats `git -C <path>`, so `git init` re-initialised the real
repository. Both the fixture and the production `_git` helper now strip `GIT_*` from the child
environment — the production side matters for anyone running `auto status` from inside a hook.

## Scope

Larger than the ~300-line guideline (~590 non-generated lines, roughly half tests). The four
changes are one causal chain — the launcher is only safe if staleness is still detected, and
neither is worth much if nothing reports which code ran — so splitting them would have shipped
a half-closed failure class. Flagging it rather than hiding it.

`make ci` green.

Fixes the automation half of #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
