### PR TITLE
fix(contact-sheet): render a frame for clips shorter than the seek

### DIFF
--- a/scripts/contact_sheet.py
+++ b/scripts/contact_sheet.py
@@ -83,21 +83,28 @@ def _thumbnail(client, asset_id: str, video_id: str | None = None):
 
     Live Photo video components do not always answer on "preview", and a run
     that silently renders grey squares cannot be reviewed.
+
+    Returns the image and, when there is none, the reason to print in its place:
+    footage the server never thumbnailed is expected, footage sitting in the
+    cache that will not decode is a broken download worth chasing, and a tile
+    that does not say which is a blank the reviewer has to guess at.
     """
     from PIL import Image
 
     last: Exception | None = None
     for size in ("preview", "thumbnail"):
         try:
-            return Image.open(io.BytesIO(client.get_asset_thumbnail(asset_id, size))).convert("RGB")
+            image = Image.open(io.BytesIO(client.get_asset_thumbnail(asset_id, size)))
+            return image.convert("RGB"), ""
         except Exception as exc:  # noqa: BLE001, PERF203 - try the next size, then give up
             last = exc
             continue
-    frame = _frame_from_cache(*dict.fromkeys(i for i in (asset_id, video_id) if i))
+    ids = tuple(dict.fromkeys(i for i in (asset_id, video_id) if i))
+    frame = _frame_from_cache(*ids)
     if frame is not None:
-        return frame
+        return frame, ""
     logger.warning("No thumbnail for %s: %s", asset_id, type(last).__name__)
-    return None
+    return None, "would not decode" if _cached_video(*ids) else "no thumbnail"
 
 
 def _cached_video(*asset_ids: str) -> Path | None:
@@ -122,26 +129,17 @@ def _cached_video(*asset_ids: str) -> Path | None:
     return None
 
 
-def _frame_from_cache(*asset_ids: str):
-    """Grab a frame from the locally cached video, if we have one.
-
-    Immich does not always hold a thumbnail — measured at 8% of assets on this
-    library, all of them standalone .MOV files. Those are perfectly good clips
-    that the pipeline selected on merit; only the review sheet could not show
-    them, and a grey rectangle is the one thing a reviewer cannot judge.
-    """
+def _decode_frame(source: Path, seek: str):
+    """One ffmpeg frame grab at a given offset, or None if it decoded nothing."""
     import subprocess
     import tempfile
 
     from PIL import Image
 
-    source = _cached_video(*asset_ids)
-    if source is None:
-        return None
     with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp:
         try:
             subprocess.run(
-                ["ffmpeg", "-y", "-v", "error", "-ss", "0.5", "-i", str(source),
+                ["ffmpeg", "-y", "-v", "error", "-ss", seek, "-i", str(source),
                  "-frames:v", "1", "-q:v", "4", tmp.name],
                 capture_output=True,
                 timeout=20,
@@ -150,6 +148,30 @@ def _frame_from_cache(*asset_ids: str):
             return Image.open(tmp.name).convert("RGB")
         except Exception:  # noqa: BLE001 - a tile is not worth failing the sheet
             return None
+
+
+def _frame_from_cache(*asset_ids: str):
+    """Grab a frame from the locally cached video, if we have one.
+
+    Immich does not always hold a thumbnail — measured at 8% of assets on this
+    library, all of them standalone .MOV files. Those are perfectly good clips
+    that the pipeline selected on merit; only the review sheet could not show
+    them, and a grey rectangle is the one thing a reviewer cannot judge.
+
+    Half a second in avoids the black lead-in most footage opens on, but it is
+    past the end of a trimmed Live Photo burst: ffmpeg writes no file at all and
+    the clip came back blank. Falling back to the first frame is worth more than
+    the lead-in it risks.
+    """
+    source = _cached_video(*asset_ids)
+    if source is None:
+        return None
+    for seek in ("0.5", "0"):
+        frame = _decode_frame(source, seek)
+        if frame is not None:
+            return frame
+    logger.warning("Cached video for %s decoded no frame: %s", asset_ids[0], source.name)
+    return None
 
 
 def _fonts():
@@ -195,13 +217,13 @@ def _draw(rows: list[dict], label: str, subtitle: str, out: Path) -> Path:
         for i, row in enumerate(rows):
             x = PAD + (i % COLUMNS) * (THUMB_W + PAD)
             y = HEADER_H + (i // COLUMNS) * (THUMB_H + LABEL_H + PAD)
-            image = _thumbnail(client, row["id"], row["video_id"])
+            image, reason = _thumbnail(client, row["id"], row["video_id"])
             row["lum"] = _mean_luma(image)
             if image is None:
                 # A blank tile is unreviewable, so say why rather than leave a
                 # grey square the reader has to guess at.
                 draw.rectangle([x, y, x + THUMB_W, y + THUMB_H], fill=(40, 40, 44))
-                draw.text((x + 10, y + THUMB_H // 2), "no thumbnail", (200, 120, 110), font=font)
+                draw.text((x + 10, y + THUMB_H // 2), reason, (200, 120, 110), font=font)
             else:
                 image.thumbnail((THUMB_W, THUMB_H))
                 sheet.paste(

--- a/tests/test_contact_sheet.py
+++ b/tests/test_contact_sheet.py
@@ -7,6 +7,7 @@ standalone footage the pipeline picked on merit.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,6 +15,33 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import contact_sheet  # noqa: E402
+
+
+def _clip(path: Path, seconds: float) -> Path:
+    """A real decodable clip, so ffmpeg does real work on a real duration."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size=160x120:rate=30:duration={seconds}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],  # fmt: skip
+        check=True,
+        capture_output=True,
+    )
+    return path
 
 
 def _cached(root: Path, asset_id: str, name: str) -> Path:
@@ -55,3 +83,51 @@ def test_a_live_photos_footage_is_found_under_its_video_component(tmp_path, monk
     _cache_at(monkeypatch, tmp_path)
 
     assert contact_sheet._cached_video("00stillid", "99videoid") == wanted
+
+
+def test_a_clip_shorter_than_the_seek_still_renders_a_frame(tmp_path, monkeypatch) -> None:
+    """The extractor seeked half a second in, so shorter footage decoded to nothing.
+
+    A trimmed Live Photo burst is routinely under half a second. ffmpeg exits
+    non-zero with no output file, which the tile-level except swallowed, and the
+    clip came back blank on a sheet whose whole job is to show it.
+    """
+    _clip(tmp_path / "video-cache" / "aa" / "aashort.mp4", seconds=0.3)
+    _cache_at(monkeypatch, tmp_path)
+
+    assert contact_sheet._frame_from_cache("aashort") is not None
+
+
+class _ServerWithoutThumbnails:
+    """WHY: Immich is the external boundary — this is a server that holds no
+    thumbnail for the asset, the 8% of a real library the fallback exists for."""
+
+    def get_asset_thumbnail(self, asset_id: str, size: str) -> bytes:
+        raise LookupError(f"no {size} for {asset_id}")
+
+
+def test_a_clip_with_no_frame_anywhere_says_so(tmp_path, monkeypatch) -> None:
+    """Nothing on the server and nothing cached is its own failure."""
+    _cache_at(monkeypatch, tmp_path)
+
+    image, reason = contact_sheet._thumbnail(_ServerWithoutThumbnails(), "aamissing")
+
+    assert image is None
+    assert reason == "no thumbnail"
+
+
+def test_a_cached_clip_that_will_not_decode_is_named_apart(tmp_path, monkeypatch) -> None:
+    """A tile can be blank two ways, and the reviewer has to be told which.
+
+    Footage the server never thumbnailed is expected; footage sitting in the
+    cache that ffmpeg cannot read is a broken download worth chasing.
+    """
+    broken = tmp_path / "video-cache" / "aa" / "aabroken.mp4"
+    broken.parent.mkdir(parents=True, exist_ok=True)
+    broken.write_bytes(b"not a video at all")
+    _cache_at(monkeypatch, tmp_path)
+
+    image, reason = contact_sheet._thumbnail(_ServerWithoutThumbnails(), "aabroken")
+
+    assert image is None
+    assert reason == "would not decode"


### PR DESCRIPTION
Closes #648

## Root cause

`scripts/contact_sheet.py::_frame_from_cache` grabbed its tile with a hardcoded `ffmpeg -ss 0.5`. A clip shorter than half a second has no frame at that offset — ffmpeg exits non-zero and writes no output file at all. The surrounding `except` (there so one bad tile cannot fail a two-hour sweep) swallowed it and returned `None`, so the clip rendered as an empty tile on a sheet whose entire job is to show it.

Reproduced with a synthetic clip: 0.3s returns `None`, 3.0s returns a frame, same code path. A trimmed Live Photo burst routinely lands under half a second, which is how whole runs of video entries came back blank.

## Fix

Retry at the first frame when the seek decodes nothing. Half a second is still tried first — it avoids the black lead-in most footage opens on — but a first frame is worth more than the lead-in it risks.

Second, a blank tile now says which failure it was. "no thumbnail" and "would not decode" are different problems: footage the server never thumbnailed is expected (~8% of a real library, all standalone footage), footage sitting in the cache that ffmpeg cannot read is a broken download worth chasing. Conflating them left the reviewer guessing.

## Tests

RED-first, against real ffmpeg output rather than a mocked one:

- `test_a_clip_shorter_than_the_seek_still_renders_a_frame` — builds a real 0.3s clip and asserts a frame comes back. Failed before the fix.
- `test_a_clip_with_no_frame_anywhere_says_so` / `test_a_cached_clip_that_will_not_decode_is_named_apart` — the two blank-tile reasons stay distinguishable.

`make ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f