### PR TITLE
docs(config): the fast preset sets six things, not five

### DIFF
--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -40,7 +40,8 @@ preset: null                       # null | fast
 `fast` sets, unless you set them yourself: `output.resolution: 1080p`, `output.codec: h264`,
 `output.quality: medium`, `hardware.encoder_preset: fast`, `speech.enabled: false` (no per-clip
 voice-activity pass), `title_screens.animated_background: false` (static title backgrounds),
-`photos.max_ratio: 0.25`; and an analysis depth of `auto` runs as `fast` (favorites first).
+`photos.max_ratio: 0.25`, `analysis.max_refinement_passes: 3` (three refinement rounds rather
+than ten); and an analysis depth of `auto` runs as `fast` (favorites first).
 The heavy optional features (LLM scoring, music generation, audio-content tagging, transcription)
 are already off by default and stay wherever you put them.
 
@@ -514,8 +515,9 @@ title_screens:
   use_first_name_only: true      # "Alice" instead of "Alice Smith" in titles
 ```
 
-Those two switches are all the look-and-feel the config file exposes; the colour palette and
-custom fonts are not configurable today. `animated_background: false` keeps the gradient still
+`animated_background` and `show_decorative_lines` are all the look-and-feel the config file
+exposes; the colour palette and custom fonts are not configurable today.
+`animated_background: false` keeps the gradient still
 — no rotation, colour pulse or vignette pulse — which is what `preset: fast` selects. The
 `immich-memories titles` command exposes more of the look as flags for previewing.
 


### PR DESCRIPTION
Two small fixes to `config-reference.md`. The measured prose on this page (the transcription confidence numbers, the 143-clip VAD threshold table, the 30-second-window hallucination example) is deliberately left alone.

## `preset: fast` was under-documented

The page lists what `fast` sets and omits one of the six. `config_presets.py` L18-26:

```python
"fast": {
    "output": {"resolution": "1080p", "codec": "h264", "quality": "medium"},
    "hardware": {"encoder_preset": "fast"},
    "speech": {"enabled": False},
    "title_screens": {"animated_background": False},
    "photos": {"max_ratio": 0.25},
    "analysis": {"max_refinement_passes": 3},   # <- not in the docs
}
```

Its own module docstring calls this out ("three refinement passes rather than ten"), so someone reading the config reference to work out why `fast` is faster was missing a real part of the answer.

## "Those two switches"

> Those two switches are all the look-and-feel the config file exposes

points back across a 14-key YAML block. The reader has to guess which two. Named them: `animated_background` and `show_decorative_lines`.

`make docs-build` and `make docs-config-check` pass.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
