### PR TITLE
ci(release): releases attest their own provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,10 @@ jobs:
       name: ${{ needs.analyze.outputs.release_type == 'major' && 'production-major' || 'production' }}
     permissions:
       contents: write
+      # Provenance: the OIDC token is what identifies this workflow to
+      # Sigstore, and attestations is where the signed statement is filed.
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -246,6 +250,38 @@ jobs:
           ls -la dist/
           unzip -p dist/*.whl '*/METADATA' | grep '^Version:'
 
+      - name: Attest build provenance
+        id: attest
+        if: inputs.dry_run != 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+
+      - name: Stage the attestation as release assets
+        if: inputs.dry_run != 'true'
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          NEXT_VERSION: ${{ needs.analyze.outputs.next_version }}
+        run: |
+          set -euo pipefail
+          # WHY not dist/: the pypi-publish job hands the whole directory to
+          # twine, which rejects anything that is not a wheel or an sdist.
+          mkdir -p attestations
+          base="attestations/immich_memories-${NEXT_VERSION}"
+
+          # The Sigstore bundle is what `gh attestation verify --bundle` reads.
+          cp "$BUNDLE" "${base}.sigstore.json"
+
+          # The same statement as a bare DSSE envelope. SLSA consumers -- and
+          # OpenSSF Scorecard's provenance probe, which matches on the name
+          # alone -- expect provenance under .intoto.jsonl. -e fails the step
+          # if the bundle ever stops carrying an envelope.
+          jq -ce '.dsseEnvelope' "$BUNDLE" > "${base}.intoto.jsonl"
+
+          ls -la attestations/
+
       - name: Generate changelog
         id: changelog
         env:
@@ -288,6 +324,8 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            attestations/*.sigstore.json
+            attestations/*.intoto.jsonl
           draft: false
           prerelease: false
 
@@ -393,6 +431,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Same provenance pair as the release job, for the image digest.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -435,6 +476,16 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.slug }}
           cache-to: type=gha,mode=max,scope=${{ matrix.slug }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true
+
+      # Attaches the attestation to the image in GHCR as an OCI referrer, so
+      # `gh attestation verify oci://...` and `cosign` can find it without
+      # knowing this repo. Each platform attests its own digest.
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Export digest
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,32 @@ We will acknowledge receipt within 48 hours and provide a detailed response with
 - Cache directory: `~/.immich-memories/cache/`
 - Clear cache periodically if disk space is a concern
 
+## Verifying a release
+
+Releases carry SLSA build provenance, signed through Sigstore by the GitHub
+Actions workflow that produced them — nothing is built on a laptop. A release
+that carries it has a `.sigstore.json` asset alongside the wheel.
+
+Wheels and sdists carry the attestation as a release asset:
+
+```bash
+VERSION=0.59.2  # whichever release you are checking
+gh release download "v$VERSION" --repo sam-dumont/immich-video-memory-generator
+gh attestation verify "immich_memories-$VERSION-py3-none-any.whl" \
+  --repo sam-dumont/immich-video-memory-generator \
+  --bundle "immich_memories-$VERSION.sigstore.json"
+```
+
+Docker images carry it in the registry, so no download is needed:
+
+```bash
+gh attestation verify oci://ghcr.io/sam-dumont/immich-video-memory-generator:latest \
+  --repo sam-dumont/immich-video-memory-generator
+```
+
+The `.intoto.jsonl` asset is the same statement as a bare in-toto envelope, for
+tools that expect the SLSA layout rather than a Sigstore bundle.
+
 ## Dependencies
 
 We regularly update dependencies to patch known vulnerabilities. Run:


### PR DESCRIPTION
Part 3 of 3 on #614 (raising the OpenSSF Scorecard score from 4.7).

## Probes addressed

`releasesAreSigned` and `releasesHaveProvenance` — the **Signed-Releases** check.

**Expected movement: 0 → 10**, but only after five releases ship with it (see below).

## Why it was 0

```
Warn: release artifact v0.59.2 not signed
Warn: release artifact v0.59.2 does not have provenance
```

…and the same for v0.59.1, v0.59.0, v0.58.0, v0.57.0. Nothing in the release train ever produced a signed statement about what it built.

## What changed

`actions/attest-build-provenance` signs, through Sigstore, with the workflow identity as the signer:

- the wheel and the sdist, in the `release` job;
- both Docker image digests, in `docker-build`, with `push-to-registry: true` so the attestation lands in GHCR as an OCI referrer.

The attestation is attached to the GitHub release under **two** names, because the consumers disagree on format:

| Asset | What it is | Who reads it |
|---|---|---|
| `.sigstore.json` | the Sigstore bundle | `gh attestation verify --bundle`, `cosign` |
| `.intoto.jsonl` | the same statement as a bare DSSE envelope | SLSA tooling, and Scorecard |

That second file is not padding. Scorecard matches on the filename and nothing else — [`probes/releasesHaveProvenance/impl.go`](https://github.com/ossf/scorecard/blob/main/probes/releasesHaveProvenance/impl.go):

```go
var provenanceExtensions = []string{".intoto.jsonl"}
```

A release with provenance scores 10; signed-only scores 8. So the `.intoto.jsonl` is what takes this check to full marks, and the `.sigstore.json` is what an actual human can verify with one `gh` command.

## Timing — this does not move the needle immediately

Signed-Releases averages over the **five most recent releases**. The five that exist now can't be retrofitted, so the check climbs as new ones land: roughly 2 after one release, 4 after two, 10 once five have shipped. At the current release cadence that's days, not months.

Also worth knowing: this PR is typed `ci(...)` on a `ci/` branch, so `analyze` will not cut a release for it. The first attested release is whatever `feat`/`fix` merges next.

## Release-train safety

The thing that could plausibly have broken this: `pypi-publish` downloads the `dist-release` artifact and hands the whole directory to twine, which rejects anything that is not a wheel or an sdist. So the attestation assets are staged in `attestations/`, not `dist/` — the `Upload artifacts` step still uploads `dist/` alone and the PyPI jobs see exactly what they saw before.

Other checks:

- Both new steps carry the same `if: inputs.dry_run != 'true'` guard as the existing tag/release steps, so a dry run is unchanged.
- `jq -ce` fails the step rather than writing a `null` file, if a future bundle format ever stops carrying `.dsseEnvelope`.
- **No release is triggered by this PR.**

## Permissions

`release` gains `id-token: write` + `attestations: write` on top of `contents: write`; `docker-build` gains the same pair on top of `packages: write`. Both jobs already declared job-level permissions under a `contents: read` top level, so this composes with #615 rather than fighting it — Scorecard does not penalise job-level writes when the workflow declares a non-write default. Re-ran the `reduceBy` simulation with both PRs applied: still 10.

## Docs

`SECURITY.md` gains a "Verifying a release" section with the two `gh attestation verify` invocations.

## Verified

- `actionlint` 1.7.7 clean on `release.yml`.
- Confirmed `actions/attest-build-provenance@4d10147` resolves to v4.2.2 via the GitHub API.
- Confirmed with `actions/attest`'s docs that multiple subjects produce **one** bundle referencing all of them, so `bundle-path` is a single JSON object and the `cp`/`jq` pair is correct.
- `make lint` passes. No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
