### PR TITLE
docs(contributing): put the must-read first and the deep-dive last

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,13 @@
 # Contributing to Immich Memories
 
-## About this project
+## The 60-second version
 
-This codebase is built almost entirely with AI (Claude by Anthropic). That's not a disclaimer: it's a deliberate choice, and the quality gates exist because of it, not in spite of it. 5,000+ tests, 20 CI gates, 80% diff-coverage on every PR, composition over inheritance, TDD.
+1. **Open an Issue first.** Let's agree on the approach before you write code.
+2. `make dev` installs everything. `make ci` runs the same gates CI runs.
+3. Keep the PR to ~300 lines, one concern, a [conventional commit](https://www.conventionalcommits.org/) title.
+4. `make ci` must pass before you request review.
 
-If you spot something the AI got wrong, please fix it. That's how this gets better.
-
-## AI Tools Welcome (With Context)
-
-This entire project was built with GenAI (Claude by Anthropic). AI-assisted contributions are absolutely welcome: this is not a project that's going to lecture you about using Copilot.
-
-That said, AI code has specific failure modes: bloat, over-abstraction, tests that test mocks instead of behavior, verbose docstrings that add no value. That's why this project has 20 CI gates, a hermetic browser launch test, and architectural rules like "no mixins": they exist specifically to catch the things AI gets wrong.
-
-When contributing with AI tools:
-
-1. **Mention it in the PR.** A quick "used Claude/Copilot for X" is enough. Not a judgment: just context for review. Following the [Apache Software Foundation approach](https://github.com/melissawm/open-source-ai-contribution-policies).
-
-2. **Review what the AI wrote.** You're responsible for every line. If the AI added a 200-line abstraction for something that needs 20 lines, catch that before submitting.
-
-3. **Run `make ci` and `make critique`.** These gates exist to catch AI-specific smells. If they pass, you're probably fine.
-
-## Code of Conduct
-
-This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this standard.
+That's the whole must-read. Everything below is detail for when you need it.
 
 ## How I Prefer to Work
 
@@ -64,42 +49,16 @@ make critique          # AI smell audit
 | Tier | Where | Command | What it needs |
 |------|-------|---------|---------------|
 | **Unit tests** | CI + local | `make test` | Nothing external |
-| **Integration tests** | Local only | `make test-integration` | FFmpeg + Immich server |
+| **Integration tests** | Local + CI (FFmpeg-only subset) + GPU runner | `make test-integration` | FFmpeg + Immich server |
 
 **Unit tests** cover pure logic: scoring math, config parsing, data models, helpers.
 They run in CI on every PR. No FFmpeg, no Immich, no network needed.
 
 **Integration tests** cover the real pipeline: download from Immich, FFmpeg assembly,
-video output validation. They run locally because they need your Immich server and
-FFmpeg. They skip gracefully if services aren't available.
-
-### Integration tests and diff-cover
-
-Every PR must have 80% coverage on the lines it changes. Code that can only run
-with real FFmpeg used to be impossible to cover: `tests/*-coverage.xml` is
-gitignored, so integration coverage produced on your machine could never reach
-CI, and the gate would fail no matter what you did.
-
-**CI now handles that for you.** Before checking diff-cover it runs the
-FFmpeg-only integration suites covering the paths you changed — and only those,
-so a PR touching nothing FFmpeg-reachable runs none of them. That job already
-has FFmpeg installed, so this costs no setup time.
-
-To reproduce locally exactly what CI will see:
-
-```bash
-make integration-coverage-for-diff   # runs only the suites your diff touches
-make diff-cover-local                # merges them with unit coverage, same as CI
-```
-
-If diff-cover still fails, the uncovered lines are not reachable from an
-integration suite and need unit tests. Subprocess boundaries can be stubbed
-rather than run for real — `tests/test_ffmpeg_pipe.py` shows the pattern: patch
-`subprocess.Popen`, hand back a fake process, and assert on what the code does
-with it.
-
-Do not try to commit coverage XMLs. They are gitignored deliberately, and
-`git add -f` is not acceptable in this repo.
+video output validation. Locally they need your Immich server and FFmpeg, and skip
+gracefully if either is missing. CI runs the FFmpeg-only subset that your diff touches
+(see [If diff-cover fails on your PR](#if-diff-cover-fails-on-your-pr)), and a
+self-hosted Linux GPU runner runs the full set.
 
 **What integration tests cover that unit tests can't:**
 - FFmpeg filter graph construction and assembly
@@ -139,13 +98,19 @@ Full rules in [CLAUDE.md](CLAUDE.md) (yes, the AI reads it too).
 src/immich_memories/
 ├── api/          # Immich API client (ImmichClient + 5 composed services)
 ├── analysis/     # Video analysis, scoring, clip selection (SmartPipeline + services)
-├── processing/   # Video assembly (VideoAssembler + 8 composed services)
+├── speech/       # VAD + transcription for cut placement
+├── photos/       # Photo-to-video animation (Ken Burns, face-aware pan, blurred fill)
+├── processing/   # Video assembly (VideoAssembler + 6 composed services)
 ├── titles/       # Title screens, map fly-overs (TitleScreenGenerator + services)
 ├── audio/        # Music generation, audio ducking, mood analysis
 ├── ui/           # NiceGUI 4-step wizard
+├── cli/          # Click commands
 ├── cache/        # Analysis, video, and thumbnail caching (SQLite)
 ├── tracking/     # Run history and job management
+├── operations/   # Lifecycle phases, storage report
+├── planning/     # Auto-duration planning
 ├── scheduling/   # Cron-based automatic generation
+├── automation/   # auto suggest/run
 └── memory_types/ # Preset system (Year in Review, Trip, Person, etc.)
 ```
 
@@ -162,6 +127,60 @@ docs: update installation for macOS
 refactor(analysis): extract scoring helpers
 test: add integration test for HDR passthrough
 ```
+
+## About this project
+
+This codebase is built almost entirely with AI (Claude by Anthropic). That's not a disclaimer: it's a deliberate choice, and the quality gates exist because of it, not in spite of it. 5,600+ tests, 20 CI gates, 80% diff-coverage on every PR, composition over inheritance, TDD.
+
+If you spot something the AI got wrong, please fix it. That's how this gets better.
+
+## AI Tools Welcome (With Context)
+
+AI-assisted contributions are absolutely welcome: this is not a project that's going to lecture you about using Copilot.
+
+That said, AI code has specific failure modes: bloat, over-abstraction, tests that test mocks instead of behavior, verbose docstrings that add no value. That's why this project has 20 CI gates, a hermetic browser launch test, and architectural rules like "no mixins": they exist specifically to catch the things AI gets wrong.
+
+When contributing with AI tools:
+
+1. **Mention it in the PR.** A quick "used Claude/Copilot for X" is enough. Not a judgment: just context for review. Following the approach in this [collection of open-source AI contribution policies](https://github.com/melissawm/open-source-ai-contribution-policies).
+
+2. **Review what the AI wrote.** You're responsible for every line. If the AI added a 200-line abstraction for something that needs 20 lines, catch that before submitting.
+
+3. **Run `make ci` and `make critique`.** These gates exist to catch AI-specific smells. If they pass, you're probably fine.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this standard.
+
+## If diff-cover fails on your PR
+
+Skip this until CI tells you otherwise.
+
+Every PR must have 80% coverage on the lines it changes. Code that can only run
+with real FFmpeg used to be impossible to cover: `tests/*-coverage.xml` is
+gitignored, so integration coverage produced on your machine could never reach
+CI, and the gate would fail no matter what you did.
+
+**CI now handles that for you.** Before checking diff-cover it runs the
+FFmpeg-only integration suites covering the paths you changed, and only those,
+so a PR touching nothing FFmpeg-reachable runs none of them. That job already
+has FFmpeg installed, so this costs no setup time.
+
+To reproduce locally exactly what CI will see:
+
+```bash
+make integration-coverage-for-diff   # runs only the suites your diff touches
+make diff-cover-local                # merges them with unit coverage, same as CI
+```
+
+If diff-cover still fails, the uncovered lines are not reachable from an
+integration suite and need unit tests. Subprocess boundaries can be stubbed
+rather than run for real: `tests/test_ffmpeg_pipe.py` shows the pattern, patch
+`subprocess.Popen`, hand back a fake process, and assert on what the code does
+with it.
+
+Do not try to commit coverage XMLs. They are gitignored deliberately, and
+`git add -f` is not acceptable in this repo.
 
 ## Getting Help
 


### PR DESCRIPTION
The rules on this page are all real CI gates and none of them should be weakened. The problem is the **order** a first-time contributor meets them in.

Today they hit, in sequence: an AI philosophy section, a Code of Conduct, maintainer preferences, and then a **33-line diff-cover mechanics deep-dive** before ever reaching "Code Rules" or the commit format. That deep-dive is the scariest block on the page, and it only matters when a PR touches FFmpeg-only code paths **and** diff-cover goes red. A minority case was presented as everyone's homework.

## What moved

No rule changed. Three structural edits:

1. **New "The 60-second version" at the top.** Four lines: open an Issue, `make dev`, `make ci`, keep it under ~300 lines with a conventional-commit title. That is genuinely the whole must-read.
2. **The AI sections moved down.** They are context for how the project is built, not a prerequisite for contributing to it.
3. **The diff-cover block moved down and retitled "If diff-cover fails on your PR."** The content is good, it explains *why* the coverage XMLs are gitignored and gives the exact two make targets. It just needs to be findable-when-needed instead of mandatory-looking.

New order: 60-second version, How I Prefer to Work, Development Setup, Code Rules, Project Structure, Commit Messages, the AI sections, Code of Conduct, diff-cover troubleshooting, Getting Help, License.

## Accuracy fixes while in the file

**"VideoAssembler + 8 composed services" was wrong. It is 6:** prober, filter_builder, encoder, engine, audio_mixer, title_inserter (`processing/video_assembler.py` L75-90). `reference/architecture.md` L18 already lists exactly those six; this page was the outlier. (`api/`'s "5 composed services" checks out: `api/immich.py` L151-155.)

**The project tree was missing six packages**, `photos/` among them, which is an entire pipeline. A wrong tree in CONTRIBUTING sends first-timers to the wrong directory. Replaced with the 16-directory tree from `contribute/development-setup.md`, which is the accurate one.

**The testing-tiers table said integration tests run "Local only"** and was contradicted 20 lines below by "CI now handles that for you", by ci.yml (`make integration-coverage-for-diff` in the test job) and by the GPU runner. Now "Local + CI (FFmpeg-only subset) + GPU runner".

**"5,000+ tests" -> "5,600+".** Measured: 6,230 collected, 5,585 in the default unit run.

**The "[Apache Software Foundation approach]" link** pointed at `github.com/melissawm/open-source-ai-contribution-policies`, a personal collection of policies, not an ASF document. The link text over-claimed its target, so it is relabelled to describe what it actually is.

Plus one duplicate sentence ("This entire project was built with GenAI (Claude by Anthropic)" restated the About paragraph, which now sits directly above it) and one em dash in the diff-cover paragraph.

Refs #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
