### PR TITLE
docs(pipeline): the refinement dial exists, say how to turn it

### DIFF
--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -68,7 +68,8 @@ Photos use a mix of metadata and optional LLM visual analysis:
 | Camera original | 0.05 | Real camera EXIF (not screenshot) |
 | LLM visual | 0.30 | VLM rates interest + quality |
 
-Photo scores are multiplied by `(1 - score_penalty)` (default 0.8) so videos win ties.
+Photo scores are multiplied by `(1 - score_penalty)`. The default penalty is 0.2, so a photo
+scores 80% of an equally good video and videos win ties.
 
 ### Live Photo Scoring
 
@@ -218,13 +219,15 @@ recap spent two of its thirty-nine slots on a single night at a venue.
 
 | memory spans | one moment is |
 |---|---|
-| up to a month | the configured window (5 minutes by default) |
+| up to a month | 5 minutes |
 | up to a season | 30 minutes |
 | up to a year | 90 minutes |
 | longer | 3 hours |
 
-The configured `temporal_dedup_window_minutes` is a floor, never a ceiling — asking for
-a wider window widens every memory type. Zero turns deduplication off entirely.
+That five minutes is `temporal_dedup_window_minutes`, and it is a floor rather than a
+ceiling: the wider spans below it always win. It is not a dial you can reach, though. The
+field lives on `PipelineConfig` in `analysis/smart_pipeline.py` with no YAML key and no CLI
+flag wired to it, so five minutes is what every run gets.
 
 A moment keeps one clip unless moments are genuinely scarce: only when there are at
 most half as many as the cut needs clips does a moment contribute more than one, which

--- a/docs-site/docs/create/pipeline/pipeline-overview.md
+++ b/docs-site/docs/create/pipeline/pipeline-overview.md
@@ -334,7 +334,8 @@ Every drop triggers a re-selection, and a re-selection admits clips that nothing
 has judged yet. So verify and judge iterate together until a round changes
 nothing, the review runs, and if the review dropped anything the whole
 stabilisation runs again. `max_refinement_passes` (10) bounds each of these
-loops.
+loops — YAML `advanced.analysis.max_refinement_passes`, CLI
+`--refinement-passes`.
 
 If the review is still dropping clips when the round budget runs out, one final
 review runs that drops without refilling — the reasoning being that a cut four
@@ -411,8 +412,7 @@ two seconds. Everything else is waiting on someone else's HTTP.
 The 11 calls are not per-clip analysis — that is all cached. They are the
 selection loop: each holistic review pass, plus each verify pass that hits a
 clip with no LLM description. `max_refinement_passes` is 10 and every round can
-cost a review call, so that bound is the main dial — see the caveat below about
-it not being reachable from config.
+cost a review call, so that bound is the main dial, and it is one you can turn.
 
 ### What to actually do about it
 
@@ -425,14 +425,18 @@ If warm runs feel slow:
 1. **Move the LLM somewhere faster.** It is an HTTP endpoint. A quicker model
    server, or a smaller model, cuts the largest single line item without
    touching anything else. This is the highest-leverage change available.
-2. **Turn `content_analysis.enabled` off.** No LLM at all: no per-clip content
+2. **Ask for fewer rounds.** `--refinement-passes 3`, or
+   `advanced.analysis.max_refinement_passes: 3` in YAML, caps the loop at three
+   rounds instead of ten. That is what `preset: fast` sets, and the flag's own
+   help calls it the biggest dial on warm-run time. The cost is that a late
+   refill may ship less scrutinised than the clips around it.
+3. **Turn `content_analysis.enabled` off.** No LLM at all: no per-clip content
    analysis, no reviewer, no verify calls. Selection falls back to vision, audio
    and metadata, which is the default configuration anyway.
 
-There is no third option today. `max_refinement_passes` is the obvious dial —
-fewer rounds, fewer review calls — but it is a `PipelineConfig` default in
-`analysis/smart_pipeline.py` with no YAML key and no CLI flag behind it. Right
-now the choice is a faster model server, or no model at all.
+Those three are ordered by what they cost you. A faster server changes nothing
+about the output. Fewer rounds trades scrutiny for time. Turning the LLM off
+trades the whole holistic pass for it.
 
 If cold runs feel slow:
 


### PR DESCRIPTION
## Description

`pipeline-overview.md` closed its performance section with a confident, wrong conclusion:

> `max_refinement_passes` is the obvious dial — fewer rounds, fewer review calls — but it is a `PipelineConfig` default in `analysis/smart_pipeline.py` with no YAML key and no CLI flag behind it. Right now the choice is a faster model server, or no model at all.

All three of those exist:

| claim | reality |
|---|---|
| no YAML key | `config_models_analysis.py:48` → `advanced.analysis.max_refinement_passes`, default 10, range 1–20 |
| no CLI flag | `cli/generate.py:406` → `--refinement-passes`, `IntRange(1, 20)`, wired at L162 |
| no third option | `config_presets.py:25` → `preset: fast` already sets it to 3 |

The flag's own help text calls itself "the biggest dial on warm-run time", which is exactly the sentence the page said did not exist. `clip-selection-scoring.md` has documented the trio correctly since #503 — the overview was the copy that drifted.

The "what to actually do about it" list now has three options ordered by what they cost you, and the three stale spots (L336, L414, L432-435) are gone.

## Also in this diff

Two smaller accuracy fixes on `clip-selection-scoring.md`, same theme:

- **`score_penalty`**: the page said "multiplied by `(1 - score_penalty)` (default 0.8)", which reads as the field defaulting to 0.8 — that would multiply photo scores by 0.2. Actual default is 0.2 (`config_models_render.py:216`), and the config block at the bottom of the same page already said so.
- **`temporal_dedup_window_minutes`**: documented as something you configure ("asking for a wider window widens every memory type"). It is a `PipelineConfig` dataclass default; `from_app_config` wires only `photos.max_ratio` and `analysis.max_refinement_passes`. No YAML key, no CLI flag. The page now says the five minutes is what every run gets, so nobody edits YAML expecting a change. Whether to wire it is a code-side question, logged on #326.

## Verification

- `make docs-check` — clean build, no broken links, no anchor warnings
- No `.py` touched
- Every number re-verified against `origin/main`, not against the review that flagged it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
