### PR TITLE
docs(meta): one gate count, current velocity numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## About this project
 
-This codebase is built almost entirely with AI (Claude by Anthropic). That's not a disclaimer: it's a deliberate choice, and the quality gates exist because of it, not in spite of it. 5,000+ tests, ~20 CI gates, 80% diff-coverage on every PR, composition over inheritance, TDD.
+This codebase is built almost entirely with AI (Claude by Anthropic). That's not a disclaimer: it's a deliberate choice, and the quality gates exist because of it, not in spite of it. 5,000+ tests, 20 CI gates, 80% diff-coverage on every PR, composition over inheritance, TDD.
 
 If you spot something the AI got wrong, please fix it. That's how this gets better.
 
@@ -10,7 +10,7 @@ If you spot something the AI got wrong, please fix it. That's how this gets bett
 
 This entire project was built with GenAI (Claude by Anthropic). AI-assisted contributions are absolutely welcome: this is not a project that's going to lecture you about using Copilot.
 
-That said, AI code has specific failure modes: bloat, over-abstraction, tests that test mocks instead of behavior, verbose docstrings that add no value. That's why this project has ~20 CI gates, a hermetic browser launch test, and architectural rules like "no mixins": they exist specifically to catch the things AI gets wrong.
+That said, AI code has specific failure modes: bloat, over-abstraction, tests that test mocks instead of behavior, verbose docstrings that add no value. That's why this project has 20 CI gates, a hermetic browser launch test, and architectural rules like "no mixins": they exist specifically to catch the things AI gets wrong.
 
 When contributing with AI tools:
 

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -21,11 +21,11 @@ The AI writes code. I make sure it's good. Every line goes through:
 - Security scanning: Bandit, Semgrep, Gitleaks
 - Dependency vulnerability auditing (pip-audit)
 - Dockerfile linting (Hadolint)
-- Docstring coverage enforcement
+- CLI and config reference drift checks (the docs cannot describe a flag that no longer exists)
 - Architecture layer enforcement
 - Conventional commit enforcement
 - OpenSSF Scorecard monitoring
-- 17 CI quality gates (tiered: cheap gates first, tests and Docker after)
+- 20 gates on every PR: 15 static checks in the quality job, 5 security scans in the security job. They are tiered, so the cheap ones fail first and the tests, Docker builds and launch check only run after
 - Pre-commit hooks running all of the above locally
 
 If a human wrote this code, nobody would bat an eye at the quality. The AI part is the interesting experiment, not a caveat.
@@ -61,4 +61,4 @@ Open a GitHub Discussion.
 
 ---
 
-*Last updated: March 2026*
+*Last updated: 2026-08-24*

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 ## Built with AI
 
 > This entire codebase was written with AI (Claude) as an experiment in building complex
-> software cleanly with AI assistance. 5,000+ tests (4,400+ unit, 600+ integration/E2E), ~20 CI quality gates, 250+ source modules.
+> software cleanly with AI assistance. 5,000+ tests (4,400+ unit, 600+ integration/E2E), 20 CI quality gates, 250+ source modules.
 > See [DISCLAIMER.md](DISCLAIMER.md) for the full story.
 
 ## License

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -40,6 +40,7 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 - Dependency hygiene (deptry)
 - Architecture layer enforcement (import-linter)
 - Code duplication detection (jscpd)
+- CLI and config reference drift (the generated pages must match the Click tree and the pydantic schema)
 - AI code critique
 
 **Tier 2: Security** (parallel with Tier 1):
@@ -59,7 +60,7 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 - Docs site build
 - Hermetic launch check on pull requests (`make launch-check`: build + docs + Playwright e2e)
 
-Locally, `make ci` runs the same 15 gates: lint, format-check, typecheck, file-length, complexity, cognitive-complexity, dead-code, security-lint, semgrep, refurb, dep-check, arch-check, duplication, critique, test. CI adds commitlint, pip-audit, gitleaks, hadolint, the build/docker/docs jobs and the launch check on top. Every PR must pass all of them.
+A PR passes 20 gates: 15 static checks in the quality job and 5 security scans in the security job. Locally, `make ci` runs 16 of them plus the unit tests: lint, format-check, typecheck, file-length, complexity, cognitive-complexity, dead-code, security-lint, semgrep, refurb, dep-check, arch-check, duplication, critique, docs-cli-check, docs-config-check, test. CI adds the four that need a remote or a diff (commitlint, pip-audit, gitleaks, hadolint), then the build/docker/docs jobs and the launch check. Every PR must pass all of them.
 
 ## Quality Gates Overview
 

--- a/docs-site/docs/welcome/built-with-ai.md
+++ b/docs-site/docs/welcome/built-with-ai.md
@@ -21,13 +21,13 @@ The music pipeline went through 6 research rounds before a single line of code. 
 
 ## The quality infrastructure
 
-AI-generated code without guardrails is fast garbage. The project has ~20 CI checks: lint, format, type checking, cyclomatic complexity limits, cognitive complexity limits, file length caps (800 lines max), dead code detection, security scanning, architectural boundary enforcement, dependency hygiene, and 5,000+ tests.
+AI-generated code without guardrails is fast garbage. Every PR passes 20 gates before a test runs: 15 static checks (lint, format, type checking, cyclomatic and cognitive complexity limits, the 800-line file cap, dead code, duplication, modernization, architectural boundaries, dependency hygiene, CLI and config reference drift, conventional commits, an AI-smell audit) and 5 security scans (Bandit, Semgrep, pip-audit, Gitleaks, Hadolint). Count them in `.github/workflows/ci.yml`. Then 5,000+ tests run across four Python and OS combinations, followed by a package build, two Docker builds, a docs build and a hermetic launch check.
 
 These aren't decoration. They catch real bugs that Claude introduces confidently. The complexity gate alone has blocked dozens of over-engineered functions. The file length cap forced a composition-based architecture (every class under 800 lines, zero mixins) that turned out to be the right call anyway.
 
 ## What the velocity actually looks like
 
-The project went from "I want to make a birthday video" to a shipped product with 64 merged PRs in about 84 days. That's nearly one PR per day, each one passing ~20 CI gates and adding to a test suite that's now past 5,000 tests.
+The project went from "I want to make a birthday video" at the end of December 2025 to a shipped v0.1.0 on 6 March 2026: about ten weeks. The repository has been public ever since, and 356 PRs have merged in the 171 days to 24 August 2026. Two a day, each one through the same 20 gates, each one adding to a test suite now past 5,000 tests.
 
 A typical feature cycle: I decide on Tuesday morning that trip memories need animated satellite maps. I spend a few hours researching map rendering approaches with Claude.ai (tile providers, zoom interpolation, Van Wijk smooth zoom for long distances vs. linear pan for short hops). By Wednesday I've picked the approach. Claude Code implements it. Thursday it's in the pipeline with tests, passing CI, ready for review.
 


### PR DESCRIPTION
Closes #609. From the 2026-08-24 docs review (section 5, findings 14 and 15; fix plan item 7).

One concern: **the project's own meta-claims should be countable.** Five pages stated how many CI gates run and none of them agreed.

## The gate count

Counted from `.github/workflows/ci.yml`, not from another page:

- **quality job: 15** named check steps. Ruff check, Ruff format check, CLI reference drift, config reference drift, mypy, Vulture, Xenon, complexipy, file length, refurb, deptry, import-linter, jscpd, `make critique`, commitlint.
- **security job: 5**. Bandit, Semgrep (the token and no-token steps are one check with two paths), pip-audit, Gitleaks, Hadolint.

**20.** Everything after that is tests, builds and the launch check, which nobody was calling gates.

The stale numbers are explained: `make ci` has 17 prerequisite targets, and `architecture.md`'s list of them was written when there were 15, before `docs-cli-check` and `docs-config-check` joined the target. So both wrong numbers were real counts of something else at some point.

| Page | Before | After |
|------|--------|-------|
| `DISCLAIMER.md` | "17 CI quality gates" | "20 gates on every PR: 15 static checks in the quality job, 5 security scans in the security job" |
| `README.md` | "~20 CI quality gates" | "20 CI quality gates" |
| `CONTRIBUTING.md` (x2) | "~20 CI gates" | "20 CI gates" |
| `built-with-ai.md` | "~20 CI checks: lint, format, ..." | Names all 20 and says where to count them |
| `architecture.md` | "`make ci` runs the same 15 gates: ..." | "A PR passes 20 gates ... `make ci` runs 16 of them plus the unit tests ... CI adds the four that need a remote or a diff". The Tier 1 list gained the reference-drift bullet, so 15 + 5 on that page now adds to 20. |

## Two other things in the same lines

**`DISCLAIMER.md` claimed "Docstring coverage enforcement".** Nothing enforces it: no interrogate, no docstr-coverage, nothing in the Makefile, `ci.yml` or `.pre-commit-config.yaml`. The bullet is now the CLI and config reference drift checks, which do run and were missing from the list.

**`built-with-ai.md`'s "64 merged PRs in about 84 days".** A launch-era number in the present tense, and unverifiable against this repo: 84 days after the first public commit there were already 168 merged PRs, so the sentence was counting the private pre-release stretch. Reframed with both endpoints dated:

> The project went from "I want to make a birthday video" at the end of December 2025 to a shipped v0.1.0 on 6 March 2026: about ten weeks. The repository has been public ever since, and 356 PRs have merged in the 171 days to 24 August 2026.

Sources: first commit `05b95fc` "Initial release: Immich Memories v0.1.0" dated 2026-03-06; `gh pr list --state merged` returns 356; end-December 2025 is the origin already told on `why-immich-memories.mdx`.

**`DISCLAIMER.md`'s stamp** moved from "March 2026" to `2026-08-24`.

## Not touched

`5,000+ tests`, `4,400+ unit`, `600+ integration/E2E` and `250+ source modules` all check out as floors (5,627 test functions, 638 of them integration/e2e, 317 source modules), so they stay as they are.

## Verification

- `make docs-build`: clean, zero warnings in the log.
- Every number counted from `ci.yml`, the `Makefile`, `git log` or `gh` before it was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
