### PR TITLE
fix(docs): the image already sets the output directory

### DIFF
--- a/docs-site/docs/deploy/common-setups/linux-nvidia.md
+++ b/docs-site/docs/deploy/common-setups/linux-nvidia.md
@@ -69,7 +69,6 @@ services:
     environment:
       IMMICH_URL: "${IMMICH_URL}"
       IMMICH_API_KEY: "${IMMICH_API_KEY}"
-      IMMICH_MEMORIES_OUTPUT__DIRECTORY: /app/output   # default is ~/Videos/Memories, outside every volume
       NVIDIA_DRIVER_CAPABILITIES: compute,video,utility   # `video` = NVENC/NVDEC libraries
     restart: unless-stopped
     deploy:
@@ -86,10 +85,8 @@ volumes:
   immich-memories-config:
 ```
 
-Two things the compose file cannot do for you:
+One thing the compose file cannot do for you:
 
-- **Output directory**: without `IMMICH_MEMORIES_OUTPUT__DIRECTORY` the videos are written to
-  `/home/immich/Videos/Memories` inside the container and vanish with it.
 - **Bind-mount ownership**: the container runs as UID/GID 1000. Create the output directory
   yourself (`mkdir -p output`; `chown 1000:1000 output` if your user isn't 1000) or Docker
   creates it as root and the app cannot write there. See

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -44,7 +44,6 @@ services:
     environment:
       IMMICH_URL: "${IMMICH_URL}"
       IMMICH_API_KEY: "${IMMICH_API_KEY}"
-      IMMICH_MEMORIES_OUTPUT__DIRECTORY: /app/output   # default is ~/Videos/Memories, outside every volume
     restart: unless-stopped
     deploy:
       resources:
@@ -56,12 +55,10 @@ volumes:
   immich-memories-config:
 ```
 
-Two things to get right before the first run:
+One thing to get right before the first run:
 
-- **`IMMICH_MEMORIES_OUTPUT__DIRECTORY`**: without it, videos are written to
-  `/home/immich/Videos/Memories` inside the container — not on any volume — and vanish when the
-  container is recreated.
-- **Ownership of `./output`**: the container runs as UID/GID 1000. Create the folder yourself
+- **Ownership of `./output`**: the image already writes to `/app/output`, so the mount above is
+  where the videos land. The container runs as UID/GID 1000. Create the folder yourself
   (`mkdir -p output`) so Docker doesn't create it as root; if your NAS user isn't 1000,
   `chown 1000:1000 output`.
   On Synology/QNAP where that is awkward, use a named volume (`immich-memories-output:/app/output`)

--- a/docs-site/docs/deploy/configuration/environment-variables.md
+++ b/docs-site/docs/deploy/configuration/environment-variables.md
@@ -80,6 +80,10 @@ export IMMICH_MEMORIES_OUTPUT__CODEC="h265"
 export IMMICH_MEMORIES_OUTPUT__CRF="20"
 ```
 
+`DIRECTORY` defaults to `~/Videos/Memories`. The Docker image overrides it to `/app/output` in the
+Dockerfile, so you only set it in a container to write somewhere else — and because it is an
+environment variable it beats `output.directory` in `config.yaml`.
+
 ### Music generation
 
 ```bash
@@ -91,16 +95,6 @@ export IMMICH_MEMORIES_ACE_STEP__ENABLED="true"
 export IMMICH_MEMORIES_ACE_STEP__MODE="api"
 export IMMICH_MEMORIES_ACE_STEP__API_URL="http://gpu-server:8000"
 ```
-
-### Output directory (Docker)
-
-```bash
-export IMMICH_MEMORIES_OUTPUT__DIRECTORY="/app/output"
-```
-
-The default is `~/Videos/Memories`, which inside the container is `/home/immich/Videos/Memories` —
-outside every volume. Set this so videos land in the `./output` mount (see
-[Docker](../installation/docker.md)).
 
 ## Shorthand overrides
 

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -36,18 +36,13 @@ exposing it. The UI is single-user, single-replica; keep this service at one ins
 The compose volume at `/home/immich/.immich-memories` must stay writable. It holds config, cache,
 automation history, and pending-delivery state.
 
-:::caution Where the videos go
-The compose file mounts `./output` at `/app/output`, but the app's default output directory is
-`~/Videos/Memories` — inside the container that is `/home/immich/Videos/Memories`, which is not on
-any volume and disappears with the container. Until the image sets it for you, add this to the
-service's `environment:` block (or use `--output` on every CLI run):
+:::caution Who owns ./output
+The image writes to `/app/output` (the Dockerfile sets `IMMICH_MEMORIES_OUTPUT__DIRECTORY`) and the
+compose file mounts `./output` there, so videos land on your host without extra configuration. That
+is an environment variable, so it beats `output.directory` in `config.yaml` — to write somewhere
+else, override the variable in the service's `environment:` block, not in the YAML.
 
-```yaml
-    environment:
-      IMMICH_MEMORIES_OUTPUT__DIRECTORY: /app/output
-```
-
-The container runs as the unprivileged `immich` user, **UID/GID 1000** — the first user on most
+What you do have to get right is ownership. The container runs as the unprivileged `immich` user, **UID/GID 1000** — the first user on most
 Linux hosts, so a `./output` folder you create yourself is writable without any `chown`. If Docker
 creates the folder for you it is owned by root; then either `mkdir -p output` before the first
 `up`, or `sudo chown 1000:1000 output`. On a host where your user is not 1000, set
@@ -82,7 +77,6 @@ docker run -d \
   -p 8080:8080 \
   -e IMMICH_URL=https://photos.example.com \
   -e IMMICH_API_KEY=your-api-key-here \
-  -e IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output \
   -v immich-memories-config:/home/immich/.immich-memories \
   -v ./output:/app/output \
   ghcr.io/sam-dumont/immich-video-memory-generator:latest
@@ -114,7 +108,6 @@ services:
     environment:
       - IMMICH_URL=http://immich-server:2283
       - IMMICH_API_KEY=${IMMICH_API_KEY}
-      - IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output
     volumes:
       - immich-memories-config:/home/immich/.immich-memories
       - ./output:/app/output   # pre-create and chown to the container UID, see above
@@ -138,7 +131,7 @@ Inside Immich's own compose stack, `immich-server` listens on **2283** (every Im
 | `IMMICH_URL` | Yes | Your Immich server URL |
 | `IMMICH_API_KEY` | Yes | Immich API key |
 | `IMMICH_MEMORIES_PRESET` | No | `fast` = CPU-only/NAS profile (1080p h264, fast encoder, static titles, no speech pass, favorites-first analysis). Explicit settings win. See the [NAS guide](../common-setups/nas-only.md#one-switch-preset-fast). |
-| `IMMICH_MEMORIES_OUTPUT__DIRECTORY` | Recommended | Set to `/app/output` so videos land in the mounted output directory (default is `~/Videos/Memories` inside the container). |
+| `IMMICH_MEMORIES_OUTPUT__DIRECTORY` | No | Already `/app/output` in the image. Set it only to write somewhere else — and note it beats `output.directory` in `config.yaml`. |
 | `IMMICH_MEMORIES_STORAGE_SECRET` | No | Session secret for the web UI. Auto-generated into the config volume if not set, so sessions already survive a restart. Set it explicitly to share one secret across hosts. It does not make multiple replicas supported. |
 | `IMMICH_MEMORIES_LLM__BASE_URL` | No | LLM endpoint (any OpenAI-compatible API). On its own it does nothing for scoring — see the next row. |
 | `IMMICH_MEMORIES_LLM__MODEL` | No | LLM model name (e.g., `qwen2.5-vl`) |


### PR DESCRIPTION
`docker/Dockerfile:101` has shipped `ENV IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output` since #323 (2026-08-18), in every image since. Four deploy pages still warn that videos are written to `/home/immich/Videos/Memories` and "vanish with the container", and three compose snippets set a variable the image already sets. New users have been reading a warning about a bug that shipped fixed in every image they can pull.

What changed:

- **`installation/docker.md`** — the "Where the videos go" caution becomes "Who owns ./output". The stale half goes, the UID/ownership half (still true, still the thing that actually bites) stays verbatim. Env-var table row: `Recommended` → `No`, "already `/app/output` in the image". Dropped the redundant `-e` from the standalone run and the `environment:` line from the Immich-stack snippet.
- **`common-setups/nas-only.md`**, **`common-setups/linux-nvidia.md`** — "Two things to get right" is now one thing (ownership); dropped the redundant env line from both compose blocks.
- **`configuration/environment-variables.md`** — the standalone "Output directory (Docker)" section collapses into two lines under the existing `### Output` section.

Added the consequence nobody had written down and which is now the only reason to think about this variable in Docker: `settings_customise_sources` puts `env_settings` ahead of the YAML source (`config_loader.py:286`), so the image's ENV **beats** `output.directory` in `config.yaml`. Someone changing the output path in the YAML inside a container would otherwise be quietly ignored.

Not touched: `installation/kubernetes.md` and `installation/terraform.md`. Those manifests set the variable explicitly (`deploy/kubernetes/base/deployment.yaml:57`, `deploy/terraform/main.tf:29`), so their mount tables describe what is actually there.

`make docs-check` passes, no broken links.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
