### PR TITLE
docs: document the two settings pages, and fix who actually saves config

### DIFF
--- a/docs-site/docs/create/web-ui/settings.mdx
+++ b/docs-site/docs/create/web-ui/settings.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_label: "Settings"
+---
+
+# Settings
+
+Two pages sit outside the four-step wizard, reachable from the sidebar at any time: **Config** (`/settings/config`) and **Cache** (`/settings/cache`).
+
+## Config — what is actually running
+
+`/settings/config` is a **read-only viewer**. It shows the merged, live configuration: what `~/.immich-memories/config.yaml` holds, after environment overrides and after any active preset has filled in the knobs you did not set. It is the answer to "the docs say the default is X, but is X what this install is using?"
+
+Each config section is a collapsible panel with its key count. `immich`, `analysis`, `output` and `defaults` are open on arrival; the rest start collapsed.
+
+If a preset is active, the page names it and says it is filling the values you have not set.
+
+### Secrets are masked
+
+Any key named `api_key`, `api_keys`, `client_secret`, `password`, `secret`, `token` or `urls` renders as `***` — a full mask, not a partial one. An earlier version showed the first and last few characters of every secret, `auth.password` included, which is a preview of a password rather than a redaction.
+
+This matters if you screenshot the page for a bug report: the masking is server-side, so what you see is all there is to leak.
+
+### The two actions
+
+- **Reload from Disk** re-reads `config.yaml` and refreshes the page. Use it after editing the file by hand — the running process holds the config in memory and will not otherwise notice.
+- The **config file path** is printed beside the button, so you know which file you are editing.
+
+:::note There is no Save button on this page
+Saving is on **Step 1**, not here. This page only reads.
+:::
+
+## Saving config from Step 1, and what it costs you
+
+Step 1's connection panel has a **Save Config** button. It writes the Immich URL and API key you entered — but it saves the **whole configuration**, not just those two fields.
+
+That has a consequence worth understanding before you press it: **every value becomes explicitly set.** A preset works by filling in what you have not chosen, so once everything is written to the file, there is nothing left for the preset to own. `preset: fast` will still be named, but the values it would have supplied are now yours and will not move again.
+
+If you want the preset back in charge of something, delete those keys from `config.yaml` by hand.
+
+Two exceptions to "everything is written":
+
+- **`server.host`** is omitted unless you set it deliberately. Writing the wildcard default would make the next load read it as a deliberate LAN bind and silently retire the localhost default.
+- **Credentials supplied through environment variables** stay in the environment; they are not baked into the file.
+
+## Cache — what is on disk, and getting rid of it
+
+`/settings/cache` lists four caches with their current size, each with its own **Clear** button, plus a clear-everything action.
+
+| Cache | Holds | Cost of clearing |
+|-------|-------|------------------|
+| **Analysis** | per-video analysis results, in SQLite | the expensive one — a cleared analysis cache means the next run re-analyses from scratch, LLM calls included |
+| **Video** | downloaded source videos | re-download from Immich; bounded by the cache size limit and evicted automatically |
+| **Thumbnail** | preview images used for scoring, contact sheets and the clip review grid | re-fetched from Immich on demand |
+| **Preview** | the `.mp4` previews the wizard plays back | regenerated when you next preview |
+
+Clearing is safe in the sense that nothing generated is lost — every cache is rebuildable from Immich plus compute. The only question is how much time and, if you point `llm.base_url` at a hosted API, how much money you spend rebuilding it.
+
+Clear the **analysis** cache when you have changed something that would alter how clips are scored and you want the change to actually take effect. Clear the **video** or **thumbnail** caches when you want the disk back.
+
+## See also
+
+- [Configuration reference](../../reference/config-reference.md) — every key, with defaults
+- [Step 1 — Configuration](./step1-configuration.mdx) — where Save Config lives

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -48,9 +48,11 @@ Env: `IMMICH_MEMORIES_PRESET=fast`. One-off on the CLI: `immich-memories --prese
 (root option, before the subcommand). The settings page names the active preset; Step 3 defaults
 its resolution to the preset's and says so.
 
-Caveat: the settings page's "save" writes every value to `config.yaml`, after which they all count
-as "set by you" — remove the keys you want the preset to own again. (`server.host` is the single
-exception; see [Server (UI)](#server-ui).)
+Caveat: **Step 1's "Save Config"** writes every value to `config.yaml`, not just the connection
+fields it appears to be about — after which they all count as "set by you", and the preset has
+nothing left to fill in. Remove the keys you want the preset to own again. (`server.host` is the
+single exception; see [Server (UI)](#server-ui).) The `/settings/config` page is read-only and
+does not save; see [Settings](../create/web-ui/settings.mdx).
 
 ## Immich connection
 

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
             'create/web-ui/step2-clip-review',
             'create/web-ui/step3-generation-options',
             'create/web-ui/step4-preview-export',
+            'create/web-ui/settings',
           ],
         },
         {


### PR DESCRIPTION
Refs #520 — the "Settings UI pages documented nowhere" item. Three nice-to-haves remain after this.

## The gap had a wrong signpost in it

`/settings/config` and `/settings/cache` (`ui/app.py:293,310`) had no page. Meanwhile `reference/config-reference.md:51` warned about *"the settings page's save"* — **that page has no save button.** It has "Reload from Disk" and a config path, and nothing else.

The save is `im_button("Save Config", ...)` at `step1_config.py:149` — on **Step 1**. So a reader following the existing caveat was looking for a control on the wrong page.

## What the new page says

**Config** is a read-only viewer of the *merged, live* configuration — file plus environment overrides plus whatever an active preset filled in. That framing is the point of the page: it answers "the docs say the default is X, but is X what this install is running?"

Documented from the code rather than the UI:

- The masked keys are exactly `api_key`, `api_keys`, `client_secret`, `password`, `secret`, `token`, `urls`, and the mask is **total**. The code comment records why: an earlier version showed the first and last characters of every secret, `auth.password` included, which is a preview of a password rather than a redaction. Worth knowing before screenshotting the page into a bug report.
- Which sections start expanded (`immich`, `analysis`, `output`, `defaults`).

**Saving, and what it costs.** Step 1's Save Config writes the whole configuration, not just the two connection fields it appears to be about. The consequence is the part worth writing down: **every value becomes explicitly set, so a preset has nothing left to fill in.** `preset: fast` stays named but stops supplying anything. Getting it back means deleting keys by hand.

Both documented exceptions come from `config_loader.save_yaml`: `server.host` is omitted unless deliberately set (writing the wildcard would make the next load read it as a deliberate LAN bind and silently retire the localhost default), and env-supplied credentials stay in the environment.

**Cache** gets a table of the four caches — analysis, video, thumbnail, preview — with what each holds and what clearing it actually costs. The distinction that matters: the **analysis** cache is the expensive one, because clearing it means re-analysing from scratch with LLM calls included, while video and thumbnail only cost a re-download. Nothing generated is ever lost; every cache rebuilds from Immich plus compute. So the real question is time, and on a hosted `llm.base_url`, money.

## Also fixed

`config-reference.md:51` now names Step 1's Save Config, says plainly that it writes every value, and points at the new page while noting `/settings/config` is read-only.

## Verification

`make docs-build` **exit 0** (clean `npm ci` in the worktree; the cross-page link resolves). `make ci` green: 5548 passed.

No screenshots — neither page has any in the repo, and I did not want to imply a `make screenshots` pass had happened.
