### PR TITLE
fix(ui): let the wizard caption clips with their place

### DIFF
--- a/docs-site/docs/create/web-ui/step3-generation-options.mdx
+++ b/docs-site/docs/create/web-ui/step3-generation-options.mdx
@@ -25,7 +25,7 @@ A collapsed expansion under the two selects:
 - **Orientation**: **Auto (detect from clips)** (default), Landscape (16:9), Portrait (9:16), Square (1:1). When the source and target aspect ratios differ, the whole frame is kept and the leftover space is filled — clips are never cropped, see [face-aware framing](../pipeline/face-aware-cropping.md).
 - **Scaling Mode**: **Blur background** (default), Letterbox (black bars). Starts on whatever `defaults.scale_mode` says, so the wizard and `--scale-mode` produce the same video.
 - **Transition Style**: **Smart (mix of fades & cuts)** (default), Crossfade, Cut, None. Smart picks per cut point: crossfade for slow scenes, hard cut for fast action.
-- **Add date overlay** and **Keep intermediate files** checkboxes.
+- **Add date overlay**, **Caption clips with their place**, and **Keep intermediate files** checkboxes. The place caption is the wizard's equivalent of the CLI's `--add-place`, and needs GPS on the clips to show anything.
 - When photos are enabled: "Photos enabled (N found)" and a **Photo duration (seconds)** field (1–10).
 
 <ThemedScreenshot name="step3-advanced" alt="Advanced generation options" />

--- a/src/immich_memories/ui/pages/_step4_generate.py
+++ b/src/immich_memories/ui/pages/_step4_generate.py
@@ -236,6 +236,7 @@ def _build_generation_params(state, selected_clips, output_path):
         ],
         output_format=_FORMAT_MAP.get(gen_options.get("format_override")),
         add_date_overlay=gen_options.get("add_date", False),
+        add_place_overlay=gen_options.get("add_place", False),
         debug_preserve_intermediates=gen_options.get("keep_intermediates", False),
         privacy_mode=state.demo_mode,
         person_name=person.name if person else None,

--- a/src/immich_memories/ui/pages/step3_options.py
+++ b/src/immich_memories/ui/pages/step3_options.py
@@ -213,6 +213,7 @@ def render_step3() -> None:
             "resolution": default_resolution_label(config),
             "format": configured_format,
             "add_date": False,
+            "add_place": False,
             "music_source": "AI Generated" if musicgen_available else "None",
             "music_file": None,
             "music_volume": 0.7,
@@ -314,6 +315,15 @@ def render_step3() -> None:
                     options["add_date"] = e.value
 
                 date_checkbox.on_value_change(on_date_change)
+
+                place_checkbox = ui.checkbox(
+                    "Caption clips with their place", value=options.get("add_place", False)
+                )
+
+                def on_place_change(e):
+                    options["add_place"] = e.value
+
+                place_checkbox.on_value_change(on_place_change)
 
                 debug_checkbox = ui.checkbox(
                     "Keep intermediate files",

--- a/tests/test_ui_place_captions.py
+++ b/tests/test_ui_place_captions.py
@@ -1,0 +1,44 @@
+"""The wizard can caption clips with their place, like the CLI's --add-place.
+
+Last row of #505's asymmetry list: `add_place_overlay` reaches assembly from
+every CLI path and from nowhere in the wizard, so the feature existed for one
+surface only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from immich_memories.config_loader import Config
+from immich_memories.ui.state import AppState
+
+
+def test_the_wizard_hands_the_place_caption_choice_to_the_pipeline(tmp_path: Path) -> None:
+    """Ticking the box has to reach params, or the option does nothing."""
+    from immich_memories.ui.pages._step4_generate import _build_generation_params
+
+    state = AppState(
+        config=Config(),
+        immich_url="http://immich.test",
+        immich_api_key="k",
+        generation_options={"add_place": True},
+    )
+
+    params = _build_generation_params(state, [], tmp_path / "memory.mp4")
+
+    assert params.add_place_overlay is True
+
+
+def test_place_captions_stay_off_unless_asked(tmp_path: Path) -> None:
+    from immich_memories.ui.pages._step4_generate import _build_generation_params
+
+    state = AppState(
+        config=Config(),
+        immich_url="http://immich.test",
+        immich_api_key="k",
+        generation_options={},
+    )
+
+    params = _build_generation_params(state, [], tmp_path / "memory.mp4")
+
+    assert params.add_place_overlay is False


### PR DESCRIPTION
Refs #505 — the row everyone's summary of that issue kept omitting, including the close criteria I was handed.

`add_place_overlay` reaches assembly from **every** CLI path:

```
cli/generate.py:947            add_place_overlay=add_place,
cli/_album_generation.py:133   add_place_overlay=add_place,
cli/_trip_generation.py:302    add_place_overlay=add_place,
cli/_pipeline_runner.py:546    add_place_overlay=add_place_overlay,
```

…and from **nowhere** under `ui/`. `git grep add_place_overlay -- src/immich_memories/ui/` returns nothing on `main`. So the wizard could not switch on a feature the CLI has had all along — exactly the asymmetry #505 is about.

## The fix mirrors the date overlay

Same shape as its sibling, which was already wired end to end:

- a default in the step-3 options dict
- a checkbox beside "Add date overlay"
- the value read into `GenerationParams`

Everything below the wizard already existed and is untouched.

## Tests

RED-first: `_build_generation_params` with `add_place` set must produce `add_place_overlay=True`. RED was `assert False is True` — the value was simply never read. Plus the off-by-default guard.

`make ci` green: **5568 passed**. `make docs-build` exit 0.

## Why this was nearly missed

Worth recording, because the pattern caused it. #505 lists eight rows; the working summaries of it consolidated to "rows 1/2/4, 5, 6, 7/8" and this row quietly fell out of the enumeration. It only resurfaced because I verified each row against `origin/main` before closing the issue rather than closing on the summary — and the grep came back empty where I expected a hit.

Closing #505 without it would have recorded a parity issue as resolved while a parity gap remained.
