### PR TITLE
docs(memory-types): quote the CLI's numbers under CLI commands

### DIFF
--- a/docs-site/docs/create/memory-types/album-memories.mdx
+++ b/docs-site/docs/create/memory-types/album-memories.mdx
@@ -42,7 +42,7 @@ directory. `--title` still overrides the title if you want something else.
 Because the album defines its own contents, `--from-album` cannot be combined with
 `--year`, `--start`/`--end`, `--period`, `--birthday`, `--season`, `--month`,
 `--memory-type` or `--person`. Everything else — `--duration`, `--orientation`,
-`--music`, `--no-music`, `--upload`, `--dry-run` — works as usual.
+`--music`, `--no-music`, `--upload-to-immich`, `--dry-run` — works as usual.
 
 ## What gets used
 

--- a/docs-site/docs/create/memory-types/monthly-person-season.mdx
+++ b/docs-site/docs/create/memory-types/monthly-person-season.mdx
@@ -42,7 +42,7 @@ Use birthday-based year (auto-detects from Immich):
 immich-memories generate --memory-type person_spotlight --person "Alice" --year 2025 --birthday
 ```
 
-Default duration: 120 seconds (full year), ~60 seconds (single month). Duration auto-scales with date range. You can also override the date range entirely with `--start/--end`.
+Default duration: the CLI scales it with the date range — about 60 seconds for a single month, 10 minutes for a full year. (The web UI's Person Spotlight card defaults to 2 minutes regardless of range; see [the note below](#ui-and-cli-defaults-disagree).) You can also override the date range entirely with `--start/--end`.
 
 **Best for:** parent-child compilations, partner videos, or any relationship where you want to see just that person's moments. Needs Immich face recognition to be set up and the person tagged.
 
@@ -56,7 +56,7 @@ Moments featuring multiple people together. By default, requires co-occurrence: 
 immich-memories generate --memory-type multi_person --person "Alice" --person "Bob" --year 2025
 ```
 
