### PR TITLE
feat(metrics): count what a run spends on the LLM, and store it

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -4764,55 +4764,55 @@
       {
         "name": "RunDatabase::update_run_status",
         "complexity": 18,
-        "line_start": 339,
-        "line_end": 400,
+        "line_start": 342,
+        "line_end": 403,
         "line_complexities": [
           {
-            "line": 354,
-            "complexity": 0
-          },
-          {
-            "line": 355,
-            "complexity": 0
-          },
-          {
-            "line": 356,
+            "line": 357,
             "complexity": 0
           },
           {
             "line": 358,
+            "complexity": 0
+          },
+          {
+            "line": 359,
+            "complexity": 0
+          },
+          {
+            "line": 361,
             "complexity": 2
           },
           {
-            "line": 362,
+            "line": 365,
             "complexity": 2
           },
           {
-            "line": 366,
+            "line": 369,
             "complexity": 2
           },
           {
-            "line": 370,
+            "line": 373,
             "complexity": 2
           },
           {
-            "line": 374,
+            "line": 377,
             "complexity": 2
           },
           {
-            "line": 378,
+            "line": 381,
             "complexity": 2
           },
           {
-            "line": 382,
+            "line": 385,
             "complexity": 2
           },
           {
-            "line": 386,
+            "line": 389,
             "complexity": 2
           },
           {
-            "line": 390,
+            "line": 393,
             "complexity": 2
           }
         ]
@@ -4820,69 +4820,69 @@
       {
         "name": "RunDatabase::update_operational_phase",
         "complexity": 21,
-        "line_start": 249,
-        "line_end": 282,
+        "line_start": 252,
+        "line_end": 285,
         "line_complexities": [
           {
-            "line": 251,
+            "line": 254,
             "complexity": 0
           },
           {
-            "line": 252,
+            "line": 255,
             "complexity": 0
-          },
-          {
-            "line": 256,
-            "complexity": 2
-          },
-          {
-            "line": 257,
-            "complexity": 0
-          },
-          {
-            "line": 258,
-            "complexity": 2
           },
           {
             "line": 259,
-            "complexity": 3
+            "complexity": 2
           },
           {
             "line": 260,
             "complexity": 0
           },
           {
-            "line": 265,
-            "complexity": 0
-          },
-          {
-            "line": 266,
+            "line": 261,
             "complexity": 2
           },
           {
-            "line": 267,
-            "complexity": 0
-          },
-          {
-            "line": 270,
+            "line": 262,
             "complexity": 3
           },
           {
-            "line": 271,
+            "line": 263,
+            "complexity": 0
+          },
+          {
+            "line": 268,
+            "complexity": 0
+          },
+          {
+            "line": 269,
+            "complexity": 2
+          },
+          {
+            "line": 270,
+            "complexity": 0
+          },
+          {
+            "line": 273,
+            "complexity": 3
+          },
+          {
+            "line": 274,
             "complexity": 4
           },
           {
-            "line": 276,
+            "line": 279,
             "complexity": 5
           },
           {
-            "line": 282,
+            "line": 285,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 103
+    "complexity": 106
   },
   {
     "path": "src/immich_memories/ui/pages/step2_review.py",

--- a/src/immich_memories/analysis/llm_metrics.py
+++ b/src/immich_memories/analysis/llm_metrics.py
@@ -1,0 +1,131 @@
+"""What a run spent on the LLM, counted where the answers arrive.
+
+The truncation counter is why this exists. `_query_openai` has always noticed
+`finish_reason == "length"` on a thinking call, logged a warning and retried
+without thinking -- and that is all. A silent, correct retry is exactly the
+shape of problem that hides: #600's truncation tax sat in an unread server log
+for months while every run paid it.
+
+A ContextVar rather than a threaded argument, for the reason
+`selection_trace` gives: `query_llm` is called from the CLI, the wizard, the
+auto runner and scripts, and giving all of them a counters parameter to carry
+data none of them read would obscure the code being measured. It is
+task-local, not global -- but it does not cross a thread-pool boundary, so
+`collecting()` must be entered *inside* the run, where `tracing()` is.
+
+Recording is a no-op when nothing is collecting, so a probe or a one-off
+script pays nothing.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_active: ContextVar[LLMCounters | None] = ContextVar("llm_counters", default=None)
+
+__all__ = ["LLMCounters", "collecting", "record_cache_hit", "record_reply", "record_wall"]
+
+
+@dataclass
+class LLMCounters:
+    """What the model was asked, and what it cost."""
+
+    calls: int = 0
+    cache_hits: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    truncated: int = 0
+    wall_seconds: float = 0.0
+
+    def as_metrics(self) -> dict[str, float | int]:
+        """The subset worth persisting, omitting whatever stayed zero.
+
+        A phase that made no LLM calls should carry no LLM keys at all, so a
+        reader can tell "did not use the model" from "used it and it was free".
+
+        Fields are listed explicitly rather than walked with `vars()`: a
+        dynamic read is invisible to Vulture, which then reports every counter
+        as unused.
+        """
+        candidates = {
+            "llm_calls": self.calls,
+            "llm_cache_hits": self.cache_hits,
+            "llm_prompt_tokens": self.prompt_tokens,
+            "llm_completion_tokens": self.completion_tokens,
+            "llm_truncated": self.truncated,
+            "llm_wall_seconds": round(self.wall_seconds, 3),
+        }
+        return {name: value for name, value in candidates.items() if value}
+
+    def since(self, mark: LLMCounters) -> LLMCounters:
+        """What has been spent since `mark` was taken."""
+        return LLMCounters(
+            calls=self.calls - mark.calls,
+            cache_hits=self.cache_hits - mark.cache_hits,
+            prompt_tokens=self.prompt_tokens - mark.prompt_tokens,
+            completion_tokens=self.completion_tokens - mark.completion_tokens,
+            truncated=self.truncated - mark.truncated,
+            wall_seconds=self.wall_seconds - mark.wall_seconds,
+        )
+
+    def snapshot(self) -> LLMCounters:
+        """A frozen copy, so a later `since` can measure against this moment."""
+        return LLMCounters(
+            calls=self.calls,
+            cache_hits=self.cache_hits,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+            truncated=self.truncated,
+            wall_seconds=self.wall_seconds,
+        )
+
+
+def record_reply(*, prompt_tokens: int = 0, completion_tokens: int = 0) -> None:
+    """One reply arrived from the model. Retries count separately, as they cost."""
+    counters = _active.get()
+    if counters is None:
+        return
+    counters.calls += 1
+    counters.prompt_tokens += prompt_tokens
+    counters.completion_tokens += completion_tokens
+
+
+def record_truncation() -> None:
+    """A thinking call hit the token budget and its reasoning was discarded."""
+    counters = _active.get()
+    if counters is not None:
+        counters.truncated += 1
+
+
+def record_cache_hit() -> None:
+    """An identical question was answered from the judgment cache, unpaid for."""
+    counters = _active.get()
+    if counters is not None:
+        counters.cache_hits += 1
+
+
+def record_wall(seconds: float) -> None:
+    counters = _active.get()
+    if counters is not None:
+        counters.wall_seconds += seconds
+
+
+def active() -> LLMCounters | None:
+    return _active.get()
+
+
+@contextmanager
+def collecting() -> Iterator[LLMCounters]:
+    """Count LLM spend for the duration of a run."""
+    counters = LLMCounters()
+    token: Token[LLMCounters | None] = _active.set(counters)
+    try:
+        yield counters
+    finally:
+        _active.reset(token)

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import base64
 import logging
+import time
 from typing import TYPE_CHECKING
 
 import httpx
 
+from immich_memories.analysis import llm_metrics
 from immich_memories.config_models_llm import LLMConfig
 
 if TYPE_CHECKING:
@@ -162,17 +164,24 @@ async def query_llm(
     remembered = _remembered(cache_path, llm_config, prompt, thinking) if not images else None
     if remembered is not None:
         logger.debug("Reusing the answer to an identical question")
+        llm_metrics.record_cache_hit()
         return remembered
-    answer = await _dispatch(
-        prompt,
-        llm_config,
-        temperature,
-        max_tokens,
-        timeout_seconds,
-        thinking,
-        images,
-        image_detail,
-    )
+    started = time.monotonic()
+    try:
+        answer = await _dispatch(
+            prompt,
+            llm_config,
+            temperature,
+            max_tokens,
+            timeout_seconds,
+            thinking,
+            images,
+            image_detail,
+        )
+    finally:
+        # In `finally` so a failed call still shows the time it burned; a run
+        # that spent four minutes on a dead server should not read as free.
+        llm_metrics.record_wall(time.monotonic() - started)
     if not images:
         _remember(cache_path, llm_config, prompt, thinking, answer)
     return answer
@@ -259,7 +268,12 @@ async def _query_ollama(
     async with httpx.AsyncClient(timeout=build_llm_timeout(float(timeout))) as client:
         resp = await client.post(f"{base_url}/api/generate", json=payload)
         resp.raise_for_status()
-        return resp.json()["response"]
+        body = resp.json()
+        llm_metrics.record_reply(
+            prompt_tokens=body.get("prompt_eval_count", 0) or 0,
+            completion_tokens=body.get("eval_count", 0) or 0,
+        )
+        return body["response"]
 
 
 def _anthropic_content(prompt: str, images: Sequence[bytes]) -> str | list[dict]:
@@ -314,7 +328,13 @@ async def _query_anthropic(
         resp = await client.post(f"{base_url}/v1/messages", json=payload)
         resp.raise_for_status()
         body = resp.json()
+        usage = body.get("usage") or {}
+        llm_metrics.record_reply(
+            prompt_tokens=usage.get("input_tokens", 0) or 0,
+            completion_tokens=usage.get("output_tokens", 0) or 0,
+        )
         if thinking and body.get("stop_reason") == "max_tokens":
+            llm_metrics.record_truncation()
             logger.warning("Thinking hit the token budget; retrying without thinking")
             return await _query_anthropic(
                 prompt, config, temperature, max_tokens, timeout, thinking=False, images=images
@@ -382,8 +402,15 @@ async def _query_openai(
         for attempt in range(3):
             resp = await _post_adapted(client, f"{base_url}/chat/completions", payload, adaptations)
             resp.raise_for_status()
-            choice = resp.json()["choices"][0]
+            body = resp.json()
+            choice = body["choices"][0]
+            usage = body.get("usage") or {}
+            llm_metrics.record_reply(
+                prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+                completion_tokens=usage.get("completion_tokens", 0) or 0,
+            )
             if thinking and choice.get("finish_reason") == "length":
+                llm_metrics.record_truncation()
                 # Truncation mid-think leaves the unfinished reasoning in the
                 # content channel — unparseable. A fast answer beats no answer.
                 logger.warning("Thinking hit the token budget; retrying without thinking")

--- a/src/immich_memories/cache/migration_v21.py
+++ b/src/immich_memories/cache/migration_v21.py
@@ -1,0 +1,32 @@
+"""v21: record what a run spent on the LLM, on the run row itself.
+
+Per-phase metrics already have a home in `phase_stats.extra_metrics`, and the
+first design for this used only that. It does not work, for a reason that is
+worth writing down: `RunTracker` records three phases -- clip_extraction,
+assembly and music -- all inside `generate_memory`, while analysis and
+selection run *before* the run row exists and spend nearly all of the model
+budget. A run-level total is therefore not a sum over phases; it has to be
+recorded in its own right.
+
+One JSON column rather than six typed ones: the shape is still settling, and
+`runs stats` does not yet aggregate across runs. When it does, the hot fields
+hoist out of here without a redesign.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate_run_llm_metrics(conn: sqlite3.Connection) -> None:
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'pipeline_runs'"
+    ).fetchone()
+    if table_exists is None:
+        return
+
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(pipeline_runs)")}
+    if "llm_metrics" in existing:
+        return
+
+    conn.execute("ALTER TABLE pipeline_runs ADD COLUMN llm_metrics TEXT")

--- a/src/immich_memories/cache/schema_migrator.py
+++ b/src/immich_memories/cache/schema_migrator.py
@@ -20,6 +20,7 @@ from immich_memories.cache.migration_v15 import migrate_notification_health
 from immich_memories.cache.migration_v16 import migrate_video_analysis_model_version
 from immich_memories.cache.migration_v17 import migrate_segment_transcripts
 from immich_memories.cache.migration_v19 import migrate_target_duration_seconds
+from immich_memories.cache.migration_v21 import migrate_run_llm_metrics
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -94,6 +95,7 @@ class SchemaMigrator:
             18: self._migration_v18_llm_category,
             19: migrate_target_duration_seconds,
             20: self._migration_v20_safe_cut_gaps,
+            21: migrate_run_llm_metrics,
         }
 
         for version in range(from_version + 1, target_version + 1):

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 ANALYSIS_VERSION = 15
 SCORING_VERSION = 3

--- a/src/immich_memories/tracking/models.py
+++ b/src/immich_memories/tracking/models.py
@@ -181,6 +181,9 @@ class RunMetadata:
     clips_analyzed: int = 0
     clips_selected: int = 0
     errors_count: int = 0
+    # What the run spent on the model. Run-level rather than per-phase because
+    # analysis and selection are not tracked phases and spend most of it.
+    llm_metrics: dict[str, float | int] = field(default_factory=dict)
 
     # System info
     system_info: SystemInfo | None = None

--- a/src/immich_memories/tracking/run_database.py
+++ b/src/immich_memories/tracking/run_database.py
@@ -126,6 +126,9 @@ def row_to_run(row: sqlite3.Row) -> RunMetadata:
         warnings=(
             json.loads(_row_value(row, "warnings_json")) if _row_value(row, "warnings_json") else []
         ),
+        llm_metrics=(
+            json.loads(_row_value(row, "llm_metrics")) if _row_value(row, "llm_metrics") else {}
+        ),
         clips_analyzed=row["clips_analyzed"] or 0,
         clips_selected=row["clips_selected"] or 0,
         errors_count=row["errors_count"] or 0,
@@ -467,6 +470,7 @@ class RunDatabase:
         clips_analyzed: int,
         clips_selected: int,
         errors_count: int,
+        llm_metrics: dict | None = None,
     ) -> RunMetadata:
         """Atomically commit artifact facts and its initial delivery lifecycle."""
         delivery_status = (
@@ -489,7 +493,8 @@ class RunDatabase:
                     delivery_error = NULL,
                     immich_asset_id = NULL,
                     delivery_album = ?,
-                    warnings_json = ?
+                    warnings_json = ?,
+                    llm_metrics = ?
                 WHERE run_id = ? AND status = 'running'
                 """,
                 (
@@ -503,6 +508,7 @@ class RunDatabase:
                     delivery_status.value,
                     delivery_album,
                     json.dumps(warnings),
+                    json.dumps(llm_metrics) if llm_metrics else None,
                     run_id,
                 ),
             )
@@ -611,6 +617,23 @@ class RunDatabase:
     # =========================================================================
     # Query Methods (from RunQueriesMixin)
     # =========================================================================
+
+    def record_llm_metrics(self, run_id: str, metrics: dict) -> None:
+        """Store what the run spent on the model.
+
+        Its own method rather than another optional field on
+        `update_run_status`: that function is a chain of "if this was passed,
+        update it" branches sitting at the cognitive-complexity ceiling, and
+        this is one unconditional write.
+        """
+        if not metrics:
+            return
+        with self._get_connection() as conn:
+            conn.execute(
+                "UPDATE pipeline_runs SET llm_metrics = ? WHERE run_id = ?",
+                (json.dumps(metrics), run_id),
+            )
+            conn.commit()
 
     def get_phase_stats(self, run_id: str) -> list[PhaseStats]:
         """Get all phase stats for a run."""

--- a/src/immich_memories/tracking/run_tracker.py
+++ b/src/immich_memories/tracking/run_tracker.py
@@ -50,6 +50,7 @@ class RunTracker:
         self._current_phase: str | None = None
         self._phase_start: datetime | None = None
         self._phase_start_time: float | None = None
+        self._phase_llm_mark: object | None = None
         self._phase_items_total: int = 0
 
     def _require_started(self) -> RunMetadata:
@@ -139,6 +140,7 @@ class RunTracker:
         self._phase_start = datetime.now(tz=UTC)
         self._phase_start_time = time.time()
         self._phase_items_total = total_items
+        self._phase_llm_mark = _llm_mark()
 
         logger.debug(f"Started phase: {phase_name} (total items: {total_items})")
 
@@ -173,7 +175,7 @@ class RunTracker:
             items_processed=items_processed,
             items_total=self._phase_items_total,
             errors=errors or [],
-            extra_metrics=extra_metrics or {},
+            extra_metrics={**_llm_spend_since(self._phase_llm_mark), **(extra_metrics or {})},
         )
 
         try:
@@ -191,6 +193,7 @@ class RunTracker:
         self._phase_start = None
         self._phase_start_time = None
         self._phase_items_total = 0
+        self._phase_llm_mark = None
 
     def update_phase_progress(self, items_processed: int) -> None:
         """Update progress within current phase.
@@ -265,6 +268,8 @@ class RunTracker:
             clips_selected=clips_selected,
             errors_count=errors_count,
         )
+
+        self.db.record_llm_metrics(self.run_id, _llm_run_total() or {})
 
         # Reload to get full data with phases
         run = self.db.get_run(self.run_id)
@@ -377,6 +382,9 @@ class RunTracker:
             completed_at=now,
             errors_count=errors_count,
         )
+        # A run that burned four minutes on the model and then fell over is
+        # exactly the one worth being able to see afterwards.
+        self.db.record_llm_metrics(self.run_id, _llm_run_total() or {})
 
         logger.error(f"Run {self.run_id} failed: {error}")
 
@@ -470,3 +478,40 @@ def format_duration(seconds: float) -> str:
         hours = int(seconds // 3600)
         minutes = int((seconds % 3600) // 60)
         return f"{hours}h {minutes:02d}m"
+
+
+def _llm_mark():
+    """What the run had spent on the model when this phase began."""
+    from immich_memories.analysis import llm_metrics
+
+    counters = llm_metrics.active()
+    return counters.snapshot() if counters else None
+
+
+def _llm_spend_since(mark) -> dict:
+    """This phase's own share of the model budget, or nothing when unmeasured.
+
+    Imported inside the call rather than at module scope: `analysis` is the
+    heavier package and tracking is used by callers that never touch it.
+    """
+    from immich_memories.analysis import llm_metrics
+
+    counters = llm_metrics.active()
+    if counters is None or mark is None:
+        return {}
+    return counters.since(mark).as_metrics()
+
+
+def _llm_run_total() -> dict | None:
+    """Everything the run spent on the model, whether or not a phase held it.
+
+    Recorded on the failure paths too: a run that burned four minutes on the
+    model and then fell over is exactly the one worth being able to see.
+
+    `None` when nothing was collecting, so an unmeasured run is left alone
+    rather than stamped with an empty record.
+    """
+    from immich_memories.analysis import llm_metrics
+
+    counters = llm_metrics.active()
+    return counters.as_metrics() if counters is not None else None

--- a/tests/test_llm_metrics.py
+++ b/tests/test_llm_metrics.py
@@ -1,0 +1,185 @@
+"""What a run spent on the LLM, counted where the answers arrive.
+
+The truncation counter is the point of the exercise. `_query_openai` has
+always detected `finish_reason == "length"` on a thinking call, logged a
+warning and retried without thinking — silently. That silence is why #600's
+2.4-hour truncation tax lived in an unread server log for months.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from immich_memories.analysis.llm_metrics import collecting
+from immich_memories.config_models_llm import LLMConfig
+
+
+def _openai_response(content='{"ok": true}', finish_reason="stop", usage=None):
+    # WHY: the LLM server is the external boundary these tests measure across.
+    response = AsyncMock()
+    response.status_code = 200
+    body = {"choices": [{"message": {"content": content}, "finish_reason": finish_reason}]}
+    if usage is not None:
+        body["usage"] = usage
+    response.json = MagicMock(return_value=body)
+    response.raise_for_status = lambda: None
+    return response
+
+
+def _thinking_config(**overrides) -> LLMConfig:
+    fields = {
+        "provider": "openai-compatible",
+        "base_url": "http://localhost:8080/v1",
+        "model": "qwen-reasoning",
+        "thinking": True,
+    }
+    fields.update(overrides)
+    return LLMConfig(**fields)
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_thinking_call_is_counted() -> None:
+    """#600's regression test: the retry is silent, the count is not."""
+    from immich_memories.analysis.llm_query import query_llm
+
+    replies = [_openai_response(finish_reason="length"), _openai_response()]
+    # WHY: the LLM server is the external boundary; two replies = truncation then retry.
+    with collecting() as counters, patch("httpx.AsyncClient.post", side_effect=replies):
+        await query_llm("Judge this cut", _thinking_config(), thinking=True)
+
+    assert counters.truncated == 1
+    assert counters.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_call_records_one_call_and_no_truncation() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    # WHY: the LLM server is the external boundary this request reaches.
+    with collecting() as counters, patch("httpx.AsyncClient.post", return_value=_openai_response()):
+        await query_llm("Describe this", _thinking_config(thinking=False))
+
+    assert counters.calls == 1
+    assert counters.truncated == 0
+    assert counters.wall_seconds >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_token_usage_is_recorded_when_the_server_reports_it() -> None:
+    """Servers that omit `usage` must not break counting — tokens stay zero."""
+    from immich_memories.analysis.llm_query import query_llm
+
+    reply = _openai_response(usage={"prompt_tokens": 1200, "completion_tokens": 34})
+    # WHY: the LLM server is the external boundary reporting its own usage.
+    with collecting() as counters, patch("httpx.AsyncClient.post", return_value=reply):
+        await query_llm("Describe this", _thinking_config(thinking=False))
+
+    assert counters.prompt_tokens == 1200
+    assert counters.completion_tokens == 34
+
+
+@pytest.mark.asyncio
+async def test_counting_is_off_unless_a_run_asked_for_it() -> None:
+    """No collector active means every record call is a no-op, not a crash."""
+    from immich_memories.analysis.llm_query import query_llm
+
+    # WHY: the LLM server is the external boundary this request reaches.
+    with patch("httpx.AsyncClient.post", return_value=_openai_response()):
+        answer = await query_llm("Describe this", _thinking_config(thinking=False))
+
+    assert answer == '{"ok": true}'
+
+
+def test_a_phase_records_only_the_llm_spend_that_happened_during_it(tmp_path) -> None:
+    """Per-phase attribution is the point: which phase spent the model budget.
+
+    A run-level total says "11 calls". The delta says the review made nine of
+    them, which is the sentence that changes what you optimise.
+    """
+    from immich_memories.analysis import llm_metrics
+    from immich_memories.tracking import RunTracker
+
+    tracker = RunTracker("metrics-phases", db_path=tmp_path / "runs.db", capture_system=False)
+    tracker.start_run(source="manual")
+
+    with llm_metrics.collecting():
+        tracker.start_phase("analysis", 2)
+        llm_metrics.record_reply(prompt_tokens=100, completion_tokens=10)
+        tracker.start_phase("selection", 1)  # completes "analysis"
+        llm_metrics.record_reply(prompt_tokens=900, completion_tokens=20)
+        llm_metrics.record_truncation()
+        tracker.complete_phase()
+
+    phases = {p.phase_name: p.extra_metrics for p in tracker.db.get_phase_stats(tracker.run_id)}
+
+    assert phases["analysis"]["llm_calls"] == 1
+    assert phases["analysis"]["llm_prompt_tokens"] == 100
+    assert "llm_truncated" not in phases["analysis"]
+    assert phases["selection"]["llm_calls"] == 1
+    assert phases["selection"]["llm_prompt_tokens"] == 900
+    assert phases["selection"]["llm_truncated"] == 1
+
+
+def test_a_phase_with_no_llm_work_carries_no_llm_keys(tmp_path) -> None:
+    """ "Did not use the model" must read differently from "used it for free"."""
+    from immich_memories.analysis import llm_metrics
+    from immich_memories.tracking import RunTracker
+
+    tracker = RunTracker("metrics-quiet", db_path=tmp_path / "runs.db", capture_system=False)
+    tracker.start_run(source="manual")
+
+    with llm_metrics.collecting():
+        tracker.start_phase("assembly", 1)
+        tracker.complete_phase()
+
+    stats = tracker.db.get_phase_stats(tracker.run_id)[0]
+
+    assert not any(key.startswith("llm_") for key in stats.extra_metrics)
+
+
+def test_the_run_row_carries_the_whole_runs_llm_spend(tmp_path) -> None:
+    """Phases cannot hold the total, because the costly work happens outside them.
+
+    RunTracker records only clip_extraction, assembly and music — all inside
+    generate_memory — while analysis and selection run before the run row
+    exists and spend nearly all of the model budget. So the run-level total is
+    not a sum over phases; it has to be recorded in its own right.
+    """
+    from immich_memories.analysis import llm_metrics
+    from immich_memories.tracking import RunDatabase, RunTracker
+
+    db_path = tmp_path / "runs.db"
+    tracker = RunTracker("metrics-run-total", db_path=db_path, capture_system=False)
+    tracker.start_run(source="manual")
+
+    with llm_metrics.collecting():
+        # spend that belongs to no tracked phase, as analysis and selection do
+        llm_metrics.record_reply(prompt_tokens=5000, completion_tokens=120)
+        llm_metrics.record_truncation()
+        tracker.start_phase("assembly", 1)
+        llm_metrics.record_reply(prompt_tokens=40, completion_tokens=4)
+        tracker.complete_phase()
+        tracker.complete_run(clips_analyzed=9, clips_selected=4)
+
+    run = RunDatabase(db_path).get_run("metrics-run-total")
+
+    assert run is not None
+    assert run.llm_metrics["llm_calls"] == 2
+    assert run.llm_metrics["llm_prompt_tokens"] == 5040
+    assert run.llm_metrics["llm_truncated"] == 1
+
+
+def test_a_run_that_never_used_the_model_stores_no_llm_metrics(tmp_path) -> None:
+    from immich_memories.tracking import RunDatabase, RunTracker
+
+    db_path = tmp_path / "runs.db"
+    tracker = RunTracker("metrics-run-quiet", db_path=db_path, capture_system=False)
+    tracker.start_run(source="manual")
+    tracker.complete_run()
+
+    run = RunDatabase(db_path).get_run("metrics-run-quiet")
+
+    assert run is not None
+    assert run.llm_metrics == {}


### PR DESCRIPTION
Refs #600. PR 1 of 2 for the run-metrics ask — **the instrument and the store**. PR 2 is the three read surfaces.

Nothing measured what the model cost. That is how #600's thinking-truncation tax lived in an unread server log for months: `_query_openai` has **always** noticed `finish_reason == "length"` on a thinking call, logged a warning, and retried without thinking. A silent, correct retry is exactly the shape of problem that hides.

## Five collection points, not three

`_dispatch` returns `str`, so `finish_reason` and `usage` were discarded inside each provider function. All three now count.

**Anthropic and Ollama are wired deliberately**, not for completeness: Anthropic has the identical truncation shape (`stop_reason == "max_tokens"`), and an OpenAI-only counter would have told an Anthropic user their run made **zero LLM calls** — a silent no-op inside the tool built to find silent no-ops.

Wall time is recorded in a `finally`, so a run that burns four minutes against a dead server does not read as free.

## Threading: ContextVar, and why that isn't a global

`analysis/llm_metrics.py` mirrors `selection_trace`, for the reason its docstring gives: `query_llm` is called from the CLI, the wizard, the auto runner and scripts, and a counters parameter would touch all of them to carry data none of them read.

It is **task-local, not global** — but it does **not** cross a thread-pool boundary. NiceGUI's `run.io_bound` uses `loop.run_in_executor(executor, partial(...))`, which does not copy context, so `collecting()` must be entered *inside* the run. Verified rather than assumed, and documented in the module.

## Two granularities, because one isn't enough

**Per-phase deltas** — a mark in `start_phase`, a diff in `complete_phase`. One merge point, zero caller changes. Answers *which phase spent the budget*.

**A run-level total** (migration **v21**) — because the per-phase view **cannot** answer what the run cost:

> `RunTracker` records exactly three phases — `clip_extraction`, `assembly`, `music` — all inside `generate_memory`. Analysis and selection are **not run phases at all**: `smart_pipeline`'s tracker is a `ProgressTracker` for the TUI, and in the CLI both run *before* `start_run`. No run row exists while nearly all LLM spend happens.

So the total is genuinely not a sum over phases. Written on **every** completion path including `fail_run` — a run that burned four minutes on the model and *then* fell over is exactly the one worth seeing afterwards.

The lifecycle fix (moving `start_run` before analysis) is on **#326** with its real dependencies stated: run identity, `has_memory_been_generated` dedup, and delivery all key off row creation. Too big to smuggle into a metrics PR.

## Absent keys, not zeros

A phase or run that never used the model carries **no `llm_*` keys**, so "did not use the model" reads differently from "used it and it was free".

## The meta-finding, which is the reason to read this section

**I designed the summary block against `PhaseStats` because it looked complete, and only afterwards checked who writes it.** The block I proposed listed five phases; three of them do not exist in the run DB. I checked the store and not the writers — the same class of error as the wrong close and the dropped row this session already caught, this time in my own design, caught before it shipped rather than after.

That is also why this PR reverses an earlier recommendation of mine that v1 needed no migration. The argument was "run totals are sums over phases". They are not, when the costly work happens outside every phase.

## Two gates that redirected the design, both correctly

- **Vulture** rejected the original 3-PR split: PR 1 alone shipped counters incremented in `src/` and read only by tests. A write-only instrument *is* the no-consumer smell, so collection and persistence land together.
- **Cognitive complexity** caught `update_run_status` going 18 → 20 when the run-level write was added as another optional field. It is now its own small method — one unconditional write does not belong in a chain of "if this was passed, update it" branches.

Also worth recording: `as_metrics` first projected via `vars(self).items()`, and **Vulture cannot see a dynamic read** — it reported every counter as unused even with a live consumer. Explicit field access fixed it and reads better.

## Tests

Eight, RED-first, headed by the #600 regression test the codebase never had: **a truncated thinking call is counted**, and its retry counts as its own call because it costs. Plus per-phase attribution, absent-keys-vs-zero on both granularities, token usage when the server reports it, and no-collector-active being a no-op rather than a crash.

`make ci` green: **5584 passed**, 9 skipped.
