### PR TITLE
refactor(analysis): give segment extent policy its own module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,6 +133,7 @@ src/immich_memories/
 │   ├── segment_transcription.py # Transcribe the top candidate segments (whisper via speech/transcription.py)
 │   ├── unified_budget.py       # Unified photo+video budget selection (merge-then-fit)
 │   ├── segment_generation.py   # Boundary detection, candidate segment generation
+│   ├── segment_extents.py      # How long a clip may run and where it may be cut (duration caps, step 3b, best-segment repair)
 │   ├── boundary_placement.py   # Where a cut may land: protected-range gaps, edge selection
 │   ├── content_analyzer.py     # LLM-based content analysis
 │   ├── llm_response_parser.py  # Content analysis response parsing

--- a/src/immich_memories/analysis/segment_extents.py
+++ b/src/immich_memories/analysis/segment_extents.py
@@ -1,0 +1,162 @@
+"""Segment extent policy: how long a clip may run, and where it may be cut.
+
+Sits between `boundary_placement`, which is pure gap geometry over a list of
+ranges, and the analyzer's `analyze` orchestration. Every decision here is
+about a segment's extents given the source length and the speech-protected
+ranges -- nothing in this module detects, scores or ranks anything.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from immich_memories.analysis.boundary_placement import (
+    cap_end_to_gap,
+    protected_gaps,
+    select_segment_boundaries,
+)
+from immich_memories.analysis.segment_generation import adjust_candidates_for_audio
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.analyzer_models import ScoredSegment
+    from immich_memories.audio.audio_models import AudioAnalysisResult
+
+logger = logging.getLogger(__name__)
+
+
+def max_segment_for_source(
+    source_duration: float,
+    max_segment_duration: float,
+    has_good_scene: bool = False,
+) -> float:
+    """Longest segment allowed out of a source of this length.
+
+    Short sources may be used whole; medium ones are capped at
+    `max_segment_duration` with 15% grace for a good scene; sources over 60s
+    get a proportional 20% limit so one long video cannot dominate a memory.
+    """
+    grace = 1.15 if has_good_scene else 1.0
+    max_with_grace = max_segment_duration * grace
+
+    if source_duration <= max_segment_duration:
+        return source_duration
+
+    if source_duration <= 60:
+        return min(max_with_grace, source_duration)
+
+    proportional = source_duration * 0.20
+    return max(max_segment_duration, min(proportional, max_with_grace))
+
+
+def dynamic_optimal_duration(
+    source_duration: float,
+    optimal_clip_duration: float,
+    max_optimal_duration: float,
+    target_extraction_ratio: float,
+) -> float:
+    """Sweet-spot clip length for a source of this length.
+
+    Sources under 20s keep the base optimal; longer ones scale toward
+    `max_optimal_duration` at `target_extraction_ratio` of the source.
+    """
+    if source_duration > 20.0:
+        return min(
+            max_optimal_duration,
+            max(optimal_clip_duration, source_duration * target_extraction_ratio),
+        )
+    return optimal_clip_duration
+
+
+def safe_cut_gaps(
+    audio_content_result: AudioAnalysisResult,
+    video_duration: float,
+    min_silence_ms: int,
+) -> list[tuple[float, float]]:
+    """Spans this source may be cut in, buffered as every other pass does."""
+    return protected_gaps(
+        audio_content_result.protected_ranges,
+        video_duration,
+        min_silence_ms,
+    )
+
+
+def adjust_candidates_for_protected_audio(
+    candidates: list,
+    audio_content_result: AudioAnalysisResult | None,
+    video_duration: float,
+    min_segment_duration: float,
+    max_segment_duration: float,
+    min_silence_ms: int,
+) -> list:
+    """Step 3b: pull candidate boundaries out of protected audio ranges."""
+    if audio_content_result and audio_content_result.protected_ranges:
+        logger.info("Step 3b: Adjusting boundaries to avoid cutting mid-laugh/speech")
+        original_count = len(candidates)
+        proportional_max = max_segment_for_source(video_duration, max_segment_duration)
+        candidates = adjust_candidates_for_audio(
+            candidates,
+            audio_content_result,
+            video_duration,
+            min_segment_duration,
+            proportional_max,
+            min_silence_ms=min_silence_ms,
+        )
+        logger.info(f"  -> Adjusted {original_count} candidates to {len(candidates)} candidates")
+        if candidates:
+            sample = candidates[0]
+            logger.info(f"     Example segment: {sample[0].time:.2f}s - {sample[1].time:.2f}s")
+    elif audio_content_result:
+        logger.info(
+            "Step 3b: SKIPPED - no protected ranges to avoid "
+            f"(detected {len(audio_content_result.events)} audio events, "
+            f"but none were speech/laughter above confidence threshold)"
+        )
+    else:
+        logger.debug("Step 3b: SKIPPED - audio content analysis not enabled/available")
+    return candidates
+
+
+def repair_best_segment(
+    best: ScoredSegment,
+    audio_content_result: AudioAnalysisResult,
+    video_duration: float,
+    min_segment_duration: float,
+    max_segment_duration: float,
+    min_silence_ms: int,
+) -> None:
+    """Fix best-segment boundaries that cut through protected audio ranges.
+
+    Modifies the segment in place. Derives its gaps from `safe_cut_gaps`, the
+    same helper step 3b uses, so this pass cannot undo what that one decided:
+    walking the raw ranges one at a time let a boundary pushed out of one range
+    land inside the next when two overlap, and inverting the unbuffered ranges
+    let this pass cut inside step 3b's safety margin.
+    """
+    gaps = safe_cut_gaps(audio_content_result, video_duration, min_silence_ms)
+    best.safe_cut_gaps = gaps
+    new_start, new_end, adjusted = select_segment_boundaries(
+        best.start_time, best.end_time, gaps, video_duration, min_segment_duration
+    )
+
+    if adjusted:
+        best.start_time = new_start
+        best.end_time = new_end
+        logger.info(f"  -> Adjusted best segment: {best.start_time:.1f}s-{best.end_time:.1f}s")
+
+    proportional_max = max_segment_for_source(video_duration, max_segment_duration)
+    final_duration = best.end_time - best.start_time
+    if final_duration > proportional_max:
+        # `start + proportional_max` is speech-blind and this is the segment
+        # that actually gets rendered -- snap the cap to a real gap, exactly
+        # as the candidate pass does.
+        best.end_time = cap_end_to_gap(
+            best.start_time,
+            best.start_time + proportional_max,
+            gaps,
+            min_segment_duration,
+        )
+        logger.info(
+            f"  -> Re-trimmed to proportional max: {best.start_time:.1f}s-{best.end_time:.1f}s "
+            f"(was {final_duration:.1f}s, max={proportional_max:.1f}s for {video_duration:.1f}s source)"
+        )

--- a/src/immich_memories/analysis/unified_analyzer.py
+++ b/src/immich_memories/analysis/unified_analyzer.py
@@ -17,15 +17,16 @@ from immich_memories.analysis.analyzer_factory import (  # noqa: F401
     create_unified_analyzer_from_config,
 )
 from immich_memories.analysis.analyzer_models import CutPoint, ScoredSegment  # noqa: F401
-from immich_memories.analysis.boundary_placement import (
-    cap_end_to_gap,
-    protected_gaps,
-    select_segment_boundaries,
-)
 from immich_memories.analysis.scenes import Scene, SceneDetector, get_video_info
 from immich_memories.analysis.scoring import SceneScorer
+from immich_memories.analysis.segment_extents import (
+    adjust_candidates_for_protected_audio,
+    dynamic_optimal_duration,
+    max_segment_for_source,
+    repair_best_segment,
+    safe_cut_gaps,
+)
 from immich_memories.analysis.segment_generation import (
-    adjust_candidates_for_audio,
     detect_audio_boundaries,
     detect_visual_boundaries,
     generate_candidate_segments,
@@ -184,99 +185,6 @@ class UnifiedSegmentAnalyzer:
         self._speech_analysis.reset_for_video()
         self.scorer.release_capture()
 
-    def _get_max_segment_for_source(
-        self, source_duration: float, has_good_scene: bool = False
-    ) -> float:
-        """Calculate maximum segment duration based on source video length.
-
-        Logic:
-        - If source <= max_segment_duration: allow full source (no trimming needed)
-        - If source > max_segment_duration: cap at max (with 15% grace if good scene)
-        - For very long videos (>60s): apply proportional limit (20% of source)
-
-        Args:
-            source_duration: Source video duration in seconds.
-            has_good_scene: If True, allow 15% grace over max_segment_duration.
-
-        Returns:
-            Maximum segment duration for this source.
-        """
-        # Grace multiplier for good scenes (15% extra allowed)
-        grace = 1.15 if has_good_scene else 1.0
-        max_with_grace = self.max_segment_duration * grace
-
-        # Short videos: allow using all of it (no trimming needed)
-        if source_duration <= self.max_segment_duration:
-            return source_duration
-
-        # Medium videos (up to 60s): use max_segment_duration (with grace if good scene)
-        if source_duration <= 60:
-            return min(max_with_grace, source_duration)
-
-        # Very long videos (>60s): apply proportional limit (20% of source)
-        # but never less than max_segment_duration
-        proportional = source_duration * 0.20
-        return max(self.max_segment_duration, min(proportional, max_with_grace))
-
-    def _safe_cut_gaps(
-        self,
-        audio_content_result: AudioAnalysisResult,
-        video_duration: float,
-    ) -> list[tuple[float, float]]:
-        """Spans this source may be cut in, buffered as every other pass does."""
-        return protected_gaps(
-            audio_content_result.protected_ranges,
-            video_duration,
-            self._speech_analysis.speech_config.min_silence_ms,
-        )
-
-    def _fix_best_segment_boundaries(
-        self,
-        best: ScoredSegment,
-        audio_content_result: AudioAnalysisResult,
-        video_duration: float,
-    ) -> None:
-        """Fix best segment boundaries that cut through protected audio ranges.
-
-        Modifies the segment in place. Derives its gaps from `protected_gaps`,
-        the same helper step 3b uses, so this pass cannot undo what that one
-        decided: walking the raw ranges one at a time let a boundary pushed out
-        of one range land inside the next when two overlap, and inverting the
-        unbuffered ranges let this pass cut inside step 3b's safety margin.
-
-        Args:
-            best: Best segment to fix.
-            audio_content_result: Audio analysis results.
-            video_duration: Total video duration.
-        """
-        gaps = self._safe_cut_gaps(audio_content_result, video_duration)
-        best.safe_cut_gaps = gaps
-        new_start, new_end, adjusted = select_segment_boundaries(
-            best.start_time, best.end_time, gaps, video_duration, self.min_segment_duration
-        )
-
-        if adjusted:
-            best.start_time = new_start
-            best.end_time = new_end
-            logger.info(f"  -> Adjusted best segment: {best.start_time:.1f}s-{best.end_time:.1f}s")
-
-        proportional_max = self._get_max_segment_for_source(video_duration)
-        final_duration = best.end_time - best.start_time
-        if final_duration > proportional_max:
-            # `start + proportional_max` is speech-blind and this is the segment
-            # that actually gets rendered -- snap the cap to a real gap, exactly
-            # as the candidate pass does.
-            best.end_time = cap_end_to_gap(
-                best.start_time,
-                best.start_time + proportional_max,
-                gaps,
-                self.min_segment_duration,
-            )
-            logger.info(
-                f"  -> Re-trimmed to proportional max: {best.start_time:.1f}s-{best.end_time:.1f}s "
-                f"(was {final_duration:.1f}s, max={proportional_max:.1f}s for {video_duration:.1f}s source)"
-            )
-
     def analyze(
         self,
         video_path: Path,
@@ -324,7 +232,12 @@ class UnifiedSegmentAnalyzer:
             )
             return []
 
-        dynamic_optimal = self._get_dynamic_optimal_duration(video_duration)
+        dynamic_optimal = dynamic_optimal_duration(
+            video_duration,
+            self.optimal_clip_duration,
+            self.max_optimal_duration,
+            self.target_extraction_ratio,
+        )
         logger.info(
             f"Duration scoring: source={video_duration:.1f}s → "
             f"optimal clip={dynamic_optimal:.1f}s "
@@ -363,7 +276,12 @@ class UnifiedSegmentAnalyzer:
 
         # Step 3: Generate candidates
         logger.info("Step 3: Generating candidate segments (must start/end on silence)")
-        dynamic_optimal = self._get_dynamic_optimal_duration(video_duration)
+        dynamic_optimal = dynamic_optimal_duration(
+            video_duration,
+            self.optimal_clip_duration,
+            self.max_optimal_duration,
+            self.target_extraction_ratio,
+        )
         candidates = generate_candidate_segments(
             cut_points,
             video_duration,
@@ -373,14 +291,21 @@ class UnifiedSegmentAnalyzer:
         )
         if not candidates:
             logger.warning("No valid segments found, using fallback (visual-only)")
-            proportional_max = self._get_max_segment_for_source(video_duration)
+            proportional_max = max_segment_for_source(video_duration, self.max_segment_duration)
             candidates = generate_fallback_segments(
                 video_duration, cut_points, self.min_segment_duration, proportional_max
             )
         logger.info(f"  -> Generated {len(candidates)} candidate segments")
 
         # Step 3b: Adjust for audio
-        candidates = self._step3b_adjust_for_audio(candidates, audio_content_result, video_duration)
+        candidates = adjust_candidates_for_protected_audio(
+            candidates,
+            audio_content_result,
+            video_duration,
+            self.min_segment_duration,
+            self.max_segment_duration,
+            self._speech_analysis.speech_config.min_silence_ms,
+        )
 
         # Step 4: Score
         logger.info(
@@ -424,66 +349,22 @@ class UnifiedSegmentAnalyzer:
                 f"Step 5: Best segment {best.start_time:.1f}s-{best.end_time:.1f}s "
                 f"(score={best.total_score:.2f}, cut_quality={best.cut_quality:.0%})"
             )
+            min_silence_ms = self._speech_analysis.speech_config.min_silence_ms
             if audio_content_result and audio_content_result.protected_ranges:
-                self._fix_best_segment_boundaries(best, audio_content_result, video_duration)
+                repair_best_segment(
+                    best,
+                    audio_content_result,
+                    video_duration,
+                    self.min_segment_duration,
+                    self.max_segment_duration,
+                    min_silence_ms,
+                )
             elif audio_content_result:
-                best.safe_cut_gaps = self._safe_cut_gaps(audio_content_result, video_duration)
+                best.safe_cut_gaps = safe_cut_gaps(
+                    audio_content_result, video_duration, min_silence_ms
+                )
 
         return scored_segments
-
-    def _step3b_adjust_for_audio(
-        self,
-        candidates: list,
-        audio_content_result: AudioAnalysisResult | None,
-        video_duration: float,
-    ) -> list:
-        """Run step 3b: adjust candidate boundaries to avoid protected audio ranges."""
-        if audio_content_result and audio_content_result.protected_ranges:
-            logger.info("Step 3b: Adjusting boundaries to avoid cutting mid-laugh/speech")
-            original_count = len(candidates)
-            proportional_max = self._get_max_segment_for_source(video_duration)
-            candidates = adjust_candidates_for_audio(
-                candidates,
-                audio_content_result,
-                video_duration,
-                self.min_segment_duration,
-                proportional_max,
-                min_silence_ms=self._speech_analysis.speech_config.min_silence_ms,
-            )
-            logger.info(
-                f"  -> Adjusted {original_count} candidates to {len(candidates)} candidates"
-            )
-            if candidates:
-                sample = candidates[0]
-                logger.info(f"     Example segment: {sample[0].time:.2f}s - {sample[1].time:.2f}s")
-        elif audio_content_result:
-            logger.info(
-                "Step 3b: SKIPPED - no protected ranges to avoid "
-                f"(detected {len(audio_content_result.events)} audio events, "
-                f"but none were speech/laughter above confidence threshold)"
-            )
-        else:
-            logger.debug("Step 3b: SKIPPED - audio content analysis not enabled/available")
-        return candidates
-
-    def _get_dynamic_optimal_duration(self, source_duration: float) -> float:
-        """Calculate the optimal clip duration based on source video length.
-
-        For short sources (< 20s): optimal stays at base (5s)
-        For longer sources: optimal scales up to max_optimal (10s)
-
-        Args:
-            source_duration: Total source video duration in seconds.
-
-        Returns:
-            Dynamic optimal clip duration in seconds.
-        """
-        if source_duration > 20.0:
-            return min(
-                self.max_optimal_duration,
-                max(self.optimal_clip_duration, source_duration * self.target_extraction_ratio),
-            )
-        return self.optimal_clip_duration
 
     def _compute_duration_score(self, clip_duration: float, source_duration: float) -> float:
         """How well this clip length suits this source, on the shared curve.

--- a/tests/test_pipeline_orchestration_coverage.py
+++ b/tests/test_pipeline_orchestration_coverage.py
@@ -17,6 +17,12 @@ from immich_memories.analysis.boundary_placement import (
     merge_buffered_ranges,
     speech_buffer_seconds,
 )
+from immich_memories.analysis.segment_extents import (
+    adjust_candidates_for_protected_audio,
+    dynamic_optimal_duration,
+    max_segment_for_source,
+    repair_best_segment,
+)
 from immich_memories.analysis.segment_generation import (
     classify_segment_events,
     collect_mixed_boundary_candidates,
@@ -89,6 +95,10 @@ def _make_analyzer(**overrides):
     }
     defaults.update(overrides)
     return UnifiedSegmentAnalyzer(**defaults)
+
+
+# SpeechConfig's default silence floor, which is what _make_analyzer runs with.
+_MIN_SILENCE_MS = 200
 
 
 # ===========================================================================
@@ -236,13 +246,11 @@ class TestUnifiedAnalyzerProportionalMaxSegment:
     """Lines 177-178: proportional limit for very long videos (>60s)."""
 
     def test_very_long_video_capped_proportionally(self):
-        analyzer = _make_analyzer(max_segment_duration=15.0)
-        result = analyzer._get_max_segment_for_source(120.0, has_good_scene=False)
+        result = max_segment_for_source(120.0, 15.0, has_good_scene=False)
         assert result == max(15.0, min(120.0 * 0.20, 15.0))
 
     def test_grace_for_good_scene_medium_video(self):
-        analyzer = _make_analyzer(max_segment_duration=15.0)
-        result = analyzer._get_max_segment_for_source(40.0, has_good_scene=True)
+        result = max_segment_for_source(40.0, 15.0, has_good_scene=True)
         assert result == min(15.0 * 1.15, 40.0)
 
 
@@ -250,24 +258,36 @@ class TestFixBestSegmentBoundaries:
     """Lines 294, 302, 307, 316-317: boundary adjustment + re-trim."""
 
     def test_boundaries_adjusted_and_retrimmed(self):
-        analyzer = _make_analyzer(max_segment_duration=5.0)
         best = ScoredSegment(start_time=3.0, end_time=8.0)
         audio_result = AudioAnalysisResult(protected_ranges=[(2.5, 3.5), (7.5, 8.5)])
-        analyzer._fix_best_segment_boundaries(best, audio_result, video_duration=30.0)
+        repair_best_segment(
+            best,
+            audio_result,
+            30.0,
+            min_segment_duration=2.0,
+            max_segment_duration=5.0,
+            min_silence_ms=_MIN_SILENCE_MS,
+        )
         assert best.start_time < 2.5 or best.start_time >= 3.5
         assert best.end_time > 8.5 or best.end_time <= 7.5
 
     def test_retrim_to_proportional_max(self):
         """Lines 316-317: segment exceeding proportional max gets re-trimmed."""
