### PR TITLE
feat(metrics): show a run what it spent, on three surfaces that agree

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1482,157 +1482,157 @@
       {
         "name": "register_runs_commands",
         "complexity": 36,
-        "line_start": 162,
-        "line_end": 370,
+        "line_start": 184,
+        "line_end": 393,
         "line_complexities": [
           {
-            "line": 201,
-            "complexity": 0
-          },
-          {
-            "line": 205,
-            "complexity": 2
-          },
-          {
-            "line": 209,
-            "complexity": 0
-          },
-          {
-            "line": 217,
-            "complexity": 0
-          },
-          {
-            "line": 225,
-            "complexity": 2
-          },
-          {
-            "line": 226,
+            "line": 223,
             "complexity": 0
           },
           {
             "line": 227,
-            "complexity": 0
-          },
-          {
-            "line": 228,
-            "complexity": 3
-          },
-          {
-            "line": 253,
-            "complexity": 0
-          },
-          {
-            "line": 254,
-            "complexity": 0
-          },
-          {
-            "line": 256,
             "complexity": 2
           },
           {
-            "line": 258,
+            "line": 231,
             "complexity": 0
           },
           {
-            "line": 259,
+            "line": 239,
             "complexity": 0
           },
           {
-            "line": 260,
+            "line": 247,
+            "complexity": 2
+          },
+          {
+            "line": 248,
+            "complexity": 0
+          },
+          {
+            "line": 249,
+            "complexity": 0
+          },
+          {
+            "line": 250,
             "complexity": 3
           },
           {
-            "line": 261,
+            "line": 275,
             "complexity": 0
-          },
-          {
-            "line": 262,
-            "complexity": 1
-          },
-          {
-            "line": 265,
-            "complexity": 1
           },
           {
             "line": 276,
+            "complexity": 0
+          },
+          {
+            "line": 278,
             "complexity": 2
           },
           {
-            "line": 279,
-            "complexity": 2
-          },
-          {
-            "line": 288,
+            "line": 280,
             "complexity": 0
           },
           {
-            "line": 294,
+            "line": 281,
             "complexity": 0
           },
           {
-            "line": 337,
-            "complexity": 0
-          },
-          {
-            "line": 338,
-            "complexity": 0
-          },
-          {
-            "line": 340,
-            "complexity": 2
-          },
-          {
-            "line": 342,
-            "complexity": 0
-          },
-          {
-            "line": 343,
-            "complexity": 0
-          },
-          {
-            "line": 344,
+            "line": 282,
             "complexity": 3
           },
           {
-            "line": 345,
+            "line": 283,
             "complexity": 0
           },
           {
-            "line": 346,
+            "line": 284,
             "complexity": 1
           },
           {
-            "line": 349,
+            "line": 287,
             "complexity": 1
           },
           {
-            "line": 354,
-            "complexity": 3
+            "line": 298,
+            "complexity": 2
           },
           {
-            "line": 355,
+            "line": 302,
+            "complexity": 2
+          },
+          {
+            "line": 311,
             "complexity": 0
           },
           {
-            "line": 357,
-            "complexity": 3
-          },
-          {
-            "line": 359,
+            "line": 317,
             "complexity": 0
           },
           {
             "line": 360,
-            "complexity": 4
+            "complexity": 0
+          },
+          {
+            "line": 361,
+            "complexity": 0
           },
           {
             "line": 363,
+            "complexity": 2
+          },
+          {
+            "line": 365,
+            "complexity": 0
+          },
+          {
+            "line": 366,
+            "complexity": 0
+          },
+          {
+            "line": 367,
+            "complexity": 3
+          },
+          {
+            "line": 368,
+            "complexity": 0
+          },
+          {
+            "line": 369,
+            "complexity": 1
+          },
+          {
+            "line": 372,
+            "complexity": 1
+          },
+          {
+            "line": 377,
+            "complexity": 3
+          },
+          {
+            "line": 378,
+            "complexity": 0
+          },
+          {
+            "line": 380,
+            "complexity": 3
+          },
+          {
+            "line": 382,
+            "complexity": 0
+          },
+          {
+            "line": 383,
+            "complexity": 4
+          },
+          {
+            "line": 386,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 62
+    "complexity": 64
   },
   {
     "path": "src/immich_memories/cli/scheduler_cmd.py",

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -386,6 +386,39 @@ Three things worth knowing:
 It uses `title_llm` if you have configured one, otherwise `llm` — the same
 resolution the rest of the pipeline uses.
 
+### What a run reports about itself
+
+Every generation ends with a short block:
+
+```
+Memory generated in 6m 27s
+
+  measured this run
+    analysis + selection     3m 49s   28 of 312 deeply analyzed, 14 planned
+    generation               2m 38s
+
+  LLM   11 calls · 4 answered from the judgment cache · 47.2k prompt / 3.1k completion · 2m 18s
+        1 thinking call truncated at the token budget and retried without it
+```
+
+**"Measured this run" means what it says.** Those two timings are wall-clock
+taken around the calls as they happen. They are *not* in the run database:
+`runs show` reports the phases the run tracker records — clip extraction,
+assembly and music — which do not include analysis or selection. Both surfaces
+report the same **model** totals, because those are stored per run; only the
+phase breakdown differs, and each says which it is showing.
+
+The cache mentioned is the **judgment cache** — repeated questions to the same
+model about the same memory — not the video, photo or analysis caches.
+
+**The truncation line only appears when it happened**, and it is the reason the
+block exists: a thinking call that overruns its token budget is retried without
+thinking, silently and correctly, and the retry costs both the wasted call and
+a worse answer. Before this line existed that cost was invisible unless someone
+read the server log.
+
+A run with no LLM configured prints no model line at all.
+
 ### Why did selection drop that clip?
 
 `--trace-selection` writes a funnel: every stage of selection, what it received, what it let

--- a/docs-site/docs/create/cli/runs.md
+++ b/docs-site/docs/create/cli/runs.md
@@ -46,6 +46,17 @@ You can use a partial run ID: if it's unambiguous, it'll match:
 immich-memories runs show 20260105_1430
 ```
 
+### Model spend
+
+`runs show` reports what the run spent on the LLM — calls, judgment-cache hits,
+tokens, wall time, and any thinking calls truncated at the token budget.
+
+It is reported **per run, not per phase**, and the phase table is labelled
+"recorded phases only" for the same reason: the run tracker records clip
+extraction, assembly and music, all of which happen after selection. Analysis
+and selection run before the run row exists and account for most of the model
+budget, so a per-phase total would understate the bill.
+
 ## runs stats
 
 Aggregate statistics across all your runs:

--- a/src/immich_memories/analysis/llm_metrics.py
+++ b/src/immich_memories/analysis/llm_metrics.py
@@ -19,6 +19,7 @@ script pays nothing.
 
 from __future__ import annotations
 
+import functools
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
@@ -29,7 +30,14 @@ if TYPE_CHECKING:
 
 _active: ContextVar[LLMCounters | None] = ContextVar("llm_counters", default=None)
 
-__all__ = ["LLMCounters", "collecting", "record_cache_hit", "record_reply", "record_wall"]
+__all__ = [
+    "LLMCounters",
+    "collecting",
+    "collects",
+    "record_cache_hit",
+    "record_reply",
+    "record_wall",
+]
 
 
 @dataclass
@@ -129,3 +137,19 @@ def collecting() -> Iterator[LLMCounters]:
         yield counters
     finally:
         _active.reset(token)
+
+
+def collects(func):
+    """Run `func` with collection switched on, and read it back with `active()`.
+
+    A decorator rather than a `with` around the body: the functions worth
+    wrapping are long and sit at the complexity ceiling, and re-indenting one
+    to add an instrument is a worse diff than the instrument is worth.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with collecting():
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -14,7 +14,9 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from immich_memories.cli._helpers import print_error, print_success
+from immich_memories.analysis import llm_metrics
+from immich_memories.cli._helpers import console, print_error, print_success
+from immich_memories.cli._run_summary import render_run_summary
 from immich_memories.timeperiod import DateRange
 
 logger = logging.getLogger(__name__)
@@ -251,6 +253,7 @@ class _AttemptPhaseReporter:
         self._progress.update(self._task, description=event.message)
 
 
+@llm_metrics.collects
 def run_pipeline_and_generate(
     *,
     assets: list,
@@ -587,6 +590,18 @@ def run_pipeline_and_generate(
         _analysis_time / _total_time * 100 if _total_time > 0 else 0,
         _gen_time,
         _gen_time / _total_time * 100 if _total_time > 0 else 0,
+    )
+
+    console.print(
+        render_run_summary(
+            total_seconds=_total_time,
+            analysis_seconds=_analysis_time,
+            generation_seconds=_gen_time,
+            eligible=len(all_candidates),
+            deeply_analyzed=pipeline.last_deep_analysis_count,
+            planned=len(selected_clips),
+            counters=llm_metrics.active(),
+        )
     )
 
     _send_notification(config, memory_type, "completed", _total_time, str(result_path))

--- a/src/immich_memories/cli/_run_summary.py
+++ b/src/immich_memories/cli/_run_summary.py
@@ -1,0 +1,112 @@
+"""The block a run prints about itself when it finishes.
+
+Two things a reader has to be able to tell apart, so the block labels them:
+
+*Measured this run* -- the CLI wraps `run_analysis` and `run_selection`, so
+their wall-clock is honest local arithmetic. It is not in the run database:
+`RunTracker` records only clip_extraction, assembly and music, all inside
+`generate_memory`. Claiming a phase breakdown the database does not hold is
+how a partial picture starts reading as the whole one.
+
+*The model's bill* -- run-level totals, which `runs show` renders from the
+database for the same run. Both surfaces agree because both count the same
+thing; neither pretends to phases that do not exist.
+"""
+
+from __future__ import annotations
+
+from immich_memories.analysis.llm_metrics import LLMCounters
+
+__all__ = ["render_llm_totals", "render_run_summary"]
+
+_NO_SPEND = LLMCounters()
+
+
+def _clock(seconds: float) -> str:
+    minutes, secs = divmod(int(round(seconds)), 60)
+    return f"{minutes}m {secs:02d}s" if minutes else f"{secs}s"
+
+
+def _thousands(count: int) -> str:
+    return f"{count / 1000:.1f}k" if count >= 1000 else str(count)
+
+
+def _llm_lines(counters: LLMCounters) -> list[str]:
+    """What the model cost, or nothing at all when it was never asked.
+
+    A run with no LLM configured -- the recommended NAS setup -- should read
+    as a normal run, not as one missing a section.
+    """
+    if not counters.calls and not counters.cache_hits:
+        return []
+
+    parts = [f"{counters.calls} calls"]
+    if counters.cache_hits:
+        parts.append(f"{counters.cache_hits} answered from the judgment cache")
+    if counters.prompt_tokens or counters.completion_tokens:
+        parts.append(
+            f"{_thousands(counters.prompt_tokens)} prompt / "
+            f"{_thousands(counters.completion_tokens)} completion"
+        )
+    if counters.wall_seconds:
+        parts.append(_clock(counters.wall_seconds))
+
+    lines = ["", "  LLM   " + " · ".join(parts)]
+    if counters.truncated:
+        # The sentence #600 needed on the night it started, instead of two
+        # months later in a server log nobody was reading.
+        call = "call" if counters.truncated == 1 else "calls"
+        lines.append(
+            f"        {counters.truncated} thinking {call} truncated at the "
+            "token budget and retried without it"
+        )
+    return lines
+
+
+def render_run_summary(
+    *,
+    total_seconds: float,
+    analysis_seconds: float,
+    generation_seconds: float,
+    eligible: int,
+    deeply_analyzed: int,
+    planned: int,
+    counters: LLMCounters | None,
+) -> str:
+    """The end-of-run block, as printable text.
+
+    `counters` may be None when nothing was collecting; handled here rather
+    than at the call site, which sits in a function with no complexity
+    headroom -- a single `or` there is enough to fail the gate.
+    """
+    counters = counters if counters is not None else _NO_SPEND
+    lines = [
+        f"Memory generated in {_clock(total_seconds)}",
+        "",
+        "  measured this run",
+        f"    analysis + selection   {_clock(analysis_seconds):>8}   "
+        f"{deeply_analyzed} of {eligible} deeply analyzed, {planned} planned",
+        f"    generation             {_clock(generation_seconds):>8}",
+    ]
+    lines.extend(_llm_lines(counters))
+    return "\n".join(lines)
+
+
+def render_llm_totals(metrics: dict) -> str:
+    """The model's bill from a stored run, phrased exactly as the run block did.
+
+    `runs show` and `auto status` read this from the database; the end-of-run
+    block computes it live. Both go through the same renderer so the same run
+    cannot be described two different ways on two surfaces.
+    """
+    from immich_memories.analysis.llm_metrics import LLMCounters
+
+    counters = LLMCounters(
+        calls=int(metrics.get("llm_calls", 0)),
+        cache_hits=int(metrics.get("llm_cache_hits", 0)),
+        prompt_tokens=int(metrics.get("llm_prompt_tokens", 0)),
+        completion_tokens=int(metrics.get("llm_completion_tokens", 0)),
+        truncated=int(metrics.get("llm_truncated", 0)),
+        wall_seconds=float(metrics.get("llm_wall_seconds", 0.0)),
+    )
+    return "\n".join(line for line in _llm_lines(counters) if line).strip()

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -331,6 +331,7 @@ def status(ctx: click.Context, as_json: bool) -> None:
         "Last completed auto run: "
         + (f"{last_run['run_id']} ({last_run['category'] or '-'})" if last_run else "none")
     )
+    _print_last_run_model_spend(config, last_run)
     print_info(
         f"Cooldown: {'active' if cooldown_status['active'] else 'ready'} "
         f"({cooldown_status['hours']}h)"
@@ -438,3 +439,21 @@ def test_notification(ctx: click.Context) -> None:
 def register_auto_commands(cli_group: click.Group) -> None:
     """Register the auto command group on the main CLI group."""
     cli_group.add_command(auto)
+
+
+def _print_last_run_model_spend(config: Config, last_run: dict | None) -> None:
+    """What the last automatic run spent on the model, if anything.
+
+    The same line `runs show` prints, from the same stored totals -- an
+    unattended run is exactly the one nobody watched, so its bill has to be
+    visible without going looking for it.
+    """
+    if not last_run or not last_run.get("run_id"):
+        return
+    from immich_memories.cli._run_summary import render_llm_totals
+    from immich_memories.tracking import RunDatabase
+
+    run = RunDatabase(config.cache.database_path).get_run(last_run["run_id"])
+    line = render_llm_totals(getattr(run, "llm_metrics", None) or {}) if run else ""
+    if line:
+        print_info(line.replace("\n", " — ").strip())

--- a/src/immich_memories/cli/runs.py
+++ b/src/immich_memories/cli/runs.py
@@ -98,10 +98,32 @@ def _print_run_details_table(run, format_duration) -> None:
     console.print(table)
 
 
-def _print_run_phases_table(run, format_duration) -> None:
-    """Print the phase timings table for a run."""
+def _print_run_llm_totals(run) -> None:
+    """What the run spent on the model, if it used one.
+
+    Run-level rather than per-phase because the phases above are only the ones
+    RunTracker records -- clip_extraction, assembly and music. Analysis and
+    selection are not tracked phases and spend most of the model budget, so a
+    per-phase total would understate the bill.
+    """
+    from immich_memories.cli._run_summary import render_llm_totals
+
+    line = render_llm_totals(getattr(run, "llm_metrics", None) or {})
+    if not line:
+        return
     console.print()
-    console.print("[bold]Phase Timings[/bold]")
+    console.print("[bold]Model[/bold]")
+    console.print(line)
+
+
+def _print_run_phases_table(run, format_duration) -> None:
+    """Print the phase timings table for a run.
+
+    These are the phases the run database holds, which is not every phase of a
+    generation -- analysis and selection run before the run row exists.
+    """
+    console.print()
+    console.print("[bold]Phase Timings (recorded phases only)[/bold]")
     console.print()
 
     phase_table = Table()
@@ -275,6 +297,7 @@ def register_runs_commands(main: click.Group) -> None:
 
         if run.phases:
             _print_run_phases_table(run, format_duration)
+        _print_run_llm_totals(run)
 
         if run.system_info:
             _print_run_system_info(run.system_info)

--- a/tests/test_run_metrics_surfaces.py
+++ b/tests/test_run_metrics_surfaces.py
@@ -1,0 +1,29 @@
+"""`runs show` and `auto status` report the same spend the run block did.
+
+Both read the run database. Neither invents phases it does not hold: the
+phase table shows the three phases the tracker records, and the model's bill
+is reported at run level, which is where it is stored and why.
+"""
+
+from __future__ import annotations
+
+from immich_memories.cli._run_summary import render_llm_totals
+
+
+def test_the_totals_line_names_the_cache_it_counted() -> None:
+    """Three caches exist in this tool; the line has to say which one it means."""
+    line = render_llm_totals({"llm_calls": 11, "llm_cache_hits": 4, "llm_wall_seconds": 138.0})
+
+    assert "11 calls" in line
+    assert "judgment cache" in line
+
+
+def test_a_truncation_is_reported_after_the_fact_too() -> None:
+    """The run block says it live; `runs show` has to still say it tomorrow."""
+    line = render_llm_totals({"llm_calls": 9, "llm_truncated": 2})
+
+    assert "2 thinking calls truncated" in line
+
+
+def test_a_run_with_no_model_spend_renders_nothing() -> None:
+    assert render_llm_totals({}) == ""

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -1,0 +1,80 @@
+"""The block a run prints about itself.
+
+Granularity is the design constraint, not a nicety. The CLI measures analysis
+and selection live because it wraps those calls; the run database does not
+record them as phases at all. The block says which is which, so a partial
+picture never reads as the whole one.
+"""
+
+from __future__ import annotations
+
+from immich_memories.analysis.llm_metrics import LLMCounters
+from immich_memories.cli._run_summary import render_run_summary
+
+
+def test_the_block_reports_what_it_measured_this_run() -> None:
+    text = render_run_summary(
+        total_seconds=387.0,
+        analysis_seconds=229.0,
+        generation_seconds=158.0,
+        eligible=312,
+        deeply_analyzed=28,
+        planned=14,
+        counters=LLMCounters(),
+    )
+
+    assert "6m 27s" in text
+    assert "measured this run" in text
+    assert "28 of 312" in text
+    assert "14 planned" in text
+
+
+def test_a_truncated_thinking_call_is_named_in_the_block() -> None:
+    """The sentence that would have surfaced #600 on the night it started."""
+    counters = LLMCounters(calls=11, cache_hits=4, truncated=1, wall_seconds=138.0)
+
+    text = render_run_summary(
+        total_seconds=387.0,
+        analysis_seconds=229.0,
+        generation_seconds=158.0,
+        eligible=312,
+        deeply_analyzed=28,
+        planned=14,
+        counters=counters,
+    )
+
+    assert "11 calls" in text
+    assert "truncated" in text
+    assert "judgment cache" in text
+
+
+def test_a_run_that_never_touched_the_model_prints_no_llm_line() -> None:
+    """A NAS run with no LLM configured should not read as a broken one."""
+    text = render_run_summary(
+        total_seconds=90.0,
+        analysis_seconds=40.0,
+        generation_seconds=50.0,
+        eligible=20,
+        deeply_analyzed=20,
+        planned=8,
+        counters=LLMCounters(),
+    )
+
+    assert "LLM" not in text
+
+
+def test_a_healthy_llm_run_stays_quiet_about_truncation() -> None:
+    counters = LLMCounters(calls=6, cache_hits=2, wall_seconds=44.0)
+
+    text = render_run_summary(
+        total_seconds=120.0,
+        analysis_seconds=70.0,
+        generation_seconds=50.0,
+        eligible=40,
+        deeply_analyzed=12,
+        planned=9,
+        counters=counters,
+    )
+
+    assert "6 calls" in text
+    assert "truncated" not in text


### PR DESCRIPTION
Refs #600. PR 2 of 2 — **the three read surfaces**, and the thing that switches collection on.

## It closes a gap PR 1 left, and I'd rather name it than paper over it

**Nothing entered `collecting()`.** PR 1 shipped the instrument and the store; in production it would have counted nothing and every surface here would have rendered zeros. Caught before building on top of it, but it was a real hole.

Collection is switched on by a **decorator** on `run_pipeline_and_generate`, not a `with` around the body: that function is long and sits at the complexity ceiling, and re-indenting it to add an instrument is a worse diff than the instrument is worth.

## The block reports only what it actually measured

The runner **already** timed analysis+selection and generation — and logged them at INFO, where nobody reads them. That is the sixth instance tonight of this codebase's dominant defect: not missing capability, but **a computed value that never reaches a reader**. This whole feature is the systemic answer to that class.

```
Memory generated in 6m 27s

  measured this run
    analysis + selection     3m 49s   28 of 312 deeply analyzed, 14 planned
    generation               2m 38s

  LLM   11 calls · 4 answered from the judgment cache · 47.2k prompt / 3.1k completion · 2m 18s
        1 thinking call truncated at the token budget and retried without it
```

**"Measured this run" is load-bearing.** Those timings are honest local wall-clock, and they are *not* in the run database — `RunTracker` records `clip_extraction`, `assembly` and `music`, none of which covers selection. Claiming a phase breakdown the database does not hold is how a partial picture starts reading as the whole one, which is the #505 disease.

## Three surfaces that agree by construction

| Surface | Shows |
|---|---|
| end-of-run block | live timings marked *measured this run*, plus the model's bill |
| `runs show` | **"Phase Timings (recorded phases only)"** + a run-level **Model** block |
| `auto status` | the same model line for the last completed auto run |

All three render the model totals through **one function** (`render_llm_totals`), so a single run cannot be described two different ways on two surfaces. They agree because they share a renderer, not because three call sites were kept in step by hand.

Every surface names the **judgment** cache specifically. This tool has video, photo, analysis and judgment caches, and "4 from cache" without a noun is exactly where a reader gets lost.

`auto status` matters most of the three: an unattended run is precisely the one nobody watched, so its bill should not require going looking for it.

## Quiet when it should be

- A run that never used a model prints **no model line at all** — the recommended NAS setup does not read as a broken run.
- The **truncation line appears only when it happened**, and it is the point of the exercise: a thinking call that overruns its budget is retried without thinking, silently and correctly, and the retry costs a wasted call *and* a worse answer. That is #600, which lived in an unread server log for months.

## Third strike on one function

`run_pipeline_and_generate` hit Xenon **D** again — this time on a single `or` in my call site (`active() or LLMCounters()`). The fallback moved into the renderer, which is where the "nothing was collecting" case belongs anyway.

Across three PRs tonight that function has tipped on a ternary, an `or`, and another `or`. It is not near the limit; it is *at* it. Investigated separately: **68% of its complexity is inline defaulting, not control flow** — 13 of 19 decision points are ternaries and `and`/`or` over 37 keyword arguments, including the same expression duplicated at lines 317 and 353. It wants normalisation, not a split. That is queued as its own design.

## Tests

Seven, RED-first: what the block reports, the truncation sentence, silence when no model was used, silence about truncation on a healthy run, the shared renderer naming the judgment cache, truncation surviving into `runs show`, and empty metrics rendering nothing.

`make ci` green on rebased main: **5592 passed**. `make docs-build` exit 0.

Docs: `create/cli/generate.md` gains the block and the measured-live vs recorded-phase paragraph; `create/cli/runs.md` says why the model totals are per-run.
