### PR TITLE
docs(hardware): finish the encoding-is-not-the-bottleneck sweep

### DIFF
--- a/docs-site/docs/deploy/hardware/cpu-only.md
+++ b/docs-site/docs/deploy/hardware/cpu-only.md
@@ -11,8 +11,8 @@ The pipeline is designed around GPU acceleration and ML-powered features for the
 
 | Feature | With GPU | Without GPU | Impact |
 |---------|----------|-------------|--------|
-| Video encoding | NVENC / VideoToolbox / VAAPI / QSV | libx264 / libx265 (software) | 3-10x slower encoding |
-| Title screens | Animated GPU-rendered (Taichi: bokeh particles, gradient animation, SDF text) | Static PIL-rendered (gradient background, text overlay) | Simpler visuals, same text |
+| Title screens | Animated GPU-rendered (Taichi: bokeh particles, gradient animation, SDF text) | Static PIL-rendered (gradient background, text overlay) | Simpler visuals, same text — and the dominant cost of a run (see below) |
+| Video encoding | NVENC / VideoToolbox / VAAPI / QSV | libx264 / libx265 (software) | 3-10x slower encoding, the smaller half |
 | Face detection (macOS) | Apple Vision (Neural Engine) | OpenCV Haar cascades (CPU) | Slightly less accurate |
 | SDF text rendering | Taichi GPU kernels + FreeType atlas | PIL text drawing | No SDF glow/shadow effects |
 | Video scaling | GPU-accelerated (scale_cuda, scale_vaapi) | FFmpeg swscale (CPU) | Slower for resolution changes |

--- a/docs-site/docs/deploy/hardware/nvidia.md
+++ b/docs-site/docs/deploy/hardware/nvidia.md
@@ -5,7 +5,7 @@ title: NVIDIA
 
 # NVIDIA
 
-NVIDIA GPUs with NVENC provide hardware-accelerated video encoding that's 5-10x faster than software encoding. If you have a GTX 1050 or newer, you've got NVENC.
+NVIDIA GPUs with NVENC provide hardware-accelerated video encoding that's 5-10x faster than software encoding. If you have a GTX 1050 or newer, you've got NVENC. The encode is not the phase that dominates a run, though — see [Encoding quality](#encoding-quality) for what the card actually buys you.
 
 ## What you get
 
@@ -13,6 +13,7 @@ NVIDIA GPUs with NVENC provide hardware-accelerated video encoding that's 5-10x 
 - **NVDEC decoding**: hardware-accelerated decode, keeps the full pipeline on GPU.
 - **CUDA scaling**: `scale_cuda` resizes frames on the GPU instead of pulling them back to CPU.
 - **CUDA scene analysis**: when OpenCV has CUDA support and `hardware.gpu_analysis` is on, frame differencing for scene detection runs on the GPU. Face detection stays on the CPU (OpenCV Haar cascades) — there is no CUDA face path.
+- **Taichi title rendering**: with the `gpu` extra installed, Taichi picks the CUDA backend (Vulkan second) for animated title screens. This is the phase that costs the most on a CPU-only box.
 
 ## Requirements
 
@@ -66,4 +67,6 @@ See [Linux + NVIDIA](../common-setups/linux-nvidia.md) for a full compose file.
 
 ## Encoding quality
 
-NVENC quality is slightly below software libx264 at the same bitrate, but for memory videos the difference is invisible. The speed gain (5-10x) is worth it. If you're encoding a 2-minute compilation, NVENC finishes in seconds instead of minutes.
+NVENC quality is slightly below software libx264 at the same bitrate, but for memory videos the difference is invisible, so take the speed.
+
+Just don't buy the card for the encode. Encoding is the smaller half of a CPU-only run: title rendering was ~263 s of a ~339 s assembly at `--cpus=2`, and analysis was 7.4 of 10.1 minutes end to end. The bigger wins from this GPU are Taichi title rendering and CUDA scene analysis. See [CPU-Only Mode](./cpu-only.md#title-rendering-is-the-bottleneck-not-encoding) for the measured split.

--- a/docs-site/docs/deploy/hardware/overview.md
+++ b/docs-site/docs/deploy/hardware/overview.md
@@ -9,6 +9,8 @@ The pipeline is designed around GPU acceleration for the best quality and speed:
 
 Encoding video in software (libx264) works everywhere but it's slow. If you have a GPU or dedicated media engine, hardware acceleration can speed up encoding by 5-10x. The pipeline auto-detects your hardware and picks the best available backend; NVENC, Quick Sync and VAAPI are only selected after a one-frame test encode succeeds, so an FFmpeg build that merely lists them (Debian's does, including inside the Docker image) doesn't send a GPU-less box down the hardware path.
 
+That 5-10x applies to a phase that is not where a run spends its time. Analysis and title rendering are — measured at `--cpus=2`, title rendering was ~263 s of a ~339 s assembly ([CPU-Only Mode](./cpu-only.md#title-rendering-is-the-bottleneck-not-encoding)), and in a measured end-to-end run analysis was 7.4 of 10.1 minutes ([NAS-Only](../common-setups/nas-only.md#performance-expectations)). Hardware acceleration shortens the last phase; a GPU earns its keep first on titles.
+
 ## Supported backends
 
 | Backend | Platform | Encode | Decode | GPU Scaling | Face Detection |


### PR DESCRIPTION
`hardware/cpu-only.md`, `common-setups/nas-only.md`, `common-setups/linux-nvidia.md` and `common-setups/kubernetes-gpu.md` (#604) all carry the measured correction: encoding is the smaller half, analysis and title rendering are where a run spends its time. The two pages a reader opens *first* when they go looking for hardware advice still sold the pre-correction story.

- **`hardware/overview.md`** — kept the 5-10x encoding claim (it's true) and added the sentence it was missing: that multiplier applies to a phase that doesn't dominate. Links to both measurements.
- **`hardware/nvidia.md`** — the close was "The speed gain (5-10x) is worth it. If you're encoding a 2-minute compilation, NVENC finishes in seconds instead of minutes", which measures only the encode phase and reads as total time. Rewritten to keep the quality-vs-libx264 point and name what the card actually buys: Taichi title rendering and CUDA scene analysis. Also added the Taichi bullet to "What you get" — it was absent, and `titles/taichi_kernels.py:199` picks `ti.cuda` first on NVIDIA, so the page was underselling the one phase the numbers are about.
- **`hardware/cpu-only.md`** — the "What changes without a GPU" table led with "3-10x slower encoding" before the page's own correction section demotes it. Titles move to the first row and the encoding row says it's the smaller half.

Numbers used, both already in the tree and unchanged here: ~263 s of a ~339 s assembly on titles at `--cpus=2` (`cpu-only.md`), 7.4 of 10.1 minutes on analysis for the `preset: fast` run (`nas-only.md` table).

`make docs-check` passes, no broken links (the two new cross-page anchors resolve).

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
