### PR TITLE
docs: the three remaining #520 nice-to-haves

### DIFF
--- a/docs-site/docs/create/cli/discovery-and-utility.md
+++ b/docs-site/docs/create/cli/discovery-and-utility.md
@@ -1,0 +1,52 @@
+---
+sidebar_label: "Discovery & utility"
+---
+
+# Discovery and utility commands
+
+Four small commands that exist mostly to answer questions before you generate anything. They were reachable only through `--help` and the generated [CLI reference](../../reference/cli-reference.md) until now.
+
+## `people` — who Immich knows
+
+```bash
+immich-memories people
+```
+
+Lists every named person in your Immich library. Useful because `--person` matches on the name Immich holds, and "Emma" versus "Emma S." is the difference between a memory and an empty pool.
+
+## `years` — where the material is
+
+```bash
+immich-memories years
+```
+
+Lists the years that actually contain video, so you are not guessing at `--year`. On a library imported from old backups this is often surprising.
+
+## `analyze` — warm the cache deliberately
+
+```bash
+immich-memories analyze --year 2024
+immich-memories analyze --year 2024 --force
+```
+
+Runs analysis over a year and caches the results without generating anything. Generation does this on demand, so `analyze` buys you nothing except **control over when it happens** — which is the whole point on a NAS. A cold year is the expensive part of a run; doing it overnight means the memory you ask for in the morning is a warm run.
+
+`--force` re-analyses videos that are already cached. You want it after changing something that would alter how clips are scored; without it, cached results are reused as-is.
+
+## `export-project` — a snapshot of what would be selected
+
+```bash
+immich-memories export-project --year 2024 --output project.json
+immich-memories export-project --year 2024 --person "Emma" --output project.json
+```
+
+Writes a JSON file describing the assets in scope: the year, the person if you named one, and every clip with its asset id, filename, date and duration, each marked `selected: true`.
+
+:::note Nothing reads this file back
+There is no import command and no flag that consumes the JSON. `export-project` is a one-way
+snapshot — useful for inspecting or scripting against what a scope contains, not for editing a
+selection and feeding it back in. Treat "for later editing" in its help text as an
+aspiration rather than a description.
+:::
+
+If you want to see how a selection was actually *reached* — including which stage dropped what — use [`generate --trace-selection`](./generate.md#why-did-selection-drop-that-clip) instead. That reports on a real run.

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -146,6 +146,7 @@ have not set explicitly; the flags below still win. Persistent form: `preset: fa
 | `--include-live-photos` | — | flag | — | Include Live Photo video clips (merged when burst-captured) |
 | `--keep-intermediates` | — | flag | — | Keep intermediate files for debugging |
 | `--quiet` | — | flag | — | Suppress interactive progress, emit log lines only |
+| `--trace-selection` | — | path | — | Write a stage-by-stage report of how the clips were chosen |
 
 ### Upload
 
@@ -357,6 +358,38 @@ trips:
 ```
 
 ## Dry run
+
+### Why did selection drop that clip?
+
+`--trace-selection` writes a funnel: every stage of selection, what it received, what it let
+through, and how many **favourites** survived each step.
+
+```bash
+immich-memories generate --year 2024 --trace-selection ~/selection.txt
+```
+
+It writes **two** files — the readable funnel at the path you gave, and the same data as JSON at
+the same path with a `.json` suffix, for scripting.
+
+The report looks like this, and the marker is the point:
+
+```
+stage                  kept  lost     favorites
+favorites first          38     0      38 -> 38
+temporal dedup           21    17      38 -> 21
+scale to duration         9    12      21 ->  0  <-- all favorites lost here
+```
+
+Selection passes a pool through a dozen filters, caps, scalers and LLM judgements. Reading the log
+and inferring which one ate your clips is slow and wrong often enough to matter — a real February
+started with 38 favourites and shipped none, and finding the stage responsible took several rounds
+of guessing. This answers it directly.
+
+:::warning Do not combine this with `--dry-run`
+`--dry-run` skips work, and some of the work it skips is selection. Photo scoring falls back to
+metadata only — the VLM scorer never runs — so a trace taken under `--dry-run` describes a
+different, cheaper pipeline than the one that makes your videos. Trace a real run.
+:::
 
 Use `--dry-run` to see how many videos match your criteria without actually generating anything:
 

--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -199,6 +199,32 @@ If Torch or PANNs is unavailable, generation does not fail. It uses the energy-o
 which can find loud and quiet structure but cannot reliably distinguish laughter from speech,
 music, babies, or background noise. `immich-memories preflight` reports which backend is active.
 
+## Speech boundaries
+
+Cuts should land in the gaps between utterances, not through the middle of a word. That is what
+the voice activity detector is for, and it is on by default.
+
+**Why voice activity rather than the event labels.** PANNs merges contiguous same-class frames
+into a single span, so a noisy clip becomes one protected range covering everything. Boundary
+adjustment then has nowhere to move and the clip ships at full duration — protection so broad it
+protects nothing. Voice activity keeps the pauses *between* utterances, which is exactly the
+material a cut needs.
+
+**It does not need `audio_content`.** Voice activity needs only the audio track and the bundled
+FireRedVAD weights, so cut placement works on a default install. Enabling `audio_content` adds
+event *scoring* on top. The two degrade independently — you can have good cut placement with no
+semantic labels, or labels with the detector off.
+
+**What still needs PANNs.** Laughter, singing, cheering and applause protection comes from the
+event labels, not the voice detector, which does not fire on them. If you want a laugh protected
+from a cut, `audio_content` has to be on.
+
+Requires the `speech` extra (`uv sync --extra speech`, included in `all` and `all-mac`). Nothing
+is downloaded at runtime — the weights ship inside the package.
+
+Settings live under `speech:` in the
+[configuration reference](../../reference/config-reference.md#speech-boundaries).
+
 ## Audio Ducking
 
 When background music plays over your clips, it should get quieter when someone's talking or when there's an interesting sound in the original audio. The music automatically dips to let the original audio through, then comes back up.

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -396,18 +396,8 @@ speech:
 Requires the `speech` extra (`uv sync --extra speech`, included in `all` and `all-mac`). The
 FireRedVAD weights ship inside the package — nothing is downloaded at runtime.
 
-Without voice activity, protected ranges come from PANNs, which merges contiguous same-class
-frames into one span: a noisy clip becomes a single protected range covering everything and
-boundary adjustment has nowhere to move, so the clip stays at full duration. Voice activity
-keeps the pauses between utterances, giving cuts somewhere to land.
-
-Speech boundaries do not require `audio_content.enabled`. Voice activity needs only the audio
-track and the bundled model, so cut placement works on a default install; enabling
-`audio_content` adds event *scoring* on top, and the two degrade independently.
-
-Laughter, singing, cheering and applause protection still comes from PANNs (`audio_content`
-above) — the voice detector does not fire on them, so that protection needs `audio_content`
-switched on.
+How this interacts with PANNs, and why cut placement still works without `audio_content`, is in
+[Audio and music → Speech boundaries](../create/pipeline/audio-and-music.md#speech-boundaries).
 
 `vad_threshold` is below FireRedVAD upstream's 0.4 on purpose: measured across 143 clips, 0.25
 detected speech in 49 more of them with no false positives on clips below -40 dBFS. Raise it if

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -40,6 +40,7 @@ const sidebars: SidebarsConfig = {
             'create/cli/scheduler',
             'create/cli/runs',
             'create/cli/discover-days',
+            'create/cli/discovery-and-utility',
           ],
         },
         {


### PR DESCRIPTION
Refs #520 — the three remaining nice-to-haves. **With #586 and #587 this completes every item in the issue**, so #520 can close once all three merge. I have not put a `Closes` on it: two of the three PRs are still in the drain, and the issue should close on the last one, not the first.

## 1. `--trace-selection`

The only `generate` flag missing from the hand-written page. It gets a table row and a section, because what it does isn't obvious from its help text.

It writes a **funnel** — each selection stage, what it received, what it let through, and how many *favourites* survived — with the marker that makes it worth running:

```
scale to duration         9    12      21 ->  0  <-- all favorites lost here
```

The module's own docstring explains why it exists: a real February started with 38 favourites and shipped none, and finding the stage responsible took several rounds of guessing.

Two things a reader would otherwise discover the hard way:

- It writes **two files** — the readable funnel at your path, and the same data as JSON at that path with a `.json` suffix.
- **Do not combine it with `--dry-run`.** Dry-run skips work, and some of that work is selection: photo scoring falls back to metadata only and the VLM scorer never runs. A trace taken under `--dry-run` describes a cheaper pipeline than the one that makes your videos. Called out in a warning admonition.

## 2. `people`, `years`, `analyze`, `export-project`

Reachable only through `--help` and the generated reference. New page.

`analyze` is framed by what it actually buys you: not results — generation caches on demand anyway — but **control over when a cold year gets paid for**. That's the entire argument on a NAS, and it isn't in the help text.

### `export-project` — documented with a caveat, not a use case

Investigated as the issue asked. It writes JSON describing every asset in scope, each marked `selected: true`. **Nothing reads it back**: no import command, no flag that consumes the file. So "Export project state for later editing" describes an intention rather than a round trip.

I documented it honestly — a one-way snapshot, useful for inspection or scripting, not for editing a selection and feeding it back — and pointed readers at `--trace-selection` for the question they probably have instead.

**I did not deprecate it.** Retiring a command is Sam's call, and it belongs in a decision, not in a docs commit. My recommendation is in the session report.

## 3. Speech boundaries moved out of the config reference

`config-reference.md` had grown an essay between two YAML blocks. The mechanism — why voice activity rather than PANNs event labels, why it works without `audio_content`, what still needs PANNs — now sits in `audio-and-music.md` beside the other audio mechanisms, which already owns the PANNs section.

The reference keeps every key and gains a pointer. **`make docs-config-check` still passes** — no key moved, only prose.

## Verification

`make ci` green (5489 passed). `make docs-build` **exit 0** with a clean `npm ci`. `make docs-config-check` and `make docs-cli-check` both pass.

All three new cross-page anchors verified to exist — worth stating because `onBrokenAnchors` is `'warn'` in this config, not `'throw'`, so a green build would not have caught a bad one. Zero anchor warnings in the log.
