### PR TITLE
docs(audio): the page contradicting itself in three places

### DIFF
--- a/docs-site/docs/create/pipeline/audio-and-music.md
+++ b/docs-site/docs/create/pipeline/audio-and-music.md
@@ -5,7 +5,7 @@ title: Audio & Music
 
 # Audio & Music
 
-The music pipeline has three stages:
+The music pipeline has four stages:
 
 1. **Mood detection**: A vision LLM looks at keyframes from your video and outputs a structured mood analysis (happy, calm, energetic, etc. plus genre and tempo suggestions).
 2. **Music generation**: The pipeline takes that mood and sends it to the configured music backend. ACE-Step can run directly in the app or through its REST API. MusicGen is the alternative generator when ACE-Step is disabled.
@@ -170,7 +170,7 @@ separation rather than paying for a Demucs run it would discard.
 
 You don't have to use AI-generated music. In the UI at Step 3, choose **Upload file** under **Background music** (MP3, M4A or WAV) and set the **Music volume** slider. On the CLI, pass `--music /path/to/track.mp3` (and `--music-volume 0.0-1.0`, default 0.5).
 
-To disable music, choose **None** in the UI or pass `--no-music` on the CLI. Without `--music`, the CLI generates an AI track when `ace_step.enabled` or `musicgen.enabled` is set, and otherwise renders with the clips' own audio.
+To disable music, choose **None** in the UI or pass `--no-music` on the CLI. Without `--music`, the CLI generates an AI track when `ace_step.enabled` or `musicgen.enabled` is set. With no generator configured — or with one that failed — it falls back to a bundled track, and only renders with the clips' own audio when the `music` extra isn't installed and there is nothing bundled to fall back to.
 
 For a local library, `immich-memories music search` and `music add` read `audio.local_music_dir` (default `~/Music/Memories`); see the [music command](../cli/music.md). Generation itself does not pick from that directory.
 
@@ -371,7 +371,7 @@ Which music plays is decided by three switches:
 | CLI | `--music PATH`, `--no-music`, `--music-volume 0.0-1.0` | Own file, no music at all, or the mix level (default 0.5) |
 | UI Step 3 | **Background music**: None / Upload file / AI Generated, plus the volume slider | Same choices per run |
 
-The music volume slider maps to a base music level of −20 dB (0.0) to 0 dB (1.0) before ducking. Ducking parameters are fixed in the mixer (sidechain threshold 0.02, ratio 4.0, 100 ms attack, 2.5 s release, 2 s fade in, 3 s fade out). The `audio:` section in the schema (`auto_music`, `music_source`, `ducking_threshold`, `ducking_ratio`, `music_volume_db`, `fade_in_seconds`, `fade_out_seconds`) is not read by generation; only `audio.local_music_dir` is used, by the `music` command. If you need custom fades or a dB level, run `immich-memories music add` on the finished file with `--volume`, `--fade-in`, `--fade-out`.
+The music volume slider maps to a base music level of −20 dB (0.0) to 0 dB (1.0) before ducking. Ducking parameters are fixed in the mixer (sidechain threshold 0.02, ratio 4.0, 100 ms attack, 2.5 s release, 2 s fade in, 3 s fade out). The `audio:` section holds exactly one key, `local_music_dir`, used by the `music` command; ducking and fades are fixed in the mixer and have no config surface. If you need custom fades or a dB level, run `immich-memories music add` on the finished file with `--volume`, `--fade-in`, `--fade-out`.
 
 ## Model Cache & Disk Usage
 


### PR DESCRIPTION
## Description

Three lines on `audio-and-music.md` that contradict the rest of the same page, or the schema.

### "The music pipeline has three stages:" — followed by four

Stage 4 ("Music steps aside for music") was added later and the sentence above it was never re-read. Now says four.

### The `--music` fallback skips the bundled branch

> Without `--music`, the CLI generates an AI track when `ace_step.enabled` or `musicgen.enabled` is set, and otherwise renders with the clips' own audio.

This contradicts the page's own "No GPU? Start here" section 150 lines above ("28 royalty-free background tracks... used automatically when no generator is configured") and `resolve_music()`, whose docstring is **"provided path, generated, bundled, or none"**. The fall-through calls `bundled_track_for_mood()`, and the `except` branch on a failed generator deliberately falls through to it too, with a comment explaining why:

> Fall through to bundled and carry the warning out with the track — a log line alone never reaches the run artifact, the UI or the nightly notification, so a dead backend stayed invisible.

Silence is the fourth branch (nothing bundled to find), not the second. Rewritten to name all three fallbacks in order.

### The `audio:` dead-keys warning names keys that no longer exist

> The `audio:` section in the schema (`auto_music`, `music_source`, `ducking_threshold`, `ducking_ratio`, `music_volume_db`, `fade_in_seconds`, `fade_out_seconds`) is not read by generation; only `audio.local_music_dir` is used

Those seven were removed from the schema. `AudioConfig` (`config_models_soundtrack.py:17`) is one field — `local_music_dir` — and its docstring already says the rest: "ducking and fades are fixed in the mixer." The warning was telling readers that keys they cannot write are ignored. Replaced with one sentence.

The measured numbers around it (slider → −20 dB..0 dB, sidechain threshold 0.02, ratio 4.0, 100 ms attack, 2.5 s release, 2 s/3 s fades) all check out against `generate_music.py:400` and `mixer.py` and are unchanged.

## Note on the local diff

The reviewer read this file with uncommitted local modifications in the shared checkout. This branch is based on `origin/main` and every line above was re-verified against that tree — all three defects are present on `main` as it stands.

## Verification

- `make docs-check` — clean build, no anchor warnings
- `make docs-config-check` — config reference still matches the schema
- No `.py` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
