### PR TITLE
fix(discover-days): give the day's event a window it can actually keep

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -42,6 +42,32 @@ occasion; the calendar disagrees.
 Two things are skipped outright: days inside a detected trip, because a trip memory
 already tells that story end to end, and holidays, which have their own memory type.
 
+## The part of the day that was the event
+
+Some days are an event; some days contain one. A track day put most of its pictures in one
+place inside a couple of hours of a long day — the rest of that day is a cat on a balcony —
+and the memory should start at the circuit. So a discovered day can carry a window: the
+hours the thing that happened actually ran.
+
+Two things look for it. The model is asked, in the same question, for the clock times the
+event ran between. It reads those off the per-picture lines, which is why it can answer at
+all: a circuit's coordinates are identical from the moment the car is parked to the moment
+it leaves, so the map cannot tell arrival from the start of the race and the pictures can.
+
+Where the model declines, the geometry is the fallback — the first and last picture of the
+place that dominates the day. That window is kept only when trimming to it removes at least
+45 minutes and at least 15% of the day, and only when what is left runs at least half an
+hour.
+
+Both bounds are there for a measured failure. Without the floor, a dense burst in one place
+produced a 69-second window on a 12.6-hour day. And the rule that came before — drop the
+window whenever the dominant place covers half the day or more — punished the days
+photographed best: a race covered from arrival to podium filled two thirds of its day and
+was given no window at all.
+
+A day that was all one thing has nothing to trim and gets no window, which is the right
+answer for a wedding that ran fifteen hours in one place.
+
 ## Fast eyes, then a considered answer
 
 With `llm.thinking: true` the question runs in two steps: one fast call that
@@ -112,8 +138,11 @@ first — ten years reads louder than nine, which is the whole appeal of arrivin
 unannounced.
 
 ```
-10 years ago  2015-06-12  A long evening out
+10 years ago  2015-06-12  A long evening out  18:40-23:55
 ```
+
+The hours on the right are the day's window, when it found one. Catalogues written before
+windows existed simply have none, and still read.
 
 `--on YYYY-MM-DD` checks a different date, and `--catalogue PATH` reads a different file.
 Anniversaries either side of New Year are found: a day at the end of December is due in

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -128,11 +128,15 @@ Give it a title and a line under it, the way a photographer would caption a
 set they were proud of. Not the date and not the place — those are already on
 the card. Say something about the day.
 
