### PR TITLE
refactor(analysis): lift face detection out of the scoring module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,7 +144,8 @@ src/immich_memories/
 │   ├── duplicate_hashing.py    # Perceptual hashing for duplicates
 │   ├── thumbnail_clustering.py # Thumbnail-based clustering
 │   ├── thumbnail_prefetch.py   # ThumbnailPrefetcher: fills the thumbnail cache before phase 1 (CLI/auto path)
-│   ├── scoring.py              # Quality scoring (face, motion, duration, segments)
+│   ├── scoring.py              # Quality scoring (motion, duration, segments) + SceneScorer
+│   ├── face_scoring.py         # Face detection scoring: Apple Vision / OpenCV backends
 │   ├── scenes.py               # Scene detection
 │   ├── silence_detection.py    # Audio silence detection
 │   ├── apple_vision.py         # macOS Vision framework integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,6 +413,7 @@ ignore_errors = true
 module = [
     "immich_memories.analysis.scenes",
     "immich_memories.analysis.scoring",
+    "immich_memories.analysis.face_scoring",
     "immich_memories.analysis.apple_vision",
     "immich_memories.processing.transforms",
     "immich_memories.processing.transforms_smart_crop",

--- a/src/immich_memories/analysis/face_scoring.py
+++ b/src/immich_memories/analysis/face_scoring.py
@@ -1,0 +1,186 @@
+"""Face detection scoring, and the two backends that provide it.
+
+Apple Vision on macOS, OpenCV's Haar cascade everywhere else. Which one is
+available is decided once and cached in `_use_vision`, because the probe
+shells out and the answer cannot change inside a run.
+
+`SceneScorer` imports these names into `analysis.scoring` and calls them
+there, so tests that patch `analysis.scoring.check_vision_available` keep
+working. Patching them here would not affect the scorer -- `from x import y`
+binds y in the importing module at import time.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "check_vision_available",
+    "compute_face_score",
+    "init_opencv_cascade",
+    "init_vision_detector",
+]
+
+
+_use_vision = None
+
+
+def check_vision_available() -> bool:
+    """Check if Apple Vision framework should be used for face detection."""
+    global _use_vision
+    if _use_vision is not None:
+        return _use_vision
+
+    if platform.system() != "Darwin":
+        _use_vision = False
+        return False
+
+    try:
+        from immich_memories.analysis.apple_vision import is_vision_available
+
+        _use_vision = is_vision_available()
+        if _use_vision:
+            logger.info("Using Apple Vision framework for face detection (GPU accelerated)")
+        return _use_vision
+    except ImportError:
+        _use_vision = False
+        return False
+
+
+def init_vision_detector():
+    """Initialize Apple Vision face detector.
+
+    Returns:
+        VisionFaceDetector instance or None if initialization fails.
+    """
+    try:
+        from immich_memories.analysis.apple_vision import VisionFaceDetector
+
+        detector = VisionFaceDetector(detect_landmarks=False)
+        logger.info("Using Apple Vision for GPU-accelerated face detection")
+        return detector
+    except (ImportError, RuntimeError, OSError) as e:
+        logger.warning(f"Failed to initialize Vision detector: {e}")
+        return None
+
+
+def init_opencv_cascade() -> cv2.CascadeClassifier | None:
+    """Initialize OpenCV face cascade classifier.
+
+    Returns:
+        CascadeClassifier instance or None if loading fails.
+    """
+    try:
+        cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+        return cv2.CascadeClassifier(cascade_path)
+    except (OSError, RuntimeError, AttributeError) as e:
+        # WHY: AttributeError is what an OpenCV build without the Haar cascade API
+        # (OpenCV 5) raises; face scoring must degrade, not take the run down.
+        logger.warning(f"Could not load face cascade: {e}")
+        return None
+
+
+def compute_face_score(
+    frame: np.ndarray,
+    use_vision: bool,
+    vision_detector,
+    face_cascade: cv2.CascadeClassifier | None,
+) -> tuple[float, list[tuple[float, float]]]:
+    """Compute face presence and size score.
+
+    Uses Apple Vision framework on Mac for GPU-accelerated detection,
+    falls back to OpenCV on other platforms.
+
+    Args:
+        frame: BGR image.
+        use_vision: Whether to use Apple Vision.
+        vision_detector: VisionFaceDetector instance (or None).
+        face_cascade: OpenCV CascadeClassifier instance (or None).
+
+    Returns:
+        Tuple of (score, list of face center positions).
+    """
+    h, w = frame.shape[:2]
+
+    if use_vision and vision_detector is not None:
+        return _compute_face_score_vision(frame, vision_detector)
+
+    return _compute_face_score_opencv(frame, w, h, face_cascade)
+
+
+def _compute_face_score_vision(
+    frame: np.ndarray,
+    vision_detector,
+) -> tuple[float, list[tuple[float, float]]]:
+    """Compute face score using Apple Vision framework."""
+    faces = vision_detector.detect_faces(frame, min_confidence=0.3)
+
+    if not faces:
+        return 0.0, []
+
+    total_coverage = 0
+    positions = []
+
+    for face in faces:
+        total_coverage += face.area
+        positions.append(face.center)
+
+    face_count_bonus = min(len(faces) * 0.1, 0.3)
+    coverage_score = min(total_coverage / 0.15, 1.0)
+
+    score = min(coverage_score + face_count_bonus, 1.0)
+    return score, positions
+
+
+def _compute_face_score_opencv(
+    frame: np.ndarray,
+    w: int,
+    h: int,
+    face_cascade: cv2.CascadeClassifier | None,
+) -> tuple[float, list[tuple[float, float]]]:
+    """Compute face score using OpenCV cascade classifier."""
+    if face_cascade is None:
+        return 0.5, []
+
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+    faces = face_cascade.detectMultiScale(
+        gray,
+        scaleFactor=1.1,
+        minNeighbors=5,
+        minSize=(30, 30),
+    )
+
+    if len(faces) == 0:  # noqa: FURB115 — `not faces` crashes on numpy arrays (Linux OpenCV)
+        return 0.0, []
+
+    total_face_area = 0
+    positions = []
+
+    for x, y, fw, fh in faces:
+        face_area = fw * fh
+        total_face_area += face_area
+
+        center_x = (x + fw / 2) / w
+        center_y = (y + fh / 2) / h
+        positions.append((center_x, center_y))
+
+    frame_area = w * h
+    coverage = total_face_area / frame_area
+
+    face_count_bonus = min(len(faces) * 0.1, 0.3)
+    coverage_score = min(coverage / 0.15, 1.0)
+
+    score = min(coverage_score + face_count_bonus, 1.0)
+    return score, positions
+
+
+# ---------------------------------------------------------------------------
+# Motion and duration scoring
+# ---------------------------------------------------------------------------

--- a/src/immich_memories/analysis/scoring.py
+++ b/src/immich_memories/analysis/scoring.py
@@ -1,13 +1,12 @@
 """Interest scoring for video moments.
 
-Contains face detection, motion/duration scoring, segment generation,
-and the main SceneScorer class. Factory functions are in scoring_factory.py.
+Motion/duration scoring, segment generation, and the main SceneScorer class.
+Face detection lives in face_scoring.py; factory functions in scoring_factory.py.
 """
 
 from __future__ import annotations
 
 import logging
-import platform
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +15,12 @@ from typing import TYPE_CHECKING
 import cv2
 import numpy as np
 
+from immich_memories.analysis.face_scoring import (
+    check_vision_available,
+    compute_face_score,
+    init_opencv_cascade,
+    init_vision_detector,
+)
 from immich_memories.analysis.scenes import Scene, get_video_info
 
 if TYPE_CHECKING:
@@ -28,178 +33,12 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "MomentScore",
     "SceneScorer",
-    "check_vision_available",
     "compute_duration_score",
-    "compute_face_score",
     "compute_motion_metrics",
     "generate_scene_aware_segments",
     "generate_segments",
-    "init_opencv_cascade",
-    "init_vision_detector",
     "subdivide_scene",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Face detection scoring
-# ---------------------------------------------------------------------------
-
-_use_vision = None
-
-
-def check_vision_available() -> bool:
-    """Check if Apple Vision framework should be used for face detection."""
-    global _use_vision
-    if _use_vision is not None:
-        return _use_vision
-
-    if platform.system() != "Darwin":
-        _use_vision = False
-        return False
-
-    try:
-        from immich_memories.analysis.apple_vision import is_vision_available
-
-        _use_vision = is_vision_available()
-        if _use_vision:
-            logger.info("Using Apple Vision framework for face detection (GPU accelerated)")
-        return _use_vision
-    except ImportError:
-        _use_vision = False
-        return False
-
-
-def init_vision_detector():
-    """Initialize Apple Vision face detector.
-
-    Returns:
-        VisionFaceDetector instance or None if initialization fails.
-    """
-    try:
-        from immich_memories.analysis.apple_vision import VisionFaceDetector
-
-        detector = VisionFaceDetector(detect_landmarks=False)
-        logger.info("Using Apple Vision for GPU-accelerated face detection")
-        return detector
-    except (ImportError, RuntimeError, OSError) as e:
-        logger.warning(f"Failed to initialize Vision detector: {e}")
-        return None
-
-
-def init_opencv_cascade() -> cv2.CascadeClassifier | None:
-    """Initialize OpenCV face cascade classifier.
-
-    Returns:
-        CascadeClassifier instance or None if loading fails.
-    """
-    try:
-        cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
-        return cv2.CascadeClassifier(cascade_path)
-    except (OSError, RuntimeError, AttributeError) as e:
-        # WHY: AttributeError is what an OpenCV build without the Haar cascade API
-        # (OpenCV 5) raises; face scoring must degrade, not take the run down.
-        logger.warning(f"Could not load face cascade: {e}")
-        return None
-
-
-def compute_face_score(
-    frame: np.ndarray,
-    use_vision: bool,
-    vision_detector,
-    face_cascade: cv2.CascadeClassifier | None,
-) -> tuple[float, list[tuple[float, float]]]:
-    """Compute face presence and size score.
-
-    Uses Apple Vision framework on Mac for GPU-accelerated detection,
-    falls back to OpenCV on other platforms.
-
-    Args:
-        frame: BGR image.
-        use_vision: Whether to use Apple Vision.
-        vision_detector: VisionFaceDetector instance (or None).
-        face_cascade: OpenCV CascadeClassifier instance (or None).
-
-    Returns:
-        Tuple of (score, list of face center positions).
-    """
-    h, w = frame.shape[:2]
-
-    if use_vision and vision_detector is not None:
-        return _compute_face_score_vision(frame, vision_detector)
-
-    return _compute_face_score_opencv(frame, w, h, face_cascade)
-
-
-def _compute_face_score_vision(
-    frame: np.ndarray,
-    vision_detector,
-) -> tuple[float, list[tuple[float, float]]]:
-    """Compute face score using Apple Vision framework."""
-    faces = vision_detector.detect_faces(frame, min_confidence=0.3)
-
-    if not faces:
-        return 0.0, []
-
-    total_coverage = 0
-    positions = []
-
-    for face in faces:
-        total_coverage += face.area
-        positions.append(face.center)
-
-    face_count_bonus = min(len(faces) * 0.1, 0.3)
-    coverage_score = min(total_coverage / 0.15, 1.0)
-
-    score = min(coverage_score + face_count_bonus, 1.0)
-    return score, positions
-
-
-def _compute_face_score_opencv(
-    frame: np.ndarray,
-    w: int,
-    h: int,
-    face_cascade: cv2.CascadeClassifier | None,
-) -> tuple[float, list[tuple[float, float]]]:
-    """Compute face score using OpenCV cascade classifier."""
-    if face_cascade is None:
-        return 0.5, []
-
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-
-    faces = face_cascade.detectMultiScale(
-        gray,
-        scaleFactor=1.1,
-        minNeighbors=5,
-        minSize=(30, 30),
-    )
-
-    if len(faces) == 0:  # noqa: FURB115 — `not faces` crashes on numpy arrays (Linux OpenCV)
-        return 0.0, []
-
-    total_face_area = 0
-    positions = []
-
-    for x, y, fw, fh in faces:
-        face_area = fw * fh
-        total_face_area += face_area
-
-        center_x = (x + fw / 2) / w
-        center_y = (y + fh / 2) / h
-        positions.append((center_x, center_y))
-
-    frame_area = w * h
-    coverage = total_face_area / frame_area
-
-    face_count_bonus = min(len(faces) * 0.1, 0.3)
-    coverage_score = min(coverage / 0.15, 1.0)
-
-    score = min(coverage_score + face_count_bonus, 1.0)
-    return score, positions
-
-
-# ---------------------------------------------------------------------------
-# Motion and duration scoring
-# ---------------------------------------------------------------------------
 
 
 def compute_motion_metrics(

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -19,11 +19,11 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from immich_memories.analysis.face_scoring import compute_face_score
 from immich_memories.analysis.scenes import Scene
 from immich_memories.analysis.scoring import (
     MomentScore,
     compute_duration_score,
-    compute_face_score,
     compute_motion_metrics,
     generate_segments,
     subdivide_scene,
@@ -1375,27 +1375,31 @@ class TestCheckVisionAvailable:
     """check_vision_available() early returns and branch conditions."""
 
     def test_non_darwin_returns_false(self):
-        import immich_memories.analysis.scoring as scoring_mod
+        import immich_memories.analysis.face_scoring as face_mod
 
         # WHY: platform.system is OS detection — mock to test non-Mac path
-        original = scoring_mod._use_vision
-        scoring_mod._use_vision = None  # reset cached value
+        original = face_mod._use_vision
+        face_mod._use_vision = None  # reset cached value
         try:
-            with patch("immich_memories.analysis.scoring.platform.system", return_value="Linux"):
-                result = scoring_mod.check_vision_available()
+            with patch(
+                "immich_memories.analysis.face_scoring.platform.system", return_value="Linux"
+            ):
+                result = face_mod.check_vision_available()
             assert result is False
         finally:
-            scoring_mod._use_vision = original
+            face_mod._use_vision = original
 
     def test_darwin_vision_available(self):
-        import immich_memories.analysis.scoring as scoring_mod
+        import immich_memories.analysis.face_scoring as face_mod
 
-        original = scoring_mod._use_vision
-        scoring_mod._use_vision = None
+        original = face_mod._use_vision
+        face_mod._use_vision = None
         try:
             # WHY: apple_vision module only exists on macOS — mock the import
             with (
-                patch("immich_memories.analysis.scoring.platform.system", return_value="Darwin"),
+                patch(
+                    "immich_memories.analysis.face_scoring.platform.system", return_value="Darwin"
+                ),
                 patch(
                     "immich_memories.analysis.scoring.is_vision_available",
                     create=True,
@@ -1410,26 +1414,28 @@ class TestCheckVisionAvailable:
                     },
                 ),
             ):
-                result = scoring_mod.check_vision_available()
+                result = face_mod.check_vision_available()
             assert result is True
         finally:
-            scoring_mod._use_vision = original
+            face_mod._use_vision = original
 
     def test_darwin_import_error_returns_false(self):
-        import immich_memories.analysis.scoring as scoring_mod
+        import immich_memories.analysis.face_scoring as face_mod
 
-        original = scoring_mod._use_vision
-        scoring_mod._use_vision = None
+        original = face_mod._use_vision
+        face_mod._use_vision = None
         try:
             # WHY: platform.system is OS detection — mock to simulate macOS
-            with patch("immich_memories.analysis.scoring.platform.system", return_value="Darwin"):
+            with patch(
+                "immich_memories.analysis.face_scoring.platform.system", return_value="Darwin"
+            ):
                 # Force ImportError on apple_vision
                 import sys
 
                 saved = sys.modules.get("immich_memories.analysis.apple_vision")
                 sys.modules["immich_memories.analysis.apple_vision"] = None  # type: ignore[assignment]
                 try:
-                    result = scoring_mod.check_vision_available()
+                    result = face_mod.check_vision_available()
                 finally:
                     if saved is None:
                         sys.modules.pop("immich_memories.analysis.apple_vision", None)
@@ -1437,14 +1443,14 @@ class TestCheckVisionAvailable:
                         sys.modules["immich_memories.analysis.apple_vision"] = saved
             assert result is False
         finally:
-            scoring_mod._use_vision = original
+            face_mod._use_vision = original
 
 
 class TestInitVisionDetector:
     """init_vision_detector() success and failure paths."""
 
     def test_success_returns_detector(self):
-        from immich_memories.analysis.scoring import init_vision_detector
+        from immich_memories.analysis.face_scoring import init_vision_detector
 
         mock_detector = MagicMock()
         # WHY: VisionFaceDetector requires macOS ObjC — mock the module import
@@ -1460,7 +1466,7 @@ class TestInitVisionDetector:
         assert result is mock_detector
 
     def test_exception_returns_none(self):
-        from immich_memories.analysis.scoring import init_vision_detector
+        from immich_memories.analysis.face_scoring import init_vision_detector
 
         # WHY: VisionFaceDetector may fail on non-Mac — mock to simulate failure
         with patch.dict(
@@ -1479,10 +1485,10 @@ class TestInitOpencvCascade:
     """init_opencv_cascade() failure path returns None."""
 
     def test_exception_returns_none(self):
-        from immich_memories.analysis.scoring import init_opencv_cascade
+        from immich_memories.analysis.face_scoring import init_opencv_cascade
 
         # WHY: cv2.data.haarcascades may not exist on headless systems
-        with patch("immich_memories.analysis.scoring.cv2") as mock_cv2:
+        with patch("immich_memories.analysis.face_scoring.cv2") as mock_cv2:
             mock_cv2.data = MagicMock()
             mock_cv2.data.haarcascades = "/nonexistent/"
             mock_cv2.CascadeClassifier.side_effect = RuntimeError("no cascade")
@@ -1491,10 +1497,10 @@ class TestInitOpencvCascade:
 
     def test_opencv_without_cascade_api_degrades_to_no_face_detection(self):
         """OpenCV 5 dropped cv2.CascadeClassifier; that must not fail the whole run (#339)."""
-        from immich_memories.analysis.scoring import init_opencv_cascade
+        from immich_memories.analysis.face_scoring import init_opencv_cascade
 
         # WHY: emulate an OpenCV build without the Haar cascade API (spec drops the attribute)
-        with patch("immich_memories.analysis.scoring.cv2", spec=["data"]) as mock_cv2:
+        with patch("immich_memories.analysis.face_scoring.cv2", spec=["data"]) as mock_cv2:
             mock_cv2.data = MagicMock(haarcascades="/opt/cv2/data/")
             result = init_opencv_cascade()
         assert result is None
@@ -1512,7 +1518,7 @@ class TestComputeFaceScoreOpencvWithDetections:
             [[50, 50, 40, 40], [100, 100, 30, 30]]
         )
 
-        from immich_memories.analysis.scoring import _compute_face_score_opencv
+        from immich_memories.analysis.face_scoring import _compute_face_score_opencv
 
         score, positions = _compute_face_score_opencv(frame, 200, 200, mock_cascade)
         # 2 faces: coverage = (40*40 + 30*30) / (200*200) = (1600+900)/40000 = 0.0625

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -17,12 +17,12 @@ try:
 except ImportError:
     pytest.skip("cv2/numpy not available", allow_module_level=True)
 
+from immich_memories.analysis.face_scoring import compute_face_score
 from immich_memories.analysis.scenes import Scene
 from immich_memories.analysis.scoring import (
     MomentScore,
     SceneScorer,
     compute_duration_score,
-    compute_face_score,
     compute_motion_metrics,
     generate_segments,
     subdivide_scene,


### PR DESCRIPTION
Refs #245 — the `analysis/scoring.py` half. No `Closes`: `unified_analyzer.py` is the companion split and is being done separately.

`scoring.py` was **845 lines** carrying four unrelated jobs: face detection, motion/duration scoring, segment generation, and `SceneScorer`.

Face detection is the one that comes away cleanly. It is the only part with platform-specific backends, its own availability probe, and module-level cached state — and **no module in `src/` imported it**. It was internal to `SceneScorer` and to tests, which is what makes it a cohesion seam rather than a line-count cut.

| | before | after |
|---|---:|---:|
| `scoring.py` | 845 | **684** |
| `face_scoring.py` | — | 186 |

## The imports in `scoring.py` are use, not re-export

Worth being explicit, because it looks like a shim and isn't. `SceneScorer` calls `check_vision_available`, `init_vision_detector` and `init_opencv_cascade` in its constructor, and `compute_face_score` when scoring a scene. Those names have to resolve in `scoring`'s namespace.

That has a useful consequence: **the twelve existing `patch("immich_memories.analysis.scoring.check_vision_available")` targets keep working untouched.** `from x import y` binds `y` in the *importing* module at import time, so `scoring`'s namespace is still where `SceneScorer` looks the name up. Patching `face_scoring.check_vision_available` instead would silently fail to affect the scorer — so those targets are deliberately left alone, and that is the correct call rather than an oversight.

Tests that import a moved symbol *directly*, reach into `_use_vision`, or patch `platform`/`cv2` for a moved function **are** repointed — scoped to the three test classes covering moved functions, so the `SceneScorer` tests that patch `scoring.cv2.VideoCapture` (still defined there) stay as they are. That distinction is the entire risk surface of this PR and I checked it site by site rather than search-and-replacing the module path.

## Behaviour neutrality, shown rather than claimed

The only lines *added* to `scoring.py` are the docstring and the import block:

```
+Motion/duration scoring, segment generation, and the main SceneScorer class.
+Face detection lives in face_scoring.py; factory functions in scoring_factory.py.
+from immich_memories.analysis.face_scoring import (
+    check_vision_available, compute_face_score, init_opencv_cascade, init_vision_detector,
+)
```

No logic moved into or out of a branch; everything else is deletion of the moved block.

## Housekeeping

- `platform` dropped from `scoring.py` — it went with the face code (ruff caught it).
- `face_scoring` joins `scoring` in the existing mypy override for modules using OpenCV APIs with incomplete stubs; `cv2.data` has no annotation.
- `ARCHITECTURE.md` updated with both modules.
- **Patch ledger unchanged at 913** (= the new exact ceiling). This PR adds no mock sites.

`make ci` green: **5519 passed**, 9 skipped.

## Found while mapping, deliberately not fixed here

`_check_vision_available` is implemented **three times** — in this module, in `analysis/apple_vision.py`, and in `processing/transforms_smart_crop.py`. Consolidating them is a behaviour question (they may not agree), not a file split, so it stays out of a refactor PR.
