### PR TITLE
fix(discover-days): skip a holiday only when the day agrees it was one

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -39,8 +39,18 @@ A day also ends when the photographs stop for five hours, not at midnight. A wed
 runs past one, or a birth that starts with contractions at ten in the evening, is one
 occasion; the calendar disagrees.
 
-Two things are skipped outright: days inside a detected trip, because a trip memory
-already tells that story end to end, and holidays, which have their own memory type.
+Two things are skipped: days inside a detected trip, because a trip memory already tells
+that story end to end, and holidays, which have their own memory type.
+
+A holiday is only skipped when the day's pictures agree that it was one — that is, when
+they were taken around home, where the holiday is actually kept. A day that merely lands
+on the same date and was spent 67 km away at a race circuit is not that holiday, and it
+goes to the model like any other candidate. A day that recorded no coordinates at all is
+skipped on the date alone, as it always was.
+
+Both filters read the thresholds under `trips:` — your homebase, how far from it counts as
+away, and how trips are grouped — so this command and the rest of the app agree on what
+"away" means.
 
 ## Fast eyes, then a considered answer
 

--- a/src/immich_memories/automation/special_day_scan.py
+++ b/src/immich_memories/automation/special_day_scan.py
@@ -24,7 +24,8 @@ from immich_memories.analysis.special_day import (
     event_window,
     sample_across_day,
 )
-from immich_memories.analysis.trip_detection import detect_trips
+from immich_memories.analysis.trip_detection import detect_trips, haversine_km
+from immich_memories.config_models_automation import TripsConfig
 from immich_memories.memory_types.date_builders import KNOWN_HOLIDAYS, resolve_holiday
 
 if TYPE_CHECKING:
@@ -85,6 +86,50 @@ def _shot_here(assets: list, analysis_config: Any) -> list:
     return kept
 
 
+def _kept_away_from_home(items: list, home: tuple[float, float], min_km: float) -> bool:
+    """Did the day's located pictures happen somewhere other than home?
+
+    The holiday memory covers the holiday as it is actually kept — at home,
+    with the people who keep it. A day that merely falls on the same date and
+    was spent 67 km away at a race circuit is not that holiday, and dropping
+    it on the date alone lost a day that would have ranked third in its year.
+
+    No coordinates at all is not evidence against the holiday, so those days
+    stay skipped exactly as before.
+    """
+    away = at_home = 0
+    for asset in items:
+        exif = getattr(asset, "exif_info", None)
+        lat = getattr(exif, "latitude", None) if exif else None
+        lon = getattr(exif, "longitude", None) if exif else None
+        if lat is None or lon is None:
+            continue
+        if haversine_km(lat, lon, *home) >= min_km:
+            away += 1
+        else:
+            at_home += 1
+    return away > at_home
+
+
+def _drop_the_holidays_it_actually_was(
+    candidates: dict[date, list],
+    holidays: set[date],
+    home: tuple[float, float] | None,
+    min_km: float,
+) -> dict[date, list]:
+    """Keep the days whose evidence disagrees with the holiday they fall on."""
+    kept: dict[date, list] = {}
+    for day, items in candidates.items():
+        if day not in holidays:
+            kept[day] = items
+        elif home and _kept_away_from_home(items, home, min_km):
+            logger.info("%s falls on a holiday but was spent away from home; keeping it", day)
+            kept[day] = items
+        else:
+            logger.info("Skipping %s: a holiday, and the day never left home", day)
+    return kept
+
+
 def scan_year(
     assets: list,
     *,
@@ -94,6 +139,7 @@ def scan_year(
     ask: int = 6,
     extra_holidays: Iterable[str] = (),
     analysis_config: Any = None,
+    trips_config: TripsConfig | None = None,
 ) -> list[DiscoveredDay]:
     """Find the days in one year's assets that stand out, and name them.
 
@@ -111,25 +157,34 @@ def scan_year(
     if not assets:
         return []
 
+    trips = trips_config or TripsConfig()
     year = assets[0].file_created_at.year
     # Dates only: the trip's name is never read here, and asking for one
     # is a live request per trip for every year of the scan.
     away = (
-        days_covered_by_trips(detect_trips(assets, *home, name_locations=False)) if home else set()
+        days_covered_by_trips(
+            detect_trips(
+                assets,
+                *home,
+                min_distance_km=trips.min_distance_km,
+                min_duration_days=trips.min_duration_days,
+                max_gap_days=trips.max_gap_days,
+                name_locations=False,
+            )
+        )
+        if home
+        else set()
     )
     holidays = holidays_in(year, extra_holidays)
 
-    candidates = {
-        day: items
-        for day, items in candidate_days(assets, away_days=away).items()
-        if day not in holidays
-    }
+    off_trip = candidate_days(assets, away_days=away)
+    candidates = _drop_the_holidays_it_actually_was(off_trip, holidays, home, trips.min_distance_km)
     logger.info(
-        "%d: %d candidate days after skipping %d on trips and %d holidays",
+        "%d: %d candidate days, %d dates covered by trips, %d dropped as the holiday they fell on",
         year,
         len(candidates),
         len(away),
-        len(holidays),
+        len(off_trip) - len(candidates),
     )
 
     found: list[DiscoveredDay] = []

--- a/src/immich_memories/cli/special_days_cmd.py
+++ b/src/immich_memories/cli/special_days_cmd.py
@@ -210,6 +210,7 @@ def _scan_library(
                 ask=per_year,
                 extra_holidays=also_skip,
                 analysis_config=config.analysis,
+                trips_config=config.trips,
             ):
                 found.append(
                     {

--- a/tests/test_special_day_scan.py
+++ b/tests/test_special_day_scan.py
@@ -86,7 +86,9 @@ class TestAHolidayIsOnlySkippedWhenTheDayLooksLikeOne:
         # WHY: ask_if_special is the LLM call; which days reach it is the subject.
         monkeypatch.setattr(
             "immich_memories.automation.special_day_scan.ask_if_special",
-            lambda *_a, **_k: SimpleNamespace(special=True, title="A day", subtitle="", what="out"),
+            lambda *_a, **_k: SimpleNamespace(
+                special=True, title="A day", subtitle="", what="out", window=None
+            ),
         )
 
     def test_a_holiday_spent_away_from_home_still_reaches_the_model(self) -> None:
@@ -141,7 +143,9 @@ def test_trip_detection_runs_with_the_thresholds_this_library_configured(monkeyp
     # WHY: ask_if_special is the LLM call, and no day needs to reach it here.
     monkeypatch.setattr(
         "immich_memories.automation.special_day_scan.ask_if_special",
-        lambda *_a, **_k: SimpleNamespace(special=False, title="", subtitle="", what=""),
+        lambda *_a, **_k: SimpleNamespace(
+            special=False, title="", subtitle="", what="", window=None
+        ),
     )
 
     scan_year(

--- a/tests/test_special_day_scan.py
+++ b/tests/test_special_day_scan.py
@@ -43,6 +43,126 @@ def _a_full_day() -> list[SimpleNamespace]:
     return [_asset(h, m) for h in range(9, 17) for m in (0, 20, 40)]
 
 
+# Synthetic coordinates: a home, and somewhere about 67 km due north of it.
+_HOME = (50.0, 4.0)
+_AWAY = (50.6, 4.0)
+
+
+def _christmas_day(where: tuple[float, float]) -> list[SimpleNamespace]:
+    """A full day of pictures on a fixed holiday, all taken in one place."""
+    return [
+        SimpleNamespace(
+            id=f"a-1225-{hour:02d}-{minute:02d}",
+            file_created_at=datetime(2021, 12, 25, hour, minute, tzinfo=UTC),
+            exif_info=SimpleNamespace(
+                city="Someplace",
+                state=None,
+                country="Belgium",
+                latitude=where[0],
+                longitude=where[1],
+            ),
+            people=[],
+        )
+        for hour in range(9, 17)
+        for minute in (0, 20, 40)
+    ]
+
+
+def _home_config() -> TripsConfig:
+    return TripsConfig(homebase_latitude=_HOME[0], homebase_longitude=_HOME[1])
+
+
+class TestAHolidayIsOnlySkippedWhenTheDayLooksLikeOne:
+    """The date alone was enough to drop a day, and dates collide.
+
+    A track-day excursion fell on a holiday: 133 photographs, seven active
+    hours, 67 km from home. It would have ranked third in its year and never
+    reached the ranking at all, because the calendar said the holiday memory
+    already had that date covered.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _a_model_that_says_yes(self, monkeypatch) -> None:
+        # WHY: ask_if_special is the LLM call; which days reach it is the subject.
+        monkeypatch.setattr(
+            "immich_memories.automation.special_day_scan.ask_if_special",
+            lambda *_a, **_k: SimpleNamespace(special=True, title="A day", subtitle="", what="out"),
+        )
+
+    def test_a_holiday_spent_away_from_home_still_reaches_the_model(self) -> None:
+        found = scan_year(
+            _christmas_day(_AWAY),
+            llm_config=None,
+            home=_HOME,
+            ask=1,
+            trips_config=_home_config(),
+        )
+
+        assert [d.day for d in found] == [date(2021, 12, 25)]
+
+    def test_a_holiday_kept_at_home_is_still_skipped(self) -> None:
+        """The holiday memory does cover this one, which is why the skip exists."""
+        found = scan_year(
+            _christmas_day(_HOME),
+            llm_config=None,
+            home=_HOME,
+            ask=1,
+            trips_config=_home_config(),
+        )
+
+        assert found == []
+
+    def test_a_holiday_that_recorded_no_location_is_skipped(self) -> None:
+        """Nothing contradicts the holiday, so the date stands as it always did."""
+        unplaced = _christmas_day(_HOME)
+        for asset in unplaced:
+            asset.exif_info.latitude = None
+            asset.exif_info.longitude = None
+
+        found = scan_year(unplaced, llm_config=None, home=_HOME, ask=1, trips_config=_home_config())
+
+        assert found == []
+
+
+def test_trip_detection_runs_with_the_thresholds_this_library_configured(monkeypatch) -> None:
+    """The scan called detect_trips on its defaults while every other caller
+    passed the configured ones, so a library that had tuned what counts as a
+    trip got a different answer from this command than from the rest.
+    """
+    seen: dict = {}
+
+    # WHY: detect_trips reverse-geocodes and clusters; what it was asked for is
+    # the whole subject of this test.
+    def _record(assets, home_lat, home_lon, **kwargs):
+        seen.update(kwargs)
+        return []
+
+    monkeypatch.setattr("immich_memories.automation.special_day_scan.detect_trips", _record)
+    # WHY: ask_if_special is the LLM call, and no day needs to reach it here.
+    monkeypatch.setattr(
+        "immich_memories.automation.special_day_scan.ask_if_special",
+        lambda *_a, **_k: SimpleNamespace(special=False, title="", subtitle="", what=""),
+    )
+
+    scan_year(
+        _a_full_day(),
+        llm_config=None,
+        home=_HOME,
+        ask=1,
+        trips_config=TripsConfig(
+            homebase_latitude=_HOME[0],
+            homebase_longitude=_HOME[1],
+            min_distance_km=120,
+            min_duration_days=4,
+            max_gap_days=1,
+        ),
+    )
+
+    assert seen["min_distance_km"] == 120
+    assert seen["min_duration_days"] == 4
+    assert seen["max_gap_days"] == 1
+
+
 def test_the_configured_homebase_is_the_one_the_scan_uses() -> None:
     """The scan read two fields that do not exist, so home was a constant.
 


### PR DESCRIPTION
Closes #663

Two skips that run before the scan ranks anything, both wrong in the same direction — they threw away days that were never theirs to throw.

## The holiday skip

`scan_year` dropped every candidate whose date appeared in `holidays_in(year)`, on the date alone. Dates collide. A track-day excursion that happened to fall on a holiday — 133 photographs, seven active hours, 67 km from home, third-ranked in its year — never reached the ranking at all.

A holiday memory covers the holiday as it is actually kept: at home, with the people who keep it. So the skip now asks whether the day's evidence agrees. A holiday is skipped when its located pictures were taken within the home radius; a day spent away from home is kept and goes to the model like any other candidate. A day that recorded no coordinates is skipped on the date exactly as before — no location is not evidence against the holiday. Both branches log their reason, so a missing day is diagnosable from the log rather than from the source.

## The trip thresholds

`special_day_scan.py:118` called `detect_trips(assets, *home, name_locations=False)` on the function's own defaults, while `cli/_trip_display.py` and `automation/event_detectors.py` both pass `config.trips.{min_distance_km,min_duration_days,max_gap_days}`. A library that had tuned what counts as a trip got a different answer from this command than from the rest of the app. It now takes the same thresholds — and the home radius the holiday test uses is that same `trips.min_distance_km`, so "away" means one thing everywhere.

Grouped because both are `scan_year`'s pre-filter and both are answered by the same new `trips_config` parameter. The purely-temporal trip grouping issue is out of scope.

## Tests

TDD, RED first: a holiday spent away from home reaches the model, a holiday kept at home does not, an unplaced holiday does not, and `detect_trips` is called with the configured thresholds.

`make ci` and `make docs-build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f