### PR TITLE
docs: fix the small claims that do not survive a check

### DIFF
--- a/docs-site/docs/deploy/common-setups/linux-nvidia.md
+++ b/docs-site/docs/deploy/common-setups/linux-nvidia.md
@@ -8,7 +8,7 @@ For Linux servers with NVIDIA GPUs. Docker with nvidia-container-toolkit for NVE
 
 ## Who this is for
 
-You have a Linux server (Ubuntu, Debian, Fedora) with an NVIDIA GPU (GTX 1060 or newer). You want hardware-accelerated encoding and optionally want to run MusicGen or ACE-Step for AI-generated background music.
+You have a Linux server (Ubuntu, Debian, Fedora) with an NVIDIA GPU (GTX 1050 or newer — Pascal is where NVENC starts). You want hardware-accelerated encoding and optionally want to run MusicGen or ACE-Step for AI-generated background music.
 
 ## Architecture
 

--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -280,7 +280,7 @@ In your config YAML, set `trusted_proxies` to Traefik's container IP (prefer a s
 
 ## Session
 
-- Sessions last 24 hours by default (`session_ttl_hours`). Range: 1--720 hours.
+- Sessions last 24 hours by default (`session_ttl_hours`). Range: 1-720 hours.
 - The same value expires session state on disk: abandoned session files are
   swept at startup and every 15 minutes thereafter, so an exposed instance
   doesn't accumulate one file per drive-by request.

--- a/docs-site/docs/deploy/configuration/network-and-privacy.md
+++ b/docs-site/docs/deploy/configuration/network-and-privacy.md
@@ -7,9 +7,9 @@ title: Network & Privacy
 
 Immich Memories runs locally and talks to your Immich server over your LAN. There is no
 telemetry, no update check and no analytics. Some features do make outbound requests, though.
-This page lists every one of them, what is sent, and how to turn it off. It is generated from a
-sweep of the source code and is kept in sync with releases; if you find an outbound call that is
-not listed here, [open an issue](https://github.com/sam-dumont/immich-video-memory-generator/issues).
+This page lists every one of them, what is sent, and how to turn it off. It is written from a sweep
+of the source code and maintained by hand — no gate checks it, so if you find an outbound call that
+is not listed here, [open an issue](https://github.com/sam-dumont/immich-video-memory-generator/issues).
 
 ## Summary table
 
@@ -24,8 +24,6 @@ not listed here, [open an issue](https://github.com/sam-dumont/immich-video-memo
 | Hugging Face / torch hub / Zenodo | first use of ACE-Step, Demucs, whisper.cpp, PANNs, smart-turn | nothing personal (model weights are downloaded once) | features are opt-in | pre-download models; air-gapped installs should disable those features |
 | Your Apprise / ntfy targets | notifications | memory type, status, duration, output path, error tail; a JPEG frame if `attach_thumbnail: true` | **yes** | `notifications.enabled: false` (default) |
 | Your OIDC provider | login | standard OIDC flow (client id, PKCE, tokens) | **yes** | basic auth or trusted-header auth |
-
-Everything below `LLM vision API` is optional and off unless you configure it.
 
 ## Details
 
@@ -52,9 +50,11 @@ today; the OSM/OpenTopo styles in the renderer are not reachable from the config
 
 ### Fonts (jsdelivr / Fontsource)
 
-**When:** a map or GPU-rendered title needs a font family that is neither bundled in the wheel
-(Montserrat is) nor already present under `~/.immich-memories/fonts/`. Then a `latin-<weight>`
-TTF is fetched from `cdn.jsdelivr.net/fontsource/fonts/<family>@latest`.
+**When:** a map or GPU-rendered title needs a font family that is neither bundled in the wheel nor
+already present under `~/.immich-memories/fonts/`. Five families ship in the wheel — Josefin Sans,
+Montserrat, Outfit, Quicksand and Raleway — which covers every built-in theme, so this only fires
+if you configure a family of your own. Then a `latin-<weight>` TTF is fetched from
+`cdn.jsdelivr.net/fontsource/fonts/<family>@latest`.
 
 **What's sent:** nothing about your library. Note the file is unpinned (`@latest`).
 

--- a/docs-site/docs/deploy/hardware/cpu-only.md
+++ b/docs-site/docs/deploy/hardware/cpu-only.md
@@ -24,7 +24,7 @@ The pipeline is designed around GPU acceleration and ML-powered features for the
 - Scene detection (PySceneDetect)
 - LLM-powered content analysis
 - Audio ducking and music mixing
-- Smart clip ordering
+- Clip ordering
 - All CLI and UI functionality
 
 ## Configuration

--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -4,8 +4,6 @@ sidebar_label: "Health, Logs & Cache"
 
 # Health, Logs & Cache
 
-Three operational aspects you'll want to understand for any deployment beyond "run it once and forget."
-
 ## Health endpoints
 
 Use `GET /health/live` for liveness and `GET /health/ready` for readiness. Liveness always returns
@@ -17,7 +15,8 @@ are usable, or `status: degraded` with HTTP `503` when configuration is missing 
 be reached. `GET /health` always returns HTTP `200` for compatibility; it rewrites a ready payload
 to `ok` and leaves a degraded payload as `degraded`. Do not use `/health` as a readiness probe.
 
-`/health/ready` returns JSON with the current system status:
+`/health/ready` returns JSON with the current system status (abridged — the real payload also
+carries automation, pending-delivery, scheduler and Immich blocks):
 
 ```json
 {

--- a/docs-site/docs/welcome/why-immich-memories.mdx
+++ b/docs-site/docs/welcome/why-immich-memories.mdx
@@ -21,7 +21,7 @@ The problem isn't storage (Immich handles that) or finding clips (search works).
 
 Tools that do parts of this exist. Cloud photo services generate annual recaps automatically, which is the right idea, but the music is pre-canned and the clip selection is a black box. Some phone platforms have beat-synced transitions and face awareness, but the output stays locked in their ecosystem. Activity trackers make beautiful GPS flyovers for bike rides and hikes, but they only work for tracked activities (not "my kid's year").
 
-Each tool does one piece well. None of them combine smart clip selection, custom music, trip maps, title screens, and video assembly in a single pipeline. And none of them run on your own server or let you control what goes in and what doesn't.
+Each tool does one piece well. None of them combine clip selection, custom music, trip maps, title screens, and video assembly in a single pipeline. And none of them run on your own server or let you control what goes in and what doesn't.
 
 If you're running Immich, you already made the decision to own your data. This tool gives you something to do with it.
 
@@ -35,7 +35,7 @@ The key: I still get to review what it picked and remove anything I don't want. 
 
 Every feature traces back to "remove a manual step from making a memory video":
 
-- **Smart clip scoring**: so I don't have to watch 400 clips to find the 25 good ones
+- **Clip scoring**: so I don't have to watch 400 clips to find the 25 good ones
 - **Face detection + recognition**: so clips with my kid in frame score higher than clips of the parking lot
 - **Scene detection**: so the tool picks the interesting 8-second segment, not the full 45-second recording
 - **Duplicate detection**: so I don't get three versions of the same moment from burst recordings


### PR DESCRIPTION
Seven small claims that don't survive a check. Each verified against code, not against the review that flagged them.

| Page | Was | Why it's wrong |
|---|---|---|
| `network-and-privacy.md` | "It is **generated** from a sweep of the source code and is **kept in sync with releases**" | Nothing generates this page and no gate checks it — `docs-cli-check` and `docs-config-check` cover other pages. An unverifiable freshness promise on the page whose whole job is being trustworthy is the one place you can't afford it. Now says what it is: written by hand from a sweep, no gate, report anything missing. |
| `network-and-privacy.md` | "neither bundled in the wheel (Montserrat is)" | Five families are bundled — `titles/bundled_fonts/`: josefin-sans, montserrat, outfit, quicksand, raleway. Understating the bundle makes the jsdelivr fallback sound routine when it only fires for a font family you configured yourself. |
| `network-and-privacy.md` | "Everything below `LLM vision API` is optional…" | No row is labelled "LLM vision API" (the row says `llm.base_url`), and rows *above* it are conditional too. Cut — the "Off by default?" column already answers it. |
| `authentication.mdx` | "Range: 1--720 hours." | MDX has no typographer pass, so it renders as a literal double hyphen. |
| `health-logs-cache.md` | "Three operational aspects you'll want to understand…" | Throat-clearing; the three H2s already say it. |
| `health-logs-cache.md` | 4-field sample readiness payload | `_compute_health_snapshot` (`ui/app.py:492`) returns eleven keys — `configuration`, an `immich` block, `automation`, `last_automation_attempt`, `last_successful_auto_run`, `pending_delivery_count`, `oldest_pending_delivery`, `notification_health`, `in_process_scheduler`… Marked "(abridged)" and named what's missing, so nobody diffs it against real output and thinks their instance is broken. |
| `linux-nvidia.md` | "GTX 1060 or newer" | `hardware/nvidia.md` says GTX 1050, and it's right — NVENC starts at Pascal. Aligned on 1050. |

Plus the last three **"smart clip"** instances (`hardware/cpu-only.md`, `welcome/why-immich-memories.mdx` ×2 — one of them found only by a case-insensitive grep). "Clip scoring" says the same thing without asking to be believed.

Both files the deep review called out as best-in-section (`authentication.mdx`, `health-logs-cache.md`) got surgical edits only — a typo and a parenthetical.

`make docs-check` passes, no broken links.

Heads-up on merge order: `linux-nvidia.md` and `authentication.mdx` are also touched by #626, and `linux-nvidia.md` by #623 and #624. Different hunks, but whichever lands last may need a rebase.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