+If one clear event fills part of the day, give the clock times it ran between,
+and leave the window null when the day was all one thing.
+
 Answer with STRICT JSON only, no prose:
 {{"special": true|false,
   "title": "<a few words, or empty>",
   "subtitle": "<one line, or empty>",
-  "what": "<a few words, or empty>"}}"""
+  "what": "<a few words, or empty>",
+  "window": ["HH:MM", "HH:MM"] or null}}"""
 
 
 def candidate_days(
@@ -407,10 +411,17 @@ def _only_if_grounded(text: str, vocabulary: set[str], *, located: bool, places:
 
 # Two places count as one if they are closer than this.
 _SAME_PLACE_KM = 2.0
-# A dominant place must hold this much of the day to define its window...
+# A dominant place must hold this much of the day to define its window.
 _DOMINANT_SHARE = 0.6
-# ...and occupy less than this much of it, or the day simply happened there.
-_WINDOW_SHARE_OF_DAY = 0.5
+# A window has to be long enough to hold a memory. Without a floor, a dense
+# burst in one place produced a 69-second window on a 12.6-hour day, and
+# everything that day was about sat outside it.
+_MIN_WINDOW = timedelta(minutes=30)
+# And trimming has to actually remove something — this much clock time, and
+# this much of the day. A ratio on its own read a race photographed from
+# arrival to podium as "the day simply happened there" and returned nothing.
+_MIN_TRIM = timedelta(minutes=45)
+_MIN_TRIM_SHARE = 0.15
 
 
 def event_window(assets: list) -> tuple[datetime, datetime] | None:
@@ -422,8 +433,10 @@ def event_window(assets: list) -> tuple[datetime, datetime] | None:
     wedding also put 83% in one place, but across all fifteen hours it ran, so
     there is nothing to trim.
 
-    What separates them is not whether a place dominates — all of them do — but
-    how much of the day it takes up.
+    What separates them is whether trimming to the dominant place would remove
+    a meaningful part of the day. Asking instead how much of the day the place
+    takes up punished the days photographed best: a race covered from arrival
+    to podium filled two thirds of its day and was given no window at all.
     """
     located = [
         (a.file_created_at, a.exif_info.latitude, a.exif_info.longitude)
@@ -450,12 +463,56 @@ def event_window(assets: list) -> tuple[datetime, datetime] | None:
     if biggest["n"] / len(located) < _DOMINANT_SHARE:
         return None
 
-    day_span = (located[-1][0] - located[0][0]).total_seconds()
-    window_span = (biggest["last"] - biggest["first"]).total_seconds()
-    if day_span <= 0 or window_span / day_span >= _WINDOW_SHARE_OF_DAY:
+    day_span = located[-1][0] - located[0][0]
+    window_span = biggest["last"] - biggest["first"]
+    trimmed = day_span - window_span
+    if window_span < _MIN_WINDOW:
+        return None
+    if trimmed < _MIN_TRIM or trimmed < _MIN_TRIM_SHARE * day_span:
         return None
 
     return biggest["first"], biggest["last"]
+
+
+# How far outside its own pictures a written clock time may fall. The model
+# reads the times off the evidence lines and rounds them — "20:00" for a last
+# picture at 19:44 — and refusing that would throw away a good window.
+_CLOCK_SLACK = timedelta(hours=1)
+
+
+def _at_clock(written: Any, first: datetime, last: datetime) -> datetime | None:
+    """A written HH:MM placed on the day's own timeline.
+
+    Placed rather than parsed: a run of activity can cross midnight, so an
+    02:00 end belongs to the following calendar date.
+    """
+    match = re.fullmatch(r"\s*(\d{1,2}):(\d{2})\s*", str(written))
+    if not match or int(match[1]) > 23 or int(match[2]) > 59:
+        return None
+    moment = first.replace(hour=int(match[1]), minute=int(match[2]), second=0, microsecond=0)
+    if moment < first - _CLOCK_SLACK:
+        moment += timedelta(days=1)
+    return moment if first - _CLOCK_SLACK <= moment <= last + _CLOCK_SLACK else None
+
+
+def _window_the_model_gave(answer: dict, assets: list) -> tuple[datetime, datetime] | None:
+    """The clock times the model put on the day's one clear event.
+
+    Worth asking for because geometry cannot answer it. A race day's
+    coordinates are identical from the moment the car is parked to the moment
+    it leaves, so the cluster starts at arrival; the per-picture lines carry
+    timestamps and say what is in the frame, so the model can tell arrival
+    from the start of the thing that happened.
+    """
+    written = answer.get("window")
+    if not isinstance(written, list) or len(written) != 2:
+        return None
+    times = [a.file_created_at for a in assets]
+    first, last = min(times), max(times)
+    start, end = _at_clock(written[0], first, last), _at_clock(written[1], first, last)
+    if start is None or end is None or end - start < _MIN_WINDOW:
+        return None
+    return start, end
 
 
 def _line_for(asset: Any, described: str | None) -> str:
@@ -580,6 +637,7 @@ class SpecialDay:
     title: str = ""
     subtitle: str = ""
     what: str = ""
+    window: tuple[datetime, datetime] | None = None
 
 
 def ask_if_special(
@@ -661,4 +719,5 @@ def ask_if_special(
             places=places,
         ),
         what=str(answer.get("what", ""))[:80].strip(),
+        window=_window_the_model_gave(answer, assets),
     )

--- a/src/immich_memories/automation/special_day_scan.py
+++ b/src/immich_memories/automation/special_day_scan.py
@@ -145,7 +145,9 @@ def scan_year(
                 subtitle=verdict.subtitle,
                 what=verdict.what,
                 photos=len(items),
-                window=event_window(items),
+                # The model read the day's own timestamps and what was in the
+                # frames; event_window only knows where the pictures were.
+                window=verdict.window or event_window(items),
             )
         )
     return found

--- a/src/immich_memories/cli/special_days_cmd.py
+++ b/src/immich_memories/cli/special_days_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import calendar
 import json
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 
 import click
@@ -95,19 +95,36 @@ def _register_due(main: click.Group) -> None:
                 subtitle=raw.get("subtitle", ""),
                 what=raw.get("what", ""),
                 photos=raw.get("photos", 0),
-                window=None,
+                window=_window_in(raw.get("window")),
             )
             for raw in _load_catalogue(catalogue)
             if raw.get("day")
         ]
 
         for entry, years in anniversaries_due(entries, when):
-            console.print(
-                f"[bold]{years} years ago[/bold]  {entry.day}  {entry.title or entry.what}"
-            )
+            line = f"[bold]{years} years ago[/bold]  {entry.day}  {entry.title or entry.what}"
+            if entry.window:
+                start, end = entry.window
+                line += f"  [dim]{start:%H:%M}-{end:%H:%M}[/dim]"
+            console.print(line)
             if entry.subtitle:
                 console.print(f"                {entry.subtitle}")
         print_success(f"{len(entries)} days in the catalogue, checked against {when}")
+
+
+def _window_in(raw: object) -> tuple[datetime, datetime] | None:
+    """The hours a catalogue entry recorded for its event, if it recorded any.
+
+    Entries written before the scan looked for one have no window, and a scan
+    of twenty years is not something to ask anybody to run again.
+    """
+    if not isinstance(raw, list) or len(raw) != 2:
+        return None
+    try:
+        return (datetime.fromisoformat(raw[0]), datetime.fromisoformat(raw[1]))
+    except (TypeError, ValueError):
+        console.print(f"[yellow]Ignoring an unreadable window in the catalogue: {raw!r}[/yellow]")
+        return None
 
 
 def _load_catalogue(path: Path) -> list[dict]:

--- a/tests/test_special_day_scan.py
+++ b/tests/test_special_day_scan.py
@@ -68,7 +68,9 @@ def test_without_a_homebase_the_scan_excludes_no_days(monkeypatch) -> None:
     # WHY: ask_if_special is the LLM call; the verdict is not what this tests.
     monkeypatch.setattr(
         "immich_memories.automation.special_day_scan.ask_if_special",
-        lambda *_a, **_k: SimpleNamespace(special=True, title="A day", subtitle="", what="out"),
+        lambda *_a, **_k: SimpleNamespace(
+            special=True, title="A day", subtitle="", what="out", window=None
+        ),
     )
     # WHY: detect_trips reverse-geocodes over the network, and without a home
     # there is nothing for it to measure against — it must not run at all.

--- a/tests/test_special_day_window.py
+++ b/tests/test_special_day_window.py
@@ -1,0 +1,237 @@
+"""The part of a day the event actually occupies.
+
+Some days are an event; some days contain one. Getting that wrong in either
+direction costs a memory: a window that covers the whole day trims nothing,
+and a window a minute wide is not an event at all.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from immich_memories.analysis.special_day import ask_if_special, event_window
+
+# Two synthetic places, far enough apart to be different clusters.
+_CIRCUIT = (50.31, 4.66)
+_HOME = (50.45, 4.90)
+_ELSEWHERE = (50.60, 5.20)
+
+
+def _shot(at: datetime, where: tuple[float, float]) -> SimpleNamespace:
+    return SimpleNamespace(
+        file_created_at=at,
+        exif_info=SimpleNamespace(latitude=where[0], longitude=where[1]),
+        people=[],
+    )
+
+
+def _run(
+    start: datetime, count: int, every: timedelta, where: tuple[float, float]
+) -> list[SimpleNamespace]:
+    return [_shot(start + every * n, where) for n in range(count)]
+
+
+def test_a_day_mostly_taken_up_by_its_event_still_gets_a_window() -> None:
+    """The predicate was a ratio, so covering the day well was disqualifying.
+
+    A race photographed from arrival to podium put its cluster across two
+    thirds of the day, with one stray picture at home that morning. The ratio
+    test read the good coverage as "the day simply happened there" and
+    returned nothing, so the memory kept the stray breakfast picture.
+    """
+    day = [
+        _shot(datetime(2021, 6, 12, 8, 24, tzinfo=UTC), _HOME),
+        *_run(datetime(2021, 6, 12, 12, 0, tzinfo=UTC), 30, timedelta(minutes=16), _CIRCUIT),
+    ]
+
+    window = event_window(day)
+
+    assert window == (
+        datetime(2021, 6, 12, 12, 0, tzinfo=UTC),
+        datetime(2021, 6, 12, 19, 44, tzinfo=UTC),
+    )
+
+
+def test_a_day_that_was_all_one_thing_has_nothing_to_trim() -> None:
+    """A wedding put everything in one place across all the hours it ran."""
+    day = _run(datetime(2021, 6, 12, 9, 0, tzinfo=UTC), 36, timedelta(minutes=20), _CIRCUIT)
+
+    assert event_window(day) is None
+
+
+def test_a_burst_a_minute_wide_is_not_an_event_window() -> None:
+    """The trim test had no floor, so a dense burst produced a 69-second window.
+
+    Everything the day was about sat outside it, and the memory it would have
+    bounded is a minute long.
+    """
+    day = [
+        _shot(datetime(2021, 6, 12, 8, 0, tzinfo=UTC), _HOME),
+        *_run(datetime(2021, 6, 12, 14, 0, tzinfo=UTC), 20, timedelta(seconds=3), _CIRCUIT),
+        _shot(datetime(2021, 6, 12, 20, 36, tzinfo=UTC), _ELSEWHERE),
+    ]
+
+    assert event_window(day) is None
+
+
+def test_an_afternoon_inside_a_long_day_is_a_window() -> None:
+    """The case the window has always been for, and still is.
+
+    A track day put most of its pictures in one place inside a couple of
+    hours; the rest of that day is a cat on a balcony.
+    """
+    day = [
+        _shot(datetime(2021, 6, 12, 8, 0, tzinfo=UTC), _HOME),
+        _shot(datetime(2021, 6, 12, 9, 30, tzinfo=UTC), _HOME),
+        *_run(datetime(2021, 6, 12, 13, 0, tzinfo=UTC), 24, timedelta(minutes=6), _CIRCUIT),
+        _shot(datetime(2021, 6, 12, 18, 36, tzinfo=UTC), _ELSEWHERE),
+    ]
+
+    window = event_window(day)
+
+    assert window == (
+        datetime(2021, 6, 12, 13, 0, tzinfo=UTC),
+        datetime(2021, 6, 12, 15, 18, tzinfo=UTC),
+    )
+
+
+class TestTheModelMaySayWhenTheEventRan:
+    """Geometry can only see where the pictures were, not what was happening.
+
+    A race day's coordinates are the same from the moment the car is parked to
+    the moment it leaves, so the cluster starts at arrival. The per-picture
+    lines carry timestamps and say what is in the frame, so the model can tell
+    arrival from the start of the race. Its answer wins; geometry is the
+    fallback.
+    """
+
+    def _day(self) -> list[SimpleNamespace]:
+        return [
+            _shot(datetime(2021, 6, 12, 8, 24, tzinfo=UTC), _HOME),
+            *_run(datetime(2021, 6, 12, 11, 0, tzinfo=UTC), 30, timedelta(minutes=18), _CIRCUIT),
+        ]
+
+    def _answer(self, payload: str) -> object:
+        # WHY: the model is the boundary; this pins what we accept back from it.
+        with patch("immich_memories.analysis.special_day._ask", return_value=payload):
+            return ask_if_special(self._day(), llm_config=SimpleNamespace())
+
+    def test_clock_times_it_read_off_the_lines_become_the_window(self) -> None:
+        """The end is rounded past the last picture, which is what a reader does."""
+        verdict = self._answer(
+            '{"special": true, "title": "A day out", "window": ["12:22", "20:00"]}'
+        )
+
+        assert verdict.window == (
+            datetime(2021, 6, 12, 12, 22, tzinfo=UTC),
+            datetime(2021, 6, 12, 20, 0, tzinfo=UTC),
+        )
+
+    def test_a_time_the_day_never_reached_is_not_a_window(self) -> None:
+        """A window has to be bounded by the day it claims to describe."""
+        verdict = self._answer(
+            '{"special": true, "title": "A day out", "window": ["12:22", "23:55"]}'
+        )
+
+        assert verdict.window is None
+
+    def test_a_window_a_minute_wide_is_no_better_from_the_model(self) -> None:
+        verdict = self._answer(
+            '{"special": true, "title": "A day out", "window": ["14:00", "14:01"]}'
+        )
+
+        assert verdict.window is None
+
+    def test_anything_that_is_not_a_clock_time_is_no_window(self) -> None:
+        verdict = self._answer(
+            '{"special": true, "title": "A day out", "window": ["morning", "evening"]}'
+        )
+
+        assert verdict.window is None
+
+    def test_a_model_that_says_nothing_about_the_window_leaves_it_open(self) -> None:
+        verdict = self._answer('{"special": true, "title": "A day out"}')
+
+        assert verdict.window is None
+
+
+def test_the_catalogue_takes_the_models_window_over_the_geometric_one(monkeypatch) -> None:
+    """Geometry is the fallback for a day the model would not bound."""
+    from immich_memories.automation.special_day_scan import scan_year
+
+    day = [
+        _shot(datetime(2021, 6, 12, 8, 24, tzinfo=UTC), _HOME),
+        *_run(datetime(2021, 6, 12, 11, 0, tzinfo=UTC), 30, timedelta(minutes=18), _CIRCUIT),
+    ]
+    judged = (
+        datetime(2021, 6, 12, 12, 22, tzinfo=UTC),
+        datetime(2021, 6, 12, 20, 0, tzinfo=UTC),
+    )
+
+    # WHY: ask_if_special is the LLM call; its verdict is the input here.
+    monkeypatch.setattr(
+        "immich_memories.automation.special_day_scan.ask_if_special",
+        lambda *_a, **_k: SimpleNamespace(
+            special=True, title="A day out", subtitle="", what="out", window=judged
+        ),
+    )
+
+    found = scan_year(day, llm_config=None, home=None, ask=1)
+
+    assert [(d.day, d.window) for d in found] == [(date(2021, 6, 12), judged)]
+
+
+def _days_due(catalogue: Path, on: str) -> str:
+    from click.testing import CliRunner
+
+    from immich_memories.cli import main
+    from immich_memories.config_loader import Config
+
+    # WHY: the CLI group loads the user's real config directory on startup.
+    with (
+        patch("immich_memories.cli.init_config_dir"),
+        patch("immich_memories.cli.get_config", return_value=Config()),
+    ):
+        result = CliRunner().invoke(
+            main,
+            ["days-due", "--on", on, "--catalogue", str(catalogue)],
+            catch_exceptions=False,
+        )
+    return result.output
+
+
+def test_the_window_survives_the_trip_through_the_catalogue(tmp_path) -> None:
+    """The scan wrote a window and days-due reloaded every entry with None.
+
+    Nothing downstream could ever have read it, which is the same as never
+    having found it.
+    """
+    catalogue = tmp_path / "special-days.json"
+    catalogue.write_text(
+        json.dumps(
+            [
+                {
+                    "day": "2015-06-12",
+                    "title": "A day out",
+                    "subtitle": "",
+                    "what": "out",
+                    "photos": 133,
+                    "window": ["2015-06-12T12:22:00", "2015-06-12T20:00:00"],
+                }
+            ]
+        )
+    )
+
+    assert "12:22" in _days_due(catalogue, "2025-06-12")
+
+
+def test_an_entry_from_before_windows_existed_still_reads(tmp_path) -> None:
+    """Catalogues predate this field, and a scan of twenty years is not cheap."""
+    catalogue = tmp_path / "special-days.json"
+    catalogue.write_text(json.dumps([{"day": "2015-06-12", "title": "A day out"}]))
+
+    assert "10 years ago" in _days_due(catalogue, "2025-06-12")


### PR DESCRIPTION
Closes #668

Some days are an event; some days contain one. Three faults sat in telling them apart, and they all belong to the same subject, so they travel together.

## The predicate punished the best days

`event_window` dropped the window whenever the dominant place covered half the day or more — the theory being that the day simply happened there. In practice the ratio rose with how well the day was photographed. A race covered from arrival to podium put its cluster across two thirds of the day, with one stray picture at home that morning, and got no window at all; the memory kept the breakfast picture.

It is now a meaningful-trim test: keep the window when trimming to it removes at least 45 minutes **and** at least 15% of the day. A wedding that ran fifteen hours in one place trims nothing and still gets `None`, which is right.

## And it had no floor

The same test happily returned a 69-second window on a 12.6-hour day — one dense burst in one place, with everything the day was about outside it. A window now has to run at least half an hour. That is what kills the 69-second case; the trim test alone never could.

## Geometry cannot see the event

A circuit's coordinates are identical from the moment the car is parked to the moment it leaves, so the cluster starts at arrival rather than at the start of the race. The step-1 per-picture lines carry timestamps and say what is in the frame — the model can tell those apart where the map cannot.

So the judge's JSON gains `"window": ["HH:MM","HH:MM"]` and the prompt gains one sentence asking for it. Its answer wins; `event_window` is the fallback. A written time is *placed* on the day's own timeline rather than parsed, so a run past midnight resolves to the right date, and a window shorter than half an hour or outside the day is refused. An hour of slack either side is allowed, because the model rounds — "20:00" for a last picture at 19:44 — and refusing that throws away a good window.

## It was write-only

`discover-days` wrote the window into the catalogue and `days-due` reloaded every entry with `window=None`, so nothing downstream could ever read it. It now carries through and is printed beside the day.

**Follow-up, not widened here:** there is no path yet that generates a memory from a catalogue entry — `days-due` prints, and nothing consumes `DiscoveredDay`. So there is no seam to bind the window to a generated memory's day-window; that seam has to be built with the generate-from-catalogue path, and it is not a small edit to this PR. `DateRange` already carries datetimes, so when that path exists the window drops straight in.

## Cache

Judgment-cache entries for the old prompt go cold by design — `judgment_key` hashes the prompt text, so editing the wording abandons the answers given to the old one.

## Tests

TDD, RED first, in a new `tests/test_special_day_window.py` — `event_window` had no tests at all. Covers the two-thirds-of-the-day case, the whole-day case, the minute-wide burst, the ordinary afternoon-inside-a-long-day case, the judge's window (accepted, out of range, too short, not a clock time, absent), the scan preferring it, and the catalogue round trip in `days-due` including an entry from before the field existed.

`make ci` and `make docs-build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f