### PR TITLE
docs(cli): run folders pile up, and re-derive the detector scores

### DIFF
--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -125,16 +125,20 @@ Backing off monthly_highlights:2026-06 — failed 3x, retrying after 3d
 
 ### Detectors
 
-| Detector | What it finds | Score range |
-|----------|---------------|-------------|
-| **MonthlyDetector** | Latest completed month, if not already generated | 0.5-0.8 |
-| **YearlyDetector** | Past years with content (only after Jan 15) | 0.5-0.7 |
-| **PersonSpotlightDetector** | Top 5 people by asset count | 0.1-0.6 |
-| **BirthdayDetector** | People whose birthday was 2-60 days ago | 0.75 |
-| **TripDetector** | GPS-detected trips from the past year | 0.1-0.5 |
-| **ActivityBurstDetector** | Months with >2x the rolling average (last 12 months) | 0.4-0.7 |
-| **OnThisDayDetector** | Dates with content across 5+ years | 0.2-0.35 |
-| **MultiPersonDetector** | Pairs who appear together frequently | 0.3-0.55 |
+Each detector has a base score and scales it by how strong the case is. The ranges
+below are derived from those formulas, so the ceiling is what a perfect case gets and
+the floor is what the detector's own admission rules allow through.
+
+| Detector | What it finds | Score | Scaled by |
+|----------|---------------|-------|-----------|
+| **YearlyDetector** | Past years with content (only after Jan 15) | 0.24-0.72 | recency, 10% per year, floored at 0.3 |
+| **BirthdayDetector** | People whose birthday was 2-60 days ago | 0.75 | nothing — fixed |
+| **MonthlyDetector** | Latest completed month, if not already generated | 0.21-0.7 | recency, 10% per month back, floored at 0.3 |
+| **ActivityBurstDetector** | Months with >2x the rolling average (last 12 months) | 0.7 | nothing — a month that clears the threshold gets the full score |
+| **TripDetector** | GPS-detected trips from the past year | up to 0.75 | trip length up to 14 days × asset count up to 200 |
+| **PersonSpotlightDetector** | Top 5 people by asset count | 0.12-0.6 | that person's share of the top person's asset count, floored at 0.2 |
+| **MultiPersonDetector** | Pairs who appear together frequently | 0.06-0.55 | estimated shared assets up to 500 (50 minimum to qualify) |
+| **OnThisDayDetector** | Dates with content across 5+ years | 0.18-0.35 | how many years the date has content in, up to 10 |
 
 ### Scoring adjustments
 

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -36,7 +36,7 @@ immich-memories generate [OPTIONS]
 | `--season` | — | choice | — | `spring`, `summer`, `fall`, `autumn`, `winter` (use with `--memory-type season`) |
 | `--month` | — | int | — | Month 1-12 (with `--year`, generates that month; selects trip by month) |
 | `--hemisphere` | — | choice | `north` | `north` or `south` (for season date calculation) |
-| `--years-back` | — | int | all | Years to look back for `on_this_day`, `holiday` or `then_and_now` |
+| `--years-back` | — | int | per type | Years to look back. Omitted: all years for `on_this_day` (30-year max), 5 for `holiday`, 10 for `then_and_now` |
 
 ### Output
 
@@ -300,16 +300,21 @@ Period format: number + unit (`d` days, `w` weeks, `m` months, `y` years). Examp
 ## Output
 
 `--output` names the file you want, not the path you get. Every run writes into
-its own folder so a rerun of the same recipe replaces itself instead of piling
-up, so:
+its own timestamped folder, so a rerun never overwrites an earlier result and a
+failed run's intermediates stay contained:
 
 ```bash
 immich-memories generate --year 2025 --output ~/Videos/summer.mp4
 ```
 
-writes `~/Videos/summer_<hash>_<timestamp>_<id>/summer_<hash>.mp4`. The folder
-is named after the file you asked for, and sits where you pointed. Album runs
-name the file after the album rather than after `--output`.
+writes `~/Videos/summer_20260105_143052_a7b3/summer.mp4`. The folder is the name
+you asked for plus the run id (timestamp, then four characters so two runs in the
+same second stay apart); the file keeps the name you gave it. The folder sits
+where you pointed. Album runs name the file after the album rather than after
+`--output`.
+
+Nothing prunes those folders, so reruns accumulate. `immich-memories runs delete`
+removes a run's output along with its record.
 
 If you don't pass `--output`, the file lands in your configured output directory (default `~/Videos/Memories/`), inside a per-run folder, with an auto-generated name of the form `{person}_{memory-type}_{date}.mp4` — for example `all_memories_2024.mp4`, `alice_year_in_review_2024.mp4` or `alice_memories_20240207-20250206.mp4`. (The web UI names its files differently, e.g. `alice_2024_memories.mp4`.)
 


### PR DESCRIPTION
## generate.md — run folders

> Every run writes into its own folder so a rerun of the same recipe replaces itself instead of piling up

The stated design rationale is the exact opposite of what the code does. `generate.py:636`:

```python
dir_slug = params.output_path.stem
run_output_dir = params.output_path.parent / f"{dir_slug}_{run_id}"
```

`run_id` is `YYYYMMDD_HHMMSS_XXXX` where the last four characters are a hash of random bytes ("handles the case where multiple runs start in the same second"). Every run gets a distinct folder by construction, and nothing in the generate path prunes old ones. The real reason for per-run folders is isolation — intermediates, crash debris, no clobbering — which is what the page says now, along with the fact that `runs delete` is what removes them (`cli/runs.py` `shutil.rmtree` on the run dir unless `--keep-output`).

The worked example was wrong in the same paragraph:

| | |
|---|---|
| page said | `~/Videos/summer_<hash>_<timestamp>_<id>/summer_<hash>.mp4` |
| code produces | `~/Videos/summer_20260105_143052_a7b3/summer.mp4` |

The folder is stem + run id (timestamp first, then the four characters); the file keeps the name you asked for, with no hash appended. `web-ui/step4-preview-export.mdx` already documented this correctly — generate.md was the outlier.

## generate.md — `--years-back`

Documented as `Default: all`. That is `on_this_day` only, where `None` becomes a 30-year max (`date_builders.py:126`). `_multi_year_ranges` reads `years_back or 5` for holiday and `years_back or 10` for then_and_now. The examples lower down the same page already stated 5 and 10.

## auto.md — detector score ranges

The "Score range" column did not match any of the `BASE_SCORE`s:

| Detector | page said | derived from code |
|---|---|---|
| MonthlyDetector | 0.5-0.8 | **0.21-0.7** (`BASE_SCORE = 0.7`, × `max(recency, 0.3)`) |
| YearlyDetector | 0.5-0.7 | **0.24-0.72** (`BASE_SCORE = 0.8`; only proposed after Jan 15 of the following year, so recency ≤ 0.9) |
| TripDetector | 0.1-0.5 | **up to 0.75** (`0.75 × min(1, days/14) × min(1, assets/200)`) |
| ActivityBurstDetector | 0.4-0.7 | **0.7 flat** — `0.7 × min(1.0, ratio / threshold)` only runs when `ratio > threshold`, so the `min` is always 1.0 |
| PersonSpotlightDetector | 0.1-0.6 | 0.12-0.6 (`0.6 × max(0.2, ratio)`) |
| MultiPersonDetector | 0.3-0.55 | 0.06-0.55 (`0.55 × min(1, shared/500)`, 50 shared minimum) |
| OnThisDayDetector | 0.2-0.35 | 0.18-0.35 (`0.35 × min(1, n_years/10)`, `MIN_YEARS = 5`) |
| BirthdayDetector | 0.75 | 0.75 ✓ |

Monthly and Yearly were swapped, Trip's ceiling was off by 0.25, and ActivityBurst is not a range at all. Rather than drop the column, every row is now derived, the table is sorted by ceiling (which is roughly the order these actually win), and a new column names **what scales the score** — the part a reader can act on when a detector keeps losing.

## Verification

- `make docs-check` — clean build, no anchor warnings
- `make docs-cli-check` — "CLI reference is up to date" (generated reference not affected)
- `uv run pytest tests/test_docs_contract.py` — 43 passed; the two pins on `auto.md` (daily-variety phrases, quiet-JSON `action` field) are untouched by this diff
- No `.py` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
