### PR TITLE
docs: list the two integration suites the docs forgot

### DIFF
--- a/docs-site/docs/contribute/development-setup.md
+++ b/docs-site/docs/contribute/development-setup.md
@@ -66,7 +66,7 @@ If `make ci` passes locally, CI will pass too. Use [conventional commit](https:/
 
 **Unit tests** (`make test`): pure logic, no external dependencies. Run in CI on every PR.
 
-**Integration tests** (`make test-integration`, or one suite such as `make test-integration-assembly`): real FFmpeg assembly, real Immich API reads. They live in per-suite folders under `tests/integration/` (`assembly`, `audio`, `auth`, `cli`, `live_photos`, `photos`, `pipeline`, `processing`, `titles`) and skip gracefully if a service isn't available. They run locally and on a self-hosted Linux GPU runner, which uploads its coverage to Codecov under the `integration-linux` flag. The per-suite coverage XMLs they write under `tests/` are gitignored — do not try to commit them.
+**Integration tests** (`make test-integration`, or one suite such as `make test-integration-assembly`): real FFmpeg assembly, real Immich API reads. They live in per-suite folders under `tests/integration/` (`assembly`, `audio`, `audio_mixing`, `auth`, `automation`, `cli`, `live_photos`, `photos`, `pipeline`, `processing`, `titles`) and skip gracefully if a service isn't available. They run locally and on a self-hosted Linux GPU runner, which uploads its coverage to Codecov under the `integration-linux` flag. The per-suite coverage XMLs they write under `tests/` are gitignored — do not try to commit them.
 
 If CI's diff-cover fails because changed lines aren't covered by unit tests, add unit tests for those lines; the GPU runner's integration coverage is merged on Codecov but does not feed diff-cover.
 

--- a/docs-site/docs/contribute/testing.md
+++ b/docs-site/docs/contribute/testing.md
@@ -29,10 +29,10 @@ Cover the real pipeline: download from Immich, FFmpeg assembly, video output val
 
 ```bash
 make test-integration            # Every suite except cli (~15 min)
-make test-integration-assembly   # One suite: assembly, audio, auth, cli, live-photos, photos, pipeline, processing, titles
+make test-integration-assembly   # One suite: assembly, audio, audio-mixing, auth, cli, live-photos, photos, pipeline, processing, titles
 ```
 
-Each suite is a folder under `tests/integration/` with its own `make test-integration-<suite>` target and rough runtime (see the table in `CLAUDE.md`). `cli` re-runs the full pipeline (~15 min) and is not part of `make test-integration`.
+Each suite is a folder under `tests/integration/`, and most have their own `make test-integration-<suite>` target with a rough runtime (see the table in `CLAUDE.md`). `automation` has no dedicated target yet; it runs as part of `make test-integration`. `cli` is the other exception: it re-runs the full pipeline (~15 min) and is not part of `make test-integration`.
 
 **What's tested:**
 - Real FFmpeg assembly (single clip, crossfade, smart transitions)
@@ -118,7 +118,9 @@ tests/
     ├── immich_fixtures.py   # requires_immich, short-clip fixtures
     ├── assembly/            # make test-integration-assembly   (FFmpeg only)
     ├── audio/               # make test-integration-audio      (demucs/acestep packages)
+    ├── audio_mixing/        # make test-integration-audio-mixing (FFmpeg only, loop seams)
     ├── auth/                # make test-integration-auth       (no external deps)
+    ├── automation/          # auto suggest/run (no dedicated target yet)
     ├── cli/                 # make test-integration-cli        (full pipeline, slow)
     ├── live_photos/         # make test-integration-live-photos (FFmpeg + Immich)
     ├── photos/              # make test-integration-photos     (FFmpeg only)


### PR DESCRIPTION
Two integration suites exist but appear in none of the lists the docs give.

`tests/integration/` holds **11** suite folders:

```
assembly  audio  audio_mixing  auth  automation  cli
live_photos  photos  pipeline  processing  titles
```

Three lists named nine of them, missing `audio_mixing/` and `automation/`:

- `contribute/development-setup.md` L69, the inline suite list
- `contribute/testing.md` L32, the `make test-integration-<suite>` comment
- `contribute/testing.md` L119-127, the directory tree

## One nuance worth flagging

They are not symmetric. `audio_mixing` has its own target (`make test-integration-audio-mixing`, Makefile L228), so it joins the target list. **`automation` has no dedicated target**, which matches the table in CLAUDE.md.

That made the surrounding sentence wrong too:

> Each suite is a folder under `tests/integration/` **with its own `make test-integration-<suite>` target**

It now names the two exceptions instead: `automation` (no target, runs as part of `make test-integration`) and `cli` (has a target, excluded from the group run because it takes ~15 min).

Nothing else on either page is touched. testing.md's "When CI fails but nothing failed" half is untouched.

`make docs-build` passes, zero anchor warnings. Verified this merges cleanly with #640, which edits the same file two lines away.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
