### PR TITLE
fix(titles): the trip map gets the title, the names and the coordinates it was already holding

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3286,7 +3286,7 @@
         "name": "TitleInserter::assemble_with_titles",
         "complexity": 22,
         "line_start": 233,
-        "line_end": 434,
+        "line_end": 435,
         "line_complexities": [
           {
             "line": 251,
@@ -3373,83 +3373,79 @@
             "complexity": 0
           },
           {
-            "line": 307,
+            "line": 308,
             "complexity": 0
-          },
-          {
-            "line": 309,
-            "complexity": 1
           },
           {
             "line": 310,
-            "complexity": 2
-          },
-          {
-            "line": 311,
-            "complexity": 0
-          },
-          {
-            "line": 321,
-            "complexity": 2
-          },
-          {
-            "line": 324,
-            "complexity": 0
-          },
-          {
-            "line": 336,
-            "complexity": 0
-          },
-          {
-            "line": 350,
-            "complexity": 2
-          },
-          {
-            "line": 353,
-            "complexity": 0
-          },
-          {
-            "line": 354,
             "complexity": 1
           },
           {
-            "line": 358,
+            "line": 311,
+            "complexity": 2
+          },
+          {
+            "line": 312,
             "complexity": 0
+          },
+          {
+            "line": 322,
+            "complexity": 2
+          },
+          {
+            "line": 325,
+            "complexity": 0
+          },
+          {
+            "line": 337,
+            "complexity": 0
+          },
+          {
+            "line": 351,
+            "complexity": 2
+          },
+          {
+            "line": 354,
+            "complexity": 0
+          },
+          {
+            "line": 355,
+            "complexity": 1
           },
           {
             "line": 359,
             "complexity": 0
           },
           {
-            "line": 365,
+            "line": 360,
             "complexity": 0
           },
           {
-            "line": 368,
-            "complexity": 1
+            "line": 366,
+            "complexity": 0
           },
           {
             "line": 369,
-            "complexity": 2
-          },
-          {
-            "line": 384,
-            "complexity": 0
-          },
-          {
-            "line": 387,
             "complexity": 1
           },
           {
-            "line": 394,
+            "line": 370,
+            "complexity": 2
+          },
+          {
+            "line": 385,
             "complexity": 0
           },
           {
-            "line": 399,
+            "line": 388,
+            "complexity": 1
+          },
+          {
+            "line": 395,
             "complexity": 0
           },
           {
-            "line": 405,
+            "line": 400,
             "complexity": 0
           },
           {
@@ -3465,12 +3461,12 @@
             "complexity": 0
           },
           {
-            "line": 413,
-            "complexity": 2
+            "line": 409,
+            "complexity": 0
           },
           {
-            "line": 417,
-            "complexity": 0
+            "line": 414,
+            "complexity": 2
           },
           {
             "line": 418,
@@ -3493,11 +3489,15 @@
             "complexity": 0
           },
           {
-            "line": 427,
+            "line": 423,
             "complexity": 0
           },
           {
-            "line": 429,
+            "line": 428,
+            "complexity": 0
+          },
+          {
+            "line": 430,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/generate_privacy.py
+++ b/src/immich_memories/generate_privacy.py
@@ -96,17 +96,27 @@ def clip_location_name(exif) -> str | None:
     return country or city
 
 
-def extract_trip_locations(assembly_clips: list[AssemblyClip]) -> list[tuple[float, float]]:
-    """Extract unique GPS locations from assembly clips for map pins."""
+def extract_trip_pins(
+    assembly_clips: list[AssemblyClip],
+) -> tuple[list[tuple[float, float]], list[str]]:
+    """Unique GPS locations for map pins, and the name to label each one with.
+
+    Both lists are built in one pass so they stay index-aligned: the renderer
+    draws labels by position, so a name list de-duplicated by a different rule
+    would caption every pin after the first repeat with the wrong place. A pin
+    whose clip carried no place name holds its slot with an empty string.
+    """
     seen: set[tuple[float, float]] = set()
     locations: list[tuple[float, float]] = []
+    names: list[str] = []
     for clip in assembly_clips:
         if clip.latitude is not None and clip.longitude is not None:
             key = (round(clip.latitude, 2), round(clip.longitude, 2))
             if key not in seen:
                 seen.add(key)
                 locations.append((clip.latitude, clip.longitude))
-    return locations
+                names.append(clip.location_name or "")
+    return locations, names
 
 
 def generate_trip_title_text(preset_params: dict) -> str | None:

--- a/src/immich_memories/generate_settings.py
+++ b/src/immich_memories/generate_settings.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from immich_memories.config_models import normalize_scale_mode
 from immich_memories.generate_privacy import (
-    extract_trip_locations,
+    extract_trip_pins,
     generate_trip_title_text,
 )
 from immich_memories.processing.assembly_config import (
@@ -149,9 +149,10 @@ def _build_title_settings(
 
     # Trip-specific title settings
     trip_locations = None
+    trip_location_names: list[str] = []
     trip_title_text = None
     if params.memory_type == "trip":
-        trip_locations = extract_trip_locations(assembly_clips)
+        trip_locations, trip_location_names = extract_trip_pins(assembly_clips)
         trip_title_text = generate_trip_title_text(params.memory_preset_params)
 
     settings = TitleScreenSettings(
@@ -172,6 +173,7 @@ def _build_title_settings(
         show_decorative_lines=config.title_screens.show_decorative_lines,
         memory_type=params.memory_type,
         trip_locations=trip_locations,
+        trip_location_names=trip_location_names,
         trip_title_text=trip_title_text,
         home_lat=params.memory_preset_params.get("home_lat"),
         home_lon=params.memory_preset_params.get("home_lon"),
@@ -189,6 +191,12 @@ def _build_title_settings(
     if params.title:
         settings.title_override = params.title
         settings.subtitle_override = params.subtitle
+        if settings.trip_title_text:
+            # The trip map intro reads trip_title_text, not title_override, so
+            # a curated title was being computed and then ignored on the one
+            # screen every viewer sees. Only replaces an existing template —
+            # whether a map appears at all is a separate decision.
+            settings.trip_title_text = params.title
 
     return settings
 

--- a/src/immich_memories/processing/assembly_config.py
+++ b/src/immich_memories/processing/assembly_config.py
@@ -6,7 +6,7 @@ used across the assembly pipeline.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from enum import StrEnum
 from pathlib import Path
@@ -96,6 +96,8 @@ class TitleScreenSettings:
     # Trip map settings (used when memory_type == "trip")
     memory_type: str | None = None  # "trip" enables map intro + location cards
     trip_locations: list[tuple[float, float]] | None = None  # (lat, lon) pairs for map pins
+    # Pin labels, index-aligned with trip_locations; "" where unknown
+    trip_location_names: list[str] = field(default_factory=list)
     trip_title_text: str | None = None  # e.g. "TWO WEEKS IN SPAIN, SUMMER 2025"
     show_location_cards: bool = True  # Insert location cards between clips
     home_lat: float | None = None  # Homebase latitude — fly-over departure point

--- a/src/immich_memories/processing/title_divider_planner.py
+++ b/src/immich_memories/processing/title_divider_planner.py
@@ -28,7 +28,9 @@ class DividerCardGenerator(Protocol):
 
     def generate_year_divider(self, year: int) -> GeneratedScreen: ...
 
-    def generate_location_card_screen(self, location_name: str) -> GeneratedScreen: ...
+    def generate_location_card_screen(
+        self, location_name: str, lat: float | None = ..., lon: float | None = ...
+    ) -> GeneratedScreen: ...
 
 
 def _divider_limit(title_settings: Any) -> int | None:
@@ -251,10 +253,17 @@ class TitleDividerPlanner:
         self,
         name: str,
         cache: dict[str, Path],
+        lat: float | None = None,
+        lon: float | None = None,
     ) -> AssemblyClip:
-        """Return an AssemblyClip for a location card, using cache to avoid duplicates."""
+        """Return an AssemblyClip for a location card, using cache to avoid duplicates.
+
+        Coordinates turn the card's background from a flat grey panel into a
+        satellite map of the place it names. Cached by name, so a place seen
+        twice keeps the first card rather than re-rendering the same map.
+        """
         if name not in cache:
-            card = self._generator.generate_location_card_screen(name)
+            card = self._generator.generate_location_card_screen(name, lat=lat, lon=lon)
             cache[name] = card.path
         return AssemblyClip(
             path=cache[name],
@@ -292,7 +301,12 @@ class TitleDividerPlanner:
                         and clip.location_name
                         and (limit is None or inserted < limit)
                     ):
-                        card = self.make_location_card_clip(clip.location_name, location_card_cache)
+                        card = self.make_location_card_clip(
+                            clip.location_name,
+                            location_card_cache,
+                            lat=clip.latitude,
+                            lon=clip.longitude,
+                        )
                         result.append(card)
                         inserted += 1
                         logger.info(f"Location card: {clip.location_name} (dist={dist:.0f}km)")

--- a/src/immich_memories/processing/title_inserter.py
+++ b/src/immich_memories/processing/title_inserter.py
@@ -303,6 +303,7 @@ class TitleInserter:
                 title_text=title_settings.trip_title_text,
                 home_lat=getattr(title_settings, "home_lat", None),
                 home_lon=getattr(title_settings, "home_lon", None),
+                location_names=getattr(title_settings, "trip_location_names", None) or None,
             )
             use_content_bg = False  # trip maps don't use content-backed
             logger.info(f"Generated trip map intro: {title_screen.path}")

--- a/src/immich_memories/titles/generator.py
+++ b/src/immich_memories/titles/generator.py
@@ -474,6 +474,8 @@ class TitleScreenGenerator:
     def generate_location_card_screen(
         self,
         location_name: str,
+        lat: float | None = None,
+        lon: float | None = None,
     ) -> GeneratedScreen:
         """Generate a location interstitial card with mood-based styling.
 
@@ -484,7 +486,7 @@ class TitleScreenGenerator:
         from .map_renderer import render_location_card
 
         width, height = self.config.output_resolution
-        card_img = render_location_card(location_name, width, height)
+        card_img = render_location_card(location_name, width, height, lat=lat, lon=lon)
         bg_array = np.array(card_img, dtype=np.float32) / 255.0
 
         divider_style = TitleStyle(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -664,7 +664,7 @@ class TestTotalClipDuration:
 class TestTripLocations:
     def test_extract_trip_locations_deduplicates(self):
         """Clips with GPS data produce unique location list."""
-        from immich_memories.generate_privacy import extract_trip_locations
+        from immich_memories.generate_privacy import extract_trip_pins
         from immich_memories.processing.assembly_config import AssemblyClip
 
         clips = [
@@ -678,8 +678,9 @@ class TestTripLocations:
                 path=Path("/fake/c.mp4"), duration=3.0, latitude=51.5074, longitude=-0.1278
             ),
         ]
-        locations = extract_trip_locations(clips)
+        locations, names = extract_trip_pins(clips)
         assert len(locations) == 2
+        assert len(names) == len(locations)
 
     def testgenerate_trip_title_text(self):
         from immich_memories.generate_privacy import generate_trip_title_text

--- a/tests/test_trip_map_titles_and_pins.py
+++ b/tests/test_trip_map_titles_and_pins.py
@@ -1,0 +1,129 @@
+"""What the trip map intro and its pins are actually given (#498).
+
+The trip path builds its own title from a template and renders its own map.
+Both were reading fewer inputs than the pipeline had already computed: the
+curated title never reached the most prominent screen in the video, and the
+pins were drawn without the names sitting next to the coordinates.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from immich_memories.config_loader import Config
+from immich_memories.generate import GenerationParams, _build_title_settings
+from immich_memories.processing.assembly_config import AssemblyClip
+
+
+def _trip_params(**overrides) -> GenerationParams:
+    base = {
+        "clips": [],
+        "output_path": Path("/tmp/trip.mp4"),
+        "config": Config(),
+        "memory_type": "trip",
+        "date_start": date(2025, 7, 1),
+        "date_end": date(2025, 7, 14),
+        "memory_preset_params": {
+            "location_name": "Spain",
+            "trip_start": date(2025, 7, 1),
+            "trip_end": date(2025, 7, 14),
+        },
+    }
+    base.update(overrides)
+    return GenerationParams(**base)
+
+
+def test_a_curated_title_reaches_the_trip_map_intro() -> None:
+    """The map intro is the most prominent screen; it must not show the template.
+
+    Every other memory type honours `title` — the LLM's suggestion, or whatever
+    the user typed over it. The trip map read `trip_title_text`, which is built
+    from the preset params, so a curated title was computed, stored and then
+    ignored on the one screen a viewer is guaranteed to see.
+    """
+    settings = _build_title_settings(_trip_params(title="Two Weeks in Spain"), Config(), [])
+
+    assert settings is not None
+    assert settings.trip_title_text == "Two Weeks in Spain"
+
+
+def test_without_a_curated_title_the_template_still_wins() -> None:
+    settings = _build_title_settings(_trip_params(), Config(), [])
+
+    assert settings is not None
+    assert settings.trip_title_text
+    assert "SPAIN" in settings.trip_title_text.upper()
+
+
+def _gps_clip(lat: float, lon: float, name: str | None) -> AssemblyClip:
+    return AssemblyClip(
+        path=Path("/fake/clip.mp4"), duration=3.0, latitude=lat, longitude=lon, location_name=name
+    )
+
+
+def test_pin_names_line_up_with_the_pins_they_label() -> None:
+    """The renderer draws labels by index, so a shifted list mislabels the map.
+
+    Coordinates are de-duplicated on a rounded key, so the names have to be
+    de-duplicated by the same rule or the two lists drift apart and every pin
+    after the first duplicate is captioned with somebody else's city.
+    """
+    settings = _build_title_settings(
+        _trip_params(),
+        Config(),
+        [
+            _gps_clip(48.8566, 2.3522, "Paris"),
+            _gps_clip(48.8566, 2.3522, "Paris"),
+            _gps_clip(51.5074, -0.1278, "London"),
+        ],
+    )
+
+    assert settings is not None
+    assert settings.trip_locations is not None
+    assert len(settings.trip_location_names) == len(settings.trip_locations)
+    assert settings.trip_location_names == ["Paris", "London"]
+
+
+def test_a_pin_with_no_known_place_still_holds_its_slot() -> None:
+    """A missing name must not shorten the list and shift every later label."""
+    settings = _build_title_settings(
+        _trip_params(),
+        Config(),
+        [_gps_clip(48.8566, 2.3522, None), _gps_clip(51.5074, -0.1278, "London")],
+    )
+
+    assert settings is not None
+    assert settings.trip_location_names == ["", "London"]
+
+
+def test_a_location_card_is_given_the_coordinates_it_is_standing_on() -> None:
+    """`render_location_card` draws a satellite map from lat/lon, or a grey box.
+
+    The planner inserts a card precisely because a clip moved more than 30 km,
+    so it is holding that clip's coordinates when it asks for the card — and
+    was passing only the name, which is how every card ended up as the
+    fallback dark gradient.
+    """
+    from immich_memories.processing.title_divider_planner import TitleDividerPlanner
+
+    generator = MagicMock()
+    generator.generate_location_card_screen.return_value = MagicMock(path=Path("/fake/card.mp4"))
+    planner = TitleDividerPlanner(generator, MagicMock(month_divider_duration=2.0))
+
+    clips = [
+        AssemblyClip(path=Path("/fake/a.mp4"), duration=3.0, latitude=48.85, longitude=2.35),
+        AssemblyClip(
+            path=Path("/fake/b.mp4"),
+            duration=3.0,
+            latitude=41.39,
+            longitude=2.17,
+            location_name="Barcelona",
+        ),
+    ]
+    planner.build_clips_with_location_dividers(clips, None)
+
+    kwargs = generator.generate_location_card_screen.call_args.kwargs
+    assert kwargs.get("lat") == 41.39
+    assert kwargs.get("lon") == 2.17


### PR DESCRIPTION
Refs #498 — three of its four gaps. No `Closes`: item 1 (map modes) needs route data that does not exist, and is on roadmap #326 instead.

All three have the same shape. **The pipeline had already computed the value, the renderer already supported it, and the call site in between did not pass it.** Nothing here is a new feature; it is connecting things that were built to connect.

## 1. The curated title never reached the map intro

Every other memory type honours `params.title` — the LLM's suggestion, or whatever the user typed over it. The trip map reads `trip_title_text`, built from preset params. So on a trip, a curated title was computed, stored as `title_override`, and then **ignored on the one screen every viewer sees**, which showed `13 DAYS IN SPAIN, JULY 2025` instead.

An override now becomes the trip title too. It only replaces an *existing* template — whether a map appears at all is a separate decision and is deliberately untouched.

## 2. Pins rendered unlabeled

`render_trip_map_array` draws labels when given `location_names`. Nothing ever gave it any.

The names now travel beside the coordinates out of a single extraction pass, and that detail is the whole point: **the renderer draws labels by index**, coordinates are de-duplicated on a rounded key, and a name list de-duplicated by any other rule would caption every pin after the first repeat with somebody else's city. One function returns both lists so the rule cannot drift. A pin whose clip carried no place name holds its slot with `""` rather than shortening the list and shifting every later label.

`extract_trip_locations` is **deleted**, not kept as a one-line delegate — vulture flagged it as unused the moment its last caller moved, which is the correct read of a shim with no consumer.

## 3. Location cards rendered a grey panel

`render_location_card` builds a satellite map of the place when handed lat/lon, and falls back to a dark gradient when it is not. It was never handed them, so **every card was the fallback**.

The planner inserts a card precisely *because* a clip moved more than 30 km — so it is holding that clip's coordinates two lines above the call that omitted them. Cards stay cached by name, so a place seen twice keeps its first render.

## Tests

Five, TDD, each RED first for the right reason — including `assert '13 DAYS IN SPAIN, JULY 2025' == 'Two Weeks in Spain'` for the title, and `assert None == 41.39` for the card coordinates. One deliberately passes from the start: *without* a curated title the template must still win, which is the guard against over-correcting.

**No `patch()` anywhere.** `TitleDividerPlanner` takes its generator through a Protocol, so the test injects a `MagicMock` as a constructor argument instead of monkeypatching a module path. That is a better test — no import-path string to rot — and it means this PR adds nothing to the `# WHY:` ledger, which now has zero slack after #589.

`make ci` green on repaired main: **5524 passed**, 9 skipped. Diff coverage **92%** (13 changed lines, 1 missing — the `render_location_card` call, which needs real rendering).

`complexipy-snapshot.json` is included per the Makefile's own note that "a passing run keeps the rewrite — that is the ratchet tightening"; the diff is line-number shift only, complexity unchanged at 22.

## Not in this PR

Item 1, the map modes. `title_only` renders today; `excursions` needs per-day route reconstruction from asset GPS that **nothing in the pipeline produces**, so it is a real feature rather than a wiring fix. Recorded on #326 rather than half-built here.
