### PR TITLE
docs(disclaimer): stop handing hostile readers their pull quote

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -2,9 +2,9 @@
 
 ## Built With AI, On Purpose
 
-This entire codebase was written with AI (Claude by Anthropic). Not by accident, not as a shortcut: this is a deliberate experiment in how far you can push AI-assisted development while maintaining a clean, production-quality codebase.
+This entire codebase was written with AI (Claude by Anthropic). That's the experiment: how far AI-assisted development goes when every change has to survive a full verification stack before it lands.
 
-The question I'm trying to answer: can you build something genuinely complex with AI and have it NOT be a mess? So far the answer is yes, but it takes real engineering discipline on the human side: architecture decisions, code review, quality gates, and knowing when the AI is confidently wrong.
+The human half is architecture decisions, code review, and spotting when the AI is confidently wrong. The gates below catch the rest.
 
 ### The quality bar
 
@@ -28,7 +28,7 @@ The AI writes code. I make sure it's good. Every line goes through:
 - 20 gates on every PR: 15 static checks in the quality job, 5 security scans in the security job. They are tiered, so the cheap ones fail first and the tests, Docker builds and launch check only run after
 - Pre-commit hooks running all of the above locally
 
-If a human wrote this code, nobody would bat an eye at the quality. The AI part is the interesting experiment, not a caveat.
+That list is the claim, and you can check it yourself: the gates live in the `Makefile`, the pipeline in `.github/workflows/ci.yml`. The build stays red until they pass.
 
 ### Standard open-source stuff
 


### PR DESCRIPTION
## Description

Three-line diff to `DISCLAIMER.md`. Framing only.

### Why

An external review quoted this line back at the project:

> If a human wrote this code, nobody would bat an eye at the quality.

That is a fair catch. The sentence argues a comparison nobody asked for, and the only thing a reader can do with it is agree or disagree — so it functions as a target. Anyone who wants to dunk on an AI-built project now has the pull quote pre-written, and a single bug report is enough to make it look silly.

The same problem, milder, sits two paragraphs up:

> can you build something genuinely complex with AI and have it NOT be a mess? So far the answer is yes

Also a claim staked on the reader's opinion rather than on anything measurable.

### What replaces them

The intro now states the experiment plainly — complex software built with AI, under heavy verification — and the closer points at the evidence instead of arguing about it:

> That list is the claim, and you can check it yourself: the gates live in the `Makefile`, the pipeline in `.github/workflows/ci.yml`. The build stays red until they pass.

Nothing to rebut. The gate list above it already does the work; it just needed to stop apologising for itself.

### Not changed

The factual content is untouched — the test count, the 20-gate breakdown (15 static + 5 security), and the `Last updated` stamp all stay exactly as merged. A repo-wide grep confirms none of the removed copy is duplicated in the docs site or the README.

## Type of Change

- [x] 📚 Documentation update

## Checklist

- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
