### PR TITLE
fix(packaging): the music package points at a GitHub handle that doesn't exist

### DIFF
--- a/packages/immich-memories-music/README.md
+++ b/packages/immich-memories-music/README.md
@@ -1,7 +1,7 @@
 # immich-memories-music
 
 Bundled royalty-free background music for
-[immich-memories](https://github.com/sdumont/immich-video-memory-generator).
+[immich-memories](https://github.com/sam-dumont/immich-video-memory-generator).
 
 Installed with the `music` extra:
 

--- a/packages/immich-memories-music/pyproject.toml
+++ b/packages/immich-memories-music/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/sdumont/immich-video-memory-generator"
+Homepage = "https://github.com/sam-dumont/immich-video-memory-generator"
 
 [tool.hatch.build.targets.wheel]
 packages = ["immich_memories_music"]


### PR DESCRIPTION
## Description

`packages/immich-memories-music` advertised `github.com/sdumont/immich-video-memory-generator` as its homepage. That account does not exist — the handle is `sam-dumont`. Two occurrences, both fixed:

- `packages/immich-memories-music/pyproject.toml:20` — `[project.urls] Homepage`
- `packages/immich-memories-music/README.md:4` — the link back to the parent project

A repo-wide `grep -rn sdumont` (excluding `node_modules`/`.git`) now returns nothing, and the near-miss variants (`samdumont`, `sam_dumont`) return nothing either.

### Why it matters

`Homepage` is what PyPI renders in the sidebar, and the README is the package's long description — both ship inside the wheel and the sdist. The version currently on PyPI (`immich-memories-music` 0.1.0) therefore points every visitor at a 404. This is metadata only; nothing at runtime reads it.

**Note:** PyPI will not re-render the live 0.1.0 page from this change. The corrected metadata goes out with the next release — `release.yml` builds the package from `packages/immich-memories-music` and publishes it, so the fix lands automatically on the next tag. Until then the published page keeps the dead link.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

No tests: this is packaging metadata with no code path behind it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
