### PR TITLE
ci(security): explicit token permissions on every workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,7 +65,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: benchmark-${{ github.event.inputs.runner || 'linux-ci' }}-${{ github.ref }}
@@ -81,6 +80,10 @@ jobs:
     name: Benchmark (Linux CI)
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # github-action-benchmark posts the regression comment on the PR.
+      pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Create LFS cache key
@@ -191,6 +194,9 @@ jobs:
     name: Ingest (${{ github.event.inputs.runner }})
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # A dispatched ingest has no PR to comment on; it only writes the cache.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 

--- a/.github/workflows/cancel-on-close.yml
+++ b/.github/workflows/cancel-on-close.yml
@@ -11,7 +11,7 @@ on:
     types: [closed]
 
 permissions:
-  actions: write
+  contents: read
 
 concurrency:
   group: cancel-on-close-${{ github.event.pull_request.number }}
@@ -22,6 +22,10 @@ jobs:
     name: Cancel this branch's leftover runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      # Cancelling a run is a write on the Actions API, and it is the only
+      # write this workflow makes.
+      actions: write
     steps:
       - name: Cancel queued and running workflows for the closed branch
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,14 +23,16 @@ concurrency:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
     if: github.repository == 'sam-dumont/immich-video-memory-generator'
+    # Building only reads the tree; the Pages artifact upload runs on the
+    # Actions runtime token, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Create LFS cache key
@@ -94,6 +96,12 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    # The deploy-pages contract: pages to publish, id-token to prove which
+    # workflow is publishing.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -30,9 +30,11 @@ on:
         required: false
         type: string
 
+# The commit status and the dispatch below are both posted with
+# CI_MIRROR_TOKEN, not GITHUB_TOKEN — they have to reach the private mirror,
+# which GITHUB_TOKEN cannot see. So GITHUB_TOKEN needs nothing but the checkout.
 permissions:
   contents: read
-  statuses: write
 
 jobs:
   mirror:

--- a/tests/test_cancel_on_close_contract.py
+++ b/tests/test_cancel_on_close_contract.py
@@ -29,8 +29,16 @@ def test_it_fires_when_a_pull_request_closes() -> None:
 
 
 def test_it_may_cancel_runs() -> None:
-    """Without actions: write the cancel call returns 403 and the tail survives."""
-    assert _workflow()["permissions"]["actions"] == "write"
+    """Without actions: write the cancel call returns 403 and the tail survives.
+
+    A job-level `permissions:` block replaces the workflow-level default rather
+    than adding to it, so the grant counts wherever it is declared. What must
+    hold is that the cancel job ends up holding it.
+    """
+    workflow = _workflow()
+    granted = workflow["jobs"]["cancel"].get("permissions", workflow.get("permissions", {}))
+
+    assert granted.get("actions") == "write"
 
 
 def test_it_cancels_queued_runs_as_well_as_running_ones() -> None:


### PR DESCRIPTION
Part 1 of 3 on #614 (raising the OpenSSF Scorecard score from 4.7).

## Probe addressed

`topLevelPermissions` / `jobLevelPermissions` — the **Token-Permissions** check.

**Expected movement: 0 → 10.**

## Why it was 0

Scorecard starts this check at 10 and subtracts per finding ([`checks/evaluation/permissions.go`](https://github.com/ossf/scorecard/blob/main/checks/evaluation/permissions.go), `reduceBy`). A **top-level** write on `contents`, `packages` or `actions` subtracts the full 10. So this, in `cancel-on-close.yml`, was on its own enough to zero the check:

```yaml
permissions:
  actions: write
```

There was a second, less obvious trap. `updateScoreFromUndeclaredJob` drops the score to zero for any job that declares no `permissions` **when its workflow has a top-level write of any kind** — so `benchmark.yml` (`pull-requests: write`) and `docs.yml` (`pages`/`id-token: write`) were each zeroing it too, via their permission-less jobs. Those two files were not cosmetic cleanups; they were part of the fix.

Job-level writes are not penalised at all as long as the workflow declares a non-write top-level default, which is why `release.yml`'s `contents: write` and `scorecard.yml`'s `security-events: write` were never the problem.

## What changed

Every workflow now defaults to `contents: read` and elevates only inside the job that actually makes the write.

| Workflow | Before (top level) | After |
|---|---|---|
| `cancel-on-close.yml` | `actions: write` | top `contents: read`; `actions: write` on the `cancel` job |
| `mirror.yml` | `contents: read` + `statuses: write` | top `contents: read`; **`statuses: write` dropped** |
| `benchmark.yml` | `contents: read` + `pull-requests: write` | top `contents: read`; `pull-requests: write` on `bench-linux`, `contents: read` on `ingest` |
| `docs.yml` | `contents: read` + `pages: write` + `id-token: write` | top `contents: read`; `pages`/`id-token` on the `deploy` job, `contents: read` on `build` |

`ci.yml`, `integration.yml`, `pr-automation.yml` and `scorecard.yml` already had a read-only top level with job-level elevations, so they are untouched.

### One judgement call worth a look

**`mirror.yml` loses `statuses: write` entirely rather than moving it down.** Both the "Set pending status" and "Trigger integration tests" steps post with `secrets.CI_MIRROR_TOKEN`, not `GITHUB_TOKEN` — they have to reach the private mirror, which `GITHUB_TOKEN` cannot see. There is no fallback path to `GITHUB_TOKEN`, so the scope was never exercised. Shout if you'd rather I moved it to the job level and kept it.

## The one test that had to change

`test_it_may_cancel_runs` asserted `_workflow()["permissions"]["actions"] == "write"` — it pinned the grant to the *workflow level*, so moving it onto the job that makes the call turned it red while the guarantee it protects ("the cancel call must not 403") still held.

It now resolves what the `cancel` job actually ends up holding, which is what its docstring always claimed to check. A job-level block replaces the workflow-level default rather than adding to it, so the grant counts wherever it is declared. Confirmed it still fails when the grant is removed from both levels, so it hasn't gone vacuous.

## Release train

`docs.yml` is called by `release.yml`'s `deploy-docs` job, which already grants `contents: read` + `pages: write` + `id-token: write` to the call. A job inside a reusable workflow may request any permission the caller granted — it can only be capped downwards, never raised — so `deploy` asking for `pages`/`id-token` composes exactly as before.

## Verified

- `actionlint` 1.7.7 clean on all four workflows (the pre-existing `gpu` self-hosted-label warning in `integration.yml` is unchanged and untouched).
- Re-implemented Scorecard's `reduceBy` scoring loop against the tree: **predicted score 10, zero penalty findings**.
- All 60 workflow-contract tests pass.
- `make lint` passes. No `src/` code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
