### PR TITLE
docs(claude): crossing 800 lines obliges the split, in that PR or the next

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,9 @@ locally, CI will pass too. Use conventional commit message format (see above).
 ### Splitting Large Files
 
 - Do not add new files over 800 lines — split proactively
+- A PR that pushes an existing file past 800 lines OWES the split: in that PR
+  or an immediately-queued follow-up. Surfing toward the 1000 hard cap is not
+  an option — moving helpers elsewhere to stay at 99x is the smell, not the fix
 - Split along **cohesion boundaries**, not arbitrary line counts
 - Extract a service class with a Protocol contract for its dependencies
 - The new module should be independently testable and importable


### PR DESCRIPTION
Owner-ordered rule after the split-wave finding: seven files sat between 800 and 999 while PRs dodged the hard cap by moving helpers elsewhere. The soft limit becomes an obligation trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f