### PR TITLE
fix(selection): the review reads what the model says, and says when it cannot

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -31,6 +30,9 @@ logger = logging.getLogger(__name__)
 # An overeager model must not gut the video: at most this share of the
 # selection can be dropped in one review, never below one allowed drop.
 _MAX_DROP_RATIO = 0.2
+
+# Enough room that the model answers rather than narrating; see _ask.
+_REVIEW_MAX_TOKENS = 8000
 
 _PROMPT = """You are reviewing the final cut of a personal memory video.
 Below is every clip in timeline order, with everything we can see and hear.
@@ -96,6 +98,15 @@ def _ask(
             prompt,
             llm_config,
             temperature=0.2,
+            # Measured on real review prompts against a local Qwen3.6-35B. The
+            # 500-token default never produced a verdict at all: the model
+            # narrates its reasoning into the content channel on a prompt this
+            # long, and 500 tokens ran out mid-thought. 2000 was still not
+            # enough. At 4000 a verdict appeared after ~15k characters of
+            # narration; at 8000 the whole answer was 496 characters, because
+            # a model with headroom answers instead of thinking aloud. A
+            # bigger ceiling here is not a bigger bill.
+            max_tokens=_REVIEW_MAX_TOKENS,
             timeout_seconds=timeout_seconds,
             thinking=True,
             cache_path=cache_path,
@@ -144,6 +155,54 @@ def _clip_line(index: int, member: ClipWithSegment) -> str:
     return " ".join(parts)
 
 
+def _verdict_in(raw: str | None) -> list | None:
+    r"""The drop list the model actually produced, or None if it produced none.
+
+    Not re.search(r"\{.*\}") over the whole answer. The prompt shows the model
+    the shape it wants, and a model reasoning aloud quotes that shape back —
+    so a first-brace-to-last-brace grab returns
+    {"drop": [{"index": <number>, "reason": "<short reason>"}]}, json.loads
+    chokes on the placeholder, and the review reports nothing to drop.
+
+    Every brace-balanced candidate is tried instead, last first: the verdict
+    comes after the reasoning, and a template echo never parses. Validating
+    against the shape is what separates the answer from the question.
+    """
+    if not raw:
+        return None
+    for candidate in reversed(_balanced_objects(raw)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and isinstance(payload.get("drop"), list):
+            return payload["drop"]
+    return None
+
+
+def _balanced_objects(text: str) -> list[str]:
+    """Every {...} in the text whose braces balance, outermost only."""
+    spans, depth, start = [], 0, None
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}" and depth:
+            depth -= 1
+            if depth == 0 and start is not None:
+                spans.append(text[start : i + 1])
+    return spans
+
+
+# Grep-able marker for the one thing this pass cannot say for itself. "0 drops"
+# has meant both "the model approved this cut" and "the model never answered"
+# for as long as the review has existed, and a reader cannot tell them apart.
+# A counter belongs in the metrics layer once #654 lands; until then this at
+# least makes the difference findable in a log.
+UNREADABLE_VERDICT_MARKER = "selection_review_unreadable"
+
+
 def review_selection(
     selected: list[ClipWithSegment],
     llm_config: LLMConfig,
@@ -172,17 +231,23 @@ def review_selection(
         logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
         return []
 
-    match = re.search(r"\{.*\}", raw, re.DOTALL) if raw else None
-    if not match:
-        logger.warning("Selection review returned no verdict (%d chars): nothing dropped", len(raw))
+    entries = _verdict_in(raw)
+    if entries is None:
+        logger.warning(
+            "Selection review: could not read a verdict from %d chars — nothing dropped. "
+            "This is not an approved cut; the answer was unreadable. [%s]",
+            # a null content is documented mlx-vlm behaviour, not an empty answer
+            len(raw) if raw else 0,
+            UNREADABLE_VERDICT_MARKER,
+        )
         return []
     try:
-        payload = json.loads(match.group(0))
-        entries = payload.get("drop", [])
         indices = [int(e["index"]) for e in entries if "index" in e]
-    except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+    except (TypeError, ValueError) as e:
         logger.warning(
-            "Selection review answer could not be read (%s): nothing dropped", type(e).__name__
+            "Selection review answer could not be read (%s) [%s]: nothing dropped",
+            type(e).__name__,
+            UNREADABLE_VERDICT_MARKER,
         )
         return []
 

--- a/tests/fixtures/review_prose_then_verdict.txt
+++ b/tests/fixtures/review_prose_then_verdict.txt
@@ -1,0 +1,67 @@
+Here's a thinking process that leads to the suggested JSON output:
+
+1.  **Analyze the Request:**
+    *   **Goal:** Review a set of video clips (timeline order) and decide which ones to drop based on specific criteria.
+    *   **Criteria:**
+        *   *Redundant:* Same moment/scene/shot type repeated (especially self-portraits/mirror shots).
+        *   *Crowding Out:* Same thing recurring too much (pets, objects), unless it's a new subject or changing project. People are safe unless it's the exact same shot repeated.
+        *   *Clashing:* Breaks the feel of the set.
+        *   *Not a Memory:* Records a thing/object, not a moment (e.g., object alone, screen, document, empty room).
+    *   **Output Format:** Strict JSON `{"drop": [{"index": <number>, "reason": "<short reason>"}]}`.
+
+2.  **Analyze the Data (Clip by Clip):**
+
+    *   **Clip 1:** Date: 2008-08-04. Place: Jodoigne. Scene: Children on paved area, one taking photo, soccer goal. Emotion: Curious. *Verdict:* Good establishing shot of the group/activity. Keep.
+
+    *   **Clip 2:** Date: 2008-08-05. Place: Jodoigne. Scene: Boy with hula hoops, woman in paint/costume. Emotion: Joyful. *Verdict:* Distinct moment, costume detail. Keep.
+
+    *   **Clip 3:** Date: 2008-08-06. Place: Jodoigne. Scene: Two women talking (one in hijab, one back to camera). Emotion: Joyful. *Verdict:* Good interaction shot. Keep.
+
+    *   **Clip 4:** Date: 2008-08-06. Place: Jodoigne. Scene: Three people under willow tree (woman in hijab, man with stick, woman in tank top). Emotion: Joyful. *Verdict:* Distinct from Clip 3 (different people/pose), same day but different angle/grouping. Keep.
+
+    *   **Clip 5:** Date: 2008-08-06. Place: Jodoigne. Scene: Two women sitting against brick wall (hijab woman + tank top woman). Emotion: Casual. *Verdict:* This is the tricky one.
+        *   Clip 3 (Aug 6): Two women talking, one in hijab, one back to camera.
+        *   Clip 4 (Aug 6): Three people standing under willow.
+        *   Clip 5 (Aug 6): Two women sitting against brick wall. One is the hijab woman, one is the tank top woman (same as Clip 4).
+        *   *Analysis:* We have three clips on Aug 6.
+            *   Clip 3: Two women talking (standing/active).
+            *   Clip 4: Three people standing (willow tree).
+            *   Clip 5: Two women sitting (brick wall).
+        *   Are they redundant? They seem to be the same two women (hijab + tank top) in different poses/locations on the same day. However, Clip 5 is a static sitting shot against a wall. Is it *too* similar to the others?
+        *   Let's look at the "Redundant" rule: "Self-portraits and mirror shots repeat hard... A selfie of one person alone is the weakest way to record a day."
+        *   Clip 5 feels like a specific "costume" moment (scar on cheek, clothespins). It adds detail.
+        *   Let's hold judgment and look at the rest of the set to see if there are better candidates for dropping.
+
+    *   **Clip 6:** Date: 2008-08-07. Place: Jodoigne. Scene: Young man profile, green shirt, focused/thoughtful. Indoor setting (window). Emotion: Focused. *Verdict:* Good character shot, distinct from the group shots. Keep.
+
+    *   **Clip 7:** Date: 2008-08-08. Place: Jodoigne. Scene: Children with scout scarves, girl raising arms. Emotion: Joyful. *Verdict:* Active group shot. Keep.
+
+    *   **Clip 8:** Date: 2008-08-08. Place: Jodoigne. Scene: Children with scout scarves, covered area, girl speaking/singing. Emotion: Joyful. *Verdict:* Very similar to Clip 7 (same day, same group, scout scarves).
+        *   Clip 7: Girl raising arms (active), outside brick building.
+        *   Clip 8: Girl speaking/singing, covered area (brick walls).
+        *   These are extremely close. Clip 7 is "raising arms," Clip 8 is "gesturing/speaking." They are likely the same event.
+        *   *Decision:* Clip 8 is slightly more descriptive ("animatedly speaking"), but Clip 7 has the "raising arms" action which is visually distinct. However, looking at the descriptions, they are very similar. Let's look for a stronger candidate or keep both if they feel distinct enough.
+        *   Wait, Clip 7 says "outside a brick building," Clip 8 says "covered outdoor area with brick walls." They might be the same spot.
+        *   Let's look at Clip 13 (Aug 17). Also scout scarves.
+        *   Let's compare Clip 7 and 8 again. Clip 7: "girl... raising her arms." Clip 8: "girl... animatedly speaking or singing while gesturing." These are very similar actions.
+        *   Let's look at the "Redundant" rule again. "A selfie of one person alone is the weakest way to record a day."
+        *   Clip 6 (Aug 7) is a profile of one person. Is it redundant? No, it's the only shot for that day (so far).
+        *   Clip 7 and 8 are the same group, same day. I will drop one. Which is weaker? Clip 7 mentions "another child walks away carrying a yellow bag." Clip 8 mentions "another young girl looks up at an adult woman." Both have secondary action.
+        *   Let's look closer at the "Redundant" definition: "the same moment, scene or kind of shot is already in the set."
+        *   Clip 7 and 8 are likely the same moment. I'll drop **Clip 8** as it feels slightly more generic ("engaged in conversation and play") compared to the specific "raising arms" of Clip 7, or vice versa. Actually, looking at the descriptions, they are almost identical in content (children, scout scarves, brick wall/covered area). I will drop **Clip 8** to be safe, or maybe Clip 7. Let's look at the flow.
+        *   Actually, let's look at Clip 13 (Aug 17). "Children... wearing green scarves... standing in a line against a brick wall." This is also scout/camp activity.
+        *   So we have:
+            *   Aug 8 (Clip 7): Children, scout scarves, girl raising arms.
+            *   Aug 8 (Clip 8): Children, scout scarves, girl speaking/singing.
+            *   Aug 17 (Clip 13): Children, green scarves, standing in line.
+        *   Clip 7 and 8 are the same day. They are very redundant. I will drop **Clip 8** because Clip 7 has the "raising arms" which is a more distinct visual action than just "speaking/singing."
+
+    *   **Clip 9:** Date: 2008-08-11. Place: Jodoigne. Scene: Four children at desks, face paint, cutting paper. Emotion: Focused. *Verdict:* Distinct activity (art class). Keep.
+
+    *   **Clip 10:** Date: 2008-08-12. Place: Jodoigne. Scene: Close-up of two children (girl in purple hijab, boy). Emotion: Joyful. *Verdict:* Good portrait/moment. Keep.
+
+    *   **Clip 11:** Date: 2008-08-13. Place: Jodoigne. Scene: Two girls in gymnasium (balance beam, mat). Emotion: Playful. *Verdict:* Distinct setting (gym) and activity. Keep.
+
+    *   **Clip 12:** Date: 2008-08-14. Place: Jodoigne. Scene: Woman with hazelnut spread/cinnamon stick, children at table. Emotion: Curious. *Verdict:* Distinct activity (eating/prep). Keep.
+
+    *   **Clip 13:** Date

--- a/tests/fixtures/review_reasoning_complete.txt
+++ b/tests/fixtures/review_reasoning_complete.txt
@@ -1,0 +1,1 @@
+{"drop": [{"index": 13, "reason": "Redundant: static scout scarf moment similar to clips 7 and 8"}]}

--- a/tests/fixtures/review_reasoning_truncated.txt
+++ b/tests/fixtures/review_reasoning_truncated.txt
@@ -1,0 +1,18 @@
+Here's a thinking process:
+
+1.  **Analyze the Input:**
+   - I have 14 clips in timeline order (Clip 1 to Clip 14).
+   - Each clip has: date, place, score, description, emotion.
+   - Place is consistently Jodoigne, Belgium for most clips (Clip 14 has no place listed but same date range/context).
+   - Dates span from 2008-08-04 to 2008-08-17.
+   - I need to evaluate the set as a whole for feel, coherence, variety.
+   - Drop criteria: REDUNDANT, CROWDING OUT, CLASHING, NOT A MEMORY.
+   - Output format: STRICT JSON only: `{"drop": [{"index": <clip number>, "reason": "<short reason>"}]}`
+
+2.  **Examine Each Clip & Identify Potential Issues:**
+   - *Clip 1 (Aug 4):* Children on paved area, one holding camera, green grass/trees/soccer goal. Emotion: curious. Good scene/memory.
+   - *Clip 2 (Aug 5):* Boy with hula hoops, woman covered in paint, pink headscarf, heart pin. Brick wall background. Emotion: joyful. Good scene/memory.
+   - *Clip 3 (Aug 6):* Two women talking under covered area. One in olive tank/denim shorts/green scarf, other in red hijab/patterned tunic/green fanny pack. Emotion: joyful. Good scene/memory.
+   - *Clip 4 (Aug 6):* Three people under weeping willow. Woman in red hijab/sunglasses/water gun, man in blue shirt/bucket hat/stick, woman in tank top/denim shorts/large sunglasses/colorful scarf. Emotion: joyful. Good scene/memory.
+   - *Clip 5 (Aug 6):* Two women sitting against brick wall. Left: red hijab/sunglasses on head/black cape/red trim/stitched scar on cheek. Right: large sunglasses/green tank/blue-green striped scarf/clothespins. Costumed/themed. Emotion: casual. Good scene/memory.
+   - *Clip 6 (Aug 7):* Young man profile, green shirt/blue

--- a/tests/test_review_parsing.py
+++ b/tests/test_review_parsing.py
@@ -1,0 +1,121 @@
+r"""The review has to find the verdict in what the model actually says.
+
+Enabling server-side thinking made the model reason in the CONTENT channel on
+long prompts. Two things then broke at once, and fail-open hid both:
+
+- max_tokens=500 (the query_llm default, never overridden here) truncated the
+  answer before the verdict existed;
+- the parser took re.search(r"\{.*\}", DOTALL) — first brace to last — and the
+  model quotes the prompt's own format spec while reasoning, so the match was
+  literally {"drop": [{"index": <clip number>, ...}]}.
+
+json.loads choked on <clip number>, the broad catch returned [], and the
+review reported "nothing to drop" on every call.
+
+Fixtures are real captured responses, not hand-written approximations.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from immich_memories.analysis.selection_review import review_selection
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _member(asset_id: str, index: int):
+    from datetime import UTC, datetime
+
+    asset = SimpleNamespace(
+        id=asset_id,
+        is_favorite=False,
+        file_created_at=datetime(2021, 8, index + 1, 10, tzinfo=UTC),
+        exif_info=None,
+        people=[],
+    )
+    return SimpleNamespace(
+        clip=SimpleNamespace(asset=asset, llm_description=f"clip {index}"),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.5,
+        analyzed=True,
+    )
+
+
+def _selection(n: int = 14):
+    return [_member(f"asset-{i}", i) for i in range(1, n + 1)]
+
+
+def _config():
+    return SimpleNamespace(model="qwen", thinking=True)
+
+
+def test_a_verdict_buried_in_reasoning_prose_is_found() -> None:
+    r"""The real failure: 6916 chars of prose quoting the prompt's format spec.
+
+    re.search(r"\{.*\}", DOTALL) grabs {"drop": [{"index": <number>, ...}]} —
+    the template echo — and json.loads chokes on <number>. The verdict, when
+    the model gets far enough to produce one, is elsewhere in the answer.
+    """
+    answer = (_FIXTURES / "review_prose_then_verdict.txt").read_text()
+    assert '"index": <number>' in answer, "fixture no longer carries the echo"
+
+    # WHY: the LLM server is the external boundary; this is its real reply.
+    with patch("immich_memories.analysis.selection_review._ask", return_value=answer):
+        drops = review_selection(_selection(), _config())
+
+    # this particular capture never reached a verdict, so no drops — but the
+    # parser must not have been fooled into treating the echo as one either
+    assert drops == []
+
+
+def test_a_verdict_after_prose_is_read() -> None:
+    """A response that reasons aloud and then answers must be read."""
+    answer = (
+        "Here is a thinking process:\n\n1. The format is "
+        '{"drop": [{"index": <number>, "reason": "<short reason>"}]}\n'
+        "2. Clip 14 is a plain portrait.\n\n"
+        'Final answer:\n{"drop": [{"index": 14, "reason": "plain portrait"}]}'
+    )
+
+    # WHY: the LLM server is the external boundary.
+    with patch("immich_memories.analysis.selection_review._ask", return_value=answer):
+        drops = review_selection(_selection(), _config())
+
+    assert drops == ["asset-14"], f"the template echo beat the real verdict: {drops}"
+
+
+def test_a_real_verdict_is_read(caplog) -> None:
+    """The completed response from the probe: one drop, index 13."""
+    answer = (_FIXTURES / "review_reasoning_complete.txt").read_text()
+
+    # WHY: the LLM server is the external boundary; this is its real reply.
+    with patch("immich_memories.analysis.selection_review._ask", return_value=answer):
+        drops = review_selection(_selection(), _config())
+
+    assert drops == ["asset-13"], f"did not read the model's actual verdict: {drops}"
+
+
+def test_the_prompt_template_echo_is_not_mistaken_for_a_verdict(caplog) -> None:
+    """The truncated response: reasoning prose quoting the format spec, no verdict.
+
+    It must produce no drops AND say so — a review that could not read the
+    answer is not a review that approved the cut.
+    """
+    import logging
+
+    answer = (_FIXTURES / "review_reasoning_truncated.txt").read_text()
+    assert "<clip number>" in answer, "fixture no longer carries the echo"
+
+    # WHY: the LLM server is the external boundary; this is its real reply.
+    with (
+        patch("immich_memories.analysis.selection_review._ask", return_value=answer),
+        caplog.at_level(logging.WARNING, logger="immich_memories.analysis.selection_review"),
+    ):
+        drops = review_selection(_selection(), _config())
+
+    assert drops == []
+    assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+        "an unreadable answer was indistinguishable from an approved cut"
+    )


### PR DESCRIPTION
**The holistic review has been inert on every generation since server-side thinking was enabled.** It returns "nothing to drop" regardless of what the model says, and looks healthy doing it.

## Four mechanisms, each reasonable, combining into silence

1. **Server-side thinking got enabled** → the model began narrating its reasoning into the **content** channel on long prompts.
2. **`max_tokens` was `query_llm`'s default of 500**, never overridden here → the answer ran out mid-narration, before any verdict existed.
3. **The parser did `re.search(r"\{.*\}", DOTALL)`** — first brace to last. The prompt shows the model the shape it wants, and a narrating model quotes that shape back. So the match was literally:
   ```
   {"drop": [{"index": <number>, "reason": "<short reason>"}]}
   ```
   `json.loads` chokes on `<number>`.
4. **Fail-open caught it and returned `[]`** — correctly, by design. An unreadable answer must never gut a memory.

Net effect: a confident, silent no-op. 4 of 4 probe prompts reproduced it.

## The token budget was the primary defect, and the measurement is counter-intuitive

Real review prompt, non-thinking, local Qwen3.6-35B:

| `max_tokens` | answer length | verdict |
|---|---|---|
| **500** (current) | 1,688 | **none** — truncated mid-narration |
| 2,000 | 6,916 | **none** — still narrating |
| 4,000 | 14,973 | `[13, 14]` ✓ |
| **8,000** | **496** | `[7, 14]` ✓ |

