### PR TITLE
feat(ui): offer Holiday and Then and Now in the wizard

### DIFF
--- a/docs-site/docs/create/web-ui/step1-configuration.mdx
+++ b/docs-site/docs/create/web-ui/step1-configuration.mdx
@@ -19,7 +19,7 @@ The rest of the page (Memory Type, Options, Next) only appears after a successfu
 
 ## Memory Type
 
-Pick one of the 9 cards: **Year in Review**, **Season**, **Person Spotlight**, **Multi-Person**, **Monthly Highlights**, **On This Day**, **Trip**, **Album**, or **Custom**.
+Pick one of the 11 cards: **Year in Review**, **Season**, **Person Spotlight**, **Multi-Person**, **Monthly Highlights**, **On This Day**, **Holiday**, **Then and Now**, **Trip**, **Album**, or **Custom**.
 
 <ThemedScreenshot name="step1-preset-cards" alt="Memory type preset cards" />
 
@@ -33,9 +33,27 @@ Each preset sets the date range and a default target duration, then shows the pa
 | Multi-Person | Year, People (select 2+) | 5 min |
 | Monthly Highlights | Year, Month | 1 min |
 | On This Day | none (uses today's date across previous years) | 45 s |
+| Holiday | Holiday, Most recent year, Years to span (2–10) | 1 min |
+| Then and Now | Now (year), Years back (1–20) | 45 s |
 | Trip | Year, then "Select a trip" from the trips detected in your GPS data | auto: 30 s + 10 s per active day, bounded 60–300 s |
 | Album | "Select an album" from your Immich albums | auto: 4 s per item in the album, bounded 30 s–10 min |
 | Custom | date range tabs and person filter (below) | ~1 min per month of range |
+
+### Memory types that span several years
+
+**On This Day**, **Holiday** and **Then and Now** do not cover one continuous
+period. Each builds a **separate window per year** and the wizard fetches every
+one of them, so a Holiday memory spanning five years queries five windows around
+that holiday rather than the five years between them.
+
+- **Holiday** takes any of the ten holidays the pipeline resolves — New Year,
+  Valentine's Day, Easter, Mother's Day, Father's Day, Halloween, Thanksgiving,
+  Christmas Eve, Christmas, New Year's Eve — plus the most recent year to
+  include and how many years to reach back. Its title is the occasion
+  ("Christmas"), subtitled "Through the Years".
+- **Then and Now** takes the recent year and how far back the other one sits.
+  There is no zero: the contrast is the point, so the two years must differ. Its
+  title names both ("2016 & 2026").
 
 The presets also drive the output filename and title screen. A Multi-Person preset with Alice and Bob for March 2025 produces `alice_bob_march_2025_memories.mp4` with "Alice & Bob" as the title subtitle.
 

--- a/src/immich_memories/memory_types/factory.py
+++ b/src/immich_memories/memory_types/factory.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from datetime import date, datetime
 
 from immich_memories.memory_types.date_builders import (
+    KNOWN_HOLIDAYS,
     build_holiday,
     build_month,
     build_on_this_day,
@@ -327,13 +328,22 @@ _HOLIDAY_LABELS = {
 }
 
 
-def _holiday_label(holiday: str, year: int) -> str:
+def holiday_label(holiday: str, year: int) -> str:
     """A printable name, falling back to the date for a household's own occasion."""
     key = holiday.strip().lower().replace("-", "_").replace(" ", "_")
     if key in _HOLIDAY_LABELS:
         return _HOLIDAY_LABELS[key]
     resolved = resolve_holiday(holiday, year)
     return resolved.strftime("%-d %B")
+
+
+def holiday_choices() -> dict[str, str]:
+    """Every holiday the pipeline resolves, with a printable name.
+
+    Keyed off KNOWN_HOLIDAYS so adding one there reaches the picker without a
+    second list to keep in step.
+    """
+    return {key: holiday_label(key, date.today().year) for key in KNOWN_HOLIDAYS}
 
 
 @register_preset(
@@ -351,7 +361,7 @@ def _holiday(
 ) -> MemoryPreset:
     """A holiday is the date a library reliably has every year, so it spans them."""
     year = year or date.today().year
-    label = _holiday_label(holiday, year)
+    label = holiday_label(holiday, year)
     person_filter = PersonFilter()
     if person_names:
         person_filter = PersonFilter(mode="single", person_names=person_names[:1])

--- a/src/immich_memories/ui/pages/pipeline_title.py
+++ b/src/immich_memories/ui/pages/pipeline_title.py
@@ -59,6 +59,7 @@ def generate_template_title(
     end_date: str,
     person_names: list[str] | None = None,
     album_name: str | None = None,
+    preset_params: dict | None = None,
 ) -> tuple[str, str | None]:
     """Generate a template-based title from memory type and date range.
 
@@ -96,6 +97,18 @@ def generate_template_title(
 
     if memory_type == "on_this_day":
         return f"On This Day \u2014 {_MONTH_NAMES[start.month]} {start.day}", None
+
+    if memory_type == "holiday":
+        # The span of five Christmases is five years; naming it by either end
+        # describes none of them. The occasion is the title.
+        from immich_memories.memory_types.factory import holiday_label
+
+        holiday = (preset_params or {}).get("holiday", "christmas")
+        return holiday_label(holiday, end.year), "Through the Years"
+
+    if memory_type == "then_and_now":
+        # Both ends, in the order the memory plays them.
+        return f"{start.year} & {end.year}", "Then and Now"
 
     # Fallback for unknown types
     span_months = (end.year - start.year) * 12 + (end.month - start.month)
@@ -252,6 +265,7 @@ async def generate_title_after_pipeline(state: AppState) -> None:
         end_date=str(end_date),
         person_names=person_names,
         album_name=state.album_name,
+        preset_params=state.memory_preset_params,
     )
     state.title_suggestion_title = template_title
     state.title_suggestion_subtitle = template_subtitle

--- a/src/immich_memories/ui/pages/step1_config.py
+++ b/src/immich_memories/ui/pages/step1_config.py
@@ -193,7 +193,7 @@ def _make_date_range_updater(
             if dr is None:
                 date_range_label.set_text("")
                 return
-            state.date_range = dr
+            state.date_ranges = [dr]
             date_range_label.set_text(f"{dr.description} ({dr.days} days)")
             auto_duration = max(1, min(60, round(dr.days / 365 * 10)))
             state.target_duration = auto_duration

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -24,6 +24,8 @@ _PRESET_CARDS: list[tuple[str, str, str, str]] = [
     (MemoryType.MULTI_PERSON, "group", "Multi-Person", "Together moments"),
     (MemoryType.MONTHLY_HIGHLIGHTS, "event_note", "Monthly Highlights", "One month, distilled"),
     (MemoryType.ON_THIS_DAY, "history", "On This Day", "This day through the years"),
+    (MemoryType.HOLIDAY, "celebration", "Holiday", "The same holiday, across the years"),
+    (MemoryType.THEN_AND_NOW, "compare_arrows", "Then and Now", "An early year beside this one"),
     (MemoryType.TRIP, "flight_takeoff", "Trip", "Auto-detect trips from GPS data"),
     (MemoryType.ALBUM, "photo_album", "Album", "Everything from one Immich album"),
     ("custom", "tune", "Custom", "Full control over date range"),
@@ -125,10 +127,110 @@ def _render_params(key: str) -> None:
                 "color: var(--im-text-secondary)"
             ).classes("text-sm italic")
             _apply_preset_to_state(memory_type)
+        elif memory_type == MemoryType.HOLIDAY:
+            _render_holiday_params()
+        elif memory_type == MemoryType.THEN_AND_NOW:
+            _render_then_and_now_params()
         elif memory_type == MemoryType.TRIP:
             _render_trip_params()
         elif memory_type == MemoryType.ALBUM:
             _render_album_picker()
+
+
+def _render_holiday_params() -> None:
+    """Holiday + year + how many years back to span."""
+    from immich_memories.memory_types.factory import holiday_choices
+
+    state = get_app_state()
+    choices = holiday_choices()
+
+    with ui.row().classes("gap-4 items-end flex-wrap"):
+        current_holiday = state.memory_preset_params.get("holiday", "christmas")
+
+        def on_holiday(e):
+            state.memory_preset_params["holiday"] = e.value
+            _apply_preset_to_state(MemoryType.HOLIDAY)
+
+        ui.select(
+            options=choices, label="Holiday", value=current_holiday, on_change=on_holiday
+        ).classes("w-48")
+
+        year_options = state.years or list(range(2024, 2019, -1))
+        current_year = state.memory_preset_params.get(
+            "year", year_options[0] if year_options else 2024
+        )
+
+        def on_year(e):
+            state.memory_preset_params["year"] = e.value
+            _apply_preset_to_state(MemoryType.HOLIDAY)
+
+        ui.select(
+            options=year_options, label="Most recent year", value=current_year, on_change=on_year
+        ).classes("w-40")
+
+        current_back = state.memory_preset_params.get("years_back", 5)
+
+        def on_years_back(e):
+            state.memory_preset_params["years_back"] = int(e.value)
+            _apply_preset_to_state(MemoryType.HOLIDAY)
+
+        ui.select(
+            options=list(range(2, 11)),
+            label="Years to span",
+            value=current_back,
+            on_change=on_years_back,
+        ).classes("w-40")
+
+    ui.label("One window around the holiday in each year, most recent first.").style(
+        "color: var(--im-text-secondary)"
+    ).classes("text-sm italic mt-2")
+
+    state.memory_preset_params.setdefault("holiday", current_holiday)
+    state.memory_preset_params.setdefault("year", current_year)
+    state.memory_preset_params.setdefault("years_back", current_back)
+    _apply_preset_to_state(MemoryType.HOLIDAY)
+
+
+def _render_then_and_now_params() -> None:
+    """The recent year, and how far back the other one sits."""
+    state = get_app_state()
+
+    with ui.row().classes("gap-4 items-end flex-wrap"):
+        year_options = state.years or list(range(2024, 2019, -1))
+        current_year = state.memory_preset_params.get(
+            "year", year_options[0] if year_options else 2024
+        )
+
+        def on_year(e):
+            state.memory_preset_params["year"] = e.value
+            _apply_preset_to_state(MemoryType.THEN_AND_NOW)
+
+        ui.select(options=year_options, label="Now", value=current_year, on_change=on_year).classes(
+            "w-40"
+        )
+
+        current_back = state.memory_preset_params.get("years_back", 10)
+
+        def on_years_back(e):
+            state.memory_preset_params["years_back"] = int(e.value)
+            _apply_preset_to_state(MemoryType.THEN_AND_NOW)
+
+        # The contrast is the point, so there is no zero here: a then-and-now
+        # with no distance between its two years is just a now.
+        ui.select(
+            options=list(range(1, 21)),
+            label="Years back",
+            value=current_back,
+            on_change=on_years_back,
+        ).classes("w-40")
+
+    ui.label("Two years, far apart on purpose — the gap is the story.").style(
+        "color: var(--im-text-secondary)"
+    ).classes("text-sm italic mt-2")
+
+    state.memory_preset_params.setdefault("year", current_year)
+    state.memory_preset_params.setdefault("years_back", current_back)
+    _apply_preset_to_state(MemoryType.THEN_AND_NOW)
 
 
 def _year_options_with_all() -> list:

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -347,7 +347,7 @@ def _render_album_picker() -> None:
         state.album_id = album_id
         state.album_name = albums.get(album_id)
         # Album mode discovers its own span from the assets, so nothing to set here.
-        state.date_range = None
+        state.date_ranges = []
         state.duration_mode = "auto"
 
     async def _load_albums() -> None:
@@ -535,7 +535,7 @@ def _render_trip_params() -> None:
         for k in ("trip_index", "trip_start", "trip_end", "location_name"):
             state.memory_preset_params.pop(k, None)
         state.detected_trips = []
-        state.date_range = None
+        state.date_ranges = []
         await _detect_trips_for_year(e.value)
 
     ui.select(
@@ -560,14 +560,13 @@ def _apply_preset_to_state(memory_type: MemoryType) -> None:
     if params.get("year") == 0:
         from datetime import date
 
-        state.date_range = custom_range(date(2000, 1, 1), date.today())
+        state.date_ranges = [custom_range(date(2000, 1, 1), date.today())]
         state.target_duration = 10
         return
 
     try:
         preset = create_preset(memory_type, **params)
-        if preset.date_ranges:
-            state.date_range = preset.date_ranges[0]
+        state.date_ranges = preset.date_ranges.copy()
         if preset.default_duration_seconds:
             state.target_duration = preset.default_duration_seconds / 60
             state.duration_mode = "auto"
@@ -576,6 +575,6 @@ def _apply_preset_to_state(memory_type: MemoryType) -> None:
             days = preset.date_ranges[0].days
             state.target_duration = max(1, min(10, round(days / 45)))
     except (ValueError, TypeError) as exc:
-        # Preset not fully configured yet (e.g. no person selected) — clear stale date range
-        state.date_range = None
+        # Preset not fully configured yet (e.g. no person selected) — clear stale ranges
+        state.date_ranges = []
         logger.debug("Preset not ready yet: %s", exc)

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -67,27 +67,51 @@ def _fetch_album(state) -> tuple[list[VideoClipInfo], list]:
             use_photos=state.include_photos,
         )
     if media.date_range is not None:
-        state.date_range = media.date_range
+        state.date_ranges = [media.date_range]
     clips, photos = album_media_as_clips(media)
     if state.duration_mode == "auto":
         state.target_duration = album_target_minutes(clips, photos)
     return clips, photos
 
 
+def _dedup_by_id(assets: list) -> list:
+    """First occurrence wins, order preserved.
+
+    Windows can overlap — a holiday window two days either side of the date
+    collides with itself when two requested years are consecutive leap-adjusted
+    neighbours, and On This Day windows overlap outright if years_back exceeds
+    the gap. The same asset must not be analysed twice.
+    """
+    seen: set[str] = set()
+    unique = []
+    for asset in assets:
+        if asset.id not in seen:
+            seen.add(asset.id)
+            unique.append(asset)
+    return unique
+
+
 def _fetch_assets(state) -> list:
-    """Blocking: fetch video assets from Immich API."""
-    date_range = state.date_range
+    """Blocking: fetch video assets from Immich API, one query per window."""
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as client:
         multi_ids = state.memory_preset_params.get("person_ids", [])
-        if len(multi_ids) >= 2:
-            return client.get_videos_for_all_persons(multi_ids, date_range)
-        if state.selected_person:
-            return client.get_videos_for_person_and_date_range(state.selected_person.id, date_range)
-        return client.get_videos_for_date_range(date_range)
+        assets: list = []
+        for date_range in state.date_ranges:
+            if len(multi_ids) >= 2:
+                assets.extend(client.get_videos_for_all_persons(multi_ids, date_range))
+            elif state.selected_person:
+                assets.extend(
+                    client.get_videos_for_person_and_date_range(
+                        state.selected_person.id, date_range
+                    )
+                )
+            else:
+                assets.extend(client.get_videos_for_date_range(date_range))
+        return _dedup_by_id(assets)
 
 
 def _filter_near_home(assets: list, state) -> list:
@@ -122,19 +146,22 @@ def _build_clips(assets: list) -> tuple[list[VideoClipInfo], int]:
     return clips, skipped
 
 
-def _fetch_photos(state, date_range) -> list:
-    """Fetch photo assets (blocking)."""
+def _fetch_photos(state) -> list:
+    """Fetch photo assets (blocking), one query per window."""
     person_id = state.selected_person.id if state.selected_person else None
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as client:
-        return client.get_photos_for_date_range(date_range, person_id=person_id)
+        photos: list = []
+        for date_range in state.date_ranges:
+            photos.extend(client.get_photos_for_date_range(date_range, person_id=person_id))
+        return _dedup_by_id(photos)
 
 
-def _fetch_live_photos(state, date_range) -> tuple[list[VideoClipInfo], set[str]]:
-    """Fetch live photo clips (blocking)."""
+def _fetch_live_photos(state) -> tuple[list[VideoClipInfo], set[str]]:
+    """Fetch live photo clips (blocking), one query per window."""
     lp_person_id = state.selected_person.id if state.selected_person else None
     multi_ids = state.memory_preset_params.get("person_ids", [])
 
@@ -143,13 +170,25 @@ def _fetch_live_photos(state, date_range) -> tuple[list[VideoClipInfo], set[str]
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as lp_client:
-        return fetch_live_photo_clips(
-            lp_client,
-            date_range,
-            person_id=lp_person_id,
-            person_ids=multi_ids if len(multi_ids) >= 2 else None,
-            config=state.config,
-        )
+        clips: list[VideoClipInfo] = []
+        video_ids: set[str] = set()
+        for date_range in state.date_ranges:
+            window_clips, window_video_ids = fetch_live_photo_clips(
+                lp_client,
+                date_range,
+                person_id=lp_person_id,
+                person_ids=multi_ids if len(multi_ids) >= 2 else None,
+                config=state.config,
+            )
+            clips.extend(window_clips)
+            video_ids |= window_video_ids
+        seen: set[str] = set()
+        unique_clips = []
+        for clip in clips:
+            if clip.asset.id not in seen:
+                seen.add(clip.asset.id)
+                unique_clips.append(clip)
+        return unique_clips, video_ids
 
 
 def _merge_live_photos(
@@ -198,8 +237,7 @@ async def _finish_load(state, clips, photo_assets, status_label, progress_bar) -
 
 async def _collect_date_range_media(state, status_label, progress_bar):
     """Discover the clip and photo pools for a date-range memory."""
-    date_range = state.date_range
-    if date_range is None:
+    if not state.date_ranges:
         raise ValueError("No date range configured")
 
     assets = _filter_near_home(await io_bound_result(_fetch_assets, state), state)
@@ -217,13 +255,13 @@ async def _collect_date_range_media(state, status_label, progress_bar):
     clips, _ = _build_clips(assets)
     if state.include_live_photos:
         status_label.set_text("Fetching Live Photos...")
-        live_clips, live_video_ids = await io_bound_result(_fetch_live_photos, state, date_range)
+        live_clips, live_video_ids = await io_bound_result(_fetch_live_photos, state)
         clips = _merge_live_photos(clips, live_clips, live_video_ids)
 
     photo_assets = []
     if state.include_photos:
         status_label.set_text("Fetching photos...")
-        photo_assets = await io_bound_result(_fetch_photos, state, date_range)
+        photo_assets = await io_bound_result(_fetch_photos, state)
         logger.info(f"Found {len(photo_assets)} photos")
 
     clips.sort(key=lambda c: c.asset.file_created_at)

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from immich_memories.api.compatibility import ApiVersionPolicy
+from immich_memories.timeperiod import DateRange
 from immich_memories.tracking.models import DeliveryStatus
 
 if TYPE_CHECKING:
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
     from immich_memories.cache.thumbnail_cache import ThumbnailCache
     from immich_memories.config_loader import Config
     from immich_memories.processing.timeline_budget import TimelinePlan
-    from immich_memories.timeperiod import DateRange
 
 
 @dataclass
@@ -52,7 +52,9 @@ class AppState:
     period_unit: str = "years"  # "months" or "years"
     custom_start: date | None = None
     custom_end: date | None = None
-    date_range: DateRange | None = None
+    # Every window the memory covers. On This Day and Holiday build one per
+    # year, Then and Now builds two far apart; the rest build exactly one.
+    date_ranges: list[DateRange] = field(default_factory=list)
 
     # Person selection
     selected_person: Person | None = None
@@ -157,6 +159,23 @@ class AppState:
     # file does not.
     thumbnail_hashes: dict[str, str] = field(default_factory=dict)
     analysis_cache: Any = None  # AnalysisCache
+
+    @property
+    def date_range(self) -> DateRange | None:
+        """The whole period the memory covers — for titles, filenames and labels.
+
+        Anything that *fetches* must use `date_ranges` instead. The span of a
+        Then and Now is a decade it has no interest in, and the span of an On
+        This Day is years it wants three days out of.
+        """
+        if not self.date_ranges:
+            return None
+        if len(self.date_ranges) == 1:
+            return self.date_ranges[0]
+        return DateRange(
+            start=min(r.start for r in self.date_ranges),
+            end=max(r.end for r in self.date_ranges),
+        )
 
     @property
     def scope_is_selected(self) -> bool:

--- a/tests/test_album_ui_support.py
+++ b/tests/test_album_ui_support.py
@@ -119,7 +119,7 @@ class TestAlbumModeState:
         state.memory_type = "album"
         state.album_id = "a-1"
         state.album_name = "Trip 2025"
-        state.date_range = None
+        state.date_ranges = []
 
         assert state.memory_type == "album"
         assert state.album_id == "a-1"
@@ -173,7 +173,7 @@ class TestScopeReadiness:
 
     def test_a_date_range_is_a_complete_scope(self):
         state = AppState()
-        state.date_range = object()
+        state.date_ranges = [object()]
 
         assert state.scope_is_selected
 

--- a/tests/test_pipeline_title.py
+++ b/tests/test_pipeline_title.py
@@ -116,9 +116,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.config = _make_config(llm_model="")  # No LLM
 
@@ -134,9 +134,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -159,9 +159,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -186,9 +186,9 @@ class TestTitleFallbackIntegration:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range(
-            datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC)
-        )
+        state.date_ranges = [
+            _make_date_range(datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 12, 31, tzinfo=UTC))
+        ]
         state.memory_type = "year_in_review"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -265,7 +265,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.config = _make_config(llm_model="")
 
         with patch(
@@ -283,7 +283,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = None
+        state.date_ranges = []
         state.config = _make_config(llm_model="omlx")
 
         with patch(
@@ -300,7 +300,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "year"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -330,7 +330,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "year"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -353,7 +353,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "person"
         state.analysis_cache = None
         state.config = _make_config(llm_model="omlx")
@@ -381,7 +381,7 @@ class TestGenerateTitleAfterPipeline:
         from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
 
         state = AppState()
-        state.date_range = _make_date_range()
+        state.date_ranges = [_make_date_range()]
         state.memory_type = "trip"
         state.clips = []
         state.analysis_cache = None

--- a/tests/test_sidebar_completion.py
+++ b/tests/test_sidebar_completion.py
@@ -26,7 +26,7 @@ class TestIsStepComplete:
     def test_step1_complete_when_config_and_date_range_set(self) -> None:
         state = AppState()
         state.config = object()  # type: ignore[assignment]
-        state.date_range = object()  # type: ignore[assignment]
+        state.date_ranges = [object()]  # type: ignore[assignment]
         assert _is_step_complete(state, 1) is True
 
     def test_step2_incomplete_when_no_clips_selected(self) -> None:

--- a/tests/test_ui_holiday_then_now.py
+++ b/tests/test_ui_holiday_then_now.py
@@ -1,0 +1,97 @@
+"""The wizard can reach the two memory types #443 built for the CLI.
+
+HOLIDAY and THEN_AND_NOW shipped as CLI-only. Both build more than one date
+range, which is why they needed the multi-range wizard state before they could
+be offered at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from immich_memories.memory_types.registry import MemoryType
+from immich_memories.ui.pages.step1_presets import _PRESET_CARDS, _apply_preset_to_state
+from immich_memories.ui.state import AppState
+
+
+def _apply(memory_type: MemoryType, **params) -> AppState:
+    state = AppState(memory_preset_params=dict(params))
+    # WHY: the wizard reads its state through a per-session accessor.
+    with patch("immich_memories.ui.pages.step1_presets.get_app_state", return_value=state):
+        _apply_preset_to_state(memory_type)
+    return state
+
+
+def test_both_memory_types_are_offered_as_cards() -> None:
+    keys = [card[0] for card in _PRESET_CARDS]
+
+    assert MemoryType.HOLIDAY in keys
+    assert MemoryType.THEN_AND_NOW in keys
+
+
+def _render(key: str, **params) -> AppState:
+    """Drive the wizard's param dispatch with the widget layer stubbed out."""
+    from immich_memories.ui.pages import step1_presets
+
+    state = AppState(memory_preset_params=dict(params))
+    with (
+        patch.object(step1_presets, "get_app_state", return_value=state),
+        # WHY: NiceGUI widgets need a live client slot; the dispatch under test
+        # does not. These two stand in for the whole widget layer.
+        patch.object(step1_presets, "ui", MagicMock()),
+        patch.object(step1_presets, "im_card", MagicMock()),
+    ):
+        step1_presets._render_params(key)
+    return state
+
+
+def test_choosing_holiday_gives_the_wizard_a_scope() -> None:
+    """A card with no params branch renders nothing and leaves state empty.
+
+    Without windows the wizard's `scope_is_selected` stays false and Step 1
+    never completes, so the card would look present and do nothing.
+    """
+    state = _render(MemoryType.HOLIDAY, holiday="christmas", year=2026, years_back=5)
+
+    assert len(state.date_ranges) == 5
+    assert state.scope_is_selected
+
+
+def test_choosing_then_and_now_gives_the_wizard_both_years() -> None:
+    state = _render(MemoryType.THEN_AND_NOW, year=2026, years_back=10)
+
+    assert [r.start.year for r in state.date_ranges] == [2026, 2016]
+    assert state.scope_is_selected
+
+
+def test_then_and_now_titles_name_both_years() -> None:
+    """The span reaches the template as its two ends, which is the whole point.
+
+    Without a branch this falls through to the generic long-span fallback and
+    becomes "Memories 2016" — the older year alone, which is the one thing a
+    then-and-now must not be called.
+    """
+    from immich_memories.ui.pages.pipeline_title import generate_template_title
+
+    title, subtitle = generate_template_title(
+        memory_type="then_and_now", start_date="2016-01-01", end_date="2026-12-31"
+    )
+
+    assert "2016" in title
+    assert "2026" in title
+    assert subtitle == "Then and Now"
+
+
+def test_holiday_titles_name_the_holiday_not_the_span() -> None:
+    """Five Christmases span five years; "Memories 2021" describes none of them."""
+    from immich_memories.ui.pages.pipeline_title import generate_template_title
+
+    title, subtitle = generate_template_title(
+        memory_type="holiday",
+        start_date="2021-12-23",
+        end_date="2026-12-27",
+        preset_params={"holiday": "christmas"},
+    )
+
+    assert title == "Christmas"
+    assert subtitle == "Through the Years"

--- a/tests/test_ui_multi_range_state.py
+++ b/tests/test_ui_multi_range_state.py
@@ -1,0 +1,87 @@
+"""The wizard has to hold every window a memory spans, not just the first.
+
+Three memory types build more than one date range — On This Day and Holiday
+build one window per year, Then and Now builds two years far apart. The wizard
+stored a single `date_range`, so it kept `date_ranges[0]` and silently dropped
+the rest. Since the builders order their windows most-recent-first, that made
+"This day through the years" a memory about this year.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from immich_memories.memory_types.registry import MemoryType
+from immich_memories.timeperiod import DateRange
+from immich_memories.ui.pages.step1_presets import _apply_preset_to_state
+from immich_memories.ui.state import AppState
+
+
+def _apply(memory_type: MemoryType, **params) -> AppState:
+    state = AppState(memory_preset_params=dict(params))
+    # WHY: the wizard reads its state through a per-session accessor; this is
+    # the seam that hands the function a state object instead of a live session.
+    with patch("immich_memories.ui.pages.step1_presets.get_app_state", return_value=state):
+        _apply_preset_to_state(memory_type)
+    return state
+
+
+def test_on_this_day_keeps_every_year_the_card_promises() -> None:
+    """The card says "This day through the years"; five years must survive."""
+    state = _apply(MemoryType.ON_THIS_DAY)
+
+    assert len(state.date_ranges) == 5
+
+
+def _year(y: int) -> DateRange:
+    return DateRange(start=datetime(y, 1, 1), end=datetime(y, 12, 31, 23, 59, 59))
+
+
+def _state_with_ranges(*years: int) -> AppState:
+    return AppState(
+        immich_url="http://immich.test",
+        immich_api_key="k",
+        date_ranges=[_year(y) for y in years],
+    )
+
+
+def test_the_wizard_fetches_each_window_not_the_span_between_them() -> None:
+    """Three windows means three queries.
+
+    Querying the span instead would pull every asset between the oldest and
+    newest window — for a Then and Now, a decade of library it has no interest
+    in, at Immich's expense and then the analyzer's.
+    """
+    from immich_memories.ui.pages.step2_loading import _fetch_assets
+
+    state = _state_with_ranges(2020, 2023, 2026)
+    client = MagicMock()
+    client.get_videos_for_date_range.return_value = []
+
+    # WHY: Immich is the external boundary — this stands in for the library read.
+    with patch("immich_memories.ui.pages.step2_loading.SyncImmichClient") as client_cls:
+        client_cls.return_value.__enter__.return_value = client
+        _fetch_assets(state)
+
+    queried = [c.args[0] for c in client.get_videos_for_date_range.call_args_list]
+    assert queried == [_year(2020), _year(2023), _year(2026)]
+
+
+def test_an_asset_in_two_overlapping_windows_is_fetched_once() -> None:
+    """Holiday windows two days either side can collide on consecutive years."""
+    from immich_memories.ui.pages.step2_loading import _fetch_assets
+
+    state = _state_with_ranges(2025, 2026)
+    shared = MagicMock()
+    shared.id = "in-both-windows"
+    client = MagicMock()
+    client.get_videos_for_date_range.return_value = [shared]
+
+    # WHY: Immich is the external boundary — this stands in for the library read.
+    with patch("immich_memories.ui.pages.step2_loading.SyncImmichClient") as client_cls:
+        client_cls.return_value.__enter__.return_value = client
+        assets = _fetch_assets(state)
+
+    assert client.get_videos_for_date_range.call_count == 2
+    assert [a.id for a in assets] == ["in-both-windows"]


### PR DESCRIPTION
Closes #461. **PR B of two — stacks on #582**, whose commit is included here. See the merge-order note at the bottom.

#443 built HOLIDAY and THEN_AND_NOW for the CLI. The wizard could not reach them, so the two surfaces offered different products. This wires them up.

## The two cards

| Card | Pickers |
|---|---|
| **Holiday** | Holiday, most recent year, years to span (2–10) |
| **Then and Now** | Now (year), years back (1–20) |

The holiday picker is keyed off `KNOWN_HOLIDAYS` through a new public `holiday_choices()`, so adding a holiday to the vocabulary reaches the UI without a second list to keep in step. The years-back picker for Then and Now **starts at one, not zero** — the factory raises on `years_back <= 0`, and its own docstring puts it well: *"a then-and-now with no distance between the two is just a now."*

## The title templates were the quiet half

This is the part the issue didn't mention and it would have shipped visibly wrong.

`generate_template_title` has a per-type branch for every memory type and ends in a long-span fallback that names a memory after the **first** year of its span. Neither new type had a branch, and both span years. So:

- five Christmases → **"Memories 2021"**
- a then-and-now of 2016 and 2026 → **"Memories 2016"** — the older year alone, which is the one thing that memory must not be called

RED for that test was literally `assert '2026' in 'Memories 2016'`.

Holiday now titles by the occasion (`Christmas` / "Through the Years"); Then and Now names both ends (`2016 & 2026` / "Then and Now"). `generate_template_title` gained an optional `preset_params` so the holiday branch can name the occasion; the caller already had it in scope.

`_holiday_label` became `holiday_label` — the UI needs a printable name for a holiday, and reaching into another module's private for it is worse than naming the helper.

## Tests

Five, strict TDD, each RED first for the right reason:

1. Both types appear in `_PRESET_CARDS`.
2. **Choosing Holiday gives the wizard a scope** — RED was `assert 0 == 5`. This is the test that matters: a card without a `_render_params` branch renders nothing and never calls `_apply_preset_to_state`, so `scope_is_selected` stays false and Step 1 never completes. The card would look present and do nothing.
3. Same for Then and Now, asserting both years and their order.
4. Then-and-now titles name both years.
5. Holiday titles name the holiday, not the span.

Tests 2 and 3 drive the real dispatch with the widget layer stubbed (`ui` and `im_card`), so they exercise the branch rather than asserting an enum exists.

`make ci` green: **5565 passed**, 9 skipped. `make docs-build` **exit 0** with a clean `npm ci` in the worktree.

## Docs

`step1-configuration.mdx` said "9 cards" and now says 11, with both rows added to the parameters table and a new section explaining why On This Day, Holiday and Then and Now query **one window per year** rather than the span between them — the distinction PR #582 made real.

**The `step1-preset-cards` screenshot is now stale** (9 cards pictured, 11 offered). It needs a `make screenshots` pass; flagging rather than blocking, as agreed.

## Merge order

This branch contains #582's commit. Either order works:

- Merge **#582 first** (preferred) — this PR then shows only its own diff.
- Merge **this first** — #582's content lands with it and #582 becomes empty.

Do not merge this and then expect #582 to still apply cleanly.
