### PR TITLE
fix(docs): development-setup told contributors the opposite of what CI does

### DIFF
--- a/docs-site/docs/contribute/development-setup.md
+++ b/docs-site/docs/contribute/development-setup.md
@@ -48,7 +48,7 @@ This runs lint, format check, type check, file length gate, complexity gate, and
 | `make lint` | Ruff linter |
 | `make format` | Auto-format code |
 | `make typecheck` | mypy type checking |
-| `make ci` | Full CI pipeline (the 15 local gates) |
+| `make ci` | Full CI pipeline (the 16 local gates, plus the unit tests) |
 | `make critique` | AI smell audit |
 | `make test-integration` | Integration tests (needs FFmpeg + Immich) |
 
@@ -68,7 +68,18 @@ If `make ci` passes locally, CI will pass too. Use [conventional commit](https:/
 
 **Integration tests** (`make test-integration`, or one suite such as `make test-integration-assembly`): real FFmpeg assembly, real Immich API reads. They live in per-suite folders under `tests/integration/` (`assembly`, `audio`, `auth`, `cli`, `live_photos`, `photos`, `pipeline`, `processing`, `titles`) and skip gracefully if a service isn't available. They run locally and on a self-hosted Linux GPU runner, which uploads its coverage to Codecov under the `integration-linux` flag. The per-suite coverage XMLs they write under `tests/` are gitignored — do not try to commit them.
 
-If CI's diff-cover fails because changed lines aren't covered by unit tests, add unit tests for those lines; the GPU runner's integration coverage is merged on Codecov but does not feed diff-cover.
+### If diff-cover fails on your PR
+
+Every PR needs 80% coverage on the lines it changes. Before checking that, CI runs the FFmpeg-only integration suites covering the paths your diff touches, and only those, then merges their coverage into the diff-cover run. So code reachable only through FFmpeg is covered for you: you do not need to write unit tests for it.
+
+To reproduce locally exactly what CI will see:
+
+```bash
+make integration-coverage-for-diff   # runs only the suites your diff touches
+make diff-cover-local                # merges them with unit coverage, same as CI
+```
+
+If diff-cover still fails after that, the uncovered lines are not reachable from an integration suite and do need unit tests. Subprocess boundaries can be stubbed rather than run for real: `tests/test_ffmpeg_pipe.py` shows the pattern.
 
 ## Project structure
 


### PR DESCRIPTION
`development-setup.md` tells contributors to do work CI stopped requiring.

## The contradiction

The page says:

> If CI's diff-cover fails because changed lines aren't covered by unit tests, add unit tests for those lines; the GPU runner's integration coverage is merged on Codecov but **does not feed diff-cover**.

CI does the opposite now. `.github/workflows/ci.yml` L233-236 runs `make integration-coverage-for-diff` **before** the diff-cover step, and `make diff-cover-ci` merges every `tests/*-coverage.xml` it produced. The WHY comment in ci.yml spells out the reasoning:

> diff-cover merges tests/*-coverage.xml, but those are gitignored and so can never arrive from a contributor's machine. Code only reachable through FFmpeg would therefore always read as uncovered.

CONTRIBUTING.md L83-93 already describes the new mechanism correctly. This page predates it, so a contributor following it writes unit tests for FFmpeg-reachable code that CI already covers for them. That is the most expensive kind of wrong doc: it costs work, not just confusion.

Rewritten to match, including the two commands that reproduce what CI sees (both verified in the Makefile, L508 and L509).

## Also on this page

**`make ci` is 16 gates, not 15.** The `ci` target (Makefile L583) runs `lint format-check typecheck file-length complexity cognitive-complexity dead-code security-lint semgrep refurb dep-check arch-check duplication critique docs-cli-check docs-config-check` plus `test`. That is 16 gates and the unit tests. `docs-cli-check` and `docs-config-check` were added after this line was written; `architecture.md` L63 already says 16.

Same file, same concern: both lines are about what your local gates actually do.

`make docs-build` passes, zero anchor warnings.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
