### PR TITLE
fix(security): correct package name, stale version, and the SLA promise

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ before reporting.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| latest release (0.40.x at time of writing) | :white_check_mark: |
+| [latest release](https://github.com/sam-dumont/immich-video-memory-generator/releases) | :white_check_mark: |
 | older   | :x:                |
 
 ## Reporting a Vulnerability
@@ -24,7 +24,10 @@ If you discover a security vulnerability in Immich Memories, please report it re
    - Potential impact
    - Suggested fix (if any)
 
-We will acknowledge receipt within 48 hours and provide a detailed response within 7 days.
+I'm a solo maintainer on a hobby project, so there is no SLA. Security reports go to the front
+of the queue, but "the front of the queue" realistically means a few days, sometimes longer. If a
+week passes with no reply, open a public issue asking me to check my inbox, without describing
+the vulnerability.
 
 ## Deployment posture (short version)
 
@@ -35,8 +38,9 @@ We will acknowledge receipt within 48 hours and provide a detailed response with
   never deletes or edits existing assets.
 - What leaves your network (geocoding, map tiles, LLM, music, notifications) is listed on the
   [network & privacy page](https://sam-dumont.github.io/immich-video-memory-generator/docs/deploy/configuration/network-and-privacy).
-- CI runs Bandit, Semgrep, pip-audit, gitleaks and OpenSSF Scorecard on every change; the
-  Docker image is digest-pinned and runs as a non-root user.
+- CI runs five security scans on every change: Bandit, Semgrep, pip-audit, Gitleaks and Hadolint.
+  OpenSSF Scorecard runs on its own schedule and on pushes to `main`. The Docker image is
+  digest-pinned and runs as a non-root user.
 
 ## Security Considerations
 
@@ -59,8 +63,10 @@ We will acknowledge receipt within 48 hours and provide a detailed response with
 
 ## Dependencies
 
-We regularly update dependencies to patch known vulnerabilities. Run:
+The pip-audit gate blocks any PR that introduces a dependency with a known CVE. To pick up the
+patches, upgrade:
 
 ```bash
-pip install --upgrade immich-video-memory-generator  # or pull latest Docker image
+uv tool upgrade immich-memories        # or: pip install --upgrade immich-memories
+docker compose pull                    # Docker installs
 ```


### PR DESCRIPTION
Three factual bugs on the security page, found in a deep docs review.

## The one that matters

```
pip install --upgrade immich-video-memory-generator
```

That is the **repo** name. The **package** is `immich-memories` (pyproject L6, and the README's own quick install is `uvx immich-memories`). So the command on our security page either fails outright or installs whatever someone else has published under that name. A security page is the worst possible place to hand people a wrong install command.

## The other two

**Stale version.** The supported-versions table said `latest release (0.40.x at time of writing)`. Latest tag is **v0.59.2**. A version number stamped into prose is wrong within a week, so the cell now links the releases page instead of naming one.

**An SLA a solo maintainer cannot keep.** "We will acknowledge receipt within 48 hours and provide a detailed response within 7 days." CONTRIBUTING already says the honest thing ("best-effort basis, usually within a few days, sometimes longer. No SLA"). A missed 48h promise on a security report reads far worse than never having made it. Replaced with matching language, plus what to do if I go quiet for a week.

## Also

The deployment-posture bullet claimed CI runs "Bandit, Semgrep, pip-audit, gitleaks and OpenSSF Scorecard on every change". Four of those are right; **Scorecard is its own workflow** on a schedule and pushes to `main`, not every change. And the list omitted **Hadolint**, which is the actual fifth security-job step, so the page contradicted the "5 security scans" count the rest of the docs now use. Fixed both.

The Dependencies section's "We regularly update dependencies" was scaffolding the pip-audit gate already states better, so it now names the gate and gives the upgrade command for both install methods.

## Verified against code, not the review

| Claim | Source |
|---|---|
| package is `immich-memories` | `pyproject.toml` L6 |
| latest tag v0.59.2 | `git tag --sort=-v:refname` |
| 5 security-job steps | `.github/workflows/ci.yml` L128-158 |
| Scorecard is a separate workflow | `.github/workflows/scorecard.yml` |
| `~/.immich-memories/config.yaml` | `config_loader.py` L315 |
| `~/.immich-memories/cache/` | `config_models.py` L109 |

The last two were flagged UNVERIFIED by the review; both check out, no change needed.

Docs-only, no code paths touched. `make docs-build` passes with zero anchor warnings.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
