### PR TITLE
fix(memories): multi-person means everyone in the frame, not anyone

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -919,273 +919,269 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 177,
-        "line_start": 183,
-        "line_end": 991,
+        "complexity": 164,
+        "line_start": 184,
+        "line_end": 992,
         "line_complexities": [
-          {
-            "line": 535,
-            "complexity": 0
-          },
           {
             "line": 536,
             "complexity": 0
           },
           {
-            "line": 543,
-            "complexity": 2
+            "line": 537,
+            "complexity": 0
           },
           {
             "line": 544,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 545,
             "complexity": 0
           },
           {
-            "line": 547,
+            "line": 546,
+            "complexity": 0
+          },
+          {
+            "line": 548,
             "complexity": 2
           },
           {
-            "line": 549,
-            "complexity": 3
-          },
-          {
-            "line": 553,
+            "line": 550,
             "complexity": 3
           },
           {
             "line": 554,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 556,
+            "line": 555,
             "complexity": 0
           },
           {
             "line": 557,
-            "complexity": 2
-          },
-          {
-            "line": 558,
-            "complexity": 1
-          },
-          {
-            "line": 563,
-            "complexity": 3
-          },
-          {
-            "line": 564,
             "complexity": 0
           },
           {
-            "line": 568,
+            "line": 558,
+            "complexity": 2
+          },
+          {
+            "line": 559,
+            "complexity": 1
+          },
+          {
+            "line": 564,
+            "complexity": 3
+          },
+          {
+            "line": 565,
             "complexity": 0
           },
           {
             "line": 569,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 570,
+            "complexity": 1
+          },
+          {
+            "line": 571,
             "complexity": 0
           },
           {
-            "line": 572,
+            "line": 573,
             "complexity": 2
           },
           {
-            "line": 588,
+            "line": 589,
             "complexity": 0
           },
           {
-            "line": 599,
+            "line": 600,
             "complexity": 3
           },
           {
-            "line": 603,
+            "line": 604,
             "complexity": 3
           },
           {
-            "line": 607,
+            "line": 608,
             "complexity": 4
           },
           {
-            "line": 611,
+            "line": 612,
             "complexity": 3
           },
           {
-            "line": 615,
+            "line": 616,
             "complexity": 3
           },
           {
-            "line": 623,
+            "line": 624,
             "complexity": 0
-          },
-          {
-            "line": 640,
-            "complexity": 2
           },
           {
             "line": 641,
-            "complexity": 0
-          },
-          {
-            "line": 642,
-            "complexity": 1
-          },
-          {
-            "line": 644,
-            "complexity": 0
-          },
-          {
-            "line": 645,
-            "complexity": 1
-          },
-          {
-            "line": 646,
-            "complexity": 0
-          },
-          {
-            "line": 647,
-            "complexity": 3
-          },
-          {
-            "line": 652,
-            "complexity": 1
-          },
-          {
-            "line": 653,
-            "complexity": 3
-          },
-          {
-            "line": 654,
-            "complexity": 0
-          },
-          {
-            "line": 655,
-            "complexity": 1
-          },
-          {
-            "line": 656,
-            "complexity": 0
-          },
-          {
-            "line": 659,
-            "complexity": 0
-          },
-          {
-            "line": 663,
             "complexity": 2
           },
           {
-            "line": 668,
+            "line": 642,
             "complexity": 0
           },
           {
-            "line": 671,
-            "complexity": 0
-          },
-          {
-            "line": 677,
+            "line": 643,
             "complexity": 1
           },
           {
-            "line": 680,
+            "line": 645,
+            "complexity": 0
+          },
+          {
+            "line": 646,
+            "complexity": 1
+          },
+          {
+            "line": 647,
+            "complexity": 0
+          },
+          {
+            "line": 648,
             "complexity": 3
+          },
+          {
+            "line": 653,
+            "complexity": 1
+          },
+          {
+            "line": 654,
+            "complexity": 3
+          },
+          {
+            "line": 655,
+            "complexity": 0
+          },
+          {
+            "line": 656,
+            "complexity": 1
+          },
+          {
+            "line": 657,
+            "complexity": 0
+          },
+          {
+            "line": 660,
+            "complexity": 0
+          },
+          {
+            "line": 664,
+            "complexity": 2
+          },
+          {
+            "line": 669,
+            "complexity": 0
+          },
+          {
+            "line": 672,
+            "complexity": 0
+          },
+          {
+            "line": 678,
+            "complexity": 1
           },
           {
             "line": 681,
             "complexity": 3
           },
           {
-            "line": 683,
-            "complexity": 0
-          },
-          {
-            "line": 690,
-            "complexity": 0
-          },
-          {
-            "line": 694,
+            "line": 682,
             "complexity": 3
+          },
+          {
+            "line": 684,
+            "complexity": 0
+          },
+          {
+            "line": 691,
+            "complexity": 0
           },
           {
             "line": 695,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 696,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 697,
-            "complexity": 0
-          },
-          {
-            "line": 699,
-            "complexity": 0
-          },
-          {
-            "line": 723,
-            "complexity": 1
-          },
-          {
-            "line": 724,
-            "complexity": 2
-          },
-          {
-            "line": 728,
-            "complexity": 1
-          },
-          {
-            "line": 739,
             "complexity": 3
           },
           {
-            "line": 740,
+            "line": 698,
             "complexity": 0
+          },
+          {
+            "line": 700,
+            "complexity": 0
+          },
+          {
+            "line": 724,
+            "complexity": 1
+          },
+          {
+            "line": 725,
+            "complexity": 2
+          },
+          {
+            "line": 729,
+            "complexity": 1
+          },
+          {
+            "line": 740,
+            "complexity": 3
           },
           {
             "line": 741,
             "complexity": 0
           },
           {
-            "line": 743,
+            "line": 742,
             "complexity": 0
           },
           {
-            "line": 745,
+            "line": 744,
             "complexity": 0
           },
           {
-            "line": 747,
+            "line": 746,
             "complexity": 0
           },
           {
-            "line": 754,
+            "line": 748,
+            "complexity": 0
+          },
+          {
+            "line": 755,
             "complexity": 5
           },
           {
-            "line": 796,
+            "line": 797,
             "complexity": 6
-          },
-          {
-            "line": 840,
-            "complexity": 0
           },
           {
             "line": 841,
-            "complexity": 5
+            "complexity": 0
           },
           {
             "line": 842,
-            "complexity": 6
+            "complexity": 5
           },
           {
             "line": 843,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 844,
@@ -1193,140 +1189,140 @@
           },
           {
             "line": 845,
-            "complexity": 7
+            "complexity": 0
           },
           {
-            "line": 853,
-            "complexity": 6
+            "line": 846,
+            "complexity": 7
           },
           {
             "line": 854,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 855,
-            "complexity": 7
+            "complexity": 0
           },
           {
             "line": 856,
+            "complexity": 7
+          },
+          {
+            "line": 857,
             "complexity": 0
           },
           {
-            "line": 858,
+            "line": 859,
             "complexity": 1
           },
           {
-            "line": 863,
-            "complexity": 7
-          },
-          {
             "line": 864,
-            "complexity": 0
+            "complexity": 7
           },
           {
-            "line": 877,
-            "complexity": 7
+            "line": 865,
+            "complexity": 0
           },
           {
             "line": 878,
-            "complexity": 0
+            "complexity": 7
           },
           {
             "line": 879,
             "complexity": 0
           },
           {
-            "line": 882,
-            "complexity": 1
+            "line": 880,
+            "complexity": 0
           },
           {
             "line": 883,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 884,
             "complexity": 0
           },
           {
-            "line": 887,
+            "line": 885,
             "complexity": 0
           },
           {
-            "line": 897,
+            "line": 888,
             "complexity": 0
           },
           {
             "line": 898,
-            "complexity": 5
+            "complexity": 0
           },
           {
             "line": 899,
-            "complexity": 6
+            "complexity": 5
           },
           {
             "line": 900,
-            "complexity": 7
+            "complexity": 0
           },
           {
-            "line": 904,
+            "line": 905,
             "complexity": 6
           },
           {
-            "line": 907,
+            "line": 908,
             "complexity": 6
           },
           {
-            "line": 912,
+            "line": 913,
             "complexity": 0
           },
           {
-            "line": 914,
+            "line": 915,
             "complexity": 5
           },
           {
-            "line": 916,
+            "line": 917,
             "complexity": 5
           },
           {
-            "line": 920,
+            "line": 921,
             "complexity": 5
           },
           {
-            "line": 923,
+            "line": 924,
             "complexity": 1
           },
           {
-            "line": 925,
+            "line": 926,
             "complexity": 0
           },
           {
-            "line": 927,
+            "line": 928,
             "complexity": 0
           },
           {
-            "line": 974,
+            "line": 975,
             "complexity": 1
           },
           {
-            "line": 977,
-            "complexity": 1
-          },
-          {
-            "line": 980,
+            "line": 978,
             "complexity": 1
           },
           {
             "line": 981,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 982,
+            "complexity": 0
+          },
+          {
+            "line": 983,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 188
+    "complexity": 175
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",

--- a/docs-site/docs/create/memory-types/monthly-person-season.mdx
+++ b/docs-site/docs/create/memory-types/monthly-person-season.mdx
@@ -50,7 +50,7 @@ Default duration: 120 seconds (full year), ~60 seconds (single month). Duration 
 
 ## Multi-Person
 
-Moments featuring multiple people together. By default, requires co-occurrence: clips must contain all named people in the same frame.
+Moments featuring multiple people together. A clip, Live Photo, or photo only qualifies when every named person is in it — two people who were never in the same frame produce an empty memory, not two solo reels.
 
 ```bash
 immich-memories generate --memory-type multi_person --person "Alice" --person "Bob" --year 2025

--- a/src/immich_memories/api/immich.py
+++ b/src/immich_memories/api/immich.py
@@ -388,16 +388,6 @@ class ImmichClient:
             person_id, date_range, progress_callback
         )
 
-    async def get_videos_for_any_person(
-        self,
-        person_ids: list[str],
-        date_range: DateRange,
-        progress_callback: Callable[[int, int], None] | None = None,
-    ) -> list[Asset]:
-        return await self.search.get_videos_for_any_person(
-            person_ids, date_range, progress_callback
-        )
-
     async def get_videos_for_all_persons(
         self,
         person_ids: list[str],
@@ -424,9 +414,10 @@ class ImmichClient:
         date_range: DateRange,
         progress_callback: Callable[[int, int], None] | None = None,
         person_id: str | None = None,
+        person_ids: list[str] | None = None,
     ) -> list[Asset]:
         return await self.search.get_photos_for_date_range(
-            date_range, progress_callback, person_id=person_id
+            date_range, progress_callback, person_id=person_id, person_ids=person_ids
         )
 
     async def get_assets_for_album(

--- a/src/immich_memories/api/search_service.py
+++ b/src/immich_memories/api/search_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, date, datetime, time
 from typing import TYPE_CHECKING, Any
 
@@ -29,6 +29,28 @@ def _api_datetime(value: date | datetime, *, inclusive_end: bool = False) -> str
         return datetime.combine(value, boundary, tzinfo=UTC).isoformat()
     value = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
     return value.isoformat()
+
+
+async def _assets_holding_every_person(
+    fetch_for_person: Callable[[str], Awaitable[list[Asset]]],
+    person_ids: list[str],
+) -> list[Asset]:
+    """Assets that contain every one of the given people, oldest first.
+
+    Immich's metadata search answers one person at a time, so co-occurrence is
+    an intersection of per-person results rather than a single query.
+    """
+    per_person: list[set[str]] = []
+    by_id: dict[str, Asset] = {}
+    for person_id in person_ids:
+        assets = await fetch_for_person(person_id)
+        per_person.append({a.id for a in assets})
+        by_id.update({a.id: a for a in assets})
+
+    common = set.intersection(*per_person) if per_person else set()
+    result = [by_id[asset_id] for asset_id in common]
+    result.sort(key=lambda a: a.file_created_at)
+    return result
 
 
 class SearchService:
@@ -250,31 +272,6 @@ class SearchService:
         all_assets.sort(key=lambda a: a.file_created_at)
         return all_assets
 
-    async def get_videos_for_any_person(
-        self,
-        person_ids: list[str],
-        date_range: DateRange,
-        progress_callback: Callable[[int, int], None] | None = None,
-    ) -> list[Asset]:
-        """Get videos containing ANY of the specified people (OR/union)."""
-        if not person_ids:
-            return []
-
-        seen: dict[str, Asset] = {}
-        for person_id in person_ids:
-            assets = await self.get_videos_for_person_and_date_range(
-                person_id=person_id,
-                date_range=date_range,
-                progress_callback=progress_callback,
-            )
-            for asset in assets:
-                if asset.id not in seen:
-                    seen[asset.id] = asset
-
-        result = list(seen.values())
-        result.sort(key=lambda a: a.file_created_at)
-        return result
-
     async def get_videos_for_all_persons(
         self,
         person_ids: list[str],
@@ -284,22 +281,12 @@ class SearchService:
         """Get videos containing ALL specified people (AND/intersection)."""
         if not person_ids:
             return []
-        per_person: list[set[str]] = []
-        assets_by_id: dict[str, Asset] = {}
-        for pid in person_ids:
-            assets = await self.get_videos_for_person_and_date_range(
-                pid,
-                date_range,
-                progress_callback,
-            )
-            per_person.append({a.id for a in assets})
-            assets_by_id.update({a.id: a for a in assets})
-        common = per_person[0]
-        for s in per_person[1:]:
-            common &= s
-        result = [assets_by_id[aid] for aid in common]
-        result.sort(key=lambda a: a.file_created_at)
-        return result
+        return await _assets_holding_every_person(
+            lambda person_id: self.get_videos_for_person_and_date_range(
+                person_id, date_range, progress_callback
+            ),
+            person_ids,
+        )
 
     async def _get_live_photos_single_person(
         self,
@@ -342,20 +329,10 @@ class SearchService:
     ) -> list[Asset]:
         """Get Live Photo IMAGE assets, optionally filtered by person(s)."""
         if person_ids and len(person_ids) >= 2:
-            per_person: list[set[str]] = []
-            assets_by_id: dict[str, Asset] = {}
-            for pid in person_ids:
-                assets = await self._get_live_photos_single_person(
-                    date_range, progress_callback, pid
-                )
-                per_person.append({a.id for a in assets})
-                assets_by_id.update({a.id: a for a in assets})
-            common = per_person[0]
-            for s in per_person[1:]:
-                common &= s
-            result_list = [assets_by_id[aid] for aid in common]
-            result_list.sort(key=lambda a: a.file_created_at)
-            return result_list
+            return await _assets_holding_every_person(
+                lambda pid: self._get_live_photos_single_person(date_range, progress_callback, pid),
+                person_ids,
+            )
 
         return await self._get_live_photos_single_person(date_range, progress_callback, person_id)
 
@@ -364,8 +341,27 @@ class SearchService:
         date_range: DateRange,
         progress_callback: Callable[[int, int], None] | None = None,
         person_id: str | None = None,
+        person_ids: list[str] | None = None,
     ) -> list[Asset]:
-        """Get regular photo assets (IMAGE, excluding live photos)."""
+        """Get regular photo assets (IMAGE, excluding live photos), by person(s) if given.
+
+        Several people means the photos holding all of them, matching how videos
+        and Live Photos answer the same question.
+        """
+        if person_ids and len(person_ids) >= 2:
+            return await _assets_holding_every_person(
+                lambda pid: self._get_photos_single_person(date_range, progress_callback, pid),
+                person_ids,
+            )
+
+        return await self._get_photos_single_person(date_range, progress_callback, person_id)
+
+    async def _get_photos_single_person(
+        self,
+        date_range: DateRange,
+        progress_callback: Callable[[int, int], None] | None = None,
+        person_id: str | None = None,
+    ) -> list[Asset]:
         query_person_ids = [person_id] if person_id else None
         all_assets: list[Asset] = []
         page = 1

--- a/src/immich_memories/api/sync_client.py
+++ b/src/immich_memories/api/sync_client.py
@@ -211,21 +211,12 @@ class SyncImmichClient:
         date_range: DateRange,
         progress_callback: Callable[[int, int], None] | None = None,
         person_id: str | None = None,
+        person_ids: list[str] | None = None,
     ) -> list[Asset]:
         return self._run(
             self._async_client.get_photos_for_date_range(
-                date_range, progress_callback, person_id=person_id
+                date_range, progress_callback, person_id=person_id, person_ids=person_ids
             )
-        )
-
-    def get_videos_for_any_person(
-        self,
-        person_ids: list[str],
-        date_range: DateRange,
-        progress_callback: Callable[[int, int], None] | None = None,
-    ) -> list[Asset]:
-        return self._run(
-            self._async_client.get_videos_for_any_person(person_ids, date_range, progress_callback)
         )
 
     def get_assets_for_person_and_date_range(

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -848,6 +848,32 @@ def _drop_photos_already_shown_as_motion(
     )
 
 
+def fetch_photos(
+    *,
+    client: SyncImmichClient,
+    date_ranges: list[DateRange],
+    person_ids: list[str],
+) -> list:
+    """Fetch still photos for the memory's windows, honouring the person filter.
+
+    Several people means the photos holding all of them, the same rule videos
+    and Live Photos already follow.
+    """
+    photos: list = []
+    seen: set[str] = set()
+    for dr in date_ranges:
+        batch = client.get_photos_for_date_range(
+            dr,
+            person_id=person_ids[0] if len(person_ids) == 1 else None,
+            person_ids=person_ids if len(person_ids) > 1 else None,
+        )
+        for photo in batch:
+            if photo.id not in seen:
+                seen.add(photo.id)
+                photos.append(photo)
+    return photos
+
+
 def fetch_videos_and_live_photos(
     *,
     client: SyncImmichClient,
@@ -866,7 +892,9 @@ def fetch_videos_and_live_photos(
     all_assets = []
     for dr in date_ranges:
         if len(person_ids) > 1:
-            batch = client.get_videos_for_any_person(person_ids, dr)
+            # Naming several people asks for the moments that hold all of them,
+            # not the union of their solo reels. Live photos already intersect.
+            batch = client.get_videos_for_all_persons(person_ids, dr)
         elif len(person_ids) == 1:
             batch = client.get_videos_for_person_and_date_range(person_ids[0], dr)
         else:

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -24,6 +24,7 @@ from immich_memories.cli._generate_display import (
 )
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
 from immich_memories.cli._pipeline_runner import (
+    fetch_photos,
     fetch_videos_and_live_photos,
     run_pipeline_and_generate,
 )
@@ -896,11 +897,11 @@ def register_generate_commands(main: click.Group) -> None:
                     # Fetch photos (if enabled)
                     fetched_photos: list = []
                     if use_photos:
-                        for dr in date_ranges:
-                            pid = person_ids[0] if len(person_ids) == 1 else None
-                            fetched_photos.extend(
-                                client.get_photos_for_date_range(dr, person_id=pid)
-                            )
+                        fetched_photos = fetch_photos(
+                            client=client,
+                            date_ranges=date_ranges,
+                            person_ids=person_ids,
+                        )
                         if fetched_photos:
                             print_info(f"Found {len(fetched_photos)} photos")
 

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -149,6 +149,7 @@ def _build_clips(assets: list) -> tuple[list[VideoClipInfo], int]:
 def _fetch_photos(state) -> list:
     """Fetch photo assets (blocking), one query per window."""
     person_id = state.selected_person.id if state.selected_person else None
+    multi_ids = state.memory_preset_params.get("person_ids", [])
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
@@ -156,7 +157,13 @@ def _fetch_photos(state) -> list:
     ) as client:
         photos: list = []
         for date_range in state.date_ranges:
-            photos.extend(client.get_photos_for_date_range(date_range, person_id=person_id))
+            photos.extend(
+                client.get_photos_for_date_range(
+                    date_range,
+                    person_id=person_id,
+                    person_ids=multi_ids if len(multi_ids) >= 2 else None,
+                )
+            )
         return _dedup_by_id(photos)
 
 

--- a/tests/integration/cli/test_generate.py
+++ b/tests/integration/cli/test_generate.py
@@ -930,14 +930,14 @@ class TestPipelineRunner:
         mock_client.get_videos_for_person_and_date_range.assert_called_once()
 
     def test_fetch_videos_multi_person(self, tmp_path):
-        """fetch with multiple person_ids calls any-person API."""
+        """fetch with multiple person_ids asks for the videos holding all of them."""
         from immich_memories.cli._pipeline_runner import fetch_videos_and_live_photos
         from immich_memories.timeperiod import DateRange
 
         mock_client = MagicMock()
         mock_config = MagicMock()
         mock_progress = MagicMock()
-        mock_client.get_videos_for_any_person.return_value = []
+        mock_client.get_videos_for_all_persons.return_value = []
 
         dr = DateRange(
             start=datetime(2025, 1, 1),
@@ -951,7 +951,7 @@ class TestPipelineRunner:
             person_ids=["p1", "p2"],
             use_live_photos=False,
         )
-        mock_client.get_videos_for_any_person.assert_called_once()
+        mock_client.get_videos_for_all_persons.assert_called_once()
 
     def test_run_pipeline_wires_config_and_calls_generate(self, tmp_path, fixture_mp4):
         """run_pipeline_and_generate builds correct GenerationParams and calls generate_memory."""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -661,12 +661,11 @@ class TestAvailableYears:
         assert not years
 
 
-class TestGetVideosForAnyPerson:
-    """Tests for OR-query across multiple person IDs."""
+class TestGetVideosForAllPersons:
+    """Naming several people asks for the videos holding all of them."""
 
     @pytest.mark.asyncio
-    async def test_single_person_returns_same_as_regular_query(self, _mock_config):
-        """Single person_id delegates to get_videos_for_person_and_date_range."""
+    async def test_single_person_returns_that_person_s_videos(self, _mock_config):
         from datetime import UTC, datetime
 
         from immich_memories.timeperiod import DateRange
@@ -677,17 +676,14 @@ class TestGetVideosForAnyPerson:
         a2 = make_asset("a2", file_created_at=datetime(2024, 6, 1, tzinfo=UTC))
         date_range = DateRange(start=datetime(2024, 1, 1), end=datetime(2024, 12, 31, 23, 59, 59))
 
-        # WHY: mock at service level — get_videos_for_any_person delegates to search service
+        # WHY: mock at service level — the client delegates to the search service
         client.search.get_videos_for_person_and_date_range = AsyncMock(return_value=[a1, a2])
 
-        result = await client.get_videos_for_any_person(["person-1"], date_range)
-        assert len(result) == 2
-        assert result[0].id == "a1"
-        assert result[1].id == "a2"
+        result = await client.get_videos_for_all_persons(["person-1"], date_range)
+        assert [a.id for a in result] == ["a1", "a2"]
 
     @pytest.mark.asyncio
-    async def test_two_people_deduplicates_shared_videos(self, _mock_config):
-        """Videos appearing for both people are deduplicated in the union."""
+    async def test_two_people_keep_only_their_shared_videos(self, _mock_config):
         from datetime import UTC, datetime
 
         from immich_memories.timeperiod import DateRange
@@ -704,26 +700,23 @@ class TestGetVideosForAnyPerson:
                 return [only_a, shared]
             return [shared, only_b]
 
-        # WHY: mock at service level — delegates to search service
+        # WHY: mock at service level — the client delegates to the search service
         client.search.get_videos_for_person_and_date_range = AsyncMock(side_effect=mock_query)
 
-        result = await client.get_videos_for_any_person(["person-a", "person-b"], date_range)
-        assert len(result) == 3
-        ids = [a.id for a in result]
-        assert ids == ["only-a", "shared", "only-b"]
+        result = await client.get_videos_for_all_persons(["person-a", "person-b"], date_range)
+        assert [a.id for a in result] == ["shared"]
 
     @pytest.mark.asyncio
     async def test_empty_person_list_returns_empty(self, _mock_config):
-        """Empty person_ids list returns empty result without any queries."""
         from datetime import datetime
 
         from immich_memories.timeperiod import DateRange
 
         client = ImmichClient(_TEST_URL, _TEST_KEY)
         date_range = DateRange(start=datetime(2024, 1, 1), end=datetime(2024, 12, 31, 23, 59, 59))
-        # WHY: mock at service level — delegates to search service
+        # WHY: mock at service level — the client delegates to the search service
         client.search.get_videos_for_person_and_date_range = AsyncMock()
 
-        result = await client.get_videos_for_any_person([], date_range)
+        result = await client.get_videos_for_all_persons([], date_range)
         assert not result
         client.search.get_videos_for_person_and_date_range.assert_not_called()

--- a/tests/test_multi_person_selection.py
+++ b/tests/test_multi_person_selection.py
@@ -1,0 +1,139 @@
+"""A multi-person memory is about the people who were there together.
+
+Naming two people asks for the moments that hold both of them, not the union of
+two solo reels. These tests pin that rule at the fetch seam the CLI uses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from immich_memories.cli._pipeline_runner import fetch_photos, fetch_videos_and_live_photos
+from immich_memories.config_loader import Config
+from immich_memories.timeperiod import DateRange
+
+PERSON_A = "person-a"
+PERSON_B = "person-b"
+
+WINDOW = DateRange(start=datetime(2025, 1, 1), end=datetime(2025, 12, 31, 23, 59, 59))
+
+
+@dataclass
+class _Asset:
+    id: str
+    people: set[str] = field(default_factory=set)
+    file_created_at: datetime = datetime(2025, 6, 1, 12, 0, 0)
+    duration_seconds: float = 8.0
+
+
+class _LibraryClient:
+    """A library that answers person queries the way the Immich client does.
+
+    Every answer is derived from the same per-person lookup, so a test cannot
+    accidentally describe a union as an intersection.
+    """
+
+    def __init__(self, videos: list[_Asset], photos: list[_Asset] | None = None) -> None:
+        self._videos = videos
+        self._photos = photos or []
+
+    def get_photos_for_date_range(
+        self,
+        date_range: DateRange,  # noqa: ARG002
+        person_id: str | None = None,
+        person_ids: list[str] | None = None,
+    ) -> list[_Asset]:
+        wanted = set(person_ids or []) | ({person_id} if person_id else set())
+        return [p for p in self._photos if wanted <= p.people]
+
+    def get_videos_for_date_range(self, date_range: DateRange) -> list[_Asset]:  # noqa: ARG002
+        return list(self._videos)
+
+    def get_videos_for_person_and_date_range(
+        self,
+        person_id: str,
+        date_range: DateRange,  # noqa: ARG002
+    ) -> list[_Asset]:
+        return [a for a in self._videos if person_id in a.people]
+
+    def get_videos_for_all_persons(
+        self, person_ids: list[str], date_range: DateRange
+    ) -> list[_Asset]:
+        per_person = [
+            {a.id for a in self.get_videos_for_person_and_date_range(p, date_range)}
+            for p in person_ids
+        ]
+        common = set.intersection(*per_person) if per_person else set()
+        return [a for a in self._videos if a.id in common]
+
+
+class _SilentProgress:
+    def add_task(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def update(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _fetch(client: _LibraryClient, person_ids: list[str]) -> list[_Asset]:
+    assets, _live = fetch_videos_and_live_photos(
+        client=client,
+        config=Config(),
+        progress=_SilentProgress(),
+        date_ranges=[WINDOW],
+        person_ids=person_ids,
+        use_live_photos=False,
+    )
+    return assets
+
+
+def test_two_people_selects_only_the_moments_that_hold_both():
+    client = _LibraryClient(
+        [
+            _Asset("a-alone", {PERSON_A}),
+            _Asset("b-alone", {PERSON_B}),
+            _Asset("a-and-b", {PERSON_A, PERSON_B}),
+        ]
+    )
+
+    assets = _fetch(client, [PERSON_A, PERSON_B])
+
+    assert [a.id for a in assets] == ["a-and-b"]
+
+
+def test_no_shared_moment_yields_nothing_rather_than_two_solo_reels():
+    client = _LibraryClient([_Asset("a-alone", {PERSON_A}), _Asset("b-alone", {PERSON_B})])
+
+    assets = _fetch(client, [PERSON_A, PERSON_B])
+
+    assert assets == []
+
+
+def test_photos_follow_the_same_rule_as_videos():
+    client = _LibraryClient(
+        [],
+        photos=[
+            _Asset("photo-a-alone", {PERSON_A}),
+            _Asset("photo-nobody-named"),
+            _Asset("photo-a-and-b", {PERSON_A, PERSON_B}),
+        ],
+    )
+
+    photos = fetch_photos(client=client, date_ranges=[WINDOW], person_ids=[PERSON_A, PERSON_B])
+
+    assert [p.id for p in photos] == ["photo-a-and-b"]
+
+
+def test_one_person_still_selects_every_moment_they_appear_in():
+    client = _LibraryClient(
+        [
+            _Asset("a-alone", {PERSON_A}),
+            _Asset("b-alone", {PERSON_B}),
+            _Asset("a-and-b", {PERSON_A, PERSON_B}),
+        ]
+    )
+
+    assets = _fetch(client, [PERSON_A])
+
+    assert {a.id for a in assets} == {"a-alone", "a-and-b"}

--- a/tests/test_titles_audio_coverage.py
+++ b/tests/test_titles_audio_coverage.py
@@ -1900,51 +1900,7 @@ class TestSearchServiceDateRange:
 
 
 class TestSearchServiceMultiPerson:
-    """Test multi-person search (union and intersection)."""
-
-    @pytest.mark.asyncio
-    async def test_get_videos_for_any_person_union(self):
-        from immich_memories.api.search_service import SearchService
-        from immich_memories.timeperiod import DateRange
-
-        # Person 1 has asset a1, person 2 has a1 + a2
-        resp_p1 = {
-            "assets": {
-                "total": 1,
-                "count": 1,
-                "items": [_make_asset("a1", "2024-01-15T00:00:00")],
-                "nextPage": None,
-            }
-        }
-        resp_p2 = {
-            "assets": {
-                "total": 2,
-                "count": 2,
-                "items": [
-                    _make_asset("a1", "2024-01-15T00:00:00"),
-                    _make_asset("a2", "2024-02-15T00:00:00"),
-                ],
-                "nextPage": None,
-            }
-        }
-        mock_request = AsyncMock(side_effect=[resp_p1, resp_p2])
-        svc = SearchService(mock_request)
-        dr = DateRange(start=datetime(2024, 1, 1), end=datetime(2024, 12, 31))
-
-        result = await svc.get_videos_for_any_person(["p1", "p2"], dr)
-        assert len(result) == 2  # Union: a1, a2 (deduplicated)
-
-    @pytest.mark.asyncio
-    async def test_get_videos_for_any_person_empty_list(self):
-        from immich_memories.api.search_service import SearchService
-        from immich_memories.timeperiod import DateRange
-
-        mock_request = AsyncMock()
-        svc = SearchService(mock_request)
-        dr = DateRange(start=datetime(2024, 1, 1), end=datetime(2024, 12, 31))
-
-        result = await svc.get_videos_for_any_person([], dr)
-        assert result == []
+    """Test multi-person search (intersection across the named people)."""
 
     @pytest.mark.asyncio
     async def test_get_videos_for_all_persons_intersection(self):


### PR DESCRIPTION
Closes #650

## The finding

A verdict pass on the memory-type matrix asked for a two-person memory and got two solo reels. With a pool holding one clip of Person A alone, one of Person B alone and one of the two of them together, `--memory-type multi_person --person "Person A" --person "Person B"` returned **all three**. The pair barely appeared in the result.

Stills were worse than that: for two or more people the photo query dropped the person filter entirely, so photos of neither named person reached the pool.

## Root cause

`cli/_pipeline_runner.fetch_videos_and_live_photos()` called `client.get_videos_for_any_person(...)` — an explicit union — whenever more than one person was named.

The intersection already existed and was already being used: the UI path (`ui/pages/step2_loading.py`) called `get_videos_for_all_persons(...)`, and Live Photos intersected in `analysis/live_photo_pipeline.py`. So the CLI was the odd one out. Another CLI/UI parity gap rather than a missing capability — worth noting as a recurring shape.

The photo hole was a separate line in the same flow: `person_id = person_ids[0] if len(person_ids) == 1 else None`, in both the CLI and the UI.

## The semantics chosen

**An asset qualifies for a multi-person memory only when every named person is in it** — videos, Live Photos and stills alike. Two people who were never in the same frame produce an empty memory, not a union.

That is what the docs already said (`memory-types/monthly-person-season.mdx`, `reference/faq.md`, `web-ui/step1-configuration.mdx`) and what the preset already declared (`PersonFilter(mode="all_of", require_co_occurrence=True)`). The code disagreed with both.

Immich answers person queries one person at a time, so co-occurrence stays a client-side intersection of per-person results rather than a single server query — the same shape the video and Live Photo paths already used.

## Changes

- `fetch_videos_and_live_photos` asks for the videos holding all named people.
- `SearchService.get_photos_for_date_range` takes `person_ids` and intersects, mirroring `get_live_photos_for_date_range`; plumbed through `immich.py` and `sync_client.py`, and wired into both the CLI (new `fetch_photos` helper) and the UI.
- `get_videos_for_any_person` had no caller left, so it is deleted rather than whitelisted. `get_assets_for_any_person` stays — trip detection genuinely wants the union.
- The three copies of the intersection loop in `SearchService` collapse into one `_assets_holding_every_person` helper.
- One docs line tightened: "By default, requires co-occurrence" implied a toggle that no flag reaches.

## Tests

RED-first in `tests/test_multi_person_selection.py`, against an injected fake library rather than patches — every answer derives from the same per-person lookup, so a test cannot accidentally describe a union as an intersection:

- A-only + B-only + A&B, two people named → only A&B (failed before: returned all three)
- no shared moment → empty, not two solo reels (failed before: returned both)
- photos follow the same rule (failed before: `fetch_photos` did not exist and the pool was unfiltered)
- one person still selects every moment they appear in

`tests/test_api_client.py` and `tests/test_titles_audio_coverage.py` had classes pinning the union at the client and service layers; they now pin the intersection.

`make ci` passes (5579 unit tests, all gates including dead-code, duplication, diff-cover ≥80%). `make docs-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
