### PR TITLE
refactor(memory-types): resolve the then-and-now date rule in one place

### DIFF
--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -263,7 +263,11 @@ def _multi_year_ranges(
     three each need their own defaults, and inlining them pushed the caller's
     cognitive complexity past the gate.
     """
-    from immich_memories.memory_types.date_builders import build_holiday, build_on_this_day
+    from immich_memories.memory_types.date_builders import (
+        build_holiday,
+        build_on_this_day,
+        build_then_and_now,
+    )
 
     if memory_type == "on_this_day":
         return build_on_this_day(on_this_day_target or date.today(), years_back=years_back)
@@ -282,13 +286,8 @@ def _multi_year_ranges(
         )
 
     if memory_type == "then_and_now":
-        # WHY two whole years rather than a window: the contrast is the point, and
-        # a narrow window in a year long past is often empty.
-        now_year = year or date.today().year
-        then_year = now_year - (years_back or 10)
-        # Most recent first, like the other multi-range types: the caller derives
-        # its display span as start=ranges[-1].start, end=ranges[0].end, which
-        # inverts on an ascending list.
-        return [calendar_year(now_year), calendar_year(then_year)]
+        # WHY the `or 10`: --years-back defaults to None here, and 0 is read as
+        # unset rather than as an error. The builder owns everything else.
+        return build_then_and_now(year or date.today().year, years_back or 10)
 
     return None

--- a/src/immich_memories/memory_types/date_builders.py
+++ b/src/immich_memories/memory_types/date_builders.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import calendar
 from datetime import date, datetime, timedelta
 
-from immich_memories.timeperiod import DateRange
+from immich_memories.timeperiod import DateRange, calendar_year
 
 # Northern hemisphere season definitions: season -> (start_month, end_month)
 # Winter spans two calendar years (Dec of year to Feb of year+1).
@@ -146,6 +146,34 @@ def build_on_this_day(
         )
 
     return ranges
+
+
+def build_then_and_now(year: int, years_back: int) -> list[DateRange]:
+    """Build the two eras of a then-and-now, most recent first.
+
+    Two whole calendar years rather than two narrow windows: a short window in a
+    year long past is usually empty, and the contrast needs enough material on
+    both sides to read.
+
+    Callers must treat the result as an ordered list of eras and key off the
+    ranges themselves, never off ``range.start.year`` — the two eras are equal
+    calendar years today, but nothing in the memory type requires them to be.
+
+    Args:
+        year: The recent end of the pair.
+        years_back: The gap to the other end, in years. Must be at least 1.
+
+    Returns:
+        ``[now, then]`` — most recent first, matching the other multi-range
+        types, whose callers derive a display span as ``ranges[-1].start`` to
+        ``ranges[0].end``.
+
+    Raises:
+        ValueError: If years_back is zero or negative.
+    """
+    if years_back <= 0:
+        raise ValueError("years_back must be at least 1 for a then-and-now memory")
+    return [calendar_year(year), calendar_year(year - years_back)]
 
 
 def _resolve_date_in_year(target: date, year: int) -> date:

--- a/src/immich_memories/memory_types/factory.py
+++ b/src/immich_memories/memory_types/factory.py
@@ -7,7 +7,7 @@ Adding a new memory type = adding a new factory function with @register_preset.
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import date, datetime
+from datetime import date
 
 from immich_memories.memory_types.date_builders import (
     KNOWN_HOLIDAYS,
@@ -15,6 +15,7 @@ from immich_memories.memory_types.date_builders import (
     build_month,
     build_on_this_day,
     build_season,
+    build_then_and_now,
     build_trip,
     resolve_holiday,
 )
@@ -24,7 +25,7 @@ from immich_memories.memory_types.presets import (
     ScoringProfile,
 )
 from immich_memories.memory_types.registry import MemoryType
-from immich_memories.timeperiod import DateRange, birthday_year, calendar_year
+from immich_memories.timeperiod import birthday_year, calendar_year
 
 # Registry: maps MemoryType -> factory callable
 _REGISTRY: dict[MemoryType, Callable[..., MemoryPreset]] = {}
@@ -395,9 +396,6 @@ def _then_and_now(
     The contrast is the whole point, so the gap is required: a then-and-now with
     no distance between the two is just a now.
     """
-    if years_back <= 0:
-        raise ValueError("years_back must be at least 1 for a then-and-now memory")
-
     year = year or date.today().year
     then_year = year - years_back
     person_filter = PersonFilter()
@@ -408,14 +406,7 @@ def _then_and_now(
         memory_type=MemoryType.THEN_AND_NOW,
         name=f"{then_year} and {year}",
         description=f"{then_year} beside {year}",
-        # Most recent first, matching the other multi-range types.
-        date_ranges=[
-            DateRange(start=datetime(year, 1, 1, 0, 0, 0), end=datetime(year, 12, 31, 23, 59, 59)),
-            DateRange(
-                start=datetime(then_year, 1, 1, 0, 0, 0),
-                end=datetime(then_year, 12, 31, 23, 59, 59),
-            ),
-        ],
+        date_ranges=build_then_and_now(year, years_back),
         person_filter=person_filter,
         scoring=ScoringProfile(face_weight=0.4, content_weight=0.3),
         title_template="{then_year} & {now_year}",

--- a/tests/test_memory_types/test_date_builders.py
+++ b/tests/test_memory_types/test_date_builders.py
@@ -10,6 +10,7 @@ from immich_memories.memory_types.date_builders import (
     build_month,
     build_on_this_day,
     build_season,
+    build_then_and_now,
 )
 from immich_memories.timeperiod import DateRange
 
@@ -200,3 +201,50 @@ class TestBuildOnThisDayFeb29:
         leap_range = result[3]  # 2020
         assert leap_range.start == datetime(2020, 2, 28, 0, 0, 0)
         assert leap_range.end == datetime(2020, 3, 1, 23, 59, 59)
+
+
+class TestBuildThenAndNow:
+    """The two-era rule, which lived in two places and could drift between them."""
+
+    def test_most_recent_era_comes_first(self) -> None:
+        result = build_then_and_now(2026, 10)
+        assert [r.start.year for r in result] == [2026, 2016]
+
+    def test_each_era_is_a_whole_calendar_year(self) -> None:
+        now, then = build_then_and_now(2026, 10)
+        assert (now.start, now.end) == (
+            datetime(2026, 1, 1, 0, 0, 0),
+            datetime(2026, 12, 31, 23, 59, 59),
+        )
+        assert (then.start, then.end) == (
+            datetime(2016, 1, 1, 0, 0, 0),
+            datetime(2016, 12, 31, 23, 59, 59),
+        )
+
+    def test_a_gap_of_zero_is_refused(self) -> None:
+        """A then-and-now with no distance between its ends is just a now."""
+        with pytest.raises(ValueError, match="years_back"):
+            build_then_and_now(2026, 0)
+
+    def test_the_cli_and_the_preset_cannot_disagree(self) -> None:
+        """The drift guard. Both front ends resolved this rule independently.
+
+        The CLI built the pair itself and read the preset factory only for a
+        default duration, so a change to one was invisible to the other.
+        """
+        from immich_memories.cli._date_resolution import resolve_date_range
+        from immich_memories.memory_types.factory import create_preset
+        from immich_memories.memory_types.registry import MemoryType
+
+        preset = create_preset(MemoryType.THEN_AND_NOW, year=2026, years_back=10)
+        cli = resolve_date_range(
+            year=2026,
+            start=None,
+            end=None,
+            period=None,
+            birthday=None,
+            memory_type="then_and_now",
+            years_back=10,
+        )
+
+        assert cli == preset.date_ranges


### PR DESCRIPTION
Refs #658

## The disease, by name

**One rule, two implementations, preset scoring silently UI-only.**

`then_and_now` built its two calendar-year ranges in two independent places — inline in `memory_types/factory.py::_then_and_now`, and again via `calendar_year()` in `cli/_date_resolution.py::_multi_year_ranges`. They agreed. Nothing made them keep agreeing.

And the CLI touches `create_preset` for exactly one thing — `default_duration_seconds` — building everything else itself. So the preset's `person_filter` and `ScoringProfile(face_weight=0.4, content_weight=0.3)` reach the **web UI only**. A CLI `then_and_now` run is scored with the defaults the preset believes it overrode.

This is the same CLI/UI drift class as **#505** ("CLI and UI ship different feature sets — verified asymmetry list") and **`280ae03`** ("multi-person means everyone in the frame, not anyone"). Each was found by tripping over it, and the fix is the same every time: one implementation, both front ends call it. The record should connect them.

`then_and_now` was also the only multi-range memory type without a builder in `date_builders.py` — `season`, `month`, `on_this_day`, `holiday` and `trip` all have one.

## This PR

Pure refactor, no behaviour change. Both front ends now call `build_then_and_now`.

Its docstring commits to the one thing that would foreclose asymmetric eras later — a renovation window against a purchase year, rather than two matched calendar years:

> Callers must treat the result as an ordered list of eras and key off the ranges themselves, never off `range.start.year`.

That costs nothing today and keeps the door open for explicit `--then` / `--now` ranges.

## The guard

`test_the_cli_and_the_preset_cannot_disagree` asserts the two front ends resolve identical ranges. It passes today — that is the point. It is the test that would have caught the drift this PR removes the possibility of.

## Deliberately not fixed here

The CLI ignoring the preset's scoring and person filter. That changes **which clips get selected**, so it needs its own PR and contact sheets rather than riding along in a refactor. Tracked on #658.

`make ci` passes (5589 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f