### PR TITLE
fix(docs): drop the deleted face extra, add the music extra

### DIFF
--- a/docs-site/docs/deploy/installation/uv-pip.md
+++ b/docs-site/docs/deploy/installation/uv-pip.md
@@ -41,8 +41,8 @@ Install optional features depending on your setup:
 # macOS: Apple Vision framework for face detection + GPU rendering
 uv sync --extra mac
 
-# Face recognition (any platform)
-uv sync --extra face
+# Bundled royalty-free music tracks
+uv sync --extra music
 
 # Local music library metadata (mutagen) for `immich-memories music search`
 uv sync --extra audio
@@ -72,8 +72,10 @@ uv sync --extra all
 uv sync --extra all-mac
 ```
 
-AI music generation (ACE-Step, MusicGen) is not a pip extra — it talks to a server or an
-in-process ACE-Step install; see [Audio and music](../../create/pipeline/audio-and-music.md).
+The `music` extra is the bundled royalty-free track library (in both `all` and `all-mac`). AI music
+generation (ACE-Step, MusicGen) is a different thing and is not a pip extra — it talks to a server
+or an in-process ACE-Step install; see
+[Audio and music](../../create/pipeline/audio-and-music.md).
 
 ### Install uv
 
@@ -116,6 +118,9 @@ Quote the package spec — zsh (the macOS default shell) treats `[...]` as a glo
 ```bash
 # macOS Apple Vision framework
 pip install "immich-memories[mac]"
+
+# Bundled royalty-free music tracks
+pip install "immich-memories[music]"
 
 # Local music library metadata (mutagen)
 pip install "immich-memories[audio]"


### PR DESCRIPTION
`installation/uv-pip.md` told people to run `uv sync --extra face`. That extra was deleted in #572 (face-recognition + dlib had zero references in `src/`), so the documented command now fails with an unknown-extra error. #572 swept the pip half of the same page and missed the uv block.

While in the file: the `music` extra (bundled royalty-free tracks via `immich-memories-music`, included in both `all` and `all-mac`) was in neither extras list. Added to both, plus one line disambiguating it from AI music generation — which is not a pip extra and was already explained there.

Verified against `pyproject.toml [project.optional-dependencies]`: `music, mac, audio, audio-ml, speech, transcribe, auth, demucs, gpu, all, all-mac`. No `face`. Every other bullet on the page matches.

`make docs-check` passes, no broken links.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
