### PR TITLE
refactor(tracking): lift row conversion and lifecycle errors out of run_database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -338,6 +338,8 @@ src/immich_memories/
 │
 ├── tracking/                   # Run history & telemetry
 │   ├── run_database.py         # SQLite run storage
+│   ├── run_database_rows.py    # SQLite row <-> model conversion
+│   ├── run_lifecycle_errors.py # Refused lifecycle transitions and their diagnosis
 │   ├── run_tracker.py          # Pipeline run tracking
 │   ├── run_id.py               # Run ID generation
 │   ├── models.py               # Run/phase data models

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -4740,55 +4740,55 @@
       {
         "name": "RunDatabase::update_run_status",
         "complexity": 18,
-        "line_start": 342,
-        "line_end": 403,
+        "line_start": 223,
+        "line_end": 284,
         "line_complexities": [
           {
-            "line": 357,
+            "line": 238,
             "complexity": 0
           },
           {
-            "line": 358,
+            "line": 239,
             "complexity": 0
           },
           {
-            "line": 359,
+            "line": 240,
             "complexity": 0
           },
           {
-            "line": 361,
+            "line": 242,
             "complexity": 2
           },
           {
-            "line": 365,
+            "line": 246,
             "complexity": 2
           },
           {
-            "line": 369,
+            "line": 250,
             "complexity": 2
           },
           {
-            "line": 373,
+            "line": 254,
             "complexity": 2
           },
           {
-            "line": 377,
+            "line": 258,
             "complexity": 2
           },
           {
-            "line": 381,
+            "line": 262,
             "complexity": 2
           },
           {
-            "line": 385,
+            "line": 266,
             "complexity": 2
           },
           {
-            "line": 389,
+            "line": 270,
             "complexity": 2
           },
           {
-            "line": 393,
+            "line": 274,
             "complexity": 2
           }
         ]
@@ -4796,69 +4796,69 @@
       {
         "name": "RunDatabase::update_operational_phase",
         "complexity": 21,
-        "line_start": 252,
-        "line_end": 285,
+        "line_start": 133,
+        "line_end": 166,
         "line_complexities": [
           {
-            "line": 254,
+            "line": 135,
             "complexity": 0
           },
           {
-            "line": 255,
+            "line": 136,
             "complexity": 0
           },
           {
-            "line": 259,
+            "line": 140,
             "complexity": 2
           },
           {
-            "line": 260,
+            "line": 141,
             "complexity": 0
           },
           {
-            "line": 261,
+            "line": 142,
             "complexity": 2
           },
           {
-            "line": 262,
+            "line": 143,
             "complexity": 3
           },
           {
-            "line": 263,
+            "line": 144,
             "complexity": 0
           },
           {
-            "line": 268,
+            "line": 149,
             "complexity": 0
           },
           {
-            "line": 269,
+            "line": 150,
             "complexity": 2
           },
           {
-            "line": 270,
+            "line": 151,
             "complexity": 0
           },
           {
-            "line": 273,
+            "line": 154,
             "complexity": 3
           },
           {
-            "line": 274,
+            "line": 155,
             "complexity": 4
           },
           {
-            "line": 279,
+            "line": 160,
             "complexity": 5
           },
           {
-            "line": 285,
+            "line": 166,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 106
+    "complexity": 101
   },
   {
     "path": "src/immich_memories/ui/pages/step2_review.py",

--- a/src/immich_memories/operations/storage_report.py
+++ b/src/immich_memories/operations/storage_report.py
@@ -47,7 +47,7 @@ class ReadOnlyRunStore:
         except sqlite3.Error:
             return []
 
-        from immich_memories.tracking.run_database import row_to_run
+        from immich_memories.tracking.run_database_rows import row_to_run
 
         return [row_to_run(row) for row in rows]
 

--- a/src/immich_memories/tracking/__init__.py
+++ b/src/immich_memories/tracking/__init__.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from immich_memories.tracking.models import DeliveryStatus, PhaseStats, RunMetadata, SystemInfo
-from immich_memories.tracking.run_database import (
+from immich_memories.tracking.run_database import RunDatabase
+from immich_memories.tracking.run_id import generate_run_id, is_valid_run_id, parse_run_id
+from immich_memories.tracking.run_lifecycle_errors import (
     DuplicateRunError,
     InvalidRunLifecycleError,
-    RunDatabase,
 )
-from immich_memories.tracking.run_id import generate_run_id, is_valid_run_id, parse_run_id
 from immich_memories.tracking.run_tracker import RunTracker, format_duration
 from immich_memories.tracking.system_info import capture_system_info
 

--- a/src/immich_memories/tracking/run_database.py
+++ b/src/immich_memories/tracking/run_database.py
@@ -1,4 +1,8 @@
-"""Database operations for run history."""
+"""Database operations for run history.
+
+Row-to-model conversion lives in run_database_rows.py; the lifecycle
+transition errors in run_lifecycle_errors.py.
+"""
 
 from __future__ import annotations
 
@@ -7,147 +11,24 @@ import logging
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
-from typing import Any, NoReturn
 
 from immich_memories.operations.phases import OperationalPhase, PhaseEvent
 from immich_memories.tracking.models import (
     DeliveryStatus,
     PhaseStats,
     RunMetadata,
-    SystemInfo,
     normalize_memory_people,
+)
+from immich_memories.tracking.run_database_rows import row_to_phase_stats, row_to_run
+from immich_memories.tracking.run_lifecycle_errors import (
+    DuplicateRunError,
+    raise_invalid_artifact_transition,
+    raise_invalid_delivery_transition,
 )
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidRunLifecycleError(RuntimeError):
-    """Raised when a run's lifecycle state forbids a requested transition."""
-
-
-class DuplicateRunError(RuntimeError):
-    """Raised when a new tracker tries to claim an existing run identity."""
-
-
-def _raise_invalid_delivery_transition(
-    conn: sqlite3.Connection,
-    run_id: str,
-) -> NoReturn:
-    row = conn.execute(
-        "SELECT status, delivery_status FROM pipeline_runs WHERE run_id = ?", (run_id,)
-    ).fetchone()
-    if row is None:
-        raise KeyError(f"Unknown pipeline run: {run_id}")
-    if row["status"] == "completed":
-        raise InvalidRunLifecycleError(
-            f"Delivery transition requires requested delivery; run '{run_id}' is "
-            f"'{row['delivery_status']}'"
-        )
-    raise InvalidRunLifecycleError(
-        f"Delivery transition requires a completed run; run '{run_id}' is '{row['status']}'"
-    )
-
-
-def _raise_invalid_artifact_transition(
-    conn: sqlite3.Connection,
-    run_id: str,
-) -> NoReturn:
-    row = conn.execute("SELECT status FROM pipeline_runs WHERE run_id = ?", (run_id,)).fetchone()
-    if row is None:
-        raise KeyError(f"Unknown pipeline run: {run_id}")
-    raise InvalidRunLifecycleError(
-        f"Artifact completion requires a running run; run '{run_id}' is '{row['status']}'"
-    )
-
-
-def _row_value(row: sqlite3.Row, column: str, default: Any = None) -> Any:
-    """Read a column that may be absent on legacy compatibility rows."""
-    try:
-        return row[column]
-    except IndexError:
-        return default
-
-
-def row_to_run(row: sqlite3.Row) -> RunMetadata:
-    """Convert database row to RunMetadata."""
-    system_info = None
-    if row["system_info"]:
-        system_info = SystemInfo.from_json(row["system_info"])
-
-    return RunMetadata(
-        run_id=row["run_id"],
-        created_at=datetime.fromisoformat(row["created_at"]),
-        completed_at=(datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None),
-        status=row["status"],
-        memory_type=_row_value(row, "memory_type"),
-        memory_key=_row_value(row, "memory_key"),
-        memory_category=_row_value(row, "memory_category"),
-        memory_people=(
-            tuple(json.loads(_row_value(row, "memory_people_json")))
-            if _row_value(row, "memory_people_json")
-            else ()
-        ),
-        source=_row_value(row, "source", "manual"),
-        automation_attempt_id=_row_value(row, "automation_attempt_id"),
-        last_phase=(
-            OperationalPhase(_row_value(row, "last_phase"))
-            if _row_value(row, "last_phase")
-            else None
-        ),
-        person_name=row["person_name"],
-        person_id=row["person_id"],
-        date_range_start=(
-            date.fromisoformat(row["date_range_start"]) if row["date_range_start"] else None
-        ),
-        date_range_end=(
-            date.fromisoformat(row["date_range_end"]) if row["date_range_end"] else None
-        ),
-        # WHY the keys() check: a reader can hold a connection while another
-        # process is mid-migration (the concurrent-upgrade tests pin that
-        # window), and sqlite3.Row raises on a column that does not exist yet.
-        target_duration_seconds=(
-            row["target_duration_seconds"]
-            if "target_duration_seconds" in row.keys()  # noqa: SIM118 — sqlite3.Row `in` checks values, not keys
-            and row["target_duration_seconds"] is not None
-            else (row["target_duration_minutes"] or 10) * 60
-        ),
-        output_path=row["output_path"],
-        output_size_bytes=row["output_size_bytes"] or 0,
-        output_duration_seconds=row["output_duration_seconds"] or 0.0,
-        delivery_status=DeliveryStatus(
-            _row_value(row, "delivery_status") or DeliveryStatus.NOT_REQUESTED
-        ),
-        delivery_attempts=_row_value(row, "delivery_attempts", 0) or 0,
-        delivery_error=_row_value(row, "delivery_error"),
-        immich_asset_id=_row_value(row, "immich_asset_id"),
-        delivery_album=_row_value(row, "delivery_album"),
-        warnings=(
-            json.loads(_row_value(row, "warnings_json")) if _row_value(row, "warnings_json") else []
-        ),
-        llm_metrics=(
-            json.loads(_row_value(row, "llm_metrics")) if _row_value(row, "llm_metrics") else {}
-        ),
-        clips_analyzed=row["clips_analyzed"] or 0,
-        clips_selected=row["clips_selected"] or 0,
-        errors_count=row["errors_count"] or 0,
-        system_info=system_info,
-    )
-
-
-def row_to_phase_stats(row: sqlite3.Row) -> PhaseStats:
-    """Convert database row to PhaseStats."""
-    return PhaseStats(
-        phase_name=row["phase_name"],
-        started_at=datetime.fromisoformat(row["started_at"]),
-        completed_at=(datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None),
-        duration_seconds=row["duration_seconds"] or 0.0,
-        items_processed=row["items_processed"] or 0,
-        items_total=row["items_total"] or 0,
-        errors=json.loads(row["errors"]) if row["errors"] else [],
-        extra_metrics=json.loads(row["extra_metrics"]) if row["extra_metrics"] else {},
-    )
 
 
 def _compute_avg_run_seconds(conn: sqlite3.Connection, completed_runs: int) -> float:
@@ -420,7 +301,7 @@ class RunDatabase:
                 (DeliveryStatus.ABANDONED.value, error, run_id),
             )
             if cursor.rowcount != 1:
-                _raise_invalid_delivery_transition(conn, run_id)
+                raise_invalid_delivery_transition(conn, run_id)
             conn.commit()
         saved = self.get_run(run_id)
         if saved is None:  # pragma: no cover - the UPDATE just matched this row
@@ -448,7 +329,7 @@ class RunDatabase:
                 (DeliveryStatus.PENDING.value, int(attempted), error, run_id),
             )
             if cursor.rowcount != 1:
-                _raise_invalid_delivery_transition(conn, run_id)
+                raise_invalid_delivery_transition(conn, run_id)
             conn.commit()
 
         updated = self.get_run(run_id)
@@ -513,7 +394,7 @@ class RunDatabase:
                 ),
             )
             if cursor.rowcount != 1:
-                _raise_invalid_artifact_transition(conn, run_id)
+                raise_invalid_artifact_transition(conn, run_id)
             conn.commit()
 
         completed = self.get_run(run_id)
@@ -546,7 +427,7 @@ class RunDatabase:
                 ),
             )
             if cursor.rowcount != 1:
-                _raise_invalid_delivery_transition(conn, run_id)
+                raise_invalid_delivery_transition(conn, run_id)
             conn.commit()
 
         updated = self.get_run(run_id)

--- a/src/immich_memories/tracking/run_database_rows.py
+++ b/src/immich_memories/tracking/run_database_rows.py
@@ -1,0 +1,104 @@
+"""SQLite row conversion for pipeline run history."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime
+from typing import Any
+
+from immich_memories.operations.phases import OperationalPhase
+from immich_memories.tracking.models import (
+    DeliveryStatus,
+    PhaseStats,
+    RunMetadata,
+    SystemInfo,
+)
+
+
+def _row_value(row: sqlite3.Row, column: str, default: Any = None) -> Any:
+    """Read a column that may be absent on legacy compatibility rows."""
+    try:
+        return row[column]
+    except IndexError:
+        return default
+
+
+def row_to_run(row: sqlite3.Row) -> RunMetadata:
+    """Convert database row to RunMetadata."""
+    system_info = None
+    if row["system_info"]:
+        system_info = SystemInfo.from_json(row["system_info"])
+
+    return RunMetadata(
+        run_id=row["run_id"],
+        created_at=datetime.fromisoformat(row["created_at"]),
+        completed_at=(datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None),
+        status=row["status"],
+        memory_type=_row_value(row, "memory_type"),
+        memory_key=_row_value(row, "memory_key"),
+        memory_category=_row_value(row, "memory_category"),
+        memory_people=(
+            tuple(json.loads(_row_value(row, "memory_people_json")))
+            if _row_value(row, "memory_people_json")
+            else ()
+        ),
+        source=_row_value(row, "source", "manual"),
+        automation_attempt_id=_row_value(row, "automation_attempt_id"),
+        last_phase=(
+            OperationalPhase(_row_value(row, "last_phase"))
+            if _row_value(row, "last_phase")
+            else None
+        ),
+        person_name=row["person_name"],
+        person_id=row["person_id"],
+        date_range_start=(
+            date.fromisoformat(row["date_range_start"]) if row["date_range_start"] else None
+        ),
+        date_range_end=(
+            date.fromisoformat(row["date_range_end"]) if row["date_range_end"] else None
+        ),
+        # WHY the keys() check: a reader can hold a connection while another
+        # process is mid-migration (the concurrent-upgrade tests pin that
+        # window), and sqlite3.Row raises on a column that does not exist yet.
+        target_duration_seconds=(
+            row["target_duration_seconds"]
+            if "target_duration_seconds" in row.keys()  # noqa: SIM118 — sqlite3.Row `in` checks values, not keys
+            and row["target_duration_seconds"] is not None
+            else (row["target_duration_minutes"] or 10) * 60
+        ),
+        output_path=row["output_path"],
+        output_size_bytes=row["output_size_bytes"] or 0,
+        output_duration_seconds=row["output_duration_seconds"] or 0.0,
+        delivery_status=DeliveryStatus(
+            _row_value(row, "delivery_status") or DeliveryStatus.NOT_REQUESTED
+        ),
+        delivery_attempts=_row_value(row, "delivery_attempts", 0) or 0,
+        delivery_error=_row_value(row, "delivery_error"),
+        immich_asset_id=_row_value(row, "immich_asset_id"),
+        delivery_album=_row_value(row, "delivery_album"),
+        warnings=(
+            json.loads(_row_value(row, "warnings_json")) if _row_value(row, "warnings_json") else []
+        ),
+        llm_metrics=(
+            json.loads(_row_value(row, "llm_metrics")) if _row_value(row, "llm_metrics") else {}
+        ),
+        clips_analyzed=row["clips_analyzed"] or 0,
+        clips_selected=row["clips_selected"] or 0,
+        errors_count=row["errors_count"] or 0,
+        system_info=system_info,
+    )
+
+
+def row_to_phase_stats(row: sqlite3.Row) -> PhaseStats:
+    """Convert database row to PhaseStats."""
+    return PhaseStats(
+        phase_name=row["phase_name"],
+        started_at=datetime.fromisoformat(row["started_at"]),
+        completed_at=(datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None),
+        duration_seconds=row["duration_seconds"] or 0.0,
+        items_processed=row["items_processed"] or 0,
+        items_total=row["items_total"] or 0,
+        errors=json.loads(row["errors"]) if row["errors"] else [],
+        extra_metrics=json.loads(row["extra_metrics"]) if row["extra_metrics"] else {},
+    )

--- a/src/immich_memories/tracking/run_lifecycle_errors.py
+++ b/src/immich_memories/tracking/run_lifecycle_errors.py
@@ -1,0 +1,47 @@
+"""Refused pipeline-run lifecycle transitions and the state that explains them."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import NoReturn
+
+
+class InvalidRunLifecycleError(RuntimeError):
+    """Raised when a run's lifecycle state forbids a requested transition."""
+
+
+class DuplicateRunError(RuntimeError):
+    """Raised when a new tracker tries to claim an existing run identity."""
+
+
+def raise_invalid_delivery_transition(
+    conn: sqlite3.Connection,
+    run_id: str,
+) -> NoReturn:
+    """Re-read the run to name which precondition the delivery transition missed."""
+    row = conn.execute(
+        "SELECT status, delivery_status FROM pipeline_runs WHERE run_id = ?", (run_id,)
+    ).fetchone()
+    if row is None:
+        raise KeyError(f"Unknown pipeline run: {run_id}")
+    if row["status"] == "completed":
+        raise InvalidRunLifecycleError(
+            f"Delivery transition requires requested delivery; run '{run_id}' is "
+            f"'{row['delivery_status']}'"
+        )
+    raise InvalidRunLifecycleError(
+        f"Delivery transition requires a completed run; run '{run_id}' is '{row['status']}'"
+    )
+
+
+def raise_invalid_artifact_transition(
+    conn: sqlite3.Connection,
+    run_id: str,
+) -> NoReturn:
+    """Re-read the run to name the status that blocked artifact completion."""
+    row = conn.execute("SELECT status FROM pipeline_runs WHERE run_id = ?", (run_id,)).fetchone()
+    if row is None:
+        raise KeyError(f"Unknown pipeline run: {run_id}")
+    raise InvalidRunLifecycleError(
+        f"Artifact completion requires a running run; run '{run_id}' is '{row['status']}'"
+    )


### PR DESCRIPTION
Refs #685 — the `tracking/run_database.py` entry in the split wave. No `Closes`: the other six files are separate PRs.

`run_database.py` was **850 lines**, over the 800-line soft limit and still growing — #643 added run-level metrics writes to it last week.

|  | before | after |
|---|---:|---:|
| `run_database.py` | 850 | **731** |
| `run_database_rows.py` | — | 104 |
| `run_lifecycle_errors.py` | — | 47 |

## The seam I rejected first

The obvious candidate was reads (the #654 surfaces: runs list/show/stats) vs writes/lifecycle. **It isn't a seam.** Four lifecycle writers — `mark_delivery_abandoned`, `mark_delivery_pending`, `complete_artifact`, `mark_delivered` — end by returning `self.get_run(run_id)`, and `get_run` and `list_runs` both call `get_phase_stats`. The halves are genuinely entangled: splitting them needs a writer holding a reader plus delegation boilerplate for twelve methods, which is the mixin/shim smell `CLAUDE.md` forbids and pure churn across every `db.list_runs(...)` call site.

So this is helpers-out, and both helpers are real cohesion boundaries.

## `run_database_rows.py`

`row_to_run`, `row_to_phase_stats` and `_row_value` are pure `sqlite3.Row` → model functions that never touch `RunDatabase`. **The precedent is already in the repo:** `cache/database.py` has exactly this module sitting beside it as `cache/database_rows.py`, same name shape, same `_row_value` + `row_to_*` contents. This mirrors it rather than inventing a layout.

`row_to_run` already had an external consumer (`operations/storage_report.py`), which is repointed to the new module — its import stays deferred inside the function, as it was, because `tracking` imports `operations.phases` at module level.

## `run_lifecycle_errors.py`

`InvalidRunLifecycleError`, `DuplicateRunError`, and the two `raise_*` helpers that re-read the run to name *which* precondition a refused transition missed. One contract, shared by four lifecycle methods — and `tracking/__init__.py` already re-exported the two exceptions as the package's public error surface, independent of the `RunDatabase` implementation.

The helpers drop their leading underscore now that they are imported across a module boundary.

## Patch-target audit

This is the risk surface of any split here, so I checked it site by site rather than trusting the module path.

**Every `patch("immich_memories.tracking.run_database...")` target in the suite is `RunDatabase`** — `test_scheduler_daemon.py:166,201` and `test_health.py:171,627`. `RunDatabase` stays in `run_database.py`, so those resolve untouched. Nothing patches `row_to_run`, `row_to_phase_stats`, `_row_value`, the raise helpers, or the exception types.

The tests that use the exceptions (`test_delivery_retry.py`, 6 sites) already imported them from `immich_memories.tracking`, not from the module, so the `__init__.py` re-export absorbs the move.

**No test file needed rewiring. 5664 pass unchanged.**

## Behaviour neutrality, shown rather than claimed

The complete set of lines *added* to `run_database.py`:

```
+"""Database operations for run history.
+
+Row-to-model conversion lives in run_database_rows.py; the lifecycle
+transition errors in run_lifecycle_errors.py.
+"""
+from datetime import datetime
+from immich_memories.tracking.run_database_rows import row_to_phase_stats, row_to_run
+from immich_memories.tracking.run_lifecycle_errors import (
+    DuplicateRunError,
+    raise_invalid_artifact_transition,
+    raise_invalid_delivery_transition,
+)
+                raise_invalid_delivery_transition(conn, run_id)   ×3
+                raise_invalid_artifact_transition(conn, run_id)   ×1
```

Docstring, import block, and the four call sites tracking the underscore drop. No logic moved into or out of a branch; everything else is deletion of the moved blocks. Moved code is carried verbatim, including the `# WHY the keys() check` comment on the mid-migration read window and the `except IndexError` (narrower than the `cache` twin's — deliberately not "harmonised").

## The complexipy cliff was not disturbed

`update_run_status` is a recorded watermark entry at **18** and `update_operational_phase` at **21**. Neither is touched. I diffed the snapshot entry-by-entry rather than trusting the gate's pass line:

```
NEW entries: {}   REMOVED entries: {}   CHANGED: {}
```

The 31/31-line snapshot diff is pure line renumbering from the deletion above them.

## Housekeeping

- `date`, `Any`, `NoReturn`, `SystemInfo` dropped from `run_database.py` — they went with the moved code (ruff and mypy confirm none is still referenced).
- `sqlite` schema untouched: no migrations in a split.
- `ARCHITECTURE.md` updated with both modules.
- jscpd reports **no clone** between `run_database_rows.py` and its `cache/` twin — the parallel is structural, not copied text.
- Patch ledger unchanged: this PR adds no mock sites.

`make ci` green end to end, plus all 14 pre-commit hooks including diff coverage ≥80% on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
