### PR TITLE
ci(security): add CodeQL to the gate line

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+# CodeQL — GitHub's own SAST, complementing the Bandit and Semgrep passes that
+# already run per-PR in ci.yml. CodeQL finds what those cannot: cross-file taint
+# flow from a source (an Immich API response, a config file, a CLI argument) to
+# a sink (subprocess, filesystem, deserialisation) across module boundaries.
+#
+# WHY NOT on pull_request: a Python analysis of this tree takes minutes, and PRs
+# here merge fast and often — putting CodeQL on the PR path would slow every
+# merge to catch something a post-merge run catches within the hour. Findings
+# land in the Security tab either way, and OpenSSF Scorecard's SAST probe counts
+# a workflow that calls github/codeql-action/analyze regardless of its trigger.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly Monday, offset from the Scorecard run at 07:25 so the two security
+    # workflows do not contend for the same runner slots.
+    - cron: '18 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    if: github.repository == 'sam-dumont/immich-video-memory-generator'
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # Publishing the SARIF results to the Security tab is the only write.
+      security-events: write
+      # CodeQL reads workflow run metadata to attribute results to a run.
+      actions: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          languages: python
+          # Python needs no compilation, so CodeQL skips the build tracer and
+          # extracts straight from source — no uv sync, no FFmpeg, no fixtures.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          category: "/language:python"


### PR DESCRIPTION
Part 2 of 3 on #614 (raising the OpenSSF Scorecard score from 4.7).

## Probe addressed

`sastToolConfigured` — the **SAST** check.

**Expected movement: 0 → 7**, trending toward 10.

## Why it was 0

> `Warn: 0 commits out of 30 are checked with a SAST tool`

Bandit, Semgrep, gitleaks and hadolint all run in `ci.yml`, but Scorecard's SAST check does not look at what a workflow runs — it looks for `github/codeql-action/analyze` in a workflow file, and for check runs from `github-advanced-security`, `sonarcloud` or `lgtm-com` on merged PRs. Neither existed, so both sub-scores were 0.

## Scoring math

From [`checks/evaluation/sast.go`](https://github.com/ossf/scorecard/blob/main/checks/evaluation/sast.go):

```go
case codeQlScore == checker.MaxResultScore:
    const sastWeight = 3
    const codeQlWeight = 7
    score := checker.AggregateScoresWithWeight(...)
```

A configured CodeQL workflow scores 10 on the 7-weight half. With the 3-weight "runs on every commit" half still at 0, that lands at **7**. It should drift upward on its own: the per-commit half counts check runs on commits that have an associated merged PR, and a push-to-`main` CodeQL run posts a `github-advanced-security` check run on exactly those commits.

## Why not on `pull_request`

Deliberate, per the brief. A Python analysis of this tree takes minutes, and PRs here merge fast and often — putting CodeQL on the PR path would slow every merge to catch something a post-merge run catches within the hour. Findings reach the Security tab either way, and the probe counts the workflow regardless of trigger. It is not wired into `ci-success`, so it can never block a PR.

## The workflow

- `push` to `main`, weekly cron at 05:18 Monday (offset from the Scorecard run at 07:25 so the two don't contend for runner slots), plus `workflow_dispatch`.
- `build-mode: none` — Python needs no compilation, so CodeQL extracts straight from source. No `uv sync`, no FFmpeg, no LFS fixtures; the job is checkout → init → analyze.
- Default query suite, not `security-and-quality`. The extended suites bury real findings under style alerts.
- Least-privilege from the start, matching #615: top-level `contents: read`, and `security-events: write` + `actions: read` only on the analyze job.
- Pinned to `c10b8064de6f491fea524254123dbe5e09572f13` (v4.35.1) — the exact digest `scorecard.yml` already uses for `codeql-action/upload-sarif`, so both bump together.

## Verified

- `actionlint` 1.7.7 clean.
- Confirmed the digest resolves to a real `github/codeql-action` tag (v4.35.1) via the GitHub API.
- Contributes no Token-Permissions penalty (re-ran the `reduceBy` simulation against the tree).
- `make lint` passes. No Python touched.

## What it does not fix

Bandit and Semgrep stay exactly where they are in `ci.yml`. This adds a scanner, it does not replace one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
