### PR TITLE
fix(docs): homepage ships 10 memory types, not 7

### DIFF
--- a/docs-site/docs/create/cli/scheduler.md
+++ b/docs-site/docs/create/cli/scheduler.md
@@ -5,7 +5,7 @@ title: scheduler
 
 # scheduler
 
-:::tip Smart automation is the easier option
+:::tip The `auto` system is the easier option
 Most users should schedule one daily [`auto run`](./auto.md#auto-run) instead: it detects trips,
 birthdays, and highlights automatically. No cron expressions or explicit schedules needed. The
 scheduler below is the advanced/legacy cron daemon for Docker/K8s deployments or exact control

--- a/docs-site/docs/create/recipes/automated-generation.md
+++ b/docs-site/docs/create/recipes/automated-generation.md
@@ -6,9 +6,9 @@ title: Automated Generation
 # Automated Generation
 
 Once you know your preferred settings, automate the whole thing. The recommended path is one daily
-smart decision; the scheduler daemon and hand-written cron are advanced/legacy alternatives.
+decision; the scheduler daemon and hand-written cron are advanced/legacy alternatives.
 
-## Smart Automation (Recommended)
+## Automation (Recommended)
 
 The `auto` system scans your library, detects what's worth turning into a memory video, and generates the best candidate. It runs 8 detectors (monthly, yearly, trips, person spotlights, birthdays, activity bursts, on-this-day, multi-person pairs) and picks the highest-scoring one.
 
@@ -62,7 +62,7 @@ appears on schedule, uploads if `upload_to_immich` is on, and notifies if notifi
 
 ## Scheduler daemon (advanced/legacy)
 
-:::tip Use smart automation instead
+:::tip Use the `auto` system instead
 Most users should use the `auto` system above — it figures out what to generate automatically. The scheduler below is for Docker/K8s deployments or when you need exact control over what generates when (specific memory types on specific dates).
 :::
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -23,7 +23,7 @@ immich-memories analyze [OPTIONS]
 
 ## `auto`
 
-Smart automation -- detect and generate memory candidates.
+Automation -- detect and generate memory candidates.
 
 ```bash
 immich-memories auto [OPTIONS]

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -603,7 +603,7 @@ scheduler:
       params: {}
 ```
 
-## Smart automation
+## Automation
 
 Controls what `immich-memories auto suggest` and `auto run` detect and generate. See the [auto CLI docs](../create/cli/auto.md) for the full command reference. Tier 2 — lives under `advanced:` when the app writes the file.
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -18,7 +18,7 @@ function HeroSection() {
             </Heading>
             <p className={styles.heroSubtitle}>
               Point it at your Immich server. Pick a year, a person, or a trip.
-              Get a polished video with smart cuts, animated maps, AI music,
+              Get a polished video with scene-aware cuts, animated maps, AI music,
               and title screens. Self-hosted. No subscription.
             </p>
             <div className={styles.heroCtas}>
@@ -120,8 +120,8 @@ type ShowcaseItem = {
 
 const showcaseItems: ShowcaseItem[] = [
   {
-    title: '7 memory types',
-    description: 'Year in Review, Season, Person Spotlight, Multi-Person, Monthly Highlights, On This Day, Trip. Pick a preset and it handles the rest.',
+    title: '10 memory types',
+    description: 'Year in Review, Season, Person Spotlight, Multi-Person, Monthly Highlights, On This Day, Holiday, Then and Now, Trip, Album. Pick a preset and it handles the rest, or take the eleventh card, Custom, and set the date range yourself.',
     image: '/img/screenshots/step1-preset-cards.png',
     alt: 'Memory type preset selection cards',
   },
@@ -185,7 +185,7 @@ function ValuesSection() {
               </svg>
             </div>
             <strong>Your data stays home</strong>
-            <p>No telemetry, no account. Runs on your hardware; the only outbound calls are the ones you configure (LLM, music server) plus map tiles for trip maps. The Immich API key never leaves your network.</p>
+            <p>No telemetry, no account. Runs on your hardware; the only outbound calls are the ones you configure (LLM, music server, notifications) plus map tiles and geocoding for trip maps. The Immich API key never leaves your network.</p>
           </div>
           <div className={styles.value}>
             <div className={styles.valueIcon}>
@@ -194,7 +194,7 @@ function ValuesSection() {
               </svg>
             </div>
             <strong>Read-only by default</strong>
-            <p>Your Immich library is never modified. Upload-back is opt-in. No risk of data loss, ever.</p>
+            <p>Your Immich library is never modified. Upload-back is opt-in.</p>
           </div>
           <div className={styles.value}>
             <div className={styles.valueIcon}>
@@ -211,7 +211,7 @@ function ValuesSection() {
                 <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
               </svg>
             </div>
-            <strong>One smart decision a day</strong>
+            <strong>One decision a day</strong>
             <p>Schedule <code>immich-memories auto run</code> daily. It picks one eligible memory or retries one pending delivery, with variety rules that stop repeat spam.</p>
           </div>
         </div>
@@ -247,7 +247,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title="Home"
-      description="Turn your Immich photo library into polished video memories. Smart clips, animated maps, AI music, title screens. Self-hosted, no cloud required.">
+      description="Turn your Immich photo library into polished video memories. Scene-aware clips, animated maps, AI music, title screens. Self-hosted, no cloud required.">
       <HeroSection />
       <QuickstartSection />
       <ShowcaseSection />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "immich-memories"
 dynamic = ["version"]
-description = "Turn your Immich photo library into video memory compilations with music and smart cuts"
+description = "Turn your Immich photo library into video memory compilations with music and scene-aware cuts"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -1,4 +1,4 @@
-"""Smart automation CLI commands -- suggest, run, install, and history."""
+"""Automation CLI commands -- suggest, run, install, and history."""
 
 from __future__ import annotations
 
@@ -159,7 +159,7 @@ def _print_history_table(runs: list) -> None:
 
 @click.group()
 def auto() -> None:
-    """Smart automation -- detect and generate memory candidates."""
+    """Automation -- detect and generate memory candidates."""
 
 
 @auto.command()


### PR DESCRIPTION
The homepage has been under-selling the headline feature by three types since Holiday, Then and Now and Album shipped.

## The count

`MemoryType` has **10** members (`memory_types/registry.py` L9-20) and Step 1 renders **11** cards, those ten plus Custom (`ui/pages/step1_presets.py` L20-32). README already says 10. The landing page still said **7** and listed seven. Fixed, with the eleventh card named.

## Two more things on that page

**Deleted "No risk of data loss, ever."** An absolute warranty sitting one click from a DISCLAIMER that tells people to keep backups is a bad trade. It buys no trust, and it hands anyone who hits a data bug a screenshot. The two sentences before it already make the claim, and unlike the third they're things the code actually guarantees:

> Your Immich library is never modified. Upload-back is opt-in.

**The privacy card under-listed outbound calls.** It said "the ones you configure (LLM, music server) plus map tiles for trip maps". SECURITY.md's own list is longer: **geocoding** and **notifications** also leave the network. Under-listing outbound calls on a card headed "Your data stays home" is exactly the kind of thing that gets found; it now matches SECURITY.md.

## The "Smart X" sweep

Three phrasings of nothing on the landing page: "smart cuts" (hero), "Smart clips" (meta description), "One smart decision a day" (values card). Scene detection is what the code actually does (`analysis/segment_generation.py`), so the cuts are scene-aware; the automation card loses an adjective it never carried weight with.

The same word lived in two places that ship or generate elsewhere:

- **`pyproject.toml` description** is the PyPI storefront line. "music and smart cuts" -> "music and scene-aware cuts".
- **The `auto` Click group docstring**, which `make docs-cli` renders into `cli-reference.md`. Fixed at the source and regenerated: editing the generated page would just fail the drift gate.

With the CLI name changed, the docs naming the same feature move with it, or the rename is half-done and the docs contradict the CLI: config-reference's `## Smart automation` heading plus the two pointers in `scheduler.md` and `automated-generation.md`. **Checked for inbound anchor links to the renamed headings first; there are none.**

## Verified against code, not the review

| Claim | Source |
|---|---|
| 10 memory types | `memory_types/registry.py` L9-20 |
| 11 preset cards | `ui/pages/step1_presets.py` L20-32 |
| cuts are scene-aware | `analysis/segment_generation.py`, `config_models_analysis.py` |
| outbound call list | `SECURITY.md` L36 |
| no `#smart-automation` inbound links | repo-wide grep |

One correction to the review that prompted this: it said the `auto` docstring "regenerates two docs pages". `scripts/generate_cli_docs.py` writes exactly one, `docs-site/docs/reference/cli-reference.md`. `create/cli/auto.md` is hand-written and never carried the string.

Gates: `make docs-build` (zero anchor warnings), `make docs-cli-check` and `make docs-config-check` clean with the regen committed, every static gate green, `make test` 5,576 passed / 9 skipped.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