-Default duration: 300 seconds. Title screen shows "Alice & Bob" as the subtitle.
+Default duration: same range-scaled curve as Person Spotlight, so 10 minutes for a full year. (The web UI card says 5 minutes; see [the note below](#ui-and-cli-defaults-disagree).) Title screen shows "Alice & Bob" as the subtitle.
 
 **Best for:** couples, families, friend groups. The co-occurrence filter means you'll get clips where they're actually together, not separate appearances.
 
@@ -68,7 +68,7 @@ Highlights from a specific season (spring, summer, fall, winter). Scoring emphas
 immich-memories generate --memory-type season --season summer --year 2025
 ```
 
-Default duration: 135 seconds (~45 seconds per month of the season). The hemisphere flag controls which calendar months map to which season:
+Default duration: the range curve again, so about 3 minutes 15 seconds for a three-month season. (The web UI card says 2 minutes 15; see [the note below](#ui-and-cli-defaults-disagree).) The hemisphere flag controls which calendar months map to which season:
 
 ```bash
 # Southern hemisphere: summer = December-February
@@ -94,3 +94,26 @@ immich-memories generate --memory-type on_this_day --years-back 3
 Default duration: 45 seconds. No `--year` needed: it automatically looks back from today's date. By default, it searches all years with data (up to 30 years back).
 
 **Best for:** daily nostalgia, "what were we doing last year" moments. Works best if you've been shooting video for 3+ years. Can be combined with the scheduler for an automatic daily memory.
+
+## UI and CLI defaults disagree
+
+For three of the four types on this page, the number the web UI puts in the duration box is
+not the number the CLI computes for the same request. The CLI runs `default_duration_for_type()`
+in `cli/_date_resolution.py`, which fits a curve through the date range (1 month → 60 s,
+12 months → 600 s). The web UI's preset cards carry a fixed value from
+`memory_types/factory.py` and ignore the range.
+
+| type | web UI card | CLI |
+|---|---|---|
+| Monthly Highlights | 1 min | ~1 min for the month |
+| Person Spotlight | 2 min | ~1 min for a month, 10 min for a year |
+| Multi-Person | 5 min | ~1 min for a month, 10 min for a year |
+| Season | 2 min 15 | ~3 min 15 for a three-month season |
+| On This Day | 45 s | 45 s |
+
+Monthly Highlights and On This Day agree because their fixed value and their curve value
+land in the same place. The other three do not, and for Person Spotlight the gap is 5x.
+Neither number is wrong for the surface it belongs to — the CLI's is range-aware and the
+UI's is a card default you can edit before you start — but they are not the same product
+decision, and this page documents the CLI unless it says otherwise. Every duration on any
+surface is an editable default, not a cap.

--- a/docs-site/docs/create/memory-types/year-in-review.mdx
+++ b/docs-site/docs/create/memory-types/year-in-review.mdx
@@ -38,7 +38,7 @@ Select the **Year in Review** card in Step 1, pick the year from the dropdown.
 
 ## What makes it special
 
-- **Monthly title dividers**: a divider screen (e.g., "January", "February") is inserted wherever the month changes between clips, so the video is split into sections. Dividers only appear when the video spans more than one month.
+- **Monthly title dividers**: a divider screen (e.g., "January", "February") is inserted wherever the month changes between clips, so the video is split into sections. Dividers only appear when the range spans four or more months: `get_divider_mode()` returns "none" for anything shorter, so a February-to-March video has no dividers at all.
 - **Density-based clip budget**: months with 50 videos get more clips than months with 5. The algorithm distributes clips proportionally to content density.
 - **Full year coverage**: the date range is exactly January 1 through December 31. Birthday-based years are supported too: `--birthday` auto-detects from Immich, or `--birthday 02/07` for manual override. You can also narrow to a single month with `--month` or override the date range entirely with `--start/--end`.
 

--- a/docs-site/docs/welcome/overview.mdx
+++ b/docs-site/docs/welcome/overview.mdx
@@ -19,11 +19,11 @@ You point it at your Immich instance, pick a time period (or a person, or a trip
 
 A polished memory video with:
 
-- **Smart cuts** from your best clips, scored by visual interest, motion, faces, and audio
+- **Cuts that earn their place**: clips scored on visual interest, motion, faces, and audio
 - **Animated satellite map** flying from home to your destination (for trip memories)
 - **AI-generated title** that actually describes the trip: "Sous les falaises de grès" instead of "TWO WEEKS IN GERMANY"
 - **AI music** that matches the mood of your clips (ACE-Step or MusicGen)
-- **Smooth transitions**: a smart mix of cuts and crossfades chosen per cut point
+- **Transitions**: cuts and crossfades, chosen per cut point rather than applied uniformly
 
 <ThemedScreenshot name="hero-step4-complete" alt="Finished memory video" />
 
@@ -48,6 +48,8 @@ The only outbound calls that are not your Immich server are the ones you configu
 | **Trip memory** | GPS-detected trip with map animation | "Lisbon, July 2024" |
 | **Season** | 3-month seasonal highlights | "Summer 2024" |
 | **On This Day** | Today's date across previous years | "June 12 — Through the Years" |
+| **Holiday** | The same holiday across several years | "Christmas Through the Years" |
+| **Then and Now** | Two years side by side, far apart on purpose | "2019 & 2026" |
 
 <ThemedScreenshot name="step1-preset-cards" alt="Memory type selection" />
 


### PR DESCRIPTION
## Description

`memory-types/monthly-person-season.mdx` states a "Default duration" under each CLI example. Three of the four quote the **web UI's preset-card** value, and the CLI computes something else.

The CLI runs `default_duration_for_type()` (`cli/_date_resolution.py:219`), which fits a quadratic through the date range — 1 month → 60 s, 12 months → 600 s. The wizard's cards carry a fixed `default_duration_seconds` from `memory_types/factory.py` and ignore the range entirely.

Measured, not guessed:

```
person_spotlight, 2024-01-01..2024-12-31 -> 600.0
person_spotlight, 2024-03-01..2024-03-31 ->  62.3
multi_person,     2024-01-01..2024-12-31 -> 600.0
season,           2024-06-01..2024-08-31 -> 195.0
```

| type | page said | CLI actually | UI card |
|---|---|---|---|
| Person Spotlight | 120 s full year | **600 s** | 120 s |
| Multi-Person | 300 s | **600 s** full year | 300 s |
| Season | 135 s | **~195 s** for 3 months | 135 s |
| Monthly Highlights | 60 s | ~62 s | 60 s (agrees) |

The Person Spotlight line also contradicted itself — "Default duration: 120 seconds (full year)... Duration auto-scales with date range" in one breath.

Each of the three now states the CLI's range-scaled number inline, and one short section at the foot of the page names the split with a table, so a reader who saw a different number in the wizard knows why rather than assuming the docs are broken. Which surface should win is a code-side question; logged on #326, not filed as a new issue.

## Also in this diff

- **`year-in-review.mdx`**: "Dividers only appear when the video spans more than one month." `get_divider_mode()` (`filename_builder.py:148`) returns `"none"` for `month_span <= 3`, so a February-to-March video gets no dividers. Now says four or more months.
- **`album-memories.mdx`**: `--upload` is not a flag. `generate.py:350` defines `--upload-to-immich`.
- **`welcome/overview.mdx`**: the memory-types table listed 7 of the 9 `--memory-type` choices — Holiday and Then and Now shipped with their own page and never made it into the front-door table. Added both, with the titles their presets actually produce (`{holiday}` and `{then_year} & {now_year}`).
- Two "Smart X" labels in the bullet list directly above that table ("**Smart cuts**", "a smart mix of cuts and crossfades" — two in one list) dropped while in the file. The second halves of both bullets already carried the meaning.

## Verification

- `make docs-check` — clean build
- `npm run build | grep -iE "warn|anchor|broken"` — no output; the new `#ui-and-cli-defaults-disagree` anchor resolves (`onBrokenAnchors: 'warn'`)
- No `.py` touched
- Durations computed by importing `default_duration_for_type` from this branch, not read off the review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
