### PR TITLE
docs(create): stop documenting four things that do not exist

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -64,8 +64,10 @@ what was in the pictures instead.
 The cost is roughly 40 seconds and about 3,000 completion tokens for each day
 it asks about. The scan asks about a handful of days per year.
 
-Run with `--verbose` to see the per-picture lines the judgement read — that is
-the record to check first when a day you expected comes back ordinary.
+The per-picture lines the judgement read would be the record to check first when a
+day you expected comes back ordinary. They are written to the log at `DEBUG`, and
+the CLI has no flag or environment variable that raises the log level that far, so
+today there is no way to see them without editing `configure_logging()`.
 
 ## Running it
 

--- a/docs-site/docs/create/cli/titles.md
+++ b/docs-site/docs/create/cli/titles.md
@@ -51,7 +51,7 @@ immich-memories titles test --year 2024 --locale fr --style vintage_charm
 
 ## titles fonts
 
-Manage the fonts used for title screens. Fonts are OFL-licensed from Google Fonts and cached locally in `~/.immich-memories/fonts/`.
+Manage the fonts used for title screens. All five are OFL-1.1 licensed and ship inside the package (`titles/bundled_fonts/`); anything downloaded on top comes from the Fontsource CDN and is cached in `~/.immich-memories/fonts/`.
 
 ```bash
 # List fonts and their status (bare command or --list)
@@ -65,4 +65,4 @@ immich-memories titles fonts --download
 immich-memories titles fonts --clear
 ```
 
-If you haven't downloaded fonts yet, title generation will still work: it'll just use whatever's available on your system. But the downloaded fonts look better.
+You do not have to run any of this. Titles render correctly on a fresh install with no network, because `get_font_path()` checks the bundled copies before the cache and the bundle already carries every weight the renderer asks for. `--download` mirrors the same files from the CDN into `~/.immich-memories/fonts/`; it is there for inspecting or replacing what ships, not for making titles work.

--- a/docs-site/docs/create/pipeline/live-photos.md
+++ b/docs-site/docs/create/pipeline/live-photos.md
@@ -101,8 +101,10 @@ For devices without audio (like Google Pixel Motion Photos), spectrogram alignme
 analysis:
   include_live_photos: true                # ON by default
   live_photo_merge_window_seconds: 10.0    # Max gap between photos to form a burst
-  live_photo_min_burst_count: 3            # Min photos needed for burst merging
 ```
+
+Two Live Photos inside that window are already a burst — pairs are common for quick
+reactions, and there is no minimum-count key to raise.
 
 In the UI wizard, there's a toggle in the Options section on Step 1. Via CLI:
 

--- a/docs-site/docs/create/pipeline/title-screens-and-maps.md
+++ b/docs-site/docs/create/pipeline/title-screens-and-maps.md
@@ -7,7 +7,7 @@ title: Title Screens & Maps
 
 This is where the output stops looking like "FFmpeg concat" and starts looking like something you'd actually want to show people.
 
-Title screens are the structural connective tissue: animated intro cards, month dividers, satellite map fly-overs, and ending sequences. They're what separates a clip dump from a memory video that feels produced. Same kind of polish as Relive, but running on your own hardware with your own data.
+Title screens are the structural connective tissue: animated intro cards, month dividers, satellite map fly-overs, and ending sequences. Same kind of polish as Relive, but running on your own hardware with your own data.
 
 ## What gets generated
 
@@ -99,7 +99,7 @@ The static map renderer supports three styles, used for pin-and-label map frames
 | `osm` | OpenStreetMap | Clean street map, good for city-level |
 | `topo` | OpenTopoMap | Topographic, useful for hiking trips |
 
-Configure with `map_style: osm` under `title_screens` if you want a different style for location cards.
+`osm` and `topo` are internal options today. `map_style` is a parameter on the renderer functions in `titles/map_renderer.py`, not a `title_screens` key, so a generate run always gets satellite.
 
 ## Trip Classification
 


### PR DESCRIPTION
## Description

Four things these pages tell you to set or run that do not exist. Each was verified against `origin/main`, not against the review that flagged it.

| page | claim | reality |
|---|---|---|
| `pipeline/live-photos.md` | `live_photo_min_burst_count: 3` in the `analysis:` block | grep for it across `src/` returns the doc line and nothing else. `AnalysisConfig` has `include_live_photos` and `live_photo_merge_window_seconds`. |
| `pipeline/title-screens-and-maps.md` | "Configure with `map_style: osm` under `title_screens`" | `map_style` is a keyword argument on four functions in `titles/map_renderer.py`, defaulted to `DEFAULT_MAP_STYLE = "satellite"`. `TitleScreenConfig` (`config_models_render.py:100`) has ten fields; none is this. |
| `cli/discover-days.md` | "Run with `--verbose`" | `special_days_cmd.py` defines `--since --until --per-year --also-skip --out --rescan`. The root group has no `--verbose` either. |
| `cli/titles.md` | "If you haven't downloaded fonts yet... it'll just use whatever's available on your system" | Fonts are bundled. `get_font_path()` checks `titles/bundled_fonts/` **before** the user cache, and every weight in `FONT_DEFINITIONS` is in there. |

## What each fix says instead

**Live Photos.** The `3` was wrong twice: the key does not exist, and the threshold it named is not 3. `_BurstCluster.is_burst` is `count >= 2` with the comment "pairs are common for quick reactions". The page now states the real behaviour and that there is no minimum-count key to raise.

**Map styles.** The three-style table stays — `osm` and `topo` are real, and useful to know about — but it now reads as an implementation note rather than an invitation to edit YAML. A generate run always gets satellite.

**discover-days.** The paragraph's intent was right: the per-picture lines are exactly what you want when a day comes back ordinary, and the code says so in a comment ("A day that comes back ordinary is diagnosed from here"). They are emitted at `DEBUG`, and `configure_logging()` is called with no level argument and no env var, so nothing a user can type reaches them. The page says that rather than naming a flag that was never wired. Whether to add the flag or an `IMMICH_MEMORIES_LOG_LEVEL` is a code-side question, logged on #326.

**Fonts.** `--download` fetches the same weights the package already ships, into a directory the lookup consults second. It is for inspecting or replacing what ships, not for making titles work — which is the opposite of what the page implied.

## Also

One sentence cut from `title-screens-and-maps.md` L10: "They're what separates a clip dump from a memory video that feels produced" mirrored the better sentence two lines above it ("stops looking like 'FFmpeg concat'"). The Relive comparison stays; it is a real anchor.

## Verification

- `make docs-check` — clean build, no broken links, no anchor warnings
- No `.py` touched
- `grep -rn "live_photo_min_burst_count\|map_style: osm" docs-site/ docs/ README.md` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
