### PR TITLE
docs: give Holiday and Then and Now a memory-types page

### DIFF
--- a/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
+++ b/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
@@ -16,7 +16,7 @@ The same occasion, across the years. Christmas 2022, 2023, 2024, 2025 and 2026 i
 immich-memories generate --memory-type holiday --holiday christmas --years-back 5
 ```
 
-`--holiday` is required. `--years-back` defaults to **5**.
+`--holiday` is required. `--years-back` defaults to **5**, and `--years-back 0` is read as *unset* rather than as an error — pass a positive number.
 
 ### What `--holiday` accepts
 

--- a/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
+++ b/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
@@ -1,0 +1,115 @@
+---
+sidebar_label: "Holiday & Then and Now"
+---
+
+# Holiday and Then and Now
+
+Two memory types that do **not** cover one continuous stretch of time. Each builds a separate window per year, and the pipeline queries every one of them — a Holiday memory across five years asks Immich for five windows around that holiday, not for the five years between them.
+
+That is the whole reason they exist. A year in review is a period; these two are a **recurrence**.
+
+## Holiday
+
+The same occasion, across the years. Christmas 2022, 2023, 2024, 2025 and 2026 in one video.
+
+```bash
+immich-memories generate --memory-type holiday --holiday christmas --years-back 5
+```
+
+`--holiday` is required. `--years-back` defaults to **5**.
+
+### What `--holiday` accepts
+
+Ten names the pipeline resolves for any year:
+
+| Name | Falls on |
+|------|----------|
+| `new_year` | 1 January |
+| `valentines` | 14 February |
+| `easter` | computed — Western Easter Sunday |
+| `mothers_day` | second Sunday of May |
+| `fathers_day` | third Sunday of June |
+| `halloween` | 31 October |
+| `thanksgiving` | fourth Thursday of November |
+| `christmas_eve` | 24 December |
+| `christmas` | 25 December |
+| `new_years_eve` | 31 December |
+
+The moving ones are calculated rather than tabulated, so they stay correct in years nobody has thought about yet.
+
+Anything else is read as **`MM-DD`**, which is how a household's own occasion works:
+
+```bash
+# The day you moved in, every year since
+immich-memories generate --memory-type holiday --holiday 09-14 --years-back 4
+```
+
+An unrecognised name that is not a valid `MM-DD` fails immediately with the list of known holidays rather than generating something wrong.
+
+### The window around the date
+
+Each year contributes **the holiday ± 2 days** — a five-day window. A celebration that starts on Christmas Eve and runs into Boxing Day is one memory, not three. This is not exposed as a CLI flag.
+
+### Asking before the holiday has happened
+
+If you omit `--year`, the starting year steps back when the occasion has not occurred yet. Asking for Christmas in August would otherwise spend one of your requested years on a window no photo can fall in.
+
+An explicit `--year` is treated as a deliberate choice and is left alone:
+
+```bash
+# In August 2026 this covers Christmas 2025, 2024, 2023
+immich-memories generate --memory-type holiday --holiday christmas --years-back 3
+
+# ...but this covers 2026, 2025, 2024 — even though 2026's has not happened
+immich-memories generate --memory-type holiday --holiday christmas --years-back 3 --year 2026
+```
+
+### When to use it
+
+When the material exists **because** of the date. A holiday is the day a library reliably has something every single year, which is what makes it worth spanning years rather than covering one occasion. If a year is missing photos, that year simply contributes nothing.
+
+## Then and Now
+
+One early year beside the present one. Not the decade between them — just the two ends.
+
+```bash
+immich-memories generate --memory-type then_and_now --years-back 10
+```
+
+`--years-back` defaults to **10** and is the gap between the two years, not a count of them. There are always exactly two.
+
+```bash
+# 2016 and 2026
+immich-memories generate --memory-type then_and_now --year 2026 --years-back 10
+```
+
+Pass a positive number. `--years-back 0` is read as *unset* and falls back to 10 rather than erroring — the flag uses a falsy default, so zero and omitted are indistinguishable to it. The web UI's picker starts at 1, so the ambiguity cannot be reached there.
+
+The gap is required either way: a then-and-now with no distance between its two years is just a now.
+
+### Two whole years, not two windows
+
+Unlike Holiday, each side is a **full calendar year**. A narrow window in a year long past is usually empty, and the point is to have enough material on both sides for the contrast to read.
+
+Clips play most recent first, so the video opens on now and reaches back.
+
+### When to use it
+
+When the subject changed and the change is the story — a child, a house, a garden, a face. It is deliberately blunt: two years, no interpolation, and the viewer does the arithmetic.
+
+## Both in the web UI
+
+Both appear as cards in Step 1. **Holiday** takes the holiday, the most recent year to include, and how many years to span. **Then and Now** takes the recent year and how far back the other sits.
+
+See [Step 1 — Configuration](../web-ui/step1-configuration.mdx).
+
+## Titles
+
+Neither is titled after its span, because the span describes neither of them — five Christmases run across five years, and a then-and-now spans a decade it deliberately skips.
+
+| Type | Title | Subtitle |
+|------|-------|----------|
+| Holiday | the occasion — "Christmas" | "Through the Years" |
+| Then and Now | both ends — "2016 & 2026" | "Then and Now" |
+
+A custom `MM-DD` holiday with no name of its own is titled by its date ("14 September").

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'create/memory-types/year-in-review',
             'create/memory-types/monthly-person-season',
+            'create/memory-types/holiday-then-and-now',
             'create/memory-types/trip-memories',
             'create/memory-types/album-memories',
           ],


### PR DESCRIPTION
Refs #520 — the "HOLIDAY and THEN_AND_NOW have no `create/memory-types/` pages" item. The issue stays open; the settings-UI page and the three nice-to-haves remain.

Both types shipped in #443 with nothing but a flag row in `generate.md` and the generated reference. Neither `--holiday`'s vocabulary nor `--years-back`'s meaning was written anywhere a reader would look for it.

## What the page covers

- The **ten holiday names**, with which are fixed dates and which are computed — Easter, Thanksgiving, Mother's Day and Father's Day are calculated per year rather than tabulated, so they stay correct in years nobody has thought about yet.
- The **`MM-DD` form** for a household's own occasion (the day you moved in, every year since).
- The **five-day window** (holiday ± 2 days) around each date, and that it is not a CLI flag.
- The rule that the **starting year steps back** when the occasion has not happened yet — asking for Christmas in August would otherwise spend one of the requested years on a window no photo can fall in — and that an explicit `--year` is treated as a choice and left alone.
- Why **Then and Now uses two whole calendar years** rather than two windows: a narrow window in a year long past is usually empty.
- Why **neither is titled after its span**: five Christmases run across five years, and a then-and-now spans a decade it deliberately skips.

## Two things I got wrong in the first draft, and checked

Both claims came out of my own reasoning and both were false. Worth listing because one is a real product wart:

**`--years-back 0` is not rejected on the CLI.** I had written that it was. The `then_and_now` path in `_date_resolution.py` computes `years_back or 10`, so **zero is indistinguishable from omitted and silently becomes 10**. `_then_and_now` in the factory *does* raise on `years_back <= 0`, but the CLI builds its ranges directly and never reaches the factory — so the guard doesn't apply where a user actually types the flag. The wizard's picker starts at 1, so it can't be reached there. Documented as it behaves.

**Holiday windows do not overlap between years.** A five-day window repeated annually leaves ~360 days between windows; they can never collide. I removed the note claiming otherwise.

Verified with `make docs-build` **exit 0** (clean `npm ci` in the worktree, links resolve) and `make ci` green: 5548 passed.

## Sidebar

Added between `monthly-person-season` and `trip-memories`, matching the existing grouping (that page already covers three types on one page).
