### PR TITLE
docs(recipes): three tips that do not do what they say

### DIFF
--- a/docs-site/docs/create/pipeline/photo-support.md
+++ b/docs-site/docs/create/pipeline/photo-support.md
@@ -18,7 +18,7 @@ Photos compete in the same selection pool as videos and live photos. There's no 
 5. **Render**: Selected photos are animated as Ken Burns clips at assembly time
 6. **Interleave**: No more than 2 consecutive clips of the same type (photo or video)
 
-Photos are capped at 50% of the final video when videos are plentiful. When videos are scarce (< 30% of selected clips), photos fill the budget freely.
+Photos are capped at 50% of the final video when videos are plentiful. Scarcity is measured against the target, not against the selection: when the video candidates available cannot fill even half the target duration, the cap is bypassed and photos fill the rest.
 
 ## Animation Effects
 

--- a/docs-site/docs/create/recipes/birthday-compilations.md
+++ b/docs-site/docs/create/recipes/birthday-compilations.md
@@ -33,7 +33,15 @@ The `--birthday` flag makes the year run from birthday to birthday (e.g., Jul 21
 
 ## UI
 
-In Step 1, select the "Birthday" time period option. Pick the birthday date and the tool calculates the range for you.
+There is no "Birthday" card. Two paths get you a birthday-to-birthday range:
+
+- **Person Spotlight** card: pick the person, then tick **Birthday to birthday**. If Immich
+  has a birth date on that person, the checkbox turns itself on when you select them.
+- **Custom** card → **Year** tab → **From Birthday**, which gives you a Birthday date field
+  and computes the range from it.
+
+Either way the range runs birthday to birthday rather than January to December. See
+[Step 1: Configuration](../web-ui/step1-configuration.mdx).
 
 ## Tips
 

--- a/docs-site/docs/create/recipes/tips-and-best-practices.md
+++ b/docs-site/docs/create/recipes/tips-and-best-practices.md
@@ -9,14 +9,16 @@ Things that save time and produce better results.
 
 ## Run Analysis First
 
-Analysis is the slow part. Run it once and cache the results:
+Analysis is the slow part on a cold library. `analyze` does it on its own, without
+rendering anything:
 
-```yaml
-analysis:
-  use_scene_detection: true
+```bash
+immich-memories analyze --year 2024
 ```
 
-Subsequent runs load from cache instantly. This matters a lot when you're iterating on clip selection.
+Subsequent generate runs read from that cache instead of re-analysing, which is what
+makes iterating on clip selection quick. On a NAS this is the thing to run overnight.
+See [Discovery & utility commands](../cli/discovery-and-utility.md).
 
 ## Use Hardware Acceleration
 
@@ -66,12 +68,15 @@ content_analysis:
 
 ## Downscaling for Analysis
 
-If analysis is slow, enable downscaling. The tool doesn't need full-resolution frames to detect scenes and score clips:
+Already on. `enable_downscaling` defaults to `true` and `analysis_resolution` to 480, so
+every run already scores clips off a 480p proxy rather than the 4K source — the tool does
+not need full-resolution frames to detect scenes or rank clips.
 
 ```yaml
 analysis:
-  enable_downscaling: true
-  analysis_resolution: 480
+  enable_downscaling: true   # default
+  analysis_resolution: 480   # default
 ```
 
-This can cut analysis time in half with virtually no impact on clip selection quality.
+The only reason to touch these is to go the other way: raise `analysis_resolution` if you
+think scoring is missing small faces in wide shots, and accept the slower analysis.


### PR DESCRIPTION
## Description

Four pieces of advice a reader could follow exactly and get nothing.

### tips-and-best-practices.md — "Run Analysis First"

> Analysis is the slow part. Run it once and cache the results:
> ```yaml
> analysis:
>   use_scene_detection: true
> ```

The tip promises cache-warming and delivers a YAML line that (a) runs nothing and (b) is already the default. The command that does what the tip describes exists — `immich-memories analyze --year 2024` — and is documented one page over with exactly this "warm the cache overnight on a NAS" rationale. Now says so, and links there.

### tips-and-best-practices.md — "Downscaling for Analysis"

> If analysis is slow, enable downscaling.

`enable_downscaling` defaults to `True` and `analysis_resolution` to 480 (`config_models_analysis.py:191`). Every run already scores off a 480p proxy. The section presented the default as an opt-in win, so a reader either copies YAML that changes nothing or concludes their analysis is slow because they forgot a setting. It now says it is on, and gives the one real reason to touch it — raise the resolution if scoring is missing small faces, and pay for it in time.

### birthday-compilations.md — the Step 1 path

> In Step 1, select the "Birthday" time period option.

There is no such option. The two real paths:

- **Person Spotlight** card → "Birthday to birthday" checkbox (`step1_presets.py:355`), which self-enables when Immich has a birth date on the selected person (`step1_presets.py:336-339`)
- **Custom** → **Year** tab → **From Birthday** (`step1_tabs.py` `_render_year_type_buttons`, `state.year_type = "birthday"`)

`web-ui/step1-configuration.mdx` documents both correctly; the recipe was describing a UI that does not exist.

### photo-support.md — the scarcity threshold

> When videos are scarce (< 30% of selected clips), photos fill the budget freely.

`clip_refiner.py:697`:

```python
available_video_duration = sum(... for c in analyzed if c.clip.asset.type != AssetType.IMAGE)
videos_scarce = available_video_duration < target_duration * 0.5
```

Different quantity (available duration, not selected count), different denominator (the target, not the selection), different threshold (50%, not 30%). The code comment says the same thing the fixed sentence does: "photos fill freely only when videos cannot fill half the budget."

## Verification

- `make docs-check` — clean build, no anchor warnings
- No `.py` touched
- Every threshold read off `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
