### PR TITLE
docs: three claims about config that the loader does not honour

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -919,289 +919,273 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 164,
-        "line_start": 184,
-        "line_end": 992,
+        "complexity": 163,
+        "line_start": 185,
+        "line_end": 995,
         "line_complexities": [
-          {
-            "line": 536,
-            "complexity": 0
-          },
           {
             "line": 537,
             "complexity": 0
           },
           {
-            "line": 544,
-            "complexity": 2
+            "line": 538,
+            "complexity": 0
           },
           {
             "line": 545,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 546,
             "complexity": 0
           },
           {
-            "line": 548,
+            "line": 547,
+            "complexity": 0
+          },
+          {
+            "line": 549,
             "complexity": 2
           },
           {
-            "line": 550,
-            "complexity": 3
-          },
-          {
-            "line": 554,
+            "line": 551,
             "complexity": 3
           },
           {
             "line": 555,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 557,
+            "line": 556,
             "complexity": 0
           },
           {
             "line": 558,
-            "complexity": 2
-          },
-          {
-            "line": 559,
-            "complexity": 1
-          },
-          {
-            "line": 564,
-            "complexity": 3
-          },
-          {
-            "line": 565,
             "complexity": 0
           },
           {
-            "line": 569,
+            "line": 559,
+            "complexity": 2
+          },
+          {
+            "line": 560,
+            "complexity": 1
+          },
+          {
+            "line": 565,
+            "complexity": 3
+          },
+          {
+            "line": 566,
             "complexity": 0
           },
           {
             "line": 570,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 571,
+            "complexity": 1
+          },
+          {
+            "line": 572,
             "complexity": 0
           },
           {
-            "line": 573,
+            "line": 574,
             "complexity": 2
           },
           {
-            "line": 589,
+            "line": 590,
             "complexity": 0
           },
           {
-            "line": 600,
+            "line": 601,
             "complexity": 3
           },
           {
-            "line": 604,
+            "line": 605,
             "complexity": 3
           },
           {
-            "line": 608,
+            "line": 609,
             "complexity": 4
           },
           {
-            "line": 612,
+            "line": 613,
             "complexity": 3
           },
           {
-            "line": 616,
+            "line": 617,
             "complexity": 3
           },
           {
-            "line": 624,
+            "line": 625,
             "complexity": 0
-          },
-          {
-            "line": 641,
-            "complexity": 2
           },
           {
             "line": 642,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 643,
-            "complexity": 1
+            "complexity": 0
           },
           {
-            "line": 645,
-            "complexity": 0
+            "line": 644,
+            "complexity": 1
           },
           {
             "line": 646,
-            "complexity": 1
-          },
-          {
-            "line": 647,
             "complexity": 0
           },
           {
-            "line": 648,
-            "complexity": 3
-          },
-          {
-            "line": 653,
+            "line": 647,
             "complexity": 1
           },
           {
-            "line": 654,
-            "complexity": 3
-          },
-          {
-            "line": 655,
+            "line": 648,
             "complexity": 0
           },
           {
             "line": 656,
-            "complexity": 1
+            "complexity": 2
           },
           {
-            "line": 657,
-            "complexity": 0
-          },
-          {
-            "line": 660,
+            "line": 661,
             "complexity": 0
           },
           {
             "line": 664,
+            "complexity": 0
+          },
+          {
+            "line": 670,
+            "complexity": 1
+          },
+          {
+            "line": 673,
+            "complexity": 3
+          },
+          {
+            "line": 674,
+            "complexity": 3
+          },
+          {
+            "line": 676,
+            "complexity": 0
+          },
+          {
+            "line": 683,
+            "complexity": 0
+          },
+          {
+            "line": 687,
+            "complexity": 3
+          },
+          {
+            "line": 688,
+            "complexity": 0
+          },
+          {
+            "line": 689,
+            "complexity": 3
+          },
+          {
+            "line": 690,
+            "complexity": 0
+          },
+          {
+            "line": 692,
+            "complexity": 0
+          },
+          {
+            "line": 716,
+            "complexity": 1
+          },
+          {
+            "line": 717,
             "complexity": 2
           },
           {
-            "line": 669,
-            "complexity": 0
-          },
-          {
-            "line": 672,
-            "complexity": 0
-          },
-          {
-            "line": 678,
+            "line": 721,
             "complexity": 1
           },
           {
-            "line": 681,
+            "line": 732,
             "complexity": 3
           },
           {
-            "line": 682,
-            "complexity": 3
-          },
-          {
-            "line": 684,
+            "line": 733,
             "complexity": 0
           },
           {
-            "line": 691,
+            "line": 734,
             "complexity": 0
           },
           {
-            "line": 695,
-            "complexity": 3
-          },
-          {
-            "line": 696,
+            "line": 736,
             "complexity": 0
           },
           {
-            "line": 697,
-            "complexity": 3
-          },
-          {
-            "line": 698,
+            "line": 738,
             "complexity": 0
-          },
-          {
-            "line": 700,
-            "complexity": 0
-          },
-          {
-            "line": 724,
-            "complexity": 1
-          },
-          {
-            "line": 725,
-            "complexity": 2
-          },
-          {
-            "line": 729,
-            "complexity": 1
           },
           {
             "line": 740,
-            "complexity": 3
-          },
-          {
-            "line": 741,
             "complexity": 0
           },
           {
-            "line": 742,
-            "complexity": 0
-          },
-          {
-            "line": 744,
-            "complexity": 0
-          },
-          {
-            "line": 746,
-            "complexity": 0
-          },
-          {
-            "line": 748,
-            "complexity": 0
-          },
-          {
-            "line": 755,
+            "line": 747,
             "complexity": 5
           },
           {
-            "line": 797,
+            "line": 789,
             "complexity": 6
           },
           {
-            "line": 841,
+            "line": 833,
             "complexity": 0
           },
           {
-            "line": 842,
+            "line": 834,
             "complexity": 5
           },
           {
-            "line": 843,
+            "line": 835,
             "complexity": 6
           },
           {
-            "line": 844,
+            "line": 836,
             "complexity": 0
           },
           {
-            "line": 845,
+            "line": 837,
             "complexity": 0
           },
           {
-            "line": 846,
+            "line": 838,
             "complexity": 7
           },
           {
-            "line": 854,
+            "line": 846,
             "complexity": 6
           },
           {
-            "line": 855,
+            "line": 847,
             "complexity": 0
+          },
+          {
+            "line": 848,
+            "complexity": 7
+          },
+          {
+            "line": 849,
+            "complexity": 0
+          },
+          {
+            "line": 851,
+            "complexity": 1
           },
           {
             "line": 856,
@@ -1212,96 +1196,88 @@
             "complexity": 0
           },
           {
-            "line": 859,
-            "complexity": 1
-          },
-          {
-            "line": 864,
+            "line": 870,
             "complexity": 7
           },
           {
-            "line": 865,
+            "line": 871,
             "complexity": 0
           },
           {
-            "line": 878,
-            "complexity": 7
-          },
-          {
-            "line": 879,
+            "line": 872,
             "complexity": 0
           },
           {
-            "line": 880,
-            "complexity": 0
-          },
-          {
-            "line": 883,
+            "line": 875,
             "complexity": 1
           },
           {
-            "line": 884,
+            "line": 876,
             "complexity": 0
           },
           {
-            "line": 885,
+            "line": 877,
             "complexity": 0
           },
           {
-            "line": 888,
+            "line": 881,
+            "complexity": 7
+          },
+          {
+            "line": 882,
             "complexity": 0
           },
           {
-            "line": 898,
+            "line": 891,
             "complexity": 0
           },
           {
-            "line": 899,
+            "line": 901,
+            "complexity": 0
+          },
+          {
+            "line": 902,
             "complexity": 5
           },
           {
-            "line": 900,
+            "line": 903,
             "complexity": 0
-          },
-          {
-            "line": 905,
-            "complexity": 6
           },
           {
             "line": 908,
             "complexity": 6
           },
           {
-            "line": 913,
+            "line": 911,
+            "complexity": 6
+          },
+          {
+            "line": 916,
             "complexity": 0
           },
           {
-            "line": 915,
+            "line": 918,
             "complexity": 5
           },
           {
-            "line": 917,
-            "complexity": 5
-          },
-          {
-            "line": 921,
+            "line": 920,
             "complexity": 5
           },
           {
             "line": 924,
+            "complexity": 5
+          },
+          {
+            "line": 927,
             "complexity": 1
           },
           {
-            "line": 926,
+            "line": 929,
             "complexity": 0
           },
           {
-            "line": 928,
+            "line": 931,
             "complexity": 0
-          },
-          {
-            "line": 975,
-            "complexity": 1
           },
           {
             "line": 978,
@@ -1312,17 +1288,21 @@
             "complexity": 1
           },
           {
-            "line": 982,
+            "line": 984,
+            "complexity": 1
+          },
+          {
+            "line": 985,
             "complexity": 0
           },
           {
-            "line": 983,
+            "line": 986,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 175
+    "complexity": 174
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",

--- a/docs-site/docs/deploy/configuration/config-file.md
+++ b/docs-site/docs/deploy/configuration/config-file.md
@@ -88,7 +88,7 @@ Everything else (`immich`, `defaults`, `output`, `audio`, `title_screens`, `cach
 `trips`, `photos`, `scheduler`) stays at the top level.
 
 Unknown keys inside a section are silently ignored — a typo does not fail the load, it just does
-nothing. Unknown top-level keys and invalid values (`codec: av1`, `llm.provider: openai`) do fail
+nothing. Unknown top-level keys and invalid values (`codec: av1`, `llm.provider: gemini`) do fail
 with a validation error at startup.
 
 ## Footage the camera roll did not shoot

--- a/docs-site/docs/deploy/maintenance/upgrading.md
+++ b/docs-site/docs/deploy/maintenance/upgrading.md
@@ -67,7 +67,7 @@ a video, create an album, or upload anything. A successful result includes the r
 
 ## Config compatibility
 
-There is no automatic config migration. If a release renames or removes a config field, you'll see a validation error on startup. The fix is always documented in the release notes: update your `config.yaml` to use the new field name.
+There is no automatic config migration, and a removed field will not tell you it is gone: unknown keys **inside** a known section are silently ignored, so a renamed field simply stops doing anything. (Unknown *top-level* keys and invalid values do fail at startup.) Renames are documented in the release notes — check them when a setting seems to have stopped taking effect.
 
 In practice, most config fields have been stable since v0.1. Breaking config changes are rare and always called out in the release notes.
 

--- a/src/immich_memories/config_models_llm.py
+++ b/src/immich_memories/config_models_llm.py
@@ -12,8 +12,10 @@ from immich_memories.config_models import expand_env_vars
 class LLMConfig(BaseModel):
     """Shared LLM provider settings.
 
-    Two providers: "ollama" (native Ollama API) or "openai-compatible"
-    (any server speaking /v1/chat/completions — OpenAI, Groq, mlx-vlm, vLLM, etc.).
+    Five accepted values, three code paths: "ollama" speaks the native Ollama
+    API, "anthropic" speaks /v1/messages, and "openai-compatible", "openai" and
+    "zai" all speak /v1/chat/completions — any server that does will work
+    (OpenAI, Groq, mlx-vlm, vLLM).
     """
 
     provider: Literal["ollama", "openai-compatible", "openai", "zai", "anthropic"] = Field(


### PR DESCRIPTION
Refs #520 — the leftovers batch. Verifying them against the loader rather than reading them changed what the batch turned out to be: **two of the four were not defects, and a fifth one nobody had flagged was.**

## Three real fixes, all verified by running the loader

**1. `LLMConfig`'s docstring said "Two providers".** The `Literal` accepts **five** — `ollama`, `openai-compatible`, `openai`, `zai`, `anthropic` — across three code paths: native Ollama, Anthropic's `/v1/messages`, and `/v1/chat/completions` for the other three.

**2. `upgrading.md` promised a validation error that never comes.** It told readers a renamed or removed field would fail at startup. Measured:

```
unknown key inside a known section  →  loads fine, silently ignored
unknown TOP-LEVEL key               →  ValidationError
codec: av1                          →  ValidationError
```

Nothing sets `extra="forbid"`. So a renamed setting **simply stops taking effect** — which is the failure mode the page should have been warning about, and is strictly worse than the error it promised, because it is silent.

It also **contradicted `config-file.md`**, which had it right all along.

**3. (Not on the list) `config-file.md` cited `llm.provider: openai` as an invalid value.** It is accepted — `provider: openai` loads fine. The provider list grew and the example did not follow, which is the *same drift* as fix 1: two docs left behind by one `Literal`. Replaced with `gemini`, and I verified the replacement actually raises rather than swapping in another guess.

## Two items deliberately not here

**The em-dash sweep.** I could not find a defect to fix. Across the four flagged pages, every line carrying more than one em-dash is either a correct paired parenthetical —

> *"people without the means — or the desire — to run a local model"*
> *"a repetition loop — whisper emitting one phrase several times over — or contain no words"*

— or two separate single appositives in one paragraph. Counts are unremarkable (3 in development-setup, 8 in testing.md, 35 across 687 lines of config-reference). Without the specific flagged lines, a pass across four files would have been prose churn by taste, which is the blanket semantic edit I have refused all session. **Happy to do it surgically if the specific lines are supplied.**

**The Smart-X remainder** was already fixed by #638 and #624 — `grep` returns nothing on either page.

`make ci` green: **5639 passed**. `make docs-build` exit 0. `make docs-config-check` passes.
