### PR TITLE
ci(deps): let Renovate watch what drifts by hand

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "timezone": "Europe/Brussels",
+  "schedule": ["* 4-8 * * 1"],
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 1,
+  "labels": ["dependencies"],
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
+  "automerge": false,
+  "platformAutomerge": false,
+  "enabledManagers": ["pep621", "npm", "github-actions", "dockerfile"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on the first day of the month"],
+    "semanticCommitType": "build"
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"],
+    "minimumReleaseAge": null,
+    "labels": ["dependencies", "security"]
+  },
+  "packageRules": [
+    {
+      "description": "Majors wait for an explicit tick on the dependency dashboard — this repo pins on purpose",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Action digests move together; the # vN comment is kept in sync",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "semanticCommitType": "ci",
+      "labels": ["dependencies", "ci"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["docs-site/package.json"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "docs-site npm packages",
+      "semanticCommitType": "build"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["docs-site/remotion/package.json"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "remotion npm packages",
+      "semanticCommitType": "build"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python dependencies",
+      "semanticCommitType": "build"
+    },
+    {
+      "description": "The runtime image is deliberately python 3.11-slim — take security rebuilds, not version jumps",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["digest"],
+      "groupName": "docker base images",
+      "semanticCommitType": "build",
+      "labels": ["dependencies", "docker"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds `renovate.json`. The repo had no Renovate and no Dependabot config — nothing watches the pins.

### Why

This repo pins hard, on purpose: every action is `@sha # vN`, the runtime image is `python:3.11-slim@sha256:…`, and `uv.lock` is committed. That is the right call, and it also means every one of those pins only moves when a human remembers it. Right now they go stale until an audit finds them.

Renovate's job here is to **propose**, never to merge. `automerge` and `platformAutomerge` are set to `false` explicitly (they are already the defaults — stated so the intent survives a future preset change), majors do not open a PR at all until you tick them on the dependency dashboard, and `minimumReleaseAge: 7 days` keeps a brand-new release from showing up in a PR before there is time for it to be yanked.

### What it watches

`enabledManagers` is an explicit allow-list, so nothing can start a PR stream that isn't listed:

| Manager | Covers |
|---|---|
| `pep621` | `pyproject.toml` + `uv.lock` |
| `npm` | `docs-site/package.json` and `docs-site/remotion/package.json` |
| `github-actions` | every `uses:` across `.github/workflows/` |
| `dockerfile` | the `python:3.11-slim` digest in `docker/Dockerfile` |

`helpers:pinGitHubActionDigests` matches the style already in the workflows, so a proposed bump updates the digest **and** the trailing `# vN` comment rather than unpinning anything.

### Rate

- minor/patch grouped per tree — one PR for docs-site, one for remotion, one for python, one for actions, instead of a dozen singles
- `prConcurrentLimit: 2`, `prHourlyLimit: 1`, schedule Monday mornings (Europe/Brussels) → roughly two PRs a week
- `lockFileMaintenance` refreshes `uv.lock` and the npm locks once a month, in its own PR
- `vulnerabilityAlerts` bypasses both the schedule and the release-age hold, and lands with the `security` label — a CVE should not wait for Monday

### Deliberate choices worth a second look

- **Docker is digest-only.** Non-digest docker updates are `enabled: false`. The 3.11 pin is intentional; this takes base-image security rebuilds without ever proposing 3.12.
- **Semantic commit types are set per manager** — `ci(deps)` for actions, `build(deps)` for everything else — so Renovate's PR titles pass the `validate-title` job without hand-editing.
- **The `pre-commit` manager is deliberately left out.** It would happily bump `astral-sh/ruff-pre-commit` independently of the `ruff` version in the dev group, and a skew there means the local hook and `make lint` disagree about formatting. Not worth the noise; those three revs stay manual.
- **Labels are limited to ones that already exist** (`dependencies`, `ci`, `docker`, `security`). Renovate errors on labels the repo doesn't have.

### Verification

```
$ npx --package renovate@latest renovate-config-validator
 INFO: Validating renovate.json
 INFO: Config validated successfully against 1 file(s)
```

(exit 0, renovate 44.39.3; also validated clean against 37.440.7)

**This PR is config only — it does nothing until the Renovate GitHub App is installed on the repo.** Installing it is a separate, reversible step you own.

## Type of Change

- [x] 🏗️ CI/Build changes

## Checklist

- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

No tests: declarative CI config, validated with the upstream validator instead.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
