### PR TITLE
fix(deploy): the default compose binds to localhost, and the LAN is an explicit choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ docker compose up -d
 # 4. Open http://localhost:8080
 ```
 
-> **Do not expose the default UI as-is.** Authentication is disabled by default, and the
-> container listens on `0.0.0.0`. Anyone who can reach port 8080 can use it. Enable
+> **The compose file publishes port 8080 on localhost only.** Authentication is disabled by
+> default, and the app holds an Immich API key to your whole library — anyone who can reach the
+> port can use it. To get to the UI from another machine, enable
 > [authentication](https://sam-dumont.github.io/immich-video-memory-generator/docs/deploy/configuration/authentication)
-> before publishing the port. The UI is single-user, single-replica; run one instance.
+> first, then change the mapping to `"8080:8080"`. The UI is single-user, single-replica; run one
+> instance.
 
 ### Resource Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 # Immich Memories — self-hoster quickstart
 # Usage: docker compose up -d
 # Then open http://localhost:8080
-# Authentication is disabled by default. Do not publish port 8080 outside a trusted network
-# until auth is enabled. The stateful UI supports one user flow in one replica.
+# Authentication is disabled by default, so the UI is published on localhost only.
+# Reaching it from another machine is a deliberate two-step change — see the ports block.
+# The stateful UI supports one user flow in one replica.
 #
 # Resource requirements:
 #   Idle (UI): ~100MB RAM
@@ -17,8 +18,11 @@ services:
   immich-memories:
     image: ghcr.io/sam-dumont/immich-video-memory-generator:latest
     container_name: immich-memories
+    # Localhost only. This container holds an Immich API key to your whole library.
+    # To reach it from other machines: turn on auth first, then use "8080:8080".
+    # https://sam-dumont.github.io/immich-video-memory-generator/docs/deploy/configuration/authentication
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - immich-memories-config:/home/immich/.immich-memories
       - ./output:/app/output

--- a/docs-site/docs/create/first-memory.mdx
+++ b/docs-site/docs/create/first-memory.mdx
@@ -40,7 +40,11 @@ docker compose up -d
 uvx immich-memories ui
 ```
 
-Open [http://localhost:8080](http://localhost:8080) in your browser.
+Open [http://localhost:8080](http://localhost:8080) in your browser. Both routes keep the UI on
+localhost: the native install binds loopback, and the compose file publishes the port there. If
+the app runs on a different machine than your browser, see the
+[Docker install page](../deploy/installation/docker.md#quick-start) — it pairs publishing the
+port with turning on authentication.
 
 ## Step 2: Connect to Immich
 

--- a/docs-site/docs/deploy/common-setups/linux-nvidia.md
+++ b/docs-site/docs/deploy/common-setups/linux-nvidia.md
@@ -62,7 +62,7 @@ services:
     image: ghcr.io/sam-dumont/immich-video-memory-generator:latest
     container_name: immich-memories
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"        # loopback only — see below to reach it remotely
     volumes:
       - immich-memories-config:/home/immich/.immich-memories
       - ./output:/app/output          # mkdir + chown to the container UID first, see below
@@ -85,6 +85,11 @@ services:
 volumes:
   immich-memories-config:
 ```
+
+The port is published on loopback only. A GPU box is usually headless, so either tunnel
+(`ssh -L 8080:localhost:8080 your-server`) or publish it properly: enable
+[authentication](../configuration/authentication) first — the app holds an Immich API key to your
+whole photo library — then change the mapping to `"8080:8080"`.
 
 Two things the compose file cannot do for you:
 

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -37,7 +37,7 @@ services:
     image: ghcr.io/sam-dumont/immich-video-memory-generator:latest
     container_name: immich-memories
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"        # loopback only — see "Reaching the UI" below
     volumes:
       - immich-memories-config:/home/immich/.immich-memories
       - ./output:/app/output          # create it first and chown to the container UID, see below
@@ -56,7 +56,17 @@ volumes:
   immich-memories-config:
 ```
 
-Two things to get right before the first run:
+### Reaching the UI
+
+The mapping above is loopback-only, so on a headless NAS nothing reaches the UI until you do one
+of two things. The cheap one is an SSH tunnel — `ssh -L 8080:localhost:8080 your-nas`, then open
+`http://localhost:8080` on your desktop. Nothing is published and there is nothing to secure.
+
+To publish it on the LAN instead, do both halves: turn on
+[authentication](../configuration/authentication) first — the app holds an Immich API key to your
+whole photo library — then change the mapping to `"8080:8080"`.
+
+Two more things to get right before the first run:
 
 - **`IMMICH_MEMORIES_OUTPUT__DIRECTORY`**: without it, videos are written to
   `/home/immich/Videos/Memories` inside the container — not on any volume — and vanish when the

--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -12,8 +12,9 @@ By default, the web UI has no authentication — and because of that, it binds t
 authentication, name the address yourself (`--host`, `IMMICH_MEMORIES_SERVER__HOST`, or a
 `server.host` in the config file that is not the `0.0.0.0` wildcard), or set
 `server.allow_unauthenticated_lan: true` — a name that spells out what it allows.
-(The Docker image passes `--host 0.0.0.0` explicitly; publishing its port is the
-compose file's deliberate decision, so enable auth there before exposing it.)
+(The Docker image passes `--host 0.0.0.0` explicitly — inside a container that is the only
+useful bind — so which port the compose file publishes is the real boundary. The shipped
+`docker-compose.yml` publishes `127.0.0.1:8080:8080`; enable auth before you widen it.)
 
 One line in a config file does not count: a bare `server.host: 0.0.0.0`. Older versions
 wrote it into every config they saved, chosen or not, so it says nothing about intent and

--- a/docs-site/docs/deploy/installation/docker.md
+++ b/docs-site/docs/deploy/installation/docker.md
@@ -25,13 +25,20 @@ curl -O https://raw.githubusercontent.com/sam-dumont/immich-video-memory-generat
 docker compose up -d
 ```
 
-UI is at [http://localhost:8080](http://localhost:8080).
+UI is at [http://localhost:8080](http://localhost:8080). The compose file publishes the port as
+`127.0.0.1:8080:8080`, so nothing else on your network reaches it out of the box.
 
 :::caution Do not publish the default UI
-Authentication is disabled by default, and the container listens on `0.0.0.0`. Anyone who can
-reach port 8080 can use the app. Enable [authentication](../configuration/authentication) before
-exposing it. The UI is single-user, single-replica; keep this service at one instance.
+Authentication is disabled by default. Inside the container the app listens on `0.0.0.0` — the
+compose port mapping is the only thing keeping it off your network, and the app holds an Immich
+API key to your whole photo library. The UI is single-user, single-replica; keep this service at
+one instance.
 :::
+
+To reach the UI from another machine, make both changes together: enable
+[authentication](../configuration/authentication), then swap the mapping to `- "8080:8080"` and
+run `docker compose up -d` again. On a headless box you can skip the exposure entirely and
+tunnel instead: `ssh -L 8080:localhost:8080 your-server`.
 
 The compose volume at `/home/immich/.immich-memories` must stay writable. It holds config, cache,
 automation history, and pending-delivery state.
@@ -79,7 +86,7 @@ If you don't use compose:
 ```bash
 docker run -d \
   --name immich-memories \
-  -p 8080:8080 \
+  -p 127.0.0.1:8080:8080 \
   -e IMMICH_URL=https://photos.example.com \
   -e IMMICH_API_KEY=your-api-key-here \
   -e IMMICH_MEMORIES_OUTPUT__DIRECTORY=/app/output \
@@ -110,7 +117,7 @@ services:
   immich-memories:
     image: ghcr.io/sam-dumont/immich-video-memory-generator:latest
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"   # drop the `127.0.0.1:` only after enabling auth
     environment:
       - IMMICH_URL=http://immich-server:2283
       - IMMICH_API_KEY=${IMMICH_API_KEY}

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -336,6 +336,19 @@ def test_image_default_output_directory_is_the_compose_output_mount() -> None:
     )
 
 
+def test_quickstart_compose_publishes_the_ui_on_loopback_only() -> None:
+    """The shipped compose file must not put the UI on the LAN by default.
+
+    The container holds an Immich API key for the whole photo library and ships with
+    authentication off, so reaching it from another machine has to be a deliberate
+    edit paired with enabling auth — not what happens to anyone who runs `up -d`.
+    """
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text())
+    published = [str(p) for p in compose["services"]["immich-memories"]["ports"]]
+
+    assert published == ["127.0.0.1:8080:8080"], published
+
+
 def test_image_runs_as_uid_1000() -> None:
     """Bind mounts (./output, ./config) and the K8s manifests assume the common host UID.
 


### PR DESCRIPTION
Closes #618

## Why

`docker-compose.yml` published `8080:8080`, so `docker compose up -d` put the UI on every
interface of the host. Authentication is off by default and the container holds an Immich API key
scoped to the **whole photo library** — the shipped default was an unauthenticated browser session
into all of someone's photos, reachable by anything on their LAN. The only thing standing between
that and a stranger was a comment in the file header.

Two external reviews reached the same conclusion independently: default-secure beats a warning.

The default is now `127.0.0.1:8080:8080`. Reaching the UI from another machine is still perfectly
possible — it just becomes a deliberate change that pairs *publishing the port* with *turning on
auth*, instead of a default nobody chose.

## Why the fix is in compose and not in the app

The app already binds `127.0.0.1` when auth is disabled and no host was named (`effective_host()`,
shipped in #476/#507). The Docker image overrides that with an explicit `--host 0.0.0.0`, which is
**correct** — inside a container that is the only useful bind. So the compose port mapping is the
real boundary, and that is the one line worth changing.

No refusal logic was added to app code; that was considered and not chosen. `authentication.mdx`
already told this story correctly, so this PR aligns that paragraph with the new default rather
than starting a parallel one.

## Known, deliberately out of scope

The deploy-docs deep review's `[BIND]` ledger notes that the *other* way to get this default —
dropping `--host 0.0.0.0` from the Dockerfile `CMD` — would **silently break the Kubernetes and
Terraform health probes**, which reach the pod on its cluster IP and would need an explicit
`IMMICH_MEMORIES_SERVER__HOST=0.0.0.0` to keep working.

This PR takes the compose route precisely to avoid that blast radius: the `CMD` is untouched, so
the k8s and Terraform manifests are unaffected and need no change. Flagging it so the constraint
is on record if anyone revisits the image default later. The shipped k8s Service is `ClusterIP`
and both guides already route through `kubectl port-forward`, so neither was LAN-exposed to begin
with.

## Pages touched

| File | Change |
|---|---|
| `docker-compose.yml` | `127.0.0.1:8080:8080` + short comment above `ports:` on how to expose it, auth first |
| `docs-site/docs/deploy/installation/docker.md` | Quick start, the standalone `docker run`, and the "existing Immich stack" snippet; added the compact expose-it step |
| `docs-site/docs/deploy/common-setups/nas-only.md` | Compose block + a "Reaching the UI" section (SSH tunnel, or auth + port) |
| `docs-site/docs/deploy/common-setups/linux-nvidia.md` | Compose block + the same pairing, headless-box framing |
| `docs-site/docs/deploy/configuration/authentication.mdx` | Aligned the existing Docker-bind parenthetical with the new shipped default |
| `docs-site/docs/create/first-memory.mdx` | Notes both routes stay on localhost, links to the expose-it step |
| `README.md` | Quickstart callout |
| `tests/test_docker_contract.py` | New contract pin (see below) |

No existing security warning was weakened. The `:::caution` on `docker.md` and the README callout
both stay, restated around the new default. The `single-user, single-replica` and
`authentication is disabled` strings that `test_docs_contract.py` pins are intact on all five
pages it checks.

Pages checked and deliberately left alone: `welcome/quick-start.md`, `common-setups/mac-local-llm.md`
and `docs/USER_GUIDE.md` are native-install flows where `localhost` was already correct;
`installation/kubernetes.md` and `installation/terraform.md` use `kubectl port-forward`.

## Tests

Added `test_quickstart_compose_publishes_the_ui_on_loopback_only` to `tests/test_docker_contract.py`
(the file that already parses the compose file for the output-mount contract). Written test-first:
confirmed RED against `['8080:8080']`, then GREEN. No mocks, so no new `# WHY:` patch sites — the
ratchet ceiling is untouched.

## Gates

- `make ci` — green (5577 passed, 9 skipped)
- `make docs-check` — green, zero anchor warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