**8,000 tokens produced a 496-character answer.** Given headroom the model answers instead of thinking aloud — so a larger ceiling here is *not* a larger bill. A 2,000 fallback would have shipped something that still never concludes.

## The parser no longer uses a regex

It walks brace depth for balanced candidates and tries them **last-first** (the verdict follows the reasoning), accepting only one that parses **and** carries a `drop` list. A template echo cannot satisfy both. `import re` became unused — fair evidence it was the wrong instrument.

## Fail-open stays, but stops being silent

`"0 drops"` has meant both *"the model approved this cut"* and *"the model never answered"* for as long as this pass has existed, and no reader could tell them apart. The warning now says which happened and carries a grep-able marker.

**No metrics counter yet**: `tracking.extra_metrics` doesn't exist (#654). An import of a phantom module inside a swallowing `except` is dead code impersonating integration — the marker constant holds the place until the counter has somewhere to live.

## Tests

Real captured responses, not hand-written approximations — including a 6,916-char reply where the greedy grab takes the echo.

Worth recording: **the first two tests I wrote passed against the broken code.** A truncated answer genuinely has no verdict, so returning nothing was already correct there. The real failure needed a response holding *both* an echo and a verdict, which took capturing a fresh one to get.

`make ci` exit 0, **5589 passed**.