### PR TITLE
chore(deploy): bump the pinned image tag to the current release

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -44,7 +44,7 @@ kubectl port-forward -n immich-memories svc/immich-memories 8080:80
 ```
 
 `base/kustomization.yaml` pins the image tag (`images: newTag`). Published tags carry no `v`
-prefix (`0.41.0`, `latest`); bump it when you upgrade.
+prefix (`0.59.2`, `latest`); bump it when you upgrade.
 
 ## How the pod is wired
 

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   #   cp ingress.yaml.example ingress.yaml
   # - ingress.yaml
 
-# Published image tags carry no `v` prefix (0.41.0, latest). Bump on upgrade.
+# Published image tags carry no `v` prefix (0.59.2, latest). Bump on upgrade.
 images:
   - name: ghcr.io/sam-dumont/immich-video-memory-generator
-    newTag: "0.41.0"
+    newTag: "0.59.2"

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -96,7 +96,7 @@ module "immich_memories" {
 | `namespace` | Kubernetes namespace | `string` | `"immich-memories"` |
 | `create_namespace` | Create the namespace | `bool` | `true` |
 | `image_repository` | Container image | `string` | `"ghcr.io/sam-dumont/immich-video-memory-generator"` |
-| `image_tag` | Image tag (no `v` prefix: `0.41.0`, `latest`) | `string` | `"latest"` |
+| `image_tag` | Image tag (no `v` prefix: `0.59.2`, `latest`) | `string` | `"latest"` |
 | `replicas` | Keep at 1 | `number` | `1` |
 | `resources` | Requests/limits object | `object` | `2Gi/1000m` – `8Gi/4000m` |
 | `tmp_size` | `/tmp` emptyDir (8Gi for 4K) | `string` | `"4Gi"` |

--- a/deploy/terraform/examples/production/terraform.tfvars.example
+++ b/deploy/terraform/examples/production/terraform.tfvars.example
@@ -7,7 +7,7 @@ namespace          = "immich-memories"
 environment        = "production"
 
 # Image (published tags carry no `v` prefix)
-image_tag = "0.41.0"
+image_tag = "0.59.2"
 
 # Immich
 immich_url     = "https://photos.example.com"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "image_repository" {
 }
 
 variable "image_tag" {
-  description = "Container image tag. Published tags carry no `v` prefix: 0.41.0, latest"
+  description = "Container image tag. Published tags carry no `v` prefix: 0.59.2, latest"
   type        = string
   default     = "latest"
 }

--- a/docs-site/docs/deploy/common-setups/kubernetes-gpu.md
+++ b/docs-site/docs/deploy/common-setups/kubernetes-gpu.md
@@ -76,7 +76,7 @@ kubectl apply -k overlays/gpu
 ```
 
 `kubectl kustomize overlays/gpu` shows the rendered result. `base/kustomization.yaml` pins the
-image tag (no `v` prefix: `0.41.0`); bump it when you upgrade.
+image tag (no `v` prefix: `0.59.2`); bump it when you upgrade.
 
 ## Access the UI
 
@@ -169,7 +169,7 @@ kubectl apply -f base/sealed-secret.yaml
   "configuration": "configured",
   "immich_reachable": true,
   "last_successful_run": "2025-12-15T10:30:00",
-  "version": "0.41.0"
+  "version": "0.59.2"
 }
 ```
 

--- a/docs-site/docs/deploy/installation/kubernetes.md
+++ b/docs-site/docs/deploy/installation/kubernetes.md
@@ -49,7 +49,7 @@ kubectl apply -k overlays/gpu
 ```
 
 `kubectl kustomize base` shows what will be applied. `base/kustomization.yaml` pins the image
-tag (`images: newTag`); published tags carry no `v` prefix (`0.41.0`, `latest`) — bump it when you
+tag (`images: newTag`); published tags carry no `v` prefix (`0.59.2`, `latest`) — bump it when you
 upgrade.
 
 ## Access the UI

--- a/docs-site/docs/deploy/installation/terraform.md
+++ b/docs-site/docs/deploy/installation/terraform.md
@@ -112,7 +112,7 @@ module "immich_memories" {
 | `namespace` | Kubernetes namespace | `string` | `"immich-memories"` |
 | `create_namespace` | Create the namespace | `bool` | `true` |
 | `image_repository` | Container image | `string` | `"ghcr.io/sam-dumont/immich-video-memory-generator"` |
-| `image_tag` | Image tag (no `v` prefix: `0.41.0`, `latest`) | `string` | `"latest"` |
+| `image_tag` | Image tag (no `v` prefix: `0.59.2`, `latest`) | `string` | `"latest"` |
 | `replicas` | Replica count — keep at 1, the UI is single-replica | `number` | `1` |
 | `resources` | Requests/limits object (`requests.memory/cpu`, `limits.memory/cpu`) | `object` | `2Gi/1000m` – `8Gi/4000m` |
 | `tmp_size` | `/tmp` emptyDir for FFmpeg intermediates (8Gi for 4K) | `string` | `"4Gi"` |

--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -24,7 +24,7 @@ to `ok` and leaves a degraded payload as `degraded`. Do not use `/health` as a r
   "status": "ready",
   "immich_reachable": true,
   "last_successful_run": "2025-12-15T10:30:00.000000",
-  "version": "0.40.1"
+  "version": "0.59.2"
 }
 ```
 

--- a/docs-site/docs/deploy/maintenance/upgrading.md
+++ b/docs-site/docs/deploy/maintenance/upgrading.md
@@ -88,7 +88,7 @@ tags: [GitHub releases](https://github.com/sam-dumont/immich-video-memory-genera
 then pull and recreate:
 
 ```yaml
-image: ghcr.io/sam-dumont/immich-video-memory-generator:0.40.1   # image tags have no `v` prefix
+image: ghcr.io/sam-dumont/immich-video-memory-generator:0.59.2   # image tags have no `v` prefix
 ```
 
 ```bash
@@ -98,9 +98,9 @@ docker compose up -d
 
 **uv/pip:**
 ```bash
-uv tool install immich-memories==0.40.1
+uv tool install immich-memories==0.59.2
 # or
-pip install immich-memories==0.40.1
+pip install immich-memories==0.59.2
 ```
 
 Your analysis cache and config are preserved across version changes. The only thing that might need attention is config field names if the version you're rolling back to used different names.


### PR DESCRIPTION
`deploy/kubernetes/base/kustomization.yaml` pinned `newTag: "0.41.0"`. Current release is **v0.59.2** — eighteen minor versions. A fresh `kubectl apply -k base` installed that stale image, and `deploy/terraform/examples/production/terraform.tfvars.example` pinned the same tag.

Those two are the real fix. The other eight hits are example strings illustrating "published tags carry no `v` prefix" and two sample `/health` payloads, all quoting `0.41.0` or `0.40.1`; they move with the pin rather than contradicting it two lines away.

Enumerated sites (no blanket replace beyond these):

| File | What it was |
|---|---|
| `deploy/kubernetes/base/kustomization.yaml` | **the pin** + its comment |
| `deploy/terraform/examples/production/terraform.tfvars.example` | **a pin someone copies** |
| `deploy/kubernetes/README.md`, `deploy/terraform/README.md`, `deploy/terraform/variables.tf` | example strings |
| `installation/kubernetes.md`, `installation/terraform.md`, `common-setups/kubernetes-gpu.md` | example strings |
| `common-setups/kubernetes-gpu.md`, `maintenance/health-logs-cache.md` | sample `/health` payload `version` |
| `maintenance/upgrading.md` | three pin-an-explicit-version examples |

`tests/test_deploy_manifests_contract.py:87` only asserts `newTag` matches `\d+\.\d+\.\d+`, so the pin stays contract-valid. `make test` (5576 passed) and `make docs-check` both pass.

Worth noting: nothing automates this. The tag goes stale again at the next release — a release step that bumps `newTag`, or pinning `latest` with a warning, would be the durable fix. Left out of this PR because it is a release-workflow change, not a version bump.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