-        analyzer = _make_analyzer(max_segment_duration=5.0)
         # After boundary adjustment, segment expands beyond proportional max.
         # Protected range forces end_time to be nudged outward.
         best = ScoredSegment(start_time=0.0, end_time=25.0)
         # source=100s => proportional_max = max(5, min(100*0.20, 5*1.0)) = max(5,5) = 5
         # After adjust, 25.0 > 5.0 => re-trim
         audio_result = AudioAnalysisResult(protected_ranges=[(24.5, 25.5)])
-        analyzer._fix_best_segment_boundaries(best, audio_result, video_duration=100.0)
-        proportional_max = analyzer._get_max_segment_for_source(100.0)
+        repair_best_segment(
+            best,
+            audio_result,
+            100.0,
+            min_segment_duration=2.0,
+            max_segment_duration=5.0,
+            min_silence_ms=_MIN_SILENCE_MS,
+        )
+        proportional_max = max_segment_for_source(100.0, 5.0)
         assert best.end_time - best.start_time <= proportional_max + 0.01
 
 
@@ -290,7 +310,6 @@ class TestStep3bAdjustForAudio:
 
     def test_audio_events_but_no_protected_ranges_skips(self):
         """Lines 469: audio result with events but empty protected_ranges."""
-        analyzer = _make_analyzer()
         audio_result = AudioAnalysisResult(
             events=[AudioEvent("Speech", 0.0, 5.0, 0.3)],
             protected_ranges=[],
@@ -298,15 +317,18 @@ class TestStep3bAdjustForAudio:
         candidates = [
             (CutPoint(0.0, True, True), CutPoint(5.0, True, True)),
         ]
-        result = analyzer._step3b_adjust_for_audio(candidates, audio_result, 10.0)
+        result = adjust_candidates_for_protected_audio(
+            candidates, audio_result, 10.0, 2.0, 15.0, _MIN_SILENCE_MS
+        )
         assert result == candidates
 
     def test_no_audio_result_skips(self):
-        analyzer = _make_analyzer()
         candidates = [
             (CutPoint(0.0, True, True), CutPoint(5.0, True, True)),
         ]
-        result = analyzer._step3b_adjust_for_audio(candidates, None, 10.0)
+        result = adjust_candidates_for_protected_audio(
+            candidates, None, 10.0, 2.0, 15.0, _MIN_SILENCE_MS
+        )
         assert result == candidates
 
 
@@ -314,14 +336,10 @@ class TestDynamicOptimalDuration:
     """Lines 527: source > 20s scales optimal up."""
 
     def test_short_source_uses_base_optimal(self):
-        analyzer = _make_analyzer(optimal_clip_duration=5.0)
-        assert analyzer._get_dynamic_optimal_duration(15.0) == 5.0
+        assert dynamic_optimal_duration(15.0, 5.0, 10.0, 0.15) == 5.0
 
     def test_long_source_scales_optimal(self):
-        analyzer = _make_analyzer(
-            optimal_clip_duration=5.0, max_optimal_duration=10.0, target_extraction_ratio=0.15
-        )
-        result = analyzer._get_dynamic_optimal_duration(80.0)
+        result = dynamic_optimal_duration(80.0, 5.0, 10.0, 0.15)
         assert result == min(10.0, max(5.0, 80.0 * 0.15))
 
 

--- a/tests/test_unified_analyzer.py
+++ b/tests/test_unified_analyzer.py
@@ -14,6 +14,10 @@ except ImportError:
     pytest.skip("cv2 not available", allow_module_level=True)
 
 from immich_memories.analysis.scoring import MomentScore
+from immich_memories.analysis.segment_extents import (
+    max_segment_for_source,
+    repair_best_segment,
+)
 from immich_memories.analysis.segment_generation import (
     find_nearest_cut_point,
     generate_candidate_segments,
@@ -421,7 +425,7 @@ class TestUnifiedSegmentAnalyzer:
             video_duration=30.0,
             cut_points=cut_points,
             min_segment_duration=analyzer.min_segment_duration,
-            proportional_max=analyzer._get_max_segment_for_source(30.0),
+            proportional_max=max_segment_for_source(30.0, analyzer.max_segment_duration),
         )
 
         assert len(result) >= 1
@@ -698,19 +702,9 @@ class TestBestSegmentOverlapHandling:
         assert not any(lo < end < hi for lo, hi in ranges)
 
 
-def _boundary_fixing_analyzer(**kwargs) -> UnifiedSegmentAnalyzer:
-    """Analyzer wired for `_fix_best_segment_boundaries` and nothing else."""
-    from immich_memories.config_models import SpeechConfig
-
-    # WHY: SceneScorer opens the video with OpenCV; the boundary-fixing pass
-    # never touches it, so a stand-in keeps the test off the filesystem.
-    return UnifiedSegmentAnalyzer(
-        scorer=MagicMock(),
-        audio_content_config=AudioContentConfig(),
-        analysis_config=AnalysisConfig(),
-        speech_config=SpeechConfig(min_silence_ms=200),
-        **kwargs,
-    )
+# The VAD only splits on 200 ms of silence, so that is the floor the
+# boundary-repair cases below are measured against.
+_VAD_MIN_SILENCE_MS = 200
 
 
 class TestBestSegmentUsesTheSameSafetyBufferAsCandidates:
@@ -724,15 +718,19 @@ class TestBestSegmentUsesTheSameSafetyBufferAsCandidates:
         from immich_memories.audio.audio_models import AudioAnalysisResult
 
         ranges = [(2.0, 6.0), (6.1, 30.0)]
-        # max_segment_duration=40 keeps the proportional-max cap out of the way.
-        analyzer = _boundary_fixing_analyzer(min_segment_duration=2.0, max_segment_duration=40.0)
         best = ScoredSegment(start_time=7.0, end_time=32.0)
 
-        analyzer._fix_best_segment_boundaries(
-            best, AudioAnalysisResult(events=[], protected_ranges=ranges), 40.0
+        repair_best_segment(
+            best,
+            AudioAnalysisResult(events=[], protected_ranges=ranges),
+            40.0,
+            min_segment_duration=2.0,
+            # 40 keeps the proportional-max cap out of the way.
+            max_segment_duration=40.0,
+            min_silence_ms=_VAD_MIN_SILENCE_MS,
         )
 
-        buffer = speech_buffer_seconds(200)
+        buffer = speech_buffer_seconds(_VAD_MIN_SILENCE_MS)
         for lo, hi in ranges:
             assert not lo - buffer < best.start_time < hi + buffer
             assert not lo - buffer < best.end_time < hi + buffer
@@ -747,11 +745,15 @@ class TestTheEndCarriesTheEvidenceThatPlacedIt:
         """
         from immich_memories.audio.audio_models import AudioAnalysisResult
 
-        analyzer = _boundary_fixing_analyzer(min_segment_duration=2.0, max_segment_duration=40.0)
         best = ScoredSegment(start_time=7.0, end_time=32.0)
 
-        analyzer._fix_best_segment_boundaries(
-            best, AudioAnalysisResult(events=[], protected_ranges=[(2.0, 6.0), (6.1, 30.0)]), 40.0
+        repair_best_segment(
+            best,
+            AudioAnalysisResult(events=[], protected_ranges=[(2.0, 6.0), (6.1, 30.0)]),
+            40.0,
+            min_segment_duration=2.0,
+            max_segment_duration=40.0,
+            min_silence_ms=_VAD_MIN_SILENCE_MS,
         )
 
         assert best.safe_cut_gaps, "the end was placed against gaps it did not hand on"
@@ -774,11 +776,15 @@ class TestBestSegmentProportionalMax:
 
         # Buffered by 80 ms these merge to (4.0, 7.5), (8.5, 29.5), (30.5, 40.0).
         ranges = [(4.08, 7.42), (8.58, 29.42), (30.58, 40.0)]
-        analyzer = _boundary_fixing_analyzer(min_segment_duration=2.0, max_segment_duration=15.0)
         best = ScoredSegment(start_time=2.0, end_time=20.0)
 
-        analyzer._fix_best_segment_boundaries(
-            best, AudioAnalysisResult(events=[], protected_ranges=ranges), 40.0
+        repair_best_segment(
+            best,
+            AudioAnalysisResult(events=[], protected_ranges=ranges),
+            40.0,
+            min_segment_duration=2.0,
+            max_segment_duration=15.0,
+            min_silence_ms=_VAD_MIN_SILENCE_MS,
         )
 
         assert best.end_time == 8.0


### PR DESCRIPTION
Refs #245 — the last of the seven oversized modules.

## The seam

After the earlier splits (`analyzer_factory`, `analyzer_models`,
`speech_analysis`, `segment_transcription`), `unified_analyzer.py` had two
jobs left: orchestrating the `analyze` pipeline, and deciding **how long a
segment may run and where it is legal to cut it**. The second one moves to
`analysis/segment_extents.py`:

| moved | was |
|---|---|
| `max_segment_for_source` | `_get_max_segment_for_source` |
| `dynamic_optimal_duration` | `_get_dynamic_optimal_duration` |
| `safe_cut_gaps` | `_safe_cut_gaps` |
| `adjust_candidates_for_protected_audio` | `_step3b_adjust_for_audio` |
| `repair_best_segment` | `_fix_best_segment_boundaries` |

They form one unit: every one is a decision about a segment's extents given
the source length and the speech-protected ranges. They call each other
(`repair_best_segment` -> `safe_cut_gaps` + `max_segment_for_source`;
step 3b -> `max_segment_for_source`) and share exactly one dependency set —
the duration config plus `min_silence_ms`. The new module sits between
`boundary_placement` (pure gap geometry over a list of ranges) and `analyze`
(now only orchestration).

The import block is objective evidence of the seam: `protected_gaps`,
`select_segment_boundaries`, `cap_end_to_gap` and `adjust_candidates_for_audio`
leave `unified_analyzer` entirely and are used **only** by the new module.

All five are plain functions over explicit parameters, not a service object
holding copies of the analyzer's config — see "why not a class" below.

**Line counts:** `unified_analyzer.py` 811 -> 692; `segment_extents.py` 162.

## Behaviour-neutrality

The diff to `unified_analyzer.py` is deletions + the import block + call-site
substitution, nothing else. The moved bodies are unchanged; `self.X` became a
parameter of the same value. One observable difference: step 3b and the
best-segment repair now log under `immich_memories.analysis.segment_extents`.
Nothing asserts on those records (grepped `Step 3b`, `Adjusted best segment`,
`Re-trimmed`); `log_top_segments`, which *is* caplog-asserted against the
`unified_analyzer` logger, stays put.

## Patch-target audit

`from x import y` binds `y` in the importing module, so a
`patch("...unified_analyzer.<name>")` only works while `unified_analyzer` still
holds and uses that binding. Every site, individually:

**Left alone — target still bound in `unified_analyzer` and still used by it:**

1. `test_unified_analyzer.py:124-136` — `monkeypatch.setattr` on
   `detect_visual_boundaries`, `detect_audio_boundaries`, `merge_boundaries`,
   `generate_candidate_segments`, `generate_fallback_segments`. All five stay
   imported and are still called from `analyze`. Not repointed.
2. `test_unified_analyzer.py:~527/551/587` — `patch()` on
   `detect_visual_boundaries`, `detect_audio_boundaries`, `get_video_info`.
   Same reasoning. Not repointed.
3. `test_unified_analyzer.py:~900` — the loop that `setattr`s the same five
   names. Not repointed.
4. `test_unified_analyzer.py:~554` — `patch.object(analyzer, "_score_visual")`.
   `_score_visual` **and** its only caller `_score_segments_visual_only` both
   stay on the analyzer, so the mock is still reached through
   `self._score_visual`. Untouched. (Splitting those two across a seam is
   precisely the dead-mock trap; they were kept together deliberately.)
5. `test_pipeline_orchestration_coverage.py:~427` —
   `patch.object(analyzer, "_compute_total_score")`, consumed by
   `_run_llm_scoring` via `self._compute_total_score`. Both stay. Untouched.
6. `test_analysis_coverage.py:2225,2258`, `test_clip_analyzer.py:884,935,973`,
   `test_preview_builder.py:147,166,191,209,231,254`,
   `test_clip_selection.py:340,361` — all patch
   `...unified_analyzer.UnifiedSegmentAnalyzer` or `.analyze`. Class and method
   stay. Untouched.
7. `test_scoring_calibration.py:251,278,294,301` — imports `log_top_segments`
   from `unified_analyzer` and asserts through
   `caplog.at_level(logger="immich_memories.analysis.unified_analyzer")`.
   `log_top_segments` stays, so both the import and the logger name remain
   correct. Untouched.
8. `test_unified_analyzer.py:~566` — `from ...unified_analyzer import
   _VisualScores`. Stays. Untouched.

**Symbols that left `unified_analyzer`'s namespace — verified nobody patched
them through it:** `protected_gaps`, `select_segment_boundaries`,
`cap_end_to_gap`, `adjust_candidates_for_audio`. Every test using these imports
them from `boundary_placement` / `segment_generation` directly
(`test_speech_boundary_scoring.py`, `test_pipeline_orchestration_coverage.py`,
`test_unified_analyzer.py:~687`). Zero patches through `unified_analyzer.*`, so
dropping them from the import block cannot orphan a mock.

**Repointed (12 sites) — direct calls, not mocks.** These call the moved
functions by their new name. None is a `patch()`; if any were wired wrong the
assertion fails, it cannot pass silently:

- `test_pipeline_orchestration_coverage.py`: `_get_max_segment_for_source` x3,
  `_fix_best_segment_boundaries` x2, `_step3b_adjust_for_audio` x2,
  `_get_dynamic_optimal_duration` x2
- `test_unified_analyzer.py`: `_get_max_segment_for_source` x1,
  `_fix_best_segment_boundaries` x3

The repointed tests now exercise the extracted unit through its public
interface rather than the analyzer's privates, and several no longer need to
build an analyzer at all. **No new `patch()` or `with-(` sites** — the WHY
ratchet moves down by one (`_boundary_fixing_analyzer`'s `MagicMock` scorer is
gone, since `repair_best_segment` takes scalars).

## What deliberately did *not* move

**`_compute_duration_score`** stays on the analyzer. `test_one_duration_score.py`
exists specifically to pin `UnifiedSegmentAnalyzer._compute_duration_score` to
`analysis.scoring.compute_duration_score` (#581, "score a duration one way, not
two"). Moving it would dissolve a guarantee that landed two days ago.

**The scoring block** (`_score_visual`, `_score_content`, `_compute_total_score`,
`_score_segments_visual_only`, `_run_llm_scoring`, `_VisualScores`,
`log_top_segments`) is the other real seam and is the larger one (~345 lines).
It stayed, for two concrete reasons:

1. `test_unified_analyzer.py:461,478` mutate `analyzer.content_weight` *after*
   construction and then call `_compute_total_score`. Any extracted scorer
   owning a copy of the weights would silently ignore that — the exact
   duplicated-config drift this file already carries a warning about
   (`_compute_duration_score`: *"tuning one would have left the other scoring
   the old way"*). Re-creating that hazard for the scoring weights is a worse
   trade than the line count.
2. `patch.object(analyzer, "_score_visual")` is consumed inside
   `_score_segments_visual_only`, so the two cannot be separated without
   creating a dead mock — meaning the scoring block can only move as one piece,
   which is a ~40-site test rewrite. That is its own PR, not this one.

## Why functions, not a class

A `SegmentExtentPolicy` object would have to hold `min_segment_duration`,
`max_segment_duration`, `optimal_clip_duration`, `max_optimal_duration` and
`target_extraction_ratio` — all of which tests read off the analyzer
(`test_analyzer_config_plumbing.py:65-67`, `test_unified_analyzer.py:622-623`),
so they must stay there too. That is duplicated state with nothing keeping the
copies honest. Plain functions over explicit parameters match what this package
already does (`segment_transcription.transcribe_top_segments`,
`boundary_placement.*`) and keep one source of truth.

## Verification

`make ci` green in full, twice: before the rebase and again on top of
`origin/main` at #591. 5527 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
