### PR TITLE
fix(discover-days): ground every specific a title claims, not only places

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -127,5 +127,6 @@ reasons from times, places and recognised names alone. That is the difference be
 "Driving through somewhere" and knowing what was being driven.
 
 Titles are checked against what the day actually recorded before they are kept. A title
-naming a place the day was never in is dropped rather than shown — a title card is the
-wrong place for a plausible invention.
+naming a place the day was never in is dropped rather than shown, and so is one claiming a
+distance or a race — "the 10K" — that nothing the model was shown mentions. A title card is
+the wrong place for a plausible invention, and a number reads exactly as true as a real one.

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -121,8 +121,8 @@ place name is often the edge of somewhere better known.
 Then say whether something happened worth remembering years later, or whether
 it was an ordinary day.
 
-Where you cannot tell, stay vague. "A track day" is right and "a day at Spa"
-is wrong, and vague costs nothing.
+Every specific — a place, a distance, a count — comes from the lines above:
+write what they show, as concretely as they show it.
 
 Give it a title and a line under it, the way a photographer would caption a
 set they were proud of. Not the date and not the place — those are already on
@@ -351,45 +351,62 @@ def _place_is_real(place: str, vocabulary: set[str]) -> bool:
     return False
 
 
-def _only_if_grounded(text: str, vocabulary: set[str], *, located: bool, places: set[str]) -> str:
-    """Drop a line that names a place the day cannot support.
+# Distances and the races named after one. Both are claims a title makes as
+# flatly as it names a place, and both read as true whether or not the day
+# recorded anything of the kind.
+_QUANTITY = re.compile(
+    r"\b\d+\s?(?:k|km|mi|miles?)\b|\b(?:marathon|triathlon|ironman|ultra)\b",
+    re.IGNORECASE,
+)
+
+
+def _same_quantity(written: str) -> str:
+    """ "20 km" and "20km" are one claim, written twice."""
+    return re.sub(r"\s+", "", written).casefold()
+
+
+def _unsupported_quantity(text: str, evidence: str) -> str | None:
+    """A distance or a race the lines the model was given never mention.
+
+    Asked about a morning of running whose evidence says only that there were
+    runners in numbered bibs, the model answered with a specific distance. The
+    place guard had nothing to say about it — it only ever read places — and a
+    number is a claim of exactly the same kind.
+    """
+    supported = {_same_quantity(q) for q in _QUANTITY.findall(evidence)}
+    return next((q for q in _QUANTITY.findall(text) if _same_quantity(q) not in supported), None)
+
+
+def _only_if_grounded(
+    text: str, vocabulary: set[str], *, located: bool, places: set[str], evidence: str
+) -> str:
+    """Drop a line whose specifics the day cannot support.
 
     Asked about a night out with no city and no GPS anywhere in it, the model
     answered with three names and a town. The names were real
     and a place was invented, in spite of the prompt forbidding it. A title card
     is the wrong place for a plausible invention.
 
