### PR TITLE
docs(llm): point at the models this is actually tested against

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,16 @@ is the one piece you can point somewhere else, and it speaks any OpenAI-compatib
 path exists for people who don't have the hardware or the patience to run a local model, not
 because the tool needs a cloud.
 
+Developed and tested against Qwen3.6-27B and Qwen3.6-35B-A3B (vision is built into the Qwen3.x
+models — no `-VL` variant to find).
+
 ```yaml
 # In ~/.immich-memories/config.yaml
 advanced:
   llm:
     provider: "openai-compatible"
-    base_url: "http://your-llm-server:8080/v1"
-    model: "qwen2.5-vl"
+    base_url: "http://your-llm-server:8000/v1"
+    model: "mlx-community/Qwen3.6-27B-8bit"
 ```
 
 ## What it does

--- a/docs-site/docs/create/pipeline/llm-content-analysis.md
+++ b/docs-site/docs/create/pipeline/llm-content-analysis.md
@@ -103,9 +103,10 @@ Content analysis needs TWO config sections: `content_analysis` controls the feat
 
 ```yaml
 # Which LLM to use (shared with title generation)
+# Tested against Qwen3.6-27B and Qwen3.6-35B-A3B
 llm:
   base_url: "http://localhost:8000/v1"
-  model: "mlx-community/Qwen2.5-VL-7B-Instruct-8bit"
+  model: "mlx-community/Qwen3.6-27B-8bit"
   api_key: "not-needed"        # for local models
   provider: "openai-compatible"  # or "ollama"
   timeout_seconds: 300

--- a/docs-site/docs/deploy/common-setups/linux-nvidia.md
+++ b/docs-site/docs/deploy/common-setups/linux-nvidia.md
@@ -112,7 +112,7 @@ IMMICH_API_KEY=your-api-key-here
 
 ## What doesn't work
 
-- **LLM content analysis on consumer GPUs**: vision-language models like Qwen2.5-VL-7B need ~14 GB VRAM at full precision. The 8-bit quant fits on an RTX 3060 12 GB, but an RTX 3060 8 GB or lower won't cut it. Use Ollama or a separate LLM server if VRAM is tight.
+- **LLM content analysis on consumer GPUs**: the tested models are Qwen3.6-27B and Qwen3.6-35B-A3B, which Ollama ships as 17 GB and 24 GB downloads. Neither stays resident on a 12 GB card — Ollama will offload the rest to system RAM and run, slowly. A 24 GB card (3090, 4090) holds the 27B comfortably. Below that, point `llm.base_url` at a box that can, or leave content analysis off: everything except the holistic review still runs.
 
 ## Performance expectations
 
@@ -133,11 +133,15 @@ roughly a third of the time.
 
 ## Adding LLM analysis
 
+Developed and tested against **Qwen3.6-27B** and **Qwen3.6-35B-A3B**. Vision is built into the
+Qwen3.x models, so there is no `-VL` variant to look for. Any OpenAI-compatible endpoint that
+accepts images works; those two are what the pipeline was exercised against.
+
 Run Ollama with GPU support alongside Immich Memories:
 
 ```bash
 docker run -d --gpus all -p 11434:11434 --name ollama ollama/ollama
-docker exec ollama ollama pull qwen2.5-vl
+docker exec ollama ollama pull qwen3.6:27b     # 17 GB; :35b is the 35B-A3B, 24 GB
 ```
 
 Then add to your Immich Memories config:
@@ -147,10 +151,13 @@ advanced:
   llm:
     provider: ollama
     base_url: http://ollama:11434
-    model: qwen2.5-vl
+    model: qwen3.6:27b
   content_analysis:
     enabled: true
 ```
+
+`model` has to be the tag you pulled, exactly. Smaller Qwen3.x sizes exist and will run — they are
+not the tested pair, so treat them as your own experiment.
 
 ## Adding AI music
 

--- a/docs-site/docs/deploy/common-setups/mac-local-llm.md
+++ b/docs-site/docs/deploy/common-setups/mac-local-llm.md
@@ -4,7 +4,7 @@ sidebar_label: "Mac + Local LLM"
 
 # Mac + Local LLM Setup
 
-For Mac users who want the full experience: local LLM for smart clip scoring, Apple Silicon hardware acceleration, and native install without Docker.
+For Mac users running everything locally: LLM clip scoring, Apple Silicon hardware acceleration, and a native install without Docker.
 
 ## Who this is for
 
@@ -17,9 +17,9 @@ You have a Mac with Apple Silicon (M1/M2/M3/M4). You want LLM-powered content an
 │ Mac (Apple Silicon)                               │
 │                                                   │
 │  ┌──────────────┐  ┌──────────────────────────┐  │
-│  │  mlx-vlm     │  │   Immich Memories         │  │
-│  │  (Qwen2.5-VL)│←─│   (native Python)         │  │
-│  │  port 8081   │  │   VideoToolbox encoding   │  │
+│  │  oMLX        │  │   Immich Memories         │  │
+│  │  (Qwen3.6)   │←─│   (native Python)         │  │
+│  │  port 8000   │  │   VideoToolbox encoding   │  │
 │  │              │  │   Vision face detection   │  │
 │  └──────────────┘  └──────────────────────────┘  │
 │                             │                     │
@@ -48,41 +48,67 @@ Framework and Taichi paths described below.
 
 Open [http://localhost:8080](http://localhost:8080).
 
-## Set up mlx-vlm for LLM analysis
+## Set up a local vision model
 
-[mlx-vlm](https://github.com/Blaizzy/mlx-vlm) runs vision-language models natively on Apple Silicon via MLX. Qwen2.5-VL is the recommended model: fast, accurate, handles video frames well.
+This is developed and tested against **Qwen3.6-27B** and **Qwen3.6-35B-A3B**, served by
+[oMLX](https://github.com/jundot/omlx) on Apple Silicon. Vision is built into the Qwen3.x models —
+there is no separate `-VL` variant to hunt for. Anything else that speaks the OpenAI
+`/v1/chat/completions` contract and accepts images will work; it just is not what the pipeline was
+exercised against.
+
+oMLX is a menu-bar app that serves MLX models over an OpenAI-compatible API. macOS 15+, Python
+3.11-3.13:
 
 ```bash
-# Install mlx-vlm
-pip install mlx-vlm
-
-# Start the server (downloads the model on first run, ~4 GB)
-mlx_vlm.server --model mlx-community/Qwen2.5-VL-7B-Instruct-8bit --port 8081
+brew tap jundot/omlx https://github.com/jundot/omlx
+brew install jundot/omlx/omlx
+omlx start        # background service on port 8000
 ```
 
-Then configure Immich Memories to use it. Add to `~/.immich-memories/config.yaml`:
+Pull a model from the admin dashboard at [http://localhost:8000/admin/chat](http://localhost:8000/admin/chat),
+or drop it into the model directory yourself. The weights are on Hugging Face:
+
+| Model | Repo | Download |
+|-------|------|----------|
+| Qwen3.6-27B, 8-bit | `mlx-community/Qwen3.6-27B-8bit` | 29.5 GB |
+| Qwen3.6-27B, 4-bit | `mlx-community/Qwen3.6-27B-4bit` | 16.1 GB |
+| Qwen3.6-35B-A3B, 8-bit | `mlx-community/Qwen3.6-35B-A3B-8bit` | 37.7 GB |
+| Qwen3.6-35B-A3B, 4-bit | `mlx-community/Qwen3.6-35B-A3B-4bit` | 20.4 GB |
+
+Those are download sizes, and the weights stay resident while the server is up — read them as the
+floor for how much unified memory the model alone takes.
+
+Then point Immich Memories at it in `~/.immich-memories/config.yaml`:
 
 ```yaml
 advanced:
   llm:
     provider: openai-compatible
-    base_url: http://localhost:8081/v1
-    model: mlx-community/Qwen2.5-VL-7B-Instruct-8bit
+    base_url: http://localhost:8000/v1
+    model: mlx-community/Qwen3.6-27B-8bit
   content_analysis:
     enabled: true
 ```
 
+`model` has to match what the server reports at `GET /v1/models`, not the name you typed anywhere else.
+
 Or set via environment variables:
 
 ```bash
-export IMMICH_MEMORIES_LLM__BASE_URL=http://localhost:8081/v1
-export IMMICH_MEMORIES_LLM__MODEL=mlx-community/Qwen2.5-VL-7B-Instruct-8bit
+export IMMICH_MEMORIES_LLM__BASE_URL=http://localhost:8000/v1
+export IMMICH_MEMORIES_LLM__MODEL=mlx-community/Qwen3.6-27B-8bit
 export IMMICH_MEMORIES_CONTENT_ANALYSIS__ENABLED=true
 ```
 
+:::note mlx-vlm
+[mlx-vlm](https://github.com/Blaizzy/mlx-vlm) is the other common way to serve a vision model on a
+Mac and works the same way from this side of the wire. Its README lists Qwen support through 3.5,
+so check it covers whatever you load before you count on it.
+:::
+
 ## What works
 
-- **LLM content analysis**: Qwen2.5-VL analyzes video frames and scores clips based on content (birthday cakes, sunsets, kids playing). Adds a content score weighted at 35% in the overall clip ranking.
+- **LLM content analysis**: the model reads video frames and scores clips on what is in them (birthday cakes, sunsets, kids playing). Adds a content score weighted at 35% in the overall clip ranking.
 - **VideoToolbox encoding**: hardware-accelerated H.264/H.265 encoding via Apple's VideoToolbox. 5-10x faster than CPU encoding.
 - **Vision framework face detection**: uses macOS native Vision framework for face detection. More accurate than the CPU fallback, no additional model downloads needed.
 - **Taichi GPU title renderer**: particle effects and gradient backgrounds rendered on Apple GPU.
@@ -119,15 +145,22 @@ On an M2 Pro (12-core, 32 GB):
 | 30 | 4K | ~5 min | ~14 min |
 | 50 | 1080p | ~8 min | ~12 min |
 
-LLM analysis is the slowest phase. The 7B model analyzes 2 frames per clip at ~3 seconds per frame. After the first run, analysis results are cached: subsequent runs for the same clips skip analysis entirely.
+Those numbers are from an earlier 7B vision model (2 frames per clip at ~3 seconds per frame) and
+have not been re-measured against the Qwen3.6 pair, which is several times larger — read them as a
+floor, not a forecast. What has not changed is the shape: LLM analysis is the slowest phase, and it
+is cached. A second run over the same clips skips it entirely.
 
-Memory usage: ~2 GB for Immich Memories, ~5 GB for mlx-vlm with the 8-bit model. Keep at least 16 GB total RAM.
+Memory is the constraint, not time. Immich Memories itself wants ~2 GB; the model wants its whole
+weight file resident (16-38 GB from the table above) for as long as the server is up.
 
-Those two are what makes local music generation tighter here than on a machine doing nothing else: mlx-vlm holding 5 GB is exactly the situation where an XL profile stops fitting. Stopping the LLM server before a music-heavy run buys back that 5 GB.
+That is what makes local music generation tighter here than on a machine doing nothing else: a
+27B model holding 30 GB is exactly the situation where an ACE-Step XL profile stops fitting.
+Stopping the LLM server before a music-heavy run buys all of it back.
 
 ## Tips
 
-- **Start mlx-vlm before Immich Memories.** If the LLM server isn't running, content analysis silently falls back to metadata-only scoring. You'll still get results, just without the LLM content understanding.
-- **The 8-bit quant is the sweet spot.** The 4-bit version is faster but less accurate. The full 16-bit version needs 16 GB+ of unified memory just for the model.
-- **Ollama works too.** If you prefer Ollama: `ollama run qwen2.5-vl`, then set `provider: ollama` and `base_url: http://localhost:11434` in config.
+- **Start the LLM server before Immich Memories.** If it isn't running, content analysis silently falls back to metadata-only scoring. You'll still get results, just without the LLM content understanding.
+- **Take 8-bit if the memory is there, 4-bit if it isn't.** 4-bit roughly halves the resident weights (16.1 GB against 29.5 GB for the 27B) and costs accuracy. On a 32 GB Mac the 4-bit 27B is the one that leaves room for anything else.
+- **Smaller Qwen3.x sizes exist** for tighter machines, and they are not part of the tested pair — treat them as your own experiment rather than a supported configuration.
+- **Ollama works too.** `ollama pull qwen3.6:27b` (17 GB), then set `provider: ollama`, `base_url: http://localhost:11434` and `model: qwen3.6:27b` in config.
 - **The default `--analysis-depth auto` is usually right.** It analyzes every eligible clip when at most 60 need fresh work, then shortlists larger libraries. Use `thorough` to force every eligible clip through LLM analysis, or `fast` to reserve LLM calls for favorites. Exact current-model cache hits are reused; stale model results restart.

--- a/docs-site/docs/deploy/configuration/config-file.md
+++ b/docs-site/docs/deploy/configuration/config-file.md
@@ -37,10 +37,11 @@ defaults:
 # ── AI analysis (any OpenAI-compatible vision model) ──────
 # Both sections are needed: `llm` says where the model is,
 # `content_analysis.enabled` turns scoring with it on.
+# Tested against Qwen3.6-27B and Qwen3.6-35B-A3B.
 llm:
   provider: "openai-compatible"
-  base_url: "http://localhost:8080/v1"
-  model: "qwen2.5-vl"
+  base_url: "http://localhost:8000/v1"
+  model: "mlx-community/Qwen3.6-27B-8bit"
 
 content_analysis:
   enabled: true

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -141,7 +141,7 @@ Inside Immich's own compose stack, `immich-server` listens on **2283** (every Im
 | `IMMICH_MEMORIES_OUTPUT__DIRECTORY` | Recommended | Set to `/app/output` so videos land in the mounted output directory (default is `~/Videos/Memories` inside the container). |
 | `IMMICH_MEMORIES_STORAGE_SECRET` | No | Session secret for the web UI. Auto-generated into the config volume if not set, so sessions already survive a restart. Set it explicitly to share one secret across hosts. It does not make multiple replicas supported. |
 | `IMMICH_MEMORIES_LLM__BASE_URL` | No | LLM endpoint (any OpenAI-compatible API). On its own it does nothing for scoring — see the next row. |
-| `IMMICH_MEMORIES_LLM__MODEL` | No | LLM model name (e.g., `qwen2.5-vl`) |
+| `IMMICH_MEMORIES_LLM__MODEL` | No | Model name as the server reports it. Tested against Qwen3.6-27B and Qwen3.6-35B-A3B (e.g. `qwen3.6:27b` on Ollama). |
 | `IMMICH_MEMORIES_CONTENT_ANALYSIS__ENABLED` | No | `true` to actually use the LLM for clip scoring. Off by default. |
 | `IMMICH_MEMORIES_AUTH_USERNAME` | No | Basic auth username. Set with `IMMICH_MEMORIES_AUTH_PASSWORD` to enable auth. |
 | `IMMICH_MEMORIES_AUTH_PASSWORD` | No | Basic auth password. Set with `IMMICH_MEMORIES_AUTH_USERNAME` to enable auth. |

--- a/docs-site/docs/deploy/installation/terraform.md
+++ b/docs-site/docs/deploy/installation/terraform.md
@@ -78,8 +78,9 @@ module "immich_memories" {
   immich_api_key = var.immich_api_key
 
   # Optional: LLM clip content analysis (any OpenAI-compatible API)
+  # Tested against Qwen3.6-27B and Qwen3.6-35B-A3B; `llm_model` is the tag the server serves
   llm_base_url = "http://ollama.ollama.svc.cluster.local:11434/v1"
-  llm_model    = "qwen2.5-vl"
+  llm_model    = "qwen3.6:27b"
 
   # Optional: anything else, e.g. the in-pod daily automation
   env = {

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -276,7 +276,7 @@ Used by content analysis and title generation. Any OpenAI-compatible endpoint wo
 llm:
   provider: "openai-compatible"   # openai-compatible | openai | zai | anthropic | ollama
   base_url: "http://localhost:8080/v1"
-  model: ""                        # e.g. mlx-community/Qwen2.5-VL-7B-Instruct-8bit
+  model: ""                        # e.g. mlx-community/Qwen3.6-27B-8bit
   api_key: ""                      # optional, only for cloud APIs
   timeout_seconds: 300             # increase for slow local models (10-3600)
   thinking: false                  # server has a reasoning switch


### PR DESCRIPTION
**Rescoped on owner direction.** This PR originally just fixed the spelling of `ollama pull qwen2.5-vl` (the registry name was `qwen2.5vl`, no hyphen). The owner's correction: don't fix the spelling of a stale recommendation, replace the recommendation. Qwen2.5-VL is not what this project runs any more.

## What the docs now claim

Developed and tested against **Qwen3.6-27B** and **Qwen3.6-35B-A3B**, run via oMLX on Apple Silicon. Vision is built into the Qwen3.x models — there is no `-VL` suffix on the 3.x line, and none appears anywhere in this diff. Smaller Qwen3.x sizes are named as **untested options**, not equals. Any OpenAI-compatible endpoint that accepts images still works.

Tested-against rather than recommended, deliberately: recommendations drift, test provenance doesn't.

## Everything verified against the registry, nothing from memory

[ollama.com/library/qwen3.6](https://ollama.com/library/qwen3.6) — pull name `qwen3.6`; `:27b` 17 GB, `:35b` 24 GB, `:latest` 24 GB, plus `27b-mlx`/`35b-mlx`. Input modalities Text + Image, 256K context.

mlx-community on Hugging Face — `Qwen3.6-27B-8bit` 29.5 GB, `Qwen3.6-27B-4bit` 16.1 GB, `Qwen3.6-35B-A3B-8bit` 37.7 GB, `Qwen3.6-35B-A3B-4bit` 20.4 GB. All tagged Image-Text-to-Text.

[github.com/jundot/omlx](https://github.com/jundot/omlx) — Homebrew tap, `omlx start`, OpenAI-compatible on port 8000 at `/v1`, admin at `/admin/chat`, macOS 15+.

## Sites changed

| File | Was |
|---|---|
| `README.md` | `model: "qwen2.5-vl"` |
| `deploy/configuration/config-file.md` | quick-start `llm` block |
| `deploy/installation/docker.md` | `LLM__MODEL` env row |
| `deploy/installation/terraform.md` | `llm_model` next to an Ollama `/v1` URL |
| `deploy/common-setups/linux-nvidia.md` | VRAM guidance sentence, `ollama pull`, config `model` |
| `deploy/common-setups/mac-local-llm.md` | diagram, server section, config, env, "what works", memory numbers, tips |
| `create/pipeline/llm-content-analysis.md` | config example |
| `reference/config-reference.md` | `model` comment example (`make docs-config-check` still passes) |

## Two judgement calls worth flagging

**The Mac page moves off mlx-vlm.** mlx-vlm's README lists Qwen support through 3.5, not 3.6, so telling people to run `mlx_vlm.server --model mlx-community/Qwen3.6-27B-8bit` would be exactly the class of unverified command this sweep exists to remove. oMLX is what the tested pair runs on, so it becomes the documented path and mlx-vlm stays as a note.

**The Mac page's perf table is labelled, not rewritten.** Those numbers were measured with a 7B model at ~3 s/frame. Re-attributing them to a 27B model would be inventing data, and deleting them would throw away a real measurement — so they are marked as the older, smaller model and framed as a floor. Same for the memory line: "~5 GB for mlx-vlm" is replaced by the verified 16-38 GB resident-weight range, and the ACE-Step contention paragraph that depended on the 5 GB figure follows it.

## Left alone on purpose

- `docker-compose.yml:32` (`# IMMICH_MEMORIES_LLM__MODEL: "qwen2.5-vl"`) — that file belongs to #626 in this session. It needs the same one-line sweep.
- `create/pipeline/llm-content-analysis.md:75` — the `Qwen2.5-VL-7B | 4.5GB | 4-5s` row in the title-model comparison table. That is a record of a measurement that happened, not a recommendation; rewriting it would fabricate numbers.

`make docs-check` and `make docs-config-check` both pass, no broken links.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
