### PR TITLE
docs: one test-count breakdown, measured

### DIFF
--- a/docs-site/docs/contribute/testing.md
+++ b/docs-site/docs/contribute/testing.md
@@ -4,7 +4,7 @@ title: Testing Guide
 
 # Testing Guide
 
-Immich Memories has about 5,000 tests: 4,400+ fast unit tests that run everywhere, and 600+ integration and E2E tests that need real services (FFmpeg, Immich, a browser).
+Immich Memories has 5,600+ tests: 5,000+ fast unit tests that run everywhere, and 600+ integration and E2E tests that need real services (FFmpeg, Immich, a browser).
 
 ## Testing Tiers
 

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -77,7 +77,7 @@ A PR passes 20 gates: 15 static checks in the quality job and 5 security scans i
 | Dependencies | pip-audit + deptry | Known CVEs; unused, missing or transitive imports |
 | Architecture | import-linter | Layer violations (e.g., UI importing from processing internals) |
 | Commits | commitizen | Non-conventional commit messages |
-| Tests | pytest | 5,000+ tests: 4,400+ unit in CI, 600+ integration/E2E locally and on the GPU runner |
+| Tests | pytest | 5,600+ tests: 5,000+ unit in CI, 600+ integration/E2E locally and on the GPU runner |
 
 ## How to Add a New Feature
 

--- a/docs-site/docs/reference/faq.md
+++ b/docs-site/docs/reference/faq.md
@@ -31,7 +31,7 @@ Yes. The CLI works without a display. Use `immich-memories generate` with flags 
 
 **Is it safe for production?**
 
-The codebase is AI-written (on purpose, as an experiment) with 5,000+ tests (4,400+ unit, 600+ integration/E2E) and strict quality gates. The output (music, clip selection, mood analysis) is AI-generated too, so results vary. Review what it produces before showing it at grandma's birthday party.
+The codebase is AI-written (on purpose, as an experiment) with 5,600+ tests (5,000+ unit, 600+ integration/E2E) and strict quality gates. The output (music, clip selection, mood analysis) is AI-generated too, so results vary. Review what it produces before showing it at grandma's birthday party.
 
 **Can I generate for multiple people at once?**
 


### PR DESCRIPTION
Three pages carry the same stale test breakdown: **"4,400+ unit"**. That number is about 1,200 short.

## Measured, not guessed

```
$ uv run pytest --collect-only -q
5585/6230 tests collected (645 deselected)

$ uv run pytest tests/integration --collect-only -q
600 deselected

$ uv run pytest tests/e2e --collect-only -q
40 deselected
```

So: **6,230 collected**, **5,585** in the default unit run, **640** integration + E2E.

The canonical phrasing already exists in README L182 and matches those numbers while staying conservative:

> 5,600+ tests (5,000+ unit, 600+ integration/E2E)

Copied into the three pages that had the drifted breakdown:

- `docs-site/docs/reference/architecture.md` L80 (the gates table)
- `docs-site/docs/reference/faq.md` L34
- `docs-site/docs/contribute/testing.md` L7

Tone untouched on all three. faq.md's "Review what it produces before showing it at grandma's birthday party" and testing.md's CI-forensics half are exactly as they were: this is a number swap, not an edit pass.

DISCLAIMER.md's "5,000+ tests" is left alone, that file is in flight on another branch.

`make docs-build` passes, zero anchor warnings.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