-    The check only applies when the day carries no location at all. Given
-    coordinates, naming the circuit they sit on is inference from data, and an
-    earlier version that policed every capitalised word threw away "Audi R8
-    V10 Track Day at a place" — a correct reading of the pictures — because
-    no EXIF field happens to contain the word Audi.
+    The capitalised-word check only applies when the day carries no location at
+    all. Given coordinates, naming the circuit they sit on is inference from
+    data, and an earlier version that policed every capitalised word threw away
+    "Audi R8 V10 Track Day at a place" — a correct reading of the pictures —
+    because no EXIF field happens to contain the word Audi.
     """
-    # A place the day never recorded. Asked about a track day at a place — with
-    # three villages all in its EXIF — the model
-    # answered "the famous circuit", Belgium's famous circuit rather
-    # than the one the coordinates sit on. Recognising the kind of place and
-    # naming the well-known instance of it is the failure that keeps recurring.
-    # Only when the day recorded place names at all. With coordinates and no
-    # city, naming the circuit they sit on is inference this cannot check, and
-    # rejecting it would throw away the model's best work.
-    if places:
-        for place in _named_places(text):
-            if not _place_is_real(place, places):
-                logger.info("Dropping %r: the day was never in %r", text, place)
-                return ""
+    # A number nothing on the day mentions. This one runs on every day,
+    # located or not: a distance is not inference from coordinates the way a
+    # circuit's name is, and the prompt asking for it costs nothing to ignore.
+    if unsupported := _unsupported_quantity(text, evidence):
+        logger.info("Dropping %r: nothing on this day mentions %r", text, unsupported)
+        return ""
 
-    # A guessed name is CamelCase and the day never mentions it. Told twice in
-    # the prompt not to name an event it could not read, the model answered
-    # "Attending KubeCon" and then, the same day, "Attending GitLab
-    # All-Hands" — a hall full of lanyards, and an invented answer to which
-    # conference it was. Both of those days knew exactly where they were, so
-    # this runs before the located early-return or it never runs at all. An
-    # internal capital is what separates it from Audi, R8 or a place name.
-    for coined in re.findall(r"\b[A-Z][a-z]+[A-Z][\w]*", text):
-        if coined.casefold() not in vocabulary:
-            logger.info("Dropping %r: %r looks like a guessed name", text, coined)
-            return ""
+    if place := _place_it_was_never_in(text, places):
+        logger.info("Dropping %r: the day was never in %r", text, place)
+        return ""
+
+    if coined := _guessed_name(text, vocabulary):
+        logger.info("Dropping %r: %r looks like a guessed name", text, coined)
+        return ""
 
     if not text or located:
         return text
@@ -403,6 +420,37 @@ def _only_if_grounded(text: str, vocabulary: set[str], *, located: bool, places:
             )
             return ""
     return text
+
+
+def _place_it_was_never_in(text: str, places: set[str]) -> str | None:
+    """A place the day never recorded.
+
+    Asked about a track day at a place — with three villages all in its EXIF —
+    the model answered "the famous circuit", Belgium's famous circuit rather
+    than the one the coordinates sit on. Recognising the kind of place and
+    naming the well-known instance of it is the failure that keeps recurring.
+
+    Only when the day recorded place names at all: with coordinates and no
+    city, naming the circuit they sit on is inference this cannot check, and
+    rejecting it would throw away the model's best work.
+    """
+    if not places:
+        return None
+    return next((p for p in _named_places(text) if not _place_is_real(p, places)), None)
+
+
+def _guessed_name(text: str, vocabulary: set[str]) -> str | None:
+    """A CamelCase name nothing on the day mentions.
+
+    Told twice in the prompt not to name an event it could not read, the model
+    answered "Attending KubeCon" and then, the same day, "Attending GitLab
+    All-Hands" — a hall full of lanyards, and an invented answer to which
+    conference it was. Both of those days knew exactly where they were, so this
+    runs before the located early-return or it never runs at all. An internal
+    capital is what separates it from Audi, R8 or a place name.
+    """
+    coined = re.findall(r"\b[A-Z][a-z]+[A-Z][\w]*", text)
+    return next((c for c in coined if c.casefold() not in vocabulary), None)
 
 
 # Two places count as one if they are closer than this.
@@ -615,7 +663,8 @@ def ask_if_special(
     if reasons:
         images = []
         timeout_seconds = max(timeout_seconds, _THINKING_TIMEOUT_SECONDS)
-    prompt = _PROMPT.format(lines=_describe(sampled, seen))
+    lines = _describe(sampled, seen)
+    prompt = _PROMPT.format(lines=lines)
     try:
         raw = _ask(prompt, llm_config, timeout_seconds, images, thinking=reasons)
     except Exception as exc:  # noqa: BLE001 - an unreachable model is not a verdict
@@ -653,12 +702,14 @@ def ask_if_special(
             grounded,
             located=located,
             places=places,
+            evidence=lines,
         ),
         subtitle=_only_if_grounded(
             str(answer.get("subtitle", ""))[:90].strip(),
             grounded,
             located=located,
             places=places,
+            evidence=lines,
         ),
         what=str(answer.get("what", ""))[:80].strip(),
     )

--- a/tests/test_special_day.py
+++ b/tests/test_special_day.py
@@ -446,3 +446,83 @@ class TestADayEndsWhenThePhotographsDo:
         ]
 
         assert len(candidate_days(two)) == 2
+
+
+class TestANumberIsAClaimLikeAnyOther:
+    """A distance the day never recorded reads exactly as true as a real one.
+
+    Asked about a day of running with nothing anywhere saying how far, the
+    model answered with a specific race distance. The place guard had nothing
+    to say about it: it only ever looked at places.
+    """
+
+    def _day(self, described: str) -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(
+                file_created_at=datetime(2021, 5, 30, hour, tzinfo=UTC),
+                exif_info=SimpleNamespace(
+                    city="Anytown",
+                    state=None,
+                    country="Belgium",
+                    latitude=50.72,
+                    longitude=4.87,
+                ),
+                people=[],
+                llm_description=described,
+            )
+            for hour in range(8, 16)
+        ]
+
+    def _answer(self, described: str, title: str, subtitle: str = "") -> object:
+        # WHY: the model is the boundary; this pins what we accept back from it.
+        with patch(
+            "immich_memories.analysis.special_day._ask",
+            return_value=f'{{"special": true, "title": "{title}", "subtitle": "{subtitle}"}}',
+        ):
+            return ask_if_special(self._day(described), llm_config=SimpleNamespace())
+
+    def test_a_distance_nothing_recorded_is_not_a_title(self) -> None:
+        result = self._answer("a crowd of runners in numbered bibs", "The 10K at Anytown")
+
+        assert result.special is True, "the day is still an occasion"
+        assert result.title == "", "but nothing on it said how far anybody ran"
+
+    def test_the_distance_the_pictures_actually_show_survives(self) -> None:
+        result = self._answer("runners passing the 20K marker", "The 20K at Anytown")
+
+        assert result.title == "The 20K at Anytown"
+
+    def test_the_same_distance_written_differently_is_the_same_distance(self) -> None:
+        """ "20 km" in a description and "20km" in a title are one claim."""
+        result = self._answer("runners passing the 20 km marker", "A 20km morning at Anytown")
+
+        assert result.title == "A 20km morning at Anytown"
+
+    def test_a_race_the_pictures_never_showed_is_not_a_title(self) -> None:
+        result = self._answer("a crowd of runners in numbered bibs", "Marathon day at Anytown")
+
+        assert result.title == ""
+
+    def test_the_line_under_the_title_is_held_to_the_same_rule(self) -> None:
+        result = self._answer(
+            "a crowd of runners in numbered bibs",
+            "A morning of running",
+            subtitle="Twenty thousand of us over 10 miles",
+        )
+
+        assert result.title == "A morning of running"
+        assert result.subtitle == ""
+
+
+def test_the_prompt_grounds_every_specific_and_not_only_places() -> None:
+    """One affirmative rule rather than a list of things not to say.
+
+    The rule it replaces was scoped to places, so a made-up distance was
+    never addressed by it at all — and answering that by appending another
+    prohibition is a game with no end.
+    """
+    from immich_memories.analysis.special_day import _PROMPT
+
+    guidance = _PROMPT.split("{lines}")[1]
+
+    assert "distance" in guidance and "count" in guidance


### PR DESCRIPTION
Closes #671

Asked about a day of running, the model titled it with a specific race distance. Nothing on that day said how far anybody ran — no description, no place, no EXIF field.

Neither half of the grounding could see it. `_only_if_grounded` checks places and CamelCase names, and a number is neither; the prompt's rule had the same scope, telling the model to stay vague about *places*. On a title card a distance reads exactly as true as a real one, which is the whole reason the place guard exists.

## The prompt: one principle, not another prohibition

The place-scoped rule is **replaced**, not extended, by one affirmative principle:

> Every specific — a place, a distance, a count — comes from the lines above:
> write what they show, as concretely as they show it.

Two lines for two — the prompt does not grow. Adding "and never state a number" would have been the third rule of that kind, and the next failure would simply be a claim nobody had thought to forbid yet. A rule that says where specifics come *from* covers the ones nobody has seen yet, and it says the useful half too: be as concrete as the evidence allows, rather than retreating into vagueness.

## The code: where the durable guard belongs

A title or subtitle carrying a distance or a race name is kept only when an evidence line carries the same claim — exactly how places are already handled. `"20 km"` in a description and `"20km"` in a title are one claim. This runs on located and unplaced days alike: naming the circuit some coordinates sit on is inference from data, but a distance is not inferable from anything the day recorded.

Extracting the place and CamelCase checks into named predicates keeps `_only_if_grounded` under the cognitive-complexity gate, and leaves it reading as what it is — a sequence of claims the day cannot support, each with the measured failure that put it there.

## Cache

Judgment-cache entries for the old prompt go cold by design: `judgment_key` hashes the prompt text, so editing the wording abandons the answers given to the old one.

## Tests

TDD, RED first, both ways: the prompt's rule must name more than places, and the code drops an unsupported distance and an unsupported race while keeping the distance the evidence actually shows — subtitles held to the same rule, and the two spellings of one distance treated as one.

`make ci` and `make docs-build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f