### PR TITLE
docs(mac): local ACE-Step works, say so with the real numbers

### DIFF
--- a/docs-site/docs/deploy/common-setups/mac-local-llm.md
+++ b/docs-site/docs/deploy/common-setups/mac-local-llm.md
@@ -86,11 +86,27 @@ export IMMICH_MEMORIES_CONTENT_ANALYSIS__ENABLED=true
 - **VideoToolbox encoding**: hardware-accelerated H.264/H.265 encoding via Apple's VideoToolbox. 5-10x faster than CPU encoding.
 - **Vision framework face detection**: uses macOS native Vision framework for face detection. More accurate than the CPU fallback, no additional model downloads needed.
 - **Taichi GPU title renderer**: particle effects and gradient backgrounds rendered on Apple GPU.
+- **AI music generation**: ACE-Step runs in-process on Apple Silicon via MLX, no server involved. A 60 s track takes ~17 s with `use_lm: false`, or ~45 s with thinking mode on. What it costs is memory, not time: see below.
 - **All memory types and features**: everything works natively on Mac.
+
+## Local music generation
+
+ACE-Step's weights have to stay resident for the model to run at all, so memory is the thing that decides whether a profile works on your machine:
+
+| Profile | Weights that must stay resident |
+|---------|----------------------------------|
+| XL (4B) + 4B planner | ~29 GB |
+| XL (4B), `use_lm: false` | ~21 GB |
+| 2B + 1.7B planner | ~11 GB |
+| 2B, `use_lm: false` | ~7 GB |
+
+A 16 GB Mac runs the 2B profiles. XL wants 20 GB of unified memory free, and that is free memory, not installed. If the profile does not fit, `lib` mode says so before loading anything and the run falls back to a bundled track rather than being killed mid-render.
+
+The config, the pinned install commands and the full memory notes are in [Fully Local Setup](../../create/pipeline/audio-and-music.md#fully-local-setup-no-servers).
 
 ## What doesn't work locally
 
-- **AI music generation**: MusicGen needs a GPU server (NVIDIA or a hosted API). ACE-Step can run locally on Mac but requires ~8 GB RAM and takes 5-10 minutes per track. If you have a remote MusicGen/ACE-Step server, configure it in the `musicgen` or `ace_step` config sections.
+- **MusicGen**: this backend only talks to an API server, so it needs an NVIDIA host or a hosted endpoint. You do not need it if ACE-Step is running: set `musicgen.enabled: false` and local Demucs handles the stem separation that ducking uses.
 
 ## Performance expectations
 
@@ -106,6 +122,8 @@ On an M2 Pro (12-core, 32 GB):
 LLM analysis is the slowest phase. The 7B model analyzes 2 frames per clip at ~3 seconds per frame. After the first run, analysis results are cached: subsequent runs for the same clips skip analysis entirely.
 
 Memory usage: ~2 GB for Immich Memories, ~5 GB for mlx-vlm with the 8-bit model. Keep at least 16 GB total RAM.
+
+Those two are what makes local music generation tighter here than on a machine doing nothing else: mlx-vlm holding 5 GB is exactly the situation where an XL profile stops fitting. Stopping the LLM server before a music-heavy run buys back that 5 GB.
 
 ## Tips
 


### PR DESCRIPTION
Closes #605

The Mac setup page filed AI music generation under **"What doesn't work locally"** and priced it at "~8 GB RAM and 5-10 minutes per track". Local in-process ACE-Step is a headline feature, and this is the one page whose stated audience is the fully-local Mac user, so it was telling exactly the wrong readers the feature was unavailable.

### The numbers, and where they come from

| Claim on the page | Reality | Source |
|---|---|---|
| "takes 5-10 minutes per track" | 60 s track: **~17 s** with `use_lm: false`, **~45 s** with thinking mode on | `audio-and-music.md`, "Thinking mode (`use_lm`)" |
| "requires ~8 GB RAM" | Resident-weight floor runs **~7 GB to ~29 GB** by profile, not one number | `audio-and-music.md` floor table, which matches `audio/generators/memory_budget.py` |

The floor table is derivable from the code, so the two agree by construction rather than by luck. `memory_budget.py` sets shared weights at 2 GB, DiT at 19 GB (4B) / 5 GB (2B), and the planner at 8 / 4 / 2 GB for 4B / 1.7B / 0.6B:

- 2B, no planner: 5 + 0 + 2 = **7 GB**
- 2B + 1.7B: 5 + 4 + 2 = **11 GB**
- XL, no planner: 19 + 0 + 2 = **21 GB**
- XL + 4B: 19 + 8 + 2 = **29 GB**

### Changes

- ACE-Step moves into **What works**, with the speed figures.
- New **Local music generation** section carrying the floor table, the point that XL needs 20 GB *free* rather than installed, and the fact that a profile which does not fit is declined before any weights load, falling back to a bundled track instead of being killed mid-render.
- One line under **Performance expectations**: a running mlx-vlm holds ~5 GB, which is precisely what pushes an XL profile out of budget on this page's setup. That is the #573 scenario, and this is the page where both halves of it are configured.
- **What doesn't work locally** now lists only MusicGen. Verified: `audio/generators/musicgen_backend.py` is "Music generation via external MusicGen API server" with no local mode, so that claim was the true half of the original bullet.
- Links **Fully Local Setup** for the config and pinned install commands rather than restating them.

### Verification

`make docs-build` passes. `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'warn'` are both configured, and the build emitted no warnings; the target anchor was also confirmed directly in the built output (`id="fully-local-setup-no-servers"` in `build/docs/create/pipeline/audio-and-music/index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
