### PR TITLE
fix(cli): --no-render stops saying it saved a file it never wrote

### DIFF
--- a/src/immich_memories/cli/_generate_display.py
+++ b/src/immich_memories/cli/_generate_display.py
@@ -116,10 +116,19 @@ def _print_generation_result(
     result_path: Path,
     should_upload: bool,
     album_name: str | None,
+    no_render: bool = False,
 ) -> None:
-    """Report a plan without claiming an artifact or upload exists."""
+    """Report a plan without claiming an artifact or upload exists.
+
+    Both flags stop at the render boundary and both return a path anyway — the
+    one the run would have written. Saying "Video saved to" for it sends people
+    looking for a file that does not exist.
+    """
     if dry_run:
         print_success("Dry-run planning complete; no video was created")
+        return
+    if no_render:
+        print_success("Selection complete; no video was created (--no-render)")
         return
     print_success(f"Video saved to: {result_path}")
     if should_upload:

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -965,6 +965,7 @@ def register_generate_commands(main: click.Group) -> None:
 
                 _print_generation_result(
                     dry_run=dry_run,
+                    no_render=no_render,
                     result_path=result_path,
                     should_upload=should_upload,
                     album_name=album_name,

--- a/tests/test_no_render_output.py
+++ b/tests/test_no_render_output.py
@@ -1,0 +1,76 @@
+"""--no-render must not claim it saved a file it never wrote.
+
+_finish_without_rendering returns a path — it always did, for --dry-run — and
+the CLI logged it unconditionally. Measured on a real run: zero encode
+operations, nothing on disk, and "Video saved to: …/all_monthly_highlights_…"
+in the output. Anyone using the flag goes looking for output that never existed.
+
+These assert on the logger rather than stdout: print_success writes through
+immich_memories.cli, so a capsys test passes alone and fails in the suite.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from immich_memories.cli._generate_display import _print_generation_result
+from immich_memories.cli._helpers import set_quiet_mode
+
+
+@pytest.fixture(autouse=True)
+def _quiet():
+    """Pin the output branch.
+
+    print_success writes to an active display, or the logger under quiet mode,
+    or the console — so which stream carries the message depends on state other
+    tests may have set. Choosing one makes these tests say what they mean.
+    """
+    set_quiet_mode(True)
+    yield
+    set_quiet_mode(False)
+
+
+def _messages(caplog) -> str:
+    return "\n".join(record.message for record in caplog.records)
+
+
+def test_no_render_does_not_claim_a_file(caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="immich_memories.cli"):
+        _print_generation_result(
+            dry_run=False,
+            no_render=True,
+            result_path=Path("/tmp/x.mp4"),
+            should_upload=False,
+            album_name=None,
+        )
+
+    out = _messages(caplog)
+    assert "Video saved to" not in out, f"claimed a file it never wrote: {out!r}"
+    assert "no video" in out.lower()
+
+
+def test_a_real_run_still_reports_its_file(caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="immich_memories.cli"):
+        _print_generation_result(
+            dry_run=False,
+            no_render=False,
+            result_path=Path("/tmp/x.mp4"),
+            should_upload=False,
+            album_name=None,
+        )
+
+    assert "Video saved to" in _messages(caplog)
+
+
+def test_dry_run_is_unchanged(caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="immich_memories.cli"):
+        _print_generation_result(
+            dry_run=True,
+            no_render=False,
+            result_path=Path("/tmp/x.mp4"),
+            should_upload=False,
+            album_name=None,
+        )
+
+    assert "Dry-run planning complete" in _messages(caplog)


### PR DESCRIPTION
Found while re-measuring the judgment cache. `--no-render` works correctly — **zero encode operations, nothing on disk** — and then prints:

```
✓ Video saved to: /Users/…/all_monthly_highlights_20090701-20090731_b8524080.mp4
```

Anyone using the flag goes looking for a file that never existed.

## Cause

`_finish_without_rendering` returns a path — it always did, for `--dry-run` — and the CLI logs it unconditionally.

`_print_generation_result` already knew this shape. Its docstring says *"Report a plan without claiming an artifact or upload exists"* and it special-cases `--dry-run`. #570 added a **second** way to reach the render boundary and taught the runner about it, but not the reporter.

That's the residual cost of a welded flag: `dry_run` meant three things, so splitting one out left other consumers of "did we render?" still asking the old question.

## Tests pin the output branch

`print_success` writes to an active display, **or** the logger under quiet mode, **or** the console — chosen by `ContextVar`s. So which stream carries the message depends on state another test may have set.

A `capsys` version of these tests passed alone and failed in the suite. A `caplog` version did the exact reverse. Neither was wrong about the code; both were wrong to *assume* a branch. An autouse fixture calls `set_quiet_mode(True)`, so the tests say what they mean.

## Verification

The defect was measured, not inferred: run with `--no-render`, `grep -c Encoding` → 0, no file at the reported path.

`make ci` exit 0, **5556 passed**.