### PR TITLE
fix(memories): the from-birthday window starts at the birthday

### DIFF
--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -32,7 +32,7 @@ immich-memories generate [OPTIONS]
 | `--holiday` | — | text | — | Holiday name or `MM-DD` (with `--memory-type holiday`) |
 | `--from-album` | — | string | — | Generate from an Immich album (name or ID) instead of a date range. See [Album Memories](../memory-types/album-memories). Cannot be combined with any time-period or person flag |
 | `--person` | `-p` | string | — | Person name from Immich face recognition (repeatable: `--person "Alice" --person "Bob"`) |
-| `--birthday` | `-b` | flag/string | — | Use birthday-based year. Bare flag auto-detects from Immich; or pass `MM/DD` to override |
+| `--birthday` | `-b` | flag/string | — | Use birthday-based year. Bare flag auto-detects from Immich; or pass `MM-DD` to override |
 | `--season` | — | choice | — | `spring`, `summer`, `fall`, `autumn`, `winter` (use with `--memory-type season`) |
 | `--month` | — | int | — | Month 1-12 (with `--year`, generates that month; selects trip by month) |
 | `--hemisphere` | — | choice | `north` | `north` or `south` (for season date calculation) |
@@ -183,7 +183,7 @@ Auto-detects the birthday from Immich when `--birthday` is used as a flag:
 immich-memories generate --year 2024 --birthday --person "Emma" --duration 900
 ```
 
-Or specify manually: `--birthday 07/21`.
+Or specify manually: `--birthday 07-21`. Slashes work too and read day-first, like every other date flag — `--birthday 07/02` is 7 February. `MM-DD` is the form that cannot be misread.
 
 ### Person spotlight for a single month
 
@@ -293,7 +293,7 @@ immich-memories generate --year 2024 --include-photos --photo-duration 5.0
 | Period from start | `--start 2024-01-01 --period 6m` | 6 months from the start date |
 | Override preset | `--memory-type season --season summer --start 2024-07-01 --end 2024-07-31` | Custom dates with preset scoring |
 
-Date formats: `YYYY-MM-DD`, `DD/MM/YYYY`, or `MM/DD` (for `--birthday` manual override).
+Date formats: `YYYY-MM-DD` or `DD/MM/YYYY`. `--birthday` also takes the year-less `MM-DD` and `DD/MM` short forms.
 
 Period format: number + unit (`d` days, `w` weeks, `m` months, `y` years). Examples: `90d`, `2w`, `6m`, `1y`.
 

--- a/docs-site/docs/create/recipes/birthday-compilations.md
+++ b/docs-site/docs/create/recipes/birthday-compilations.md
@@ -25,11 +25,13 @@ Or specify the date manually:
 immich-memories generate \
   --person "Emma" \
   --year 2024 \
-  --birthday 07/21 \
+  --birthday 07-21 \
   --duration 600
 ```
 
 The `--birthday` flag makes the year run from birthday to birthday (e.g., Jul 21, 2024 through Jul 20, 2025) instead of January to December.
+
+Give the date as `MM-DD` — that form has only one reading. A slashed `DD/MM` works too and is read day-first, the same way `--start` and `--end` read `DD/MM/YYYY`.
 
 ## UI
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -260,7 +260,7 @@ immich-memories generate [OPTIONS]
 | `--start` | text | - | Start date (YYYY-MM-DD or DD/MM/YYYY) |
 | `--end` | text | - | End date (use with --start) |
 | `--period` | text | - | Period from start date (e.g., 6m, 1y, 2w) |
-| `--birthday`, `-b` | text | - | Use birthday-based year (auto-detects from Immich, or specify MM/DD) |
+| `--birthday`, `-b` | text | - | Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15) |
 | `--from-album` | text | - | Generate from an Immich album (name or ID) instead of a date range |
 | `--person`, `-p` | text | - | Person name (repeatable) |
 | `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` \| `holiday` \| `then_and_now` | - | Memory type preset |

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from datetime import date, datetime
 
 import click
@@ -15,18 +16,40 @@ from immich_memories.timeperiod import (
     parse_date,
 )
 
+# A leap year, so a 29 February birthday survives being given a filler one.
+_BIRTHDAY_FILLER_YEAR = 2000
+
+# How a birthday read out of Immich is written back into the --birthday value.
+# Month first and dash-separated is the one short form _parse_birthday reads
+# with no ambiguity, so auto-detection cannot disagree with a typed birthday.
+BIRTHDAY_FLAG_FORMAT = "%m-%d"
+
 
 def _parse_birthday(value: str) -> date:
-    """Parse the birthday option's documented MM/DD forms before generic dates."""
-    for candidate, date_format in (
-        (value, "%m/%d/%Y"),
-        (f"{value}/2000", "%m/%d/%Y"),
-    ):
-        try:
-            return datetime.strptime(candidate, date_format).date()
-        except ValueError:
-            continue
-    return parse_date(value)
+    """Read --birthday in the same date dialect as every other date flag.
+
+    parse_date handles anything carrying a year. The short forms do not, so
+    they get their own attempt: dashes are month-day, matching --holiday's
+    MM-DD; slashes are day-first, matching parse_date's DD/MM/YYYY, and fall
+    back to month-first only when day-first cannot be a date.
+
+    This flag alone used to read slashes month-first, so 07/02 meant July for
+    a 7 February birthday and the memory covered the wrong half of two years.
+    """
+    with contextlib.suppress(ValueError):
+        return parse_date(value)
+
+    with contextlib.suppress(ValueError):
+        return datetime.strptime(f"{_BIRTHDAY_FILLER_YEAR}-{value}", "%Y-%m-%d").date()
+
+    for date_format in ("%d/%m/%Y", "%m/%d/%Y"):
+        with contextlib.suppress(ValueError):
+            return datetime.strptime(f"{value}/{_BIRTHDAY_FILLER_YEAR}", date_format).date()
+
+    raise ValueError(
+        f"Cannot parse birthday: '{value}'. Expected MM-DD (e.g. 03-15), "
+        "DD/MM, or a full date such as YYYY-MM-DD."
+    )
 
 
 def _resolve_manual_dates(

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import click
 
 from immich_memories.cli._date_resolution import (
+    BIRTHDAY_FLAG_FORMAT,
     default_duration_for_type,
     duration_from_date_range,
     infer_memory_type,
@@ -28,7 +29,7 @@ from immich_memories.cli._pipeline_runner import (
     run_pipeline_and_generate,
 )
 from immich_memories.cli._trip_generation import handle_trip_generation, resolve_music_arg
-from immich_memories.filename_builder import normalize_output_path
+from immich_memories.filename_builder import build_memory_output_path, normalize_output_path
 from immich_memories.processing.encoding_plan import resolve_output_selection
 from immich_memories.timeperiod import DateRange, parse_date
 
@@ -196,7 +197,7 @@ def register_generate_commands(main: click.Group) -> None:
         is_flag=False,
         flag_value="auto",
         default=None,
-        help="Use birthday-based year (auto-detects from Immich, or specify MM/DD)",
+        help="Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15)",
     )
     @click.option(
         "--from-album",
@@ -643,21 +644,12 @@ def register_generate_commands(main: click.Group) -> None:
             # A placeholder directory anchor; the album handler names the file.
             output_path = config.output.output_path / f"album.{output_selection.container}"
         else:
-            output_dir = config.output.output_path
-            person_slug = (
-                "_".join(n.lower().replace(" ", "_") for n in person_names)
-                if person_names
-                else "all"
-            )
-            type_slug = memory_type or "memories"
-            if date_range.is_calendar_year:
-                date_slug = str(date_range.start.year)
-            else:
-                date_slug = (
-                    f"{date_range.start.strftime('%Y%m%d')}-{date_range.end.strftime('%Y%m%d')}"
-                )
-            output_path = output_dir / (
-                f"{person_slug}_{type_slug}_{date_slug}.{output_selection.container}"
+            output_path = build_memory_output_path(
+                output_dir=config.output.output_path,
+                person_names=person_names,
+                memory_type=memory_type,
+                date_range=date_range,
+                container=output_selection.container,
             )
 
         if not quiet:
@@ -853,7 +845,7 @@ def register_generate_commands(main: click.Group) -> None:
                     if birthday == "auto" and person_names:
                         found = client.get_person_by_name(person_names[0])
                         if found and found.birth_date:
-                            birthday = found.birth_date.strftime("%m/%d")
+                            birthday = found.birth_date.strftime(BIRTHDAY_FLAG_FORMAT)
                             print_success(f"Using birthday: {birthday}")
                         else:
                             print_error(f"No birthday found in Immich for {person_names[0]}")
@@ -882,6 +874,17 @@ def register_generate_commands(main: click.Group) -> None:
                             else:
                                 date_range = date_result
                                 date_ranges = [date_result]
+                            print_info(f"Memory window: {date_range.description}")
+                            # The file was named before the birthday was known,
+                            # off the stand-in calendar year used until now.
+                            if not output:
+                                output_path = build_memory_output_path(
+                                    output_dir=config.output.output_path,
+                                    person_names=person_names,
+                                    memory_type=memory_type,
+                                    date_range=date_range,
+                                    container=output_selection.container,
+                                )
 
                     # Fetch videos and optionally live photos
                     assets, live_photo_clips = fetch_videos_and_live_photos(

--- a/src/immich_memories/filename_builder.py
+++ b/src/immich_memories/filename_builder.py
@@ -9,7 +9,10 @@ import re
 from collections.abc import Mapping, Sequence
 from datetime import date
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from immich_memories.timeperiod import DateRange
 
 # 8 hex characters: short enough to read in a filename, and with a few hundred
 # renders per library the odds of two recipes colliding are negligible.
@@ -32,6 +35,26 @@ def normalize_output_path(path: Path, container: Literal["mp4", "mov"]) -> Path:
     if path.suffix.lower() == expected_suffix:
         return path
     return path.with_suffix(expected_suffix)
+
+
+def build_memory_output_path(
+    *,
+    output_dir: Path,
+    person_names: list[str] | tuple[str, ...],
+    memory_type: str | None,
+    date_range: DateRange,
+    container: str,
+) -> Path:
+    """The CLI's default file name for a memory: who is in it, what it covers."""
+    person_slug = (
+        "_".join(n.lower().replace(" ", "_") for n in person_names) if person_names else "all"
+    )
+    type_slug = memory_type or "memories"
+    if date_range.is_calendar_year:
+        date_slug = str(date_range.start.year)
+    else:
+        date_slug = f"{date_range.start.strftime('%Y%m%d')}-{date_range.end.strftime('%Y%m%d')}"
+    return output_dir / f"{person_slug}_{type_slug}_{date_slug}.{container}"
 
 
 def build_output_filename(

--- a/tests/test_date_resolution.py
+++ b/tests/test_date_resolution.py
@@ -6,7 +6,11 @@ from datetime import date, datetime
 
 import pytest
 
-from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
+from immich_memories.cli._date_resolution import (
+    BIRTHDAY_FLAG_FORMAT,
+    default_duration_for_type,
+    resolve_date_range,
+)
 from immich_memories.cli._trip_display import _closest_trip_to_date, select_trips
 from immich_memories.timeperiod import DateRange
 
@@ -309,13 +313,98 @@ class TestBackwardCompatibility:
             start=None,
             end=None,
             period=None,
-            birthday="03/01/2000",
+            birthday="2000-03-01",
             memory_type="person_spotlight",
         )
 
         assert isinstance(result, DateRange)
         assert result.start == datetime(2025, 3, 1)
         assert result.end == datetime(2026, 2, 28, 23, 59, 59)
+
+    def test_ambiguous_slash_birthday_reads_day_first_like_every_other_date(self):
+        """07/02 is 7 February here, exactly as it is for --start and --end."""
+        result = resolve_date_range(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday="07/02",
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(result, DateRange)
+        assert result.start == datetime(2025, 2, 7)
+        assert result.end == datetime(2026, 2, 6, 23, 59, 59)
+
+    def test_slash_birthday_that_can_only_be_month_first_still_parses(self):
+        """21 cannot be a month, so 07/21 keeps its only possible reading."""
+        result = resolve_date_range(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday="07/21",
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(result, DateRange)
+        assert result.start == datetime(2025, 7, 21)
+
+    def test_dashed_birthday_is_month_day_like_the_holiday_flag(self):
+        result = resolve_date_range(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday="02-07",
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(result, DateRange)
+        assert result.start == datetime(2025, 2, 7)
+
+    def test_late_year_birthday_window_crosses_into_the_next_year(self):
+        result = resolve_date_range(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday="11-20",
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(result, DateRange)
+        assert result.start == datetime(2025, 11, 20)
+        assert result.end == datetime(2026, 11, 19, 23, 59, 59)
+
+    def test_birthday_detected_from_immich_round_trips_into_the_window(self):
+        """What auto-detection writes must mean the same thing when read back."""
+        detected = date(1990, 2, 7)
+
+        result = resolve_date_range(
+            year=2025,
+            start=None,
+            end=None,
+            period=None,
+            birthday=detected.strftime(BIRTHDAY_FLAG_FORMAT),
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(result, DateRange)
+        assert result.start == datetime(2025, 2, 7)
+
+    def test_unparseable_birthday_is_a_usage_error(self):
+        import click
+
+        with pytest.raises(click.UsageError, match="birthday"):
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="not-a-date",
+                memory_type="person_spotlight",
+            )
 
     def test_person_spotlight_auto_birthday_value_handles_leap_day(self):
         result = resolve_date_range(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1076,3 +1076,68 @@ class TestDurationBudgetTolerance:
         """Past a point it is a planning bug, not jitter."""
         with pytest.raises(GenerationError, match="duration budget"):
             _validate_final_duration(self._params(tmp_path, 100.0), 130.0)
+
+
+class TestBirthdayFlagNamesTheWindowItRenders:
+    """The bare --birthday flag resolves the window after the file was named."""
+
+    def _person(self):
+        person = MagicMock()
+        person.id = "person-a"
+        person.name = "Person A"
+        person.birth_date = date(1990, 3, 15)
+        return person
+
+    def test_auto_detected_birthday_names_the_file_after_the_real_window(
+        self, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from immich_memories.cli import main
+
+        config = Config(immich={"url": "https://immich.example.com", "api_key": "k"})
+        config.output.directory = str(tmp_path)
+
+        client = MagicMock()
+        client.__enter__.return_value = client
+        client.__exit__.return_value = False
+        client.get_person_by_name.return_value = self._person()
+
+        captured: dict[str, Path] = {}
+
+        def _capture(**kwargs):
+            captured["output_path"] = kwargs["output_path"]
+            return kwargs["output_path"], False, None
+
+        # WHY: config on disk and the Immich HTTP client are external.
+        with (
+            patch("immich_memories.cli.get_config", return_value=config),
+            patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
+            # WHY: asset discovery needs a live Immich library.
+            patch(
+                "immich_memories.cli.generate.fetch_videos_and_live_photos",
+                return_value=([make_asset("a1")], []),
+            ),
+            # WHY: rendering a real video is minutes of FFmpeg; we want its arguments.
+            patch(
+                "immich_memories.cli.generate.run_pipeline_and_generate",
+                side_effect=_capture,
+            ),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "generate",
+                    "--memory-type",
+                    "person_spotlight",
+                    "--person",
+                    "Person A",
+                    "--year",
+                    "2025",
+                    "--birthday",
+                    "--no-music",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["output_path"].name == "person_a_person_spotlight_20250315-20260314.mp4"


### PR DESCRIPTION
Closes #655

## The finding

A verdict pass on the memory-type matrix asked for a person spotlight anchored on an early-year birthday and got a **July to July** window. Nothing errored. The run reported the wrong year confidently, which is the worst shape a bug can take.

## Root cause

`--birthday` spoke a different date dialect from every other date flag in the CLI.

`_parse_birthday` tried `%m/%d/%Y` **first**, then a filler-year `%m/%d/%Y`, and only then fell back to the shared `timeperiod.parse_date` — which tries `DD/MM/YYYY` before `MM/DD/YYYY`. So within one command:

| flag | `07/02` |
|---|---|
| `--start`, `--end` | 7 February |
| `--birthday` | 2 July |

A day-first European birthday landed five months away, and the window ran from the wrong month of one year to the wrong month of the next.

## The semantics chosen

**One parser, one date dialect.** `parse_date` handles anything carrying a year. The year-less short forms need their own attempt, and they get:

- **dashes are month-day** — `03-15`, matching `--holiday`'s existing `MM-DD`. This is the unambiguous form and what the help text and docs now recommend.
- **slashes are day-first** — `15/03`, matching `parse_date`'s `DD/MM/YYYY`, falling back to month-first only when day-first cannot be a date. So `07/21` still reads as 21 July (21 is not a month) and `02/29` still reads as 29 February, while `07/02` now means what it means everywhere else in the CLI.

`birthday_year()` itself was already correct — the window runs from the birthday to the day before the next one, leap days included — so it is untouched.

### Auto-detection had to move with it

The bare `--birthday` flag reads the date out of Immich and writes it back into the flag value as a string. That string was `%m/%d`, which the new day-first reader would flip. It is now the dashed month-day form, exported as `BIRTHDAY_FLAG_FORMAT` next to the parser and pinned by a round-trip test, so writer and reader cannot drift apart again.

## Second bug in the same flow

With the bare `--birthday` flag, `_resolve_generation_scope` strips `birthday="auto"` (the birth date is not known until the client is up), so the first resolution yields a stand-in **calendar year**. The output path was derived from that stand-in, and the range was only re-resolved afterwards.

Result: the rendered video covered March 2025 to March 2026 while the file was named `person_a_person_spotlight_2025.mp4`.

The path is now derived again once the window is real (unless `--output` was given), and the resolved window is printed. The name-building moves to `filename_builder.py`, which already owns output naming — that also keeps `cli/generate.py` under the 1000-line hard gate.

The duration is deliberately **not** recomputed: both spans are a year, so `duration_from_date_range` returns the same value. Adding code with no observable effect would be noise.

## Tests

RED-first. In `tests/test_date_resolution.py`:

- `07/02` reads as 7 February (failed before: 2 July)
- `07/21` still parses — 21 cannot be a month, so its only reading survives
- `02-07` is the dashed month-day form (failed before: unparseable)
- late-year birthday (`11-20`) crosses into the next year
- leap day (`02/29`) keeps its existing window, unchanged
- an auto-detected birth date round-trips through `BIRTHDAY_FLAG_FORMAT` into the right window
- an unparseable value is a usage error naming the birthday

One existing test used `03/01/2000` to assert a March window; that value is exactly the ambiguity this fixes, so it now uses the ISO form.

In `tests/test_generate.py`, a CLI-level test drives `generate --memory-type person_spotlight --person "Person A" --year 2025 --birthday` against a fake Immich person and asserts the derived output path: `person_a_person_spotlight_20250315-20260314.mp4` (failed before: `person_a_person_spotlight_2025.mp4`).

All fixtures are synthetic — "Person A", birthday 15 March.

## Docs

`create/cli/generate.md`, `create/recipes/birthday-compilations.md` and the generated `reference/cli-reference.md` now say `MM-DD` and explain the day-first slash reading. `make docs-build` passes.

`make ci` passes (5584 unit tests, every gate including file-length, dead-code, duplication, critique and diff-cover ≥80%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
