### PR TITLE
test: give today's fourteen un-commented mocks their WHY lines

### DIFF
--- a/scripts/critique_tests.py
+++ b/scripts/critique_tests.py
@@ -23,7 +23,7 @@ EXIT_FAILURE = 1
 # enforceable; they may fall and must not rise. Raising one accepts new
 # untested mocking rather than fixing it, so do it in a commit that says so.
 MAX_MOCK_ONLY_TESTS = 41
-MAX_PATCHES_WITHOUT_WHY = 926
+MAX_PATCHES_WITHOUT_WHY = 913
 EXIT_SUCCESS = 0
 
 

--- a/tests/test_auto_status.py
+++ b/tests/test_auto_status.py
@@ -303,6 +303,7 @@ def test_status_names_the_code_that_would_run_and_flags_it_when_stale(tmp_path: 
         commit="ea892ad",
         drift=CheckoutDrift(upstream="origin/main", commits_behind=32),
     )
+    # WHY: suggest reads the Immich library; get_scheduler_status shells out to launchctl.
     with (
         patch.object(AutoRunner, "suggest", return_value=[]),
         patch(

--- a/tests/test_burst_encoding_plan.py
+++ b/tests/test_burst_encoding_plan.py
@@ -32,6 +32,7 @@ def _merge_command(
     capabilities: HWAccelCapabilities | None = None,
 ) -> list[str]:
     caps = capabilities if capabilities is not None else HWAccelCapabilities()
+    # WHY: build_merge_command probes the file and the host encoder; a.mov never exists.
     with (
         # WHY: the audio ffprobe boundary.
         patch(
@@ -111,6 +112,7 @@ def test_the_download_path_carries_the_setting_into_the_merge() -> None:
     clips = [Path("a.mov"), Path("b.mov")]
     trims = [(0.0, 1.0), (0.0, 1.0)]
 
+    # WHY: _try_merge_burst validates, builds, and runs FFmpeg; a.mov and b.mov are names only.
     with (
         # WHY: the ffprobe validation of files that do not exist on disk.
         patch(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -436,6 +436,7 @@ class TestAutoRunOutput:
             drift=CheckoutDrift(upstream="origin/main", commits_behind=32),
         )
 
+        # WHY: AutoRunner is the whole generation pipeline — Immich, LLM, FFmpeg.
         with (
             patch("immich_memories.automation.runner.AutoRunner", return_value=auto_runner),
             # WHY: runtime_provenance shells out to git against the real checkout

--- a/tests/test_clip_pipeline_ui.py
+++ b/tests/test_clip_pipeline_ui.py
@@ -188,6 +188,7 @@ def test_blocking_pipeline_hands_the_photo_merge_its_thumbnail_cache() -> None:
     )
     progress_state = {"cancelled": False, "done": False, "error": None}
 
+    # WHY: get_config would read the developer's own config.yaml off disk.
     with (
         # WHY: Immich is the external boundary — the wizard's library read.
         patch("immich_memories.ui.pages.clip_pipeline.SyncImmichClient") as client_cls,

--- a/tests/test_llm_titles.py
+++ b/tests/test_llm_titles.py
@@ -209,8 +209,7 @@ class TestTitleGenerationThinks:
         from immich_memories.titles.llm_titles import generate_title_with_llm
 
         config = LLMConfig(provider="openai-compatible", model="qwen", thinking=True)
-        # WHY: query_llm is the boundary to the LLM server; the behavior under
-        # test is that title generation requests reasoning mode.
+        # WHY: query_llm is the boundary to the LLM server; only the request is under test.
         with patch(
             "immich_memories.titles.llm_titles.query_llm",
             new_callable=AsyncMock,

--- a/tests/test_music_pipeline.py
+++ b/tests/test_music_pipeline.py
@@ -399,8 +399,7 @@ class TestSeparationIsOptional:
         config = Config()
         config.ace_step.enabled = True
 
-        # WHY: replaces the ACE-Step/MusicGen generation call, which needs a GPU
-        # or a running server.
+        # WHY: replaces the ACE-Step/MusicGen call, which needs a GPU or a running server.
         with patch(
             "immich_memories.audio.music_generator.generate_music_for_video",
             new_callable=AsyncMock,

--- a/tests/test_photo_cap_plumbing.py
+++ b/tests/test_photo_cap_plumbing.py
@@ -59,6 +59,7 @@ def test_the_cli_hands_the_pipeline_the_configured_cap(tmp_path) -> None:
     clip.asset.id = "asset-1"
     clip.width, clip.height = 1920, 1080
 
+    # WHY: run_pipeline_and_generate otherwise talks to Immich and runs a full analysis.
     with (
         # WHY: Immich is the external boundary — this stands in for the library read.
         patch("immich_memories.generate.assets_to_clips", return_value=[clip]),

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -166,6 +166,7 @@ class TestPhotoScoring:
             request=httpx.Request("POST", "http://localhost:9999/v1/chat/completions"),
         )
 
+        # WHY: the VLM server is the network boundary; this is its 404 for a removed model.
         with patch("httpx.AsyncClient.post", return_value=response) as request:
             first = score_photo_with_llm(
                 photo_a, 0.42, PhotoConfig(), config, provider_circuit=circuit

--- a/tests/test_refinement_passes_config.py
+++ b/tests/test_refinement_passes_config.py
@@ -35,6 +35,7 @@ def _generate_with(args: list[str], config: Config):
     client.__exit__.return_value = False
     client.get_photos_for_date_range.return_value = []
     asset = MagicMock(duration_seconds=10.0)
+    # WHY: the CLI otherwise reads Immich and creates the real ~/.immich-memories config dir.
     with (
         # WHY: Immich is the external boundary — no live server in a unit test.
         patch("immich_memories.api.immich.SyncImmichClient", return_value=client),

--- a/tests/test_timestamp_migration.py
+++ b/tests/test_timestamp_migration.py
@@ -343,6 +343,7 @@ def test_brussels_daily_auto_run_is_not_inside_24_hour_cooldown(
     )
     runner = AutoRunner(config)
 
+    # WHY: the clock decides the cooldown, and suggest would query the real Immich library.
     with (
         patch("immich_memories.automation.status.datetime", wraps=datetime) as clock,
         patch.object(runner, "suggest", return_value=[]),

--- a/tests/test_ui_holiday_then_now.py
+++ b/tests/test_ui_holiday_then_now.py
@@ -34,6 +34,7 @@ def _render(key: str, **params) -> AppState:
     from immich_memories.ui.pages import step1_presets
 
     state = AppState(memory_preset_params=dict(params))
+    # WHY: the wizard reads its state through a per-session accessor.
     with (
         patch.object(step1_presets, "get_app_state", return_value=state),
         # WHY: NiceGUI widgets need a live client slot; the dispatch under test

--- a/tests/test_ui_multi_range_state.py
+++ b/tests/test_ui_multi_range_state.py
@@ -20,8 +20,7 @@ from immich_memories.ui.state import AppState
 
 def _apply(memory_type: MemoryType, **params) -> AppState:
     state = AppState(memory_preset_params=dict(params))
-    # WHY: the wizard reads its state through a per-session accessor; this is
-    # the seam that hands the function a state object instead of a live session.
+    # WHY: the wizard's per-session accessor, which needs a live NiceGUI session.
     with patch("immich_memories.ui.pages.step1_presets.get_app_state", return_value=state):
         _apply_preset_to_state(memory_type)
     return state


### PR DESCRIPTION
## Why 12 files of comments

`main` is red, and so is every open PR — not because of anything any of them did.

`scripts/critique_tests.py` counts patch sites with no `# WHY:` above them and
compares that running total against a frozen ceiling. On `main` the count was
**928** against a ceiling of **926**. That breaks two things at once:

- `make critique` exits 1, so the **Quality Gates** job fails.
- `tests/test_critique_gate.py::test_the_backlog_ceilings_are_not_above_what_exists`
  asserts the same inequality, so **`make test` is red too**.

Both fire on `main`'s own content, which means every branch cut from `main`
inherits the failure regardless of what it changed. That is the fleet-wide
blocker this PR clears.

## How it tipped

Nothing regressed the checker. The ratchet is a running total across the whole
suite, and #577's test deletions had been quietly paying for mocks landing
without a WHY — the ledger only crossed the line once today's merges added more
than the deletions absorbed. The overshoot was **+2**.

Fourteen patch sites, all merged today, are the debt. They now say which
external boundary they replace: Immich library reads, `launchctl` and `git`
shell-outs, ffprobe/FFmpeg probes, the LLM and VLM servers, the
ACE-Step/MusicGen generation call, NiceGUI's per-session state accessor, and
the on-disk config dir.

## Three of them already had a WHY

The checker could not see them, for two mechanical reasons worth knowing:

1. **A wrapped comment is invisible.** `_explained_above` walks upward and stops
   at the first line that is not blank, a patch, or a `# WHY:` — so the
   continuation line of a two-line comment ends the walk before the `# WHY:` is
   reached. Collapsed to one line in `test_llm_titles.py`,
   `test_music_pipeline.py`, `test_ui_multi_range_state.py`.
2. **A `with (` group opener is itself a checked site.** WHYs written inside the
   parens, above individual `patch(...)` entries, do not cover the opener. Those
   groups got a line above the `with (` naming the boundary that was still
   undocumented inside — no duplication of what was already there.

Only comments changed. No test logic, no assertions, no fixtures.

## The ceiling drops with the count

`MAX_PATCHES_WITHOUT_WHY` goes **926 → 913**, the exact new actual count.
Leaving the 13 recovered slots as slack would rebuild the buffer that let this
backlog grow unnoticed until it tipped — the gate's own docstring says the
ceilings "freeze today's backlog so it can only shrink". Zero slack, matching
how the ratchet was set originally.

## Verification

```
make critique   → exit 0
                  913 patches have no # WHY: above them (ceiling 913)
                  (was: FAIL, 928 vs ceiling 926)

make test       → exit 0
                  5519 passed, 9 skipped, 645 deselected
                  test_critique_gate.py::test_the_backlog_ceilings_are_not_above_what_exists PASSED
```

Committed with the full pre-commit suite — all 14 hooks passed, no `--no-verify`.
A commit that repairs the ledger satisfies the gate it repairs, because the
hooks measure the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
