### PR TITLE
feat(titles): give a then-and-now a card for each of its eras

### DIFF
--- a/src/immich_memories/processing/timeline_budget.py
+++ b/src/immich_memories/processing/timeline_budget.py
@@ -86,12 +86,22 @@ def _month_divider_count(clips: list[Any], title_settings: Any) -> int:
     return max(0, len(eligible) - 1)
 
 
-def _year_divider_count(clips: list[Any]) -> int:
+# Memory types whose windows are disjoint eras rather than one continuous span.
+# Their title card names the two ends as a pair — "2016 & 2026" — not the year
+# the opening block happens to belong to, so every era needs a card of its own.
+ERA_LABELED_TYPES = frozenset({"then_and_now"})
+
+
+def _year_divider_count(clips: list[Any], memory_type: str | None = None) -> int:
     years = list(
         dict.fromkeys(
             clip_date.year for clip in clips if (clip_date := _item_date(clip)) is not None
         )
     )
+    if memory_type in ERA_LABELED_TYPES:
+        return len(years)
+    # One fewer than the years present: a memory running continuously through
+    # them opens on a title card that already names the first.
     return max(0, len(years) - 1)
 
 
@@ -118,7 +128,7 @@ def _eligible_dividers(clips: list[Any], title_settings: Any, memory_type: str |
         return _location_divider_count(clips)
     divider_mode = getattr(title_settings, "divider_mode", "month")
     if divider_mode == "year":
-        return _year_divider_count(clips)
+        return _year_divider_count(clips, memory_type)
     if divider_mode == "month" and getattr(title_settings, "show_month_dividers", True):
         return _month_divider_count(clips, title_settings)
     return 0

--- a/src/immich_memories/processing/title_divider_planner.py
+++ b/src/immich_memories/processing/title_divider_planner.py
@@ -115,6 +115,19 @@ class TitleDividerPlanner:
         self._generator = generator
         self._title_settings = title_settings
 
+    @property
+    def _labels_every_era(self) -> bool:
+        """Whether the opening block needs a card of its own.
+
+        Normally it does not: a memory running continuously through its years
+        opens on a title card that already names the first, so a divider there
+        would say it twice. A then-and-now's title names its two ends as a pair
+        and never says which era the opening block is, so both get labeled.
+        """
+        from immich_memories.processing.timeline_budget import ERA_LABELED_TYPES
+
+        return getattr(self._title_settings, "memory_type", None) in ERA_LABELED_TYPES
+
     def generate_year_dividers(
         self,
         clips: list[AssemblyClip],
@@ -130,13 +143,41 @@ class TitleDividerPlanner:
             progress_callback(0.05, "Generating year dividers...")
 
         limit = _divider_limit(self._title_settings)
-        planned_changes = year_changes if limit is None else year_changes[1 : limit + 1]
+        if limit is None:
+            planned_changes = year_changes
+        elif self._labels_every_era:
+            planned_changes = year_changes[:limit]
+        else:
+            planned_changes = year_changes[1 : limit + 1]
         for _, year in planned_changes:
             if year not in year_divider_paths:
                 divider = self._generator.generate_year_divider(year)
                 year_divider_paths[year] = divider.path
                 logger.info(f"Generated year divider: {year}")
         return year_divider_paths
+
+    def _needs_a_year_card(
+        self,
+        year: int,
+        current_year: int | None,
+        limit: int | None,
+        available: dict[int, Path],
+    ) -> bool:
+        """Whether this clip begins a stretch whose year has to be named."""
+        if year not in available:
+            return False
+        if current_year is not None:
+            return year != current_year
+        return limit is None or self._labels_every_era
+
+    def _year_card(self, year: int, path: Path) -> AssemblyClip:
+        return AssemblyClip(
+            path=path,
+            duration=self._title_settings.month_divider_duration,
+            date=None,
+            asset_id=f"year_divider_{year}",
+            is_title_screen=True,
+        )
 
     def build_clips_with_year_dividers(
         self,
@@ -151,22 +192,12 @@ class TitleDividerPlanner:
         for clip in clips:
             clip_date = parse_clip_date(clip)
             if clip_date:
-                if (
-                    (limit is current_year is None)
-                    or (current_year is not None and clip_date.year != current_year)
-                ) and clip_date.year in year_divider_paths:
-                    if limit is not None and inserted >= limit:
-                        current_year = clip_date.year
-                        result.append(clip)
-                        continue
+                room_left = limit is None or inserted < limit
+                if room_left and self._needs_a_year_card(
+                    clip_date.year, current_year, limit, year_divider_paths
+                ):
                     result.append(
-                        AssemblyClip(
-                            path=year_divider_paths[clip_date.year],
-                            duration=self._title_settings.month_divider_duration,
-                            date=None,
-                            asset_id=f"year_divider_{clip_date.year}",
-                            is_title_screen=True,
-                        )
+                        self._year_card(clip_date.year, year_divider_paths[clip_date.year])
                     )
                     inserted += 1
                 current_year = clip_date.year

--- a/tests/test_era_dividers.py
+++ b/tests/test_era_dividers.py
@@ -1,0 +1,87 @@
+"""A then-and-now has to name both of its eras on screen.
+
+Year dividers are generated from the year *changes* in a cut, and the first
+change is dropped: a memory running continuously through its years opens on a
+title card that already names the one it starts in, so a card there would say
+it twice.
+
+A then-and-now's title names its two ends as a pair. Nothing says which era the
+opening block belongs to, and the older half — the whole reason the memory
+exists — played unlabeled.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from immich_memories.processing.assembly_config import AssemblyClip
+from immich_memories.processing.title_divider_planner import TitleDividerPlanner
+
+
+def _clip(date: str) -> AssemblyClip:
+    return AssemblyClip(path=Path(f"/{date}.mp4"), duration=5.0, asset_id=date, date=date)
+
+
+def _cut() -> list[AssemblyClip]:
+    """A then-and-now as the assembler orders it: oldest era first, grouped."""
+    return [_clip("2016-03-01"), _clip("2016-07-01"), _clip("2026-04-01"), _clip("2026-09-01")]
+
+
+def _planner(memory_type: str | None, max_dividers: int) -> tuple[TitleDividerPlanner, MagicMock]:
+    # WHY: the card generator renders video through FFmpeg; the planner under
+    # test only needs to know which cards it was asked for.
+    generator = MagicMock()
+    generator.generate_year_divider.side_effect = lambda year: SimpleNamespace(
+        path=Path(f"/divider-{year}.mp4")
+    )
+    settings = SimpleNamespace(
+        max_dividers=max_dividers,
+        month_divider_duration=2.0,
+        memory_type=memory_type,
+    )
+    return TitleDividerPlanner(generator, settings), generator
+
+
+def test_both_eras_get_a_card() -> None:
+    planner, _ = _planner("then_and_now", max_dividers=2)
+
+    paths = planner.generate_year_dividers(_cut(), None)
+
+    assert sorted(paths) == [2016, 2026]
+
+
+def test_the_older_eras_card_opens_the_memory() -> None:
+    """Order matters as much as existence — the label has to precede its block."""
+    planner, _ = _planner("then_and_now", max_dividers=2)
+    clips = _cut()
+
+    result = planner.build_clips_with_year_dividers(
+        clips, planner.generate_year_dividers(clips, None)
+    )
+
+    assert [c.asset_id for c in result] == [
+        "year_divider_2016",
+        "2016-03-01",
+        "2016-07-01",
+        "year_divider_2026",
+        "2026-04-01",
+        "2026-09-01",
+    ]
+
+
+def test_a_continuous_memory_still_opens_without_a_card() -> None:
+    """The rule the then-and-now case is an exception to, kept honest.
+
+    A year in review that runs 2025 into 2026 is titled after the year it opens
+    in, so a card naming it again is noise.
+    """
+    planner, _ = _planner("year_in_review", max_dividers=1)
+    clips = [_clip("2025-11-01"), _clip("2026-02-01")]
+
+    result = planner.build_clips_with_year_dividers(
+        clips, planner.generate_year_dividers(clips, None)
+    )
+
+    assert [c.asset_id for c in result] == ["2025-11-01", "year_divider_2026", "2026-02-01"]

--- a/tests/test_timeline_budget.py
+++ b/tests/test_timeline_budget.py
@@ -392,3 +392,40 @@ def test_year_dividers_keep_the_existing_capped_budget() -> None:
     assert plan.eligible_dividers == 2
     assert plan.max_dividers == 2
     assert plan.title_budget == 6.0
+
+
+def _then_and_now_titles() -> TitleScreenSettings:
+    titles = _titles()
+    titles.divider_mode = "year"
+    titles.memory_type = "then_and_now"
+    return titles
+
+
+def test_a_then_and_now_budgets_a_card_for_each_era() -> None:
+    """Both eras are the subject, so both get named.
+
+    The year divider budget is len(years) - 1, because on a memory that runs
+    continuously through its years the title card already names the one it
+    opens on. A then-and-now's title names its two ends as a pair, not the year
+    the first block belongs to, so the older era went unlabeled.
+    """
+    from immich_memories.processing.timeline_budget import plan_timeline
+
+    clips = [_clip("old", "2016-05-05"), _clip("new", "2026-05-05")]
+
+    plan = plan_timeline(clips, _then_and_now_titles(), 45.0, "then_and_now")
+
+    assert plan.eligible_dividers == 2
+
+
+def test_a_continuous_multi_year_memory_still_skips_its_opening_year() -> None:
+    """The rule this exception is carved out of, kept honest."""
+    from immich_memories.processing.timeline_budget import plan_timeline
+
+    titles = _titles()
+    titles.divider_mode = "year"
+    clips = [_clip("a", "2024-05-05"), _clip("b", "2025-05-05"), _clip("c", "2026-05-05")]
+
+    plan = plan_timeline(clips, titles, 120.0, "year_in_review")
+
+    assert plan.eligible_dividers == 2


### PR DESCRIPTION
Closes #662

PR 3 of the Then and Now rework — **divider half only**. The target shrink is deliberately held; see below.

## The defect

A `then_and_now` rendered one year divider, for the **later** era. Verified against a two-era cut at the real budget:

```
2016-03, 2016-07, [year_divider_2026], 2026-04, 2026-09
```

The older block — the whole reason the memory type exists — played with nothing naming it.

## Why it happened, and why the old rule was right

Three mechanisms agree on dropping the head:

- `_year_divider_count` returns `max(0, len(years) - 1)` → **1** for two eras
- `generate_year_dividers` slices `year_changes[1 : limit + 1]`
- `build_clips_with_year_dividers` inserts before the first clip only when uncapped

That is correct for a memory running continuously through its years: a year-in-review spanning 2025 into 2026 opens on a title card that already names 2025, so a divider there says it twice.

It is wrong for a then-and-now, whose title card names its two ends **as a pair** — "2016 & 2026" (#653) — and never says which era the opening block belongs to.

## The fix

`ERA_LABELED_TYPES` marks memory types whose windows are disjoint eras rather than one continuous span. For those, the budget allows one card per era and the planner keeps the head.

`test_a_continuous_multi_year_memory_still_skips_its_opening_year` and `test_a_continuous_memory_still_opens_without_a_card` guard the general rule, so this exception cannot quietly widen into the behaviour it is an exception to.

Costs one extra card — roughly 2-3s of a 45s default.

## Held back: the target shrink

The other half of PR 3 was a per-era duration shrink. The signed-off definition is *"what both eras can fill **without near-duplicates**"* — and near-duplicate detection (`deduplicate_temporal_clusters`, `thumbnail_clustering`) is mid-rework in another session. Building against an interface that is about to change is how collisions happen, so it waits for that contract.

## Also fixed on the way

`build_clips_with_year_dividers` crossed the cognitive-complexity gate once the era branch landed. Split into a `_needs_a_year_card` decision and a `_year_card` constructor, which removed the `continue` and flattened the loop. Behaviour identical — the pre-existing tests covered it throughout.

`make ci` passes (5590 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f