### PR TITLE
fix(titles): name a then-and-now by its two ends, not by the decade between

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3285,39 +3285,35 @@
       {
         "name": "TitleInserter::assemble_with_titles",
         "complexity": 22,
-        "line_start": 233,
-        "line_end": 435,
+        "line_start": 234,
+        "line_end": 436,
         "line_complexities": [
           {
-            "line": 251,
+            "line": 252,
             "complexity": 1
           },
           {
-            "line": 252,
-            "complexity": 0
-          },
-          {
-            "line": 254,
+            "line": 253,
             "complexity": 0
           },
           {
             "line": 255,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 256,
+            "complexity": 2
+          },
+          {
+            "line": 257,
             "complexity": 0
           },
           {
-            "line": 260,
+            "line": 261,
             "complexity": 1
           },
           {
-            "line": 262,
-            "complexity": 0
-          },
-          {
-            "line": 264,
+            "line": 263,
             "complexity": 0
           },
           {
@@ -3325,131 +3321,131 @@
             "complexity": 0
           },
           {
-            "line": 267,
+            "line": 266,
             "complexity": 0
           },
           {
-            "line": 270,
+            "line": 268,
             "complexity": 0
           },
           {
             "line": 271,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 272,
-            "complexity": 0
-          },
-          {
-            "line": 279,
-            "complexity": 0
-          },
-          {
-            "line": 289,
-            "complexity": 0
-          },
-          {
-            "line": 292,
             "complexity": 1
           },
           {
-            "line": 295,
+            "line": 273,
             "complexity": 0
+          },
+          {
+            "line": 280,
+            "complexity": 0
+          },
+          {
+            "line": 290,
+            "complexity": 0
+          },
+          {
+            "line": 293,
+            "complexity": 1
           },
           {
             "line": 296,
             "complexity": 0
           },
           {
-            "line": 299,
+            "line": 297,
             "complexity": 0
           },
           {
             "line": 300,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 301,
+            "complexity": 2
+          },
+          {
+            "line": 302,
             "complexity": 0
           },
           {
-            "line": 308,
+            "line": 309,
             "complexity": 0
-          },
-          {
-            "line": 310,
-            "complexity": 1
           },
           {
             "line": 311,
-            "complexity": 2
-          },
-          {
-            "line": 312,
-            "complexity": 0
-          },
-          {
-            "line": 322,
-            "complexity": 2
-          },
-          {
-            "line": 325,
-            "complexity": 0
-          },
-          {
-            "line": 337,
-            "complexity": 0
-          },
-          {
-            "line": 351,
-            "complexity": 2
-          },
-          {
-            "line": 354,
-            "complexity": 0
-          },
-          {
-            "line": 355,
             "complexity": 1
           },
           {
-            "line": 359,
+            "line": 312,
+            "complexity": 2
+          },
+          {
+            "line": 313,
             "complexity": 0
+          },
+          {
+            "line": 323,
+            "complexity": 2
+          },
+          {
+            "line": 326,
+            "complexity": 0
+          },
+          {
+            "line": 338,
+            "complexity": 0
+          },
+          {
+            "line": 352,
+            "complexity": 2
+          },
+          {
+            "line": 355,
+            "complexity": 0
+          },
+          {
+            "line": 356,
+            "complexity": 1
           },
           {
             "line": 360,
             "complexity": 0
           },
           {
-            "line": 366,
+            "line": 361,
             "complexity": 0
           },
           {
-            "line": 369,
-            "complexity": 1
+            "line": 367,
+            "complexity": 0
           },
           {
             "line": 370,
-            "complexity": 2
-          },
-          {
-            "line": 385,
-            "complexity": 0
-          },
-          {
-            "line": 388,
             "complexity": 1
           },
           {
-            "line": 395,
+            "line": 371,
+            "complexity": 2
+          },
+          {
+            "line": 386,
             "complexity": 0
           },
           {
-            "line": 400,
+            "line": 389,
+            "complexity": 1
+          },
+          {
+            "line": 396,
             "complexity": 0
           },
           {
-            "line": 406,
+            "line": 401,
             "complexity": 0
           },
           {
@@ -3465,12 +3461,12 @@
             "complexity": 0
           },
           {
-            "line": 414,
-            "complexity": 2
+            "line": 410,
+            "complexity": 0
           },
           {
-            "line": 418,
-            "complexity": 0
+            "line": 415,
+            "complexity": 2
           },
           {
             "line": 419,
@@ -3493,11 +3489,15 @@
             "complexity": 0
           },
           {
-            "line": 428,
+            "line": 424,
             "complexity": 0
           },
           {
-            "line": 430,
+            "line": 429,
+            "complexity": 0
+          },
+          {
+            "line": 431,
             "complexity": 0
           }
         ]

--- a/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
+++ b/docs-site/docs/create/memory-types/holiday-then-and-now.mdx
@@ -91,7 +91,7 @@ The gap is required either way: a then-and-now with no distance between its two 
 
 Unlike Holiday, each side is a **full calendar year**. A narrow window in a year long past is usually empty, and the point is to have enough material on both sides for the contrast to read.
 
-Clips play most recent first, so the video opens on now and reaches back.
+Clips play in chronological order, so the "then" year runs as one block and the "now" year follows it. The two ranges are built most-recent-first internally — that is how the memory derives its span — but the cut itself is oldest to newest, like every other memory.
 
 ### When to use it
 
@@ -111,5 +111,7 @@ Neither is titled after its span, because the span describes neither of them —
 |------|-------|----------|
 | Holiday | the occasion — "Christmas" | "Through the Years" |
 | Then and Now | both ends — "2016 & 2026" | "Then and Now" |
+
+Holiday's pair is currently produced by the web UI only. On the CLI a Holiday memory still falls through to the generic span title ("December 2021 to December 2026"); Then and Now is titled correctly on both.
 
 A custom `MM-DD` holiday with no name of its own is titled by its date ("14 September").

--- a/src/immich_memories/processing/title_inserter.py
+++ b/src/immich_memories/processing/title_inserter.py
@@ -89,6 +89,7 @@ class TitleInserter:
             encoding_plan=self.settings.encoding_plan,
             title_override=title_settings.title_override,
             subtitle_override=title_settings.subtitle_override,
+            memory_type=title_settings.memory_type,
         )
 
     def _decide_transitions_for_final_clips(self, clips: list[AssemblyClip]) -> list[str]:

--- a/src/immich_memories/titles/_text_memory_types.py
+++ b/src/immich_memories/titles/_text_memory_types.py
@@ -96,3 +96,26 @@ def generate_on_this_day_title(
         subtitle=subtitle,
         selection_type=SelectionType.ON_THIS_DAY,
     )
+
+
+def generate_then_and_now_title(
+    start_date: date | None,
+    end_date: date | None,
+    locale: str,
+) -> TitleInfo:
+    """Generate title for a Then and Now memory.
+
+    Named by its two ends rather than its span: the years between them are
+    exactly what the type leaves out, so "January 2016 to December 2026" — what
+    the generic date-range fallback produced — describes the one thing it is not.
+    """
+    if start_date is None or end_date is None:
+        raise ValueError("Start and end dates required for Then and Now selection")
+    patterns = TITLE_PATTERNS.get(locale, TITLE_PATTERNS["en"])
+    return TitleInfo(
+        main_title=patterns["then_and_now"].format(
+            then_year=start_date.year, now_year=end_date.year
+        ),
+        subtitle=patterns["then_and_now_subtitle"],
+        selection_type=SelectionType.THEN_AND_NOW,
+    )

--- a/src/immich_memories/titles/generator.py
+++ b/src/immich_memories/titles/generator.py
@@ -70,6 +70,9 @@ class TitleScreenConfig:
     title_override: str | None = None
     subtitle_override: str | None = None
 
+    # The memory type, for the ones whose dates cannot reveal them.
+    memory_type: str | None = None
+
     # Month dividers
     show_month_dividers: bool = True
     month_divider_threshold: int = 2  # Minimum clips to show month divider
@@ -192,6 +195,7 @@ class TitleScreenGenerator:
                 start_date=start_date,
                 end_date=end_date,
                 birthday_age=birthday_age,
+                memory_type=self.config.memory_type,
             )
 
         # Use LLM-generated title if available

--- a/src/immich_memories/titles/text_builder.py
+++ b/src/immich_memories/titles/text_builder.py
@@ -33,6 +33,7 @@ class SelectionType(Enum):
     PERSON_SPOTLIGHT = "person_spotlight"
     MULTI_PERSON = "multi_person"
     ON_THIS_DAY = "on_this_day"
+    THEN_AND_NOW = "then_and_now"
 
 
 @dataclass
@@ -73,6 +74,8 @@ TITLE_PATTERNS: dict[str, dict[str, str]] = {
         "season_year_span": "{season} {start_year}-{end_year}",
         "on_this_day": "{month} {day}",
         "on_this_day_subtitle": "Through the Years",
+        "then_and_now": "{then_year} & {now_year}",
+        "then_and_now_subtitle": "Then and Now",
         "person_spotlight_subtitle": "Your Year with {person}",
     },
     "fr": {
@@ -84,6 +87,8 @@ TITLE_PATTERNS: dict[str, dict[str, str]] = {
         "season_year_span": "{season} {start_year}-{end_year}",
         "on_this_day": "{month} {day}",
         "on_this_day_subtitle": "À travers les années",
+        "then_and_now": "{then_year} & {now_year}",
+        "then_and_now_subtitle": "Avant et maintenant",
         "person_spotlight_subtitle": "Votre année avec {person}",
     },
 }
@@ -221,6 +226,12 @@ def _title_on_this_day(**kwargs) -> TitleInfo:
     return generate_on_this_day_title(kwargs["start_date"], kwargs["locale"])
 
 
+def _title_then_and_now(**kwargs) -> TitleInfo:
+    from immich_memories.titles._text_memory_types import generate_then_and_now_title
+
+    return generate_then_and_now_title(kwargs["start_date"], kwargs["end_date"], kwargs["locale"])
+
+
 _TITLE_DISPATCH: dict[SelectionType, Callable[..., TitleInfo]] = {
     SelectionType.CALENDAR_YEAR: _title_calendar_year,
     SelectionType.BIRTHDAY_YEAR: _title_birthday_year,
@@ -231,6 +242,7 @@ _TITLE_DISPATCH: dict[SelectionType, Callable[..., TitleInfo]] = {
     SelectionType.PERSON_SPOTLIGHT: _title_person_spotlight,
     SelectionType.MULTI_PERSON: _title_multi_person,
     SelectionType.ON_THIS_DAY: _title_on_this_day,
+    SelectionType.THEN_AND_NOW: _title_then_and_now,
 }
 
 
@@ -375,6 +387,7 @@ def infer_selection_type(
     start_date: date | None = None,
     end_date: date | None = None,
     birthday_age: int | None = None,
+    memory_type: str | None = None,
 ) -> SelectionType:
     """Infer the selection type from provided parameters.
 
@@ -384,10 +397,17 @@ def infer_selection_type(
         start_date: Start date.
         end_date: End date.
         birthday_age: Birthday age if applicable.
+        memory_type: Memory type key, for the types the dates cannot reveal.
 
     Returns:
         Inferred SelectionType.
     """
+    # A then-and-now's two years look exactly like any other range spanning
+    # them, and the years in between are what it leaves out. Nothing in the
+    # dates can say so, so the type has to.
+    if memory_type == "then_and_now":
+        return SelectionType.THEN_AND_NOW
+
     if birthday_age is not None:
         return SelectionType.BIRTHDAY_YEAR
 

--- a/tests/test_title_orchestration.py
+++ b/tests/test_title_orchestration.py
@@ -91,6 +91,30 @@ class TestGenerateTitleScreen:
         assert call_kwargs.kwargs["width"] == 720
         assert call_kwargs.kwargs["height"] == 1280
 
+    def test_then_and_now_is_titled_by_its_two_ends(
+        self, tmp_output, mock_rendering, mock_ending, mock_trip
+    ):
+        """The card named the decade the memory type deliberately skips.
+
+        With only dates to go on the generator inferred a plain date range and
+        rendered "January 2016 to December 2026" — the years in between being
+        exactly what a then-and-now leaves out. The type has to reach it.
+        """
+        from datetime import date
+
+        gen = _make_generator(
+            tmp_output,
+            mock_rendering,
+            mock_ending,
+            mock_trip,
+            memory_type="then_and_now",
+        )
+        gen.generate_title_screen(start_date=date(2016, 1, 1), end_date=date(2026, 12, 31))
+
+        call_kwargs = mock_rendering.create_title_video.call_args.kwargs
+        assert call_kwargs["title"] == "2016 & 2026"
+        assert call_kwargs["subtitle"] == "Then and Now"
+
     def test_passes_correct_duration(self, tmp_output, mock_rendering, mock_ending, mock_trip):
         gen = _make_generator(
             tmp_output,

--- a/tests/test_title_resolution.py
+++ b/tests/test_title_resolution.py
@@ -27,6 +27,7 @@ def _fake_title_settings(**overrides) -> SimpleNamespace:
         "show_decorative_lines": False,
         "title_override": None,
         "subtitle_override": None,
+        "memory_type": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -237,6 +237,35 @@ class TestTextBuilder:
         )
         assert sel_type == SelectionType.DATE_RANGE
 
+    def test_then_and_now_is_not_inferable_from_its_dates(self):
+        """Two years ten apart look exactly like any other eleven-year range.
+
+        Only the memory type distinguishes them, which is why it has to be
+        threaded through rather than guessed at.
+        """
+        sel_type = infer_selection_type(
+            start_date=date(2016, 1, 1),
+            end_date=date(2026, 12, 31),
+            memory_type="then_and_now",
+        )
+        assert sel_type == SelectionType.THEN_AND_NOW
+
+    def test_generate_title_then_and_now_en(self):
+        """Its span is a decade it deliberately skips, so it is titled by its ends.
+
+        The generic date-range fallback rendered "January 2016 to December 2026"
+        — the one description a then-and-now must not carry, since the years
+        between them are exactly what it leaves out.
+        """
+        title_info = generate_title(
+            SelectionType.THEN_AND_NOW,
+            start_date=date(2016, 1, 1),
+            end_date=date(2026, 12, 31),
+            locale="en",
+        )
+        assert title_info.main_title == "2016 & 2026"
+        assert title_info.subtitle == "Then and Now"
+
     def test_generate_title_calendar_year_en(self):
         """Test title generation for calendar year in English."""
         title_info = generate_title(


### PR DESCRIPTION
Closes #651

**Minimal coherence fix — the Then and Now rule itself is still under review.** This changes only what the card says, not what the memory selects or in what order.

## Root cause

`title_inserter.assemble_with_titles` calls `generate_title_screen(...)` without a `selection_type`, so the generator falls back to `infer_selection_type(...)`. With only `start_date` and `end_date` to go on, two years ten apart are indistinguishable from any other eleven-year range — it returns `SelectionType.DATE_RANGE` and the generic "spanning years" pattern renders:

```
January 2016 to December 2026
```

with no subtitle. That is the one description a then-and-now must not carry: the years in between are exactly what the type leaves out.

`MemoryPreset.title_template` already held the intended `"{then_year} & {now_year}"`, but nothing in the codebase has ever read `title_template` or `subtitle_template` — both are whitelisted in `vulture-whitelist.py` as unused. The web UI does not hit this because `generate_template_title` has a `then_and_now` branch whose result is applied as a title override; the CLI has no equivalent, so it is the CLI that rendered the wrong card.

## Fix

The memory type now reaches the title system the way every other one does — a `SelectionType.THEN_AND_NOW` with its own locale patterns and generator function, alongside `ON_THIS_DAY` and the rest. It is carried down through `TitleScreenConfig.memory_type`, because no amount of date inspection can recover it.

Result: **"2016 & 2026" / "Then and Now"**, matching the documented behaviour and the web UI.

Blast radius is one memory type: `infer_selection_type` short-circuits only on `"then_and_now"`, so every other type resolves exactly as before.

## Also

- Corrects the docs' claim that "clips play most recent first". The assembly sort is `selected.sort(key=... file_created_at)` — ascending — so the "then" year runs first as one block and "now" follows. The two ranges are built most-recent-first internally (that is how the span is derived), but the cut is oldest to newest.
- Notes in the docs that Holiday has the identical CLI gap. Not fixed here — separate concern.

## Tests

- `test_generate_title_then_and_now_en` — the title text itself.
- `test_then_and_now_is_not_inferable_from_its_dates` — why the type has to be threaded rather than guessed.
- `test_then_and_now_is_titled_by_its_two_ends` — the wiring, asserted on what actually reaches the renderer.

`make ci` and `make docs-build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f