### PR TITLE
chore(sweep): report photo cache activity in the sweep summary

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -921,7 +921,7 @@
         "name": "register_generate_commands",
         "complexity": 177,
         "line_start": 183,
-        "line_end": 990,
+        "line_end": 991,
         "line_complexities": [
           {
             "line": 535,
@@ -1304,23 +1304,23 @@
             "complexity": 0
           },
           {
-            "line": 973,
+            "line": 974,
             "complexity": 1
           },
           {
-            "line": 976,
-            "complexity": 1
-          },
-          {
-            "line": 979,
+            "line": 977,
             "complexity": 1
           },
           {
             "line": 980,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 981,
+            "complexity": 0
+          },
+          {
+            "line": 982,
             "complexity": 1
           }
         ]

--- a/scripts/sweep_contact_sheets.py
+++ b/scripts/sweep_contact_sheets.py
@@ -15,12 +15,60 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
+
+# Photo scoring reports its own cache, once per pass, and a run has more than
+# one: the shortlist pass and the look at whatever reached the cut uncached.
+_PHOTO_CACHE = re.compile(r"Photo score cache: (\d+) hits, (\d+) misses")
+
+
+def cache_activity(output: str) -> dict[str, int]:
+    """What the caches did on a run, read back out of its log.
+
+    The sweep only ever sees a subprocess's text, so this is the whole record
+    of whether a month's minutes went on cache reads or on real work. Counting
+    clips alone made a photo-era month — where the clip caches genuinely have
+    nothing to do — indistinguishable from a month that did nothing at all.
+    """
+    photo = [(int(hits), int(misses)) for hits, misses in _PHOTO_CACHE.findall(output)]
+    return {
+        "cached_clips": output.count("Using cached analysis"),
+        "analyzed_clips": output.count("Step 1a:"),
+        "cached_photos": sum(hits for hits, _ in photo),
+        "scored_photos": sum(misses for _, misses in photo),
+    }
+
+
+def was_cold(timing: dict) -> bool:
+    """Did this run pay for its analysis, or read it back?
+
+    Counts both media: a photo-era month analyses no clips either way, so on
+    clips alone every one of them scored as warm. Reads the photo keys
+    defensively — timings.json accumulates across sweeps and rows written
+    before those keys existed come back on the next run.
+    """
+    fresh = timing["analyzed_clips"] + timing.get("scored_photos", 0)
+    reused = timing["cached_clips"] + timing.get("cached_photos", 0)
+    return fresh > reused
+
+
+def summarise(elapsed: float, counts: dict[str, int]) -> str:
+    """Where a run's time went, per medium.
+
+    Both media are named even when one is at zero: an unlabelled pair of
+    zeroes is what made a fully cached photo month look like a dead run.
+    """
+    return (
+        f"{elapsed:.0f}s, "
+        f"video: {counts['cached_clips']} cached / {counts['analyzed_clips']} analyzed, "
+        f"photos: {counts['cached_photos']} cached / {counts['scored_photos']} scored"
+    )
 
 
 def main() -> int:
@@ -74,18 +122,13 @@ def main() -> int:
 
         # Where the time went. A month whose clips are already in the analysis
         # cache finishes in seconds; the same month cold pays for every frame.
-        cached = output.count("Using cached analysis")
-        analyzed = output.count("Step 1a:")
-        print(
-            f"    {status}  ({elapsed:.0f}s, {cached} cached / {analyzed} analyzed)",
-            flush=True,
-        )
+        counts = cache_activity(output)
+        print(f"    {status}  ({summarise(elapsed, counts)})", flush=True)
         timings.append(
             {
                 "label": label,
                 "seconds": round(elapsed, 1),
-                "cached_clips": cached,
-                "analyzed_clips": analyzed,
+                **counts,
                 "rendered": (args.out / f"{label}.png").exists(),
                 "note": entry.get("note", ""),
             }
@@ -98,8 +141,8 @@ def main() -> int:
     lines = ["# Contact sheet sweep", ""]
     measured = [t for t in timings if t["seconds"]]
     if measured:
-        cold = [t for t in measured if t["analyzed_clips"] > t["cached_clips"]]
-        warm = [t for t in measured if t["analyzed_clips"] <= t["cached_clips"]]
+        cold = [t for t in measured if was_cold(t)]
+        warm = [t for t in measured if not was_cold(t)]
         lines += ["## Timing", ""]
         for name, group in (("cold (mostly unanalyzed)", cold), ("warm (mostly cached)", warm)):
             if group:

--- a/src/immich_memories/photos/scoring.py
+++ b/src/immich_memories/photos/scoring.py
@@ -386,7 +386,9 @@ def _enhance_with_llm(
                 model_version=model_version,
             )
 
-    if cache_hits:
+    # Reported on any pass that had photos, not just one that hit: an all-miss
+    # pass staying silent is indistinguishable in a log from no photo work.
+    if scored:
         logger.info(f"Photo score cache: {cache_hits} hits, {len(scored) - cache_hits} misses")
 
     return enhanced, payloads

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -631,3 +631,40 @@ class TestPhotosAskTheSameWayEverythingElseDoes:
             _query_photo_llm(photo, self._config("openai-compatible", "http://host:8080/v1/"))
 
         assert post.call_args[0][0] == "http://host:8080/v1/chat/completions"
+
+
+def test_a_cold_photo_pass_reports_the_photos_it_had_to_score(tmp_path: Path, caplog) -> None:
+    """The count was gated on a hit, so an all-miss pass reported nothing at all.
+
+    A sweep reading the log back cannot otherwise tell a month whose photo
+    cache served everything from one that scored every photo from scratch.
+    """
+    import logging
+
+    from immich_memories.analysis.provider_health import ProviderCircuit
+    from immich_memories.config import Config
+    from immich_memories.photos.photo_pipeline import score_photos
+
+    # An open circuit is how the pipeline itself declines to call the model,
+    # so scoring runs end to end here without reaching the network.
+    circuit = ProviderCircuit()
+    circuit.disable("model unavailable")
+    config = Config(
+        cache={"database": str(tmp_path / "cache.db"), "directory": str(tmp_path)},
+        content_analysis={"enabled": True},
+        llm={"model": "some-vlm"},
+    )
+
+    with caplog.at_level(logging.INFO):
+        score_photos(
+            [_photo("cold-1"), _photo("cold-2")],
+            config.photos,
+            video_clip_count=0,
+            work_dir=tmp_path,
+            download_fn=None,
+            db_path=config.cache.database_path,
+            app_config=config,
+            provider_circuit=circuit,
+        )
+
+    assert "Photo score cache: 0 hits, 2 misses" in caplog.text

--- a/tests/test_sweep_contact_sheets.py
+++ b/tests/test_sweep_contact_sheets.py
@@ -1,0 +1,59 @@
+"""The sweep's per-run summary has to account for photo work as well as video.
+
+A pre-2019 month is almost all stills. Its clip caches genuinely do nothing,
+so the summary read "0 cached / 0 analyzed" while the photo look cache served
+every photo in the month — the one line reporting on a run said no work
+happened on the run that was entirely cache hits.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sweep_contact_sheets  # noqa: E402
+
+
+def test_photo_cache_hits_are_counted() -> None:
+    """The photo look cache reports itself; nothing was reading it."""
+    log = "Photo score cache: 37 hits, 2 misses\n"
+
+    counts = sweep_contact_sheets.cache_activity(log)
+
+    assert counts["cached_photos"] == 37
+    assert counts["scored_photos"] == 2
+
+
+def test_the_summary_says_which_medium_each_count_is_about() -> None:
+    """Unlabelled counts read as "nothing happened" on a photo-era month."""
+    counts = {
+        "cached_clips": 0,
+        "analyzed_clips": 0,
+        "cached_photos": 37,
+        "scored_photos": 2,
+    }
+
+    line = sweep_contact_sheets.summarise(480.0, counts)
+
+    assert line == "480s, video: 0 cached / 0 analyzed, photos: 37 cached / 2 scored"
+
+
+def test_a_month_that_only_scored_photos_is_a_cold_run() -> None:
+    """It landed in "warm" because zero clips is never more than zero clips."""
+    timing = {
+        "cached_clips": 0,
+        "analyzed_clips": 0,
+        "cached_photos": 0,
+        "scored_photos": 30,
+    }
+
+    assert sweep_contact_sheets.was_cold(timing) is True
+
+
+def test_timings_written_before_photo_counts_existed_still_classify() -> None:
+    """The sweep appends to timings.json across runs, so old rows come back."""
+    timing = {"cached_clips": 4, "analyzed_clips": 41}
+
+    assert sweep_contact_sheets.was_cold(timing) is True


### PR DESCRIPTION
## The misread

Running a sweep over a long span of months, the pre-2019 memories all reported this:

```
[7/40] 2016-08: 24 clips -> sheets/2016-08.png  (480s, 0 cached / 0 analyzed)
```

Eight minutes of wall clock, and a summary line saying nothing happened. Those months are almost entirely stills — the *clip* caches genuinely have nothing to do, so both counters sit at zero whether the run did everything from scratch or served the whole month out of cache. The photo look cache was doing all the work and the one line reporting on the run couldn't say so.

Worse, it was silently wrong in both directions: the cold/warm split keys off `analyzed_clips > cached_clips`, so every photo-era month landed in "warm (mostly cached)" regardless of what it actually paid for.

## The change

Label both media, and count the photo look cache beside the clip cache:

```
(480s, video: 0 cached / 0 analyzed, photos: 37 cached / 2 scored)
```

- `cached_clips` / `analyzed_clips` keep their exact meaning, so timings from earlier sweeps stay comparable. The new `cached_photos` / `scored_photos` land beside them.
- `was_cold()` now counts photo work too, and reads the photo keys defensively — `timings.json` accumulates across sweeps, so rows written before these keys existed come back on the next run.
- Counts come from `Photo score cache: N hits, M misses`, which photo scoring already tracked. Summed across passes, since a run has more than one (the LLM shortlist, plus the look at whatever reached the cut uncached).

## The one pipeline change

That line already existed but was gated on `if cache_hits:` — it only spoke when something *hit*. An all-miss pass logged nothing, which is the same defect one level down: indistinguishable in a log from no photo work at all, and it meant `photos: 0 cached / N scored` could never be printed. It now reports on any pass that had photos.

Behaviour-neutral for generation: nothing about selection, scoring or rendering moves. One INFO line, on runs that already log `Photo scoring:` and `Rendered N photo clips`, and only when photos were actually scored.

## Tests

TDD, one behaviour per cycle, all through public seams:

- photo cache hits are counted out of a log
- the summary names which medium each count is about
- a month that only scored photos is a cold run
- timings written before the photo counts existed still classify
- a cold photo pass reports the photos it had to score — drives `score_photos` end to end with an open `ProviderCircuit`, which is how the pipeline itself declines to call the model, so it needs no mocks and touches no network

`make ci` green. Zero new patch sites: the critique ratchet ceilings (41 mock-only assertions, 906 unWHYed patches) are unchanged.

## Note on the snapshot

`complexipy-snapshot.json` carries a one-line-number refresh for `generate.py` that was already stale on `main` (the file is 991 lines; the snapshot said 990). No complexity values changed — only `line`/`line_end` fields. It's included because the pre-commit hook regenerates it and stashes unstaged changes, so a commit can't otherwise get past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
