### PR TITLE
feat(server): one authenticated POST that does what auto run decides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -307,6 +307,7 @@ src/immich_memories/
 │   ├── app.py                  # App setup & routing
 │   ├── auth.py                 # Auth middleware, credential verification, session helpers
 │   ├── auth_oidc.py            # OIDC client (authlib starlette integration, singleton)
+│   ├── trigger_api.py          # POST /api/trigger — runs what `auto run` decides, 202 + status URL
 │   ├── reverse_proxy.py        # Secure cookie + trusted X-Forwarded-* kwargs for ui.run
 │   ├── state.py                # Shared UI state
 │   ├── session_storage.py      # Expire the storage-user-*.json files NiceGUI writes but never cleans

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -351,115 +351,27 @@
       {
         "name": "AutoRunner::_run_one_under_lease",
         "complexity": 25,
-        "line_start": 467,
-        "line_end": 608,
+        "line_start": 526,
+        "line_end": 667,
         "line_complexities": [
-          {
-            "line": 477,
-            "complexity": 0
-          },
-          {
-            "line": 481,
-            "complexity": 0
-          },
-          {
-            "line": 482,
-            "complexity": 2
-          },
-          {
-            "line": 483,
-            "complexity": 0
-          },
-          {
-            "line": 485,
-            "complexity": 0
-          },
-          {
-            "line": 486,
-            "complexity": 2
-          },
-          {
-            "line": 487,
-            "complexity": 0
-          },
-          {
-            "line": 489,
-            "complexity": 0
-          },
-          {
-            "line": 493,
-            "complexity": 3
-          },
-          {
-            "line": 494,
-            "complexity": 0
-          },
-          {
-            "line": 496,
-            "complexity": 0
-          },
-          {
-            "line": 497,
-            "complexity": 2
-          },
-          {
-            "line": 498,
-            "complexity": 0
-          },
-          {
-            "line": 499,
-            "complexity": 0
-          },
-          {
-            "line": 500,
-            "complexity": 1
-          },
-          {
-            "line": 501,
-            "complexity": 0
-          },
-          {
-            "line": 509,
-            "complexity": 2
-          },
-          {
-            "line": 511,
-            "complexity": 0
-          },
-          {
-            "line": 521,
-            "complexity": 0
-          },
-          {
-            "line": 522,
-            "complexity": 1
-          },
-          {
-            "line": 523,
-            "complexity": 0
-          },
-          {
-            "line": 524,
-            "complexity": 0
-          },
-          {
-            "line": 528,
-            "complexity": 0
-          },
-          {
-            "line": 534,
-            "complexity": 1
-          },
-          {
-            "line": 535,
-            "complexity": 1
-          },
           {
             "line": 536,
             "complexity": 0
           },
           {
-            "line": 538,
+            "line": 540,
+            "complexity": 0
+          },
+          {
+            "line": 541,
+            "complexity": 2
+          },
+          {
+            "line": 542,
+            "complexity": 0
+          },
+          {
+            "line": 544,
             "complexity": 0
           },
           {
@@ -471,27 +383,39 @@
             "complexity": 0
           },
           {
-            "line": 547,
+            "line": 548,
             "complexity": 0
           },
           {
-            "line": 549,
+            "line": 552,
+            "complexity": 3
+          },
+          {
+            "line": 553,
+            "complexity": 0
+          },
+          {
+            "line": 555,
             "complexity": 0
           },
           {
             "line": 556,
-            "complexity": 0
-          },
-          {
-            "line": 560,
             "complexity": 2
           },
           {
-            "line": 561,
+            "line": 557,
             "complexity": 0
           },
           {
-            "line": 562,
+            "line": 558,
+            "complexity": 0
+          },
+          {
+            "line": 559,
+            "complexity": 1
+          },
+          {
+            "line": 560,
             "complexity": 0
           },
           {
@@ -499,23 +423,7 @@
             "complexity": 2
           },
           {
-            "line": 569,
-            "complexity": 0
-          },
-          {
             "line": 570,
-            "complexity": 0
-          },
-          {
-            "line": 577,
-            "complexity": 0
-          },
-          {
-            "line": 578,
-            "complexity": 2
-          },
-          {
-            "line": 579,
             "complexity": 0
           },
           {
@@ -523,37 +431,129 @@
             "complexity": 0
           },
           {
-            "line": 588,
+            "line": 581,
+            "complexity": 1
+          },
+          {
+            "line": 582,
             "complexity": 0
           },
           {
-            "line": 596,
+            "line": 583,
+            "complexity": 0
+          },
+          {
+            "line": 587,
+            "complexity": 0
+          },
+          {
+            "line": 593,
             "complexity": 1
+          },
+          {
+            "line": 594,
+            "complexity": 1
+          },
+          {
+            "line": 595,
+            "complexity": 0
           },
           {
             "line": 597,
             "complexity": 0
           },
           {
-            "line": 598,
-            "complexity": 1
+            "line": 604,
+            "complexity": 2
           },
           {
-            "line": 600,
+            "line": 605,
             "complexity": 0
           },
           {
-            "line": 607,
+            "line": 606,
             "complexity": 0
           },
           {
             "line": 608,
             "complexity": 0
+          },
+          {
+            "line": 615,
+            "complexity": 0
+          },
+          {
+            "line": 619,
+            "complexity": 2
+          },
+          {
+            "line": 620,
+            "complexity": 0
+          },
+          {
+            "line": 621,
+            "complexity": 0
+          },
+          {
+            "line": 627,
+            "complexity": 2
+          },
+          {
+            "line": 628,
+            "complexity": 0
+          },
+          {
+            "line": 629,
+            "complexity": 0
+          },
+          {
+            "line": 636,
+            "complexity": 0
+          },
+          {
+            "line": 637,
+            "complexity": 2
+          },
+          {
+            "line": 638,
+            "complexity": 0
+          },
+          {
+            "line": 639,
+            "complexity": 0
+          },
+          {
+            "line": 647,
+            "complexity": 0
+          },
+          {
+            "line": 655,
+            "complexity": 1
+          },
+          {
+            "line": 656,
+            "complexity": 0
+          },
+          {
+            "line": 657,
+            "complexity": 1
+          },
+          {
+            "line": 659,
+            "complexity": 0
+          },
+          {
+            "line": 666,
+            "complexity": 0
+          },
+          {
+            "line": 667,
+            "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 60
+    "complexity": 61
   },
   {
     "path": "src/immich_memories/cli/_analyze_export.py",

--- a/docs-site/docs/create/recipes/automated-generation.md
+++ b/docs-site/docs/create/recipes/automated-generation.md
@@ -60,6 +60,10 @@ appears on schedule, uploads if `upload_to_immich` is on, and notifies if notifi
 - The timer never runs when `enabled` is `false` (the default) — `auto install` stays the route
   for bare-metal installs.
 
+To fire the same decision on demand instead of on a clock — from an Immich workflow, a cron on
+another machine, a phone shortcut — see
+[Trigger from Immich or Anything Else](./trigger-endpoint.md).
+
 ## Scheduler daemon (advanced/legacy)
 
 :::tip Use the `auto` system instead

--- a/docs-site/docs/create/recipes/tips-and-best-practices.md
+++ b/docs-site/docs/create/recipes/tips-and-best-practices.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Tips & Best Practices
 ---
 

--- a/docs-site/docs/create/recipes/trigger-endpoint.md
+++ b/docs-site/docs/create/recipes/trigger-endpoint.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 3
+title: Trigger from Immich or Anything Else
+---
+
+# Trigger from Immich or Anything Else
+
+The server accepts one POST that starts a memory. It takes no parameters: it runs exactly the
+decision `immich-memories auto run` would have made — same detectors, same variety rules, same
+cooldown, same history. You are choosing *when*, not *what*.
+
+That makes it the piece Immich Workflows was missing. A workflow that fires when an album fills
+up, a cron on another box, a phone shortcut, a Home Assistant automation — anything that can make
+an HTTP request can now start a memory.
+
+## Turn it on
+
+The endpoint is **not served at all** unless something can authenticate the caller. This process
+holds your Immich API key, so an anonymous request that could spend it is not a thing that exists.
+
+| `auth.enabled` | `server.trigger_token` | `POST /api/trigger` |
+|---|---|---|
+| off | unset | **404** — the route is not enabled |
+| off | set | token required |
+| on | unset | logged-in session required (browsers only) |
+| on | set | token **or** session |
+
+For headless callers, set a token:
+
+```yaml
+advanced:
+  server:
+    trigger_token: "${IMMICH_MEMORIES_TRIGGER_TOKEN}"
+```
+
+Generate something long and random (`openssl rand -hex 32`) and keep it in the environment rather
+than in `config.yaml` — `IMMICH_MEMORIES_SERVER__TRIGGER_TOKEN` works too. The value is compared in
+constant time and redacted from logs, `/health`, and the config viewer like every other secret.
+
+The token is a shared secret over whatever transport your server already uses. If the UI is
+reachable from outside your LAN, put it behind the same HTTPS reverse proxy you use for the web
+interface — a token sent over plain HTTP is a token you have published.
+
+## Start a run
+
+```bash
+curl -X POST https://memories.example.com/api/trigger \
+  -H "x-api-key: $IMMICH_MEMORIES_TRIGGER_TOKEN"
+```
+
+```json
+{
+  "status": "accepted",
+  "attempt_id": "6f1c2a54-9d0e-4c31-9f6a-2c1d0b7e8a44",
+  "status_url": "/api/trigger/6f1c2a54-9d0e-4c31-9f6a-2c1d0b7e8a44"
+}
+```
+
+`202 Accepted`, not `200 OK` — a generation takes minutes to hours, so the call returns the moment
+the run is booked. `Authorization: Bearer <token>` works in place of `x-api-key` if your caller
+prefers it.
+
+**409 Conflict** means a run is already going, and the body names it:
+
+```json
+{ "detail": "a run is already active", "attempt_id": "…" }
+```
+
+One automation decision runs at a time, enforced by the same lock the nightly timer and
+`immich-memories auto run` use. A trigger cannot make two generations fight over your GPU.
+
+## Poll for progress
+
+```bash
+curl -s https://memories.example.com/api/trigger/$ATTEMPT_ID \
+  -H "x-api-key: $IMMICH_MEMORIES_TRIGGER_TOKEN"
+```
+
+```json
+{
+  "attempt_id": "6f1c2a54-9d0e-4c31-9f6a-2c1d0b7e8a44",
+  "state": "running",
+  "reason": "http trigger",
+  "started_at": "2026-08-24T09:15:02+00:00",
+  "finished_at": null,
+  "phase": "analysis",
+  "memory_type": "monthly_highlights",
+  "error": null,
+  "run": null
+}
+```
+
+`phase` is live: the generation reports each pipeline stage back as it goes, so you see
+`discovery` → `analysis` → `assembly` rather than a flat "running". When it finishes, `state`
+becomes one of `completed`, `failed`, `skipped`, or `dry_run`, and `run` carries the record from
+the run database — run id, status, output duration, and the Immich asset id if it was uploaded.
+
+`skipped` is a normal answer, not a failure. The trigger runs what `auto run` decides, and `auto
+run` declines when the cooldown is still active or nothing scored well enough. `reason` says which.
+
+## From an Immich workflow
+
+Immich Workflows can call an external URL when something happens in your library. Point one at
+`/api/trigger` with the token header and you have "when this happens in Immich, make a memory".
+
+Two things worth knowing before you wire it up:
+
+- **The cooldown still applies.** A workflow that fires on every upload will mostly get `skipped`
+  back, which is the system working. Pick a trigger that fires about as often as you want videos.
+- **The server picks the memory.** A workflow that fires on a trip album does not generate *that*
+  album — it asks for the best candidate right now, which may be something else entirely. If you
+  want a specific memory, use the CLI or the web UI.
+
+## Turning it off
+
+Clear `server.trigger_token`. With authentication also off, the routes stop being served and go
+back to answering 404.

--- a/docs-site/docs/deploy/configuration/authentication.mdx
+++ b/docs-site/docs/deploy/configuration/authentication.mdx
@@ -287,6 +287,9 @@ In your config YAML, set `trusted_proxies` to Traefik's container IP (prefer a s
   doesn't accumulate one file per drive-by request.
 - Logout via the sidebar button or by navigating to `/logout`.
 - OIDC logout redirects to the IdP's `end_session_endpoint` when available (the IdP terminates the SSO session too). Falls back to a local-only logout if the IdP doesn't advertise that endpoint.
+- A session is for browsers. Scripts and workflows authenticate to
+  [the trigger endpoint](../../create/recipes/trigger-endpoint.md) with `server.trigger_token`
+  instead — no cookie, no login page.
 
 :::warning Behind a reverse proxy: bind locally, name the proxy, mark the cookie Secure
 

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -563,12 +563,20 @@ server:
   port: 8080                     # Listen port (1-65535)
   enable_demo_mode: false        # Show the demo/privacy (blur) toggle in the sidebar
   secure_cookies: false          # Mark the session cookie Secure (turn on behind an HTTPS reverse proxy)
+  trigger_token: ""              # Shared secret for POST /api/trigger. Empty, and with auth
+                                 # off, the trigger API is not served at all
   allow_unauthenticated_lan: false  # Listen beyond localhost with auth disabled —
                                  # anyone reaching the port can use the UI and the
                                  # Immich library behind it
 ```
 
 These can also be set via CLI flags: `immich-memories ui --host 127.0.0.1 --port 9090`.
+
+`trigger_token` turns on the HTTP trigger — one POST that runs whatever `auto run` would have
+decided, so an Immich workflow (or a cron, or a phone shortcut) can start a memory. See
+[Trigger from Immich or anything else](../create/recipes/trigger-endpoint.md). Keep it out of
+`config.yaml` with `IMMICH_MEMORIES_SERVER__TRIGGER_TOKEN` or a `${VAR}` reference; either way it
+is redacted from logs, `/health`, and the config viewer like every other secret.
 
 `host` is the one value "save" leaves out of `config.yaml` when you never set it. Writing the
 `0.0.0.0` default would make the next load treat it as your decision and quietly retire the

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'create/recipes/birthday-compilations',
             'create/recipes/automated-generation',
+            'create/recipes/trigger-endpoint',
             'create/recipes/tips-and-best-practices',
           ],
         },

--- a/src/immich_memories/automation/runner.py
+++ b/src/immich_memories/automation/runner.py
@@ -61,7 +61,8 @@ class AutomationLease:
         self._lock_path = lock_path
         self._fd: Any = None
 
-    def __enter__(self) -> AutomationLease:
+    def acquire(self) -> None:
+        """Take the lease, or refuse because another process already holds it."""
         import fcntl
 
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -72,15 +73,57 @@ class AutomationLease:
             self._fd.close()
             self._fd = None
             raise AutomationAlreadyRunningError("automation already running") from None
-        return self
 
-    def __exit__(self, *exc: object) -> None:
+    def release(self) -> None:
+        """Drop the lease. Safe to call when it was never taken."""
         import fcntl
 
         if self._fd is not None:
             fcntl.flock(self._fd, fcntl.LOCK_UN)
             self._fd.close()
             self._fd = None
+
+    def __enter__(self) -> AutomationLease:
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.release()
+
+
+@dataclass(frozen=True)
+class StartedAutoRun:
+    """A held automation lease plus the durable attempt that owns it.
+
+    WHY this exists apart from `run_one`: an HTTP trigger has to answer with an
+    identifier while the generation it started is still hours from finishing, so
+    the attempt must become durable before the work runs — and the lease has to
+    survive the handover to whatever thread executes it.
+    """
+
+    runner: AutoRunner
+    attempt: AutomationAttempt
+    lease: AutomationLease
+
+    def execute(
+        self,
+        *,
+        force: bool = False,
+        cooldown_hours: int | None = None,
+        upload: bool = False,
+        dry_run: bool = False,
+    ) -> AutoRunResult:
+        """Run the decision this attempt owns, releasing its lease when it ends."""
+        try:
+            return self.runner._run_one_under_lease(
+                self.attempt,
+                force=force,
+                cooldown_hours=cooldown_hours,
+                upload=upload,
+                dry_run=dry_run,
+            )
+        finally:
+            self.lease.release()
 
 
 @dataclass(frozen=True)
@@ -438,6 +481,25 @@ class AutoRunner:
         self.last_backoff_skips = discovered.backoff_skips
         return discovered.candidates
 
+    def start_one(self, *, reason: str = "daily wake") -> StartedAutoRun:
+        """Take the automation lease and open the durable attempt that owns it.
+
+        The caller must execute the returned handle — that is what releases the
+        lease. `reason` becomes the attempt's history entry, so a triggered run
+        is told apart from a nightly one everywhere automation is inspected.
+
+        Raises:
+            AutomationAlreadyRunningError: another process holds the lease.
+        """
+        lease = AutomationLease(self.config.cache.database_path.parent / ".auto.lock")
+        lease.acquire()
+        try:
+            attempt = self.state.start_attempt(reason=reason)
+        except BaseException:
+            lease.release()
+            raise
+        return StartedAutoRun(self, attempt, lease)
+
     def run_one(
         self,
         *,
@@ -447,22 +509,19 @@ class AutoRunner:
         dry_run: bool = False,
     ) -> AutoRunResult:
         """Run one durable automation decision and return its exact outcome."""
-        lease_path = self.config.cache.database_path.parent / ".auto.lock"
         try:
-            with AutomationLease(lease_path):
-                attempt = self.state.start_attempt(reason="daily wake")
-                return self._run_one_under_lease(
-                    attempt,
-                    force=force,
-                    cooldown_hours=cooldown_hours,
-                    upload=upload,
-                    dry_run=dry_run,
-                )
+            started = self.start_one()
         except AutomationAlreadyRunningError:
             return AutoRunResult(
                 outcome=AutoOutcome.SKIPPED,
                 reason="automation already running",
             )
+        return started.execute(
+            force=force,
+            cooldown_hours=cooldown_hours,
+            upload=upload,
+            dry_run=dry_run,
+        )
 
     def _run_one_under_lease(
         self,

--- a/src/immich_memories/automation/state_store.py
+++ b/src/immich_memories/automation/state_store.py
@@ -207,6 +207,14 @@ class AutomationStateStore:
         assert row is not None
         return _row_to_attempt(row)
 
+    def get_attempt(self, attempt_id: str) -> AutomationAttempt | None:
+        """Return one attempt by id, or None when nothing was ever started under it."""
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM automation_attempts WHERE id = ?", (attempt_id,)
+            ).fetchone()
+        return _row_to_attempt(row) if row else None
+
     def get_last_attempt(self) -> AutomationAttempt | None:
         """Return the most recently started automation attempt."""
         with self._get_connection() as conn:

--- a/src/immich_memories/config_models_server.py
+++ b/src/immich_memories/config_models_server.py
@@ -22,6 +22,13 @@ class ServerConfig(BaseModel):
         default=False,
         description="Mark the session cookie Secure (only when every visitor arrives over HTTPS)",
     )
+    trigger_token: str = Field(
+        default="",
+        description=(
+            "Shared secret a headless caller sends to POST /api/trigger. Unset, and "
+            "with authentication off, the trigger API is not served at all."
+        ),
+    )
     allow_unauthenticated_lan: bool = Field(
         default=False,
         description=(

--- a/src/immich_memories/security.py
+++ b/src/immich_memories/security.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 # Control characters for sanitizing filenames
 _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
 # Field names that hold a secret, wherever they appear in the config tree.
-CREDENTIAL_FIELD_NAMES = frozenset({"api_key", "password", "client_secret"})
+CREDENTIAL_FIELD_NAMES = frozenset({"api_key", "password", "client_secret", "trigger_token"})
 
 
 def write_secret_file(path: Path, text: str) -> None:

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -38,12 +38,15 @@ from immich_memories.ui.auth import (
     is_bypass_path,
     is_health_probe_path,
     is_rate_limited,
+    is_trigger_path,
     is_trusted_proxy,
     set_session,
+    trigger_token_authorizes,
 )
 from immich_memories.ui.reverse_proxy import reverse_proxy_run_kwargs
 from immich_memories.ui.state import ensure_config, get_app_state
 from immich_memories.ui.theme import apply_theme, render_theme_toggle
+from immich_memories.ui.trigger_api import register_trigger_routes
 
 logger = logging.getLogger(__name__)
 
@@ -587,6 +590,10 @@ app.add_api_route("/health", _health_handler, methods=["GET"])
 app.add_api_route("/health/live", _liveness_handler, methods=["GET"])
 app.add_api_route("/health/ready", _readiness_handler, methods=["GET"])
 
+# The URL an Immich workflow (or anything else) POSTs to. Off unless authentication
+# or `server.trigger_token` is configured — see ui/trigger_api.py.
+register_trigger_routes(app)
+
 
 # ============================================================================
 # Auth: Middleware + Routes
@@ -636,6 +643,13 @@ def _check_session_ttl(ttl_hours: int) -> RedirectResponse | None:
     return None
 
 
+def _unauthenticated_response(path: str) -> Response:
+    """Send an API caller a status it can act on, and a browser to the login page."""
+    if is_trigger_path(path):
+        return JSONResponse({"detail": "authentication required"}, status_code=401)
+    return RedirectResponse("/login", status_code=307)
+
+
 @app.middleware("http")
 async def _auth_middleware(request: Request, call_next):
     """Provider-agnostic auth check using NiceGUI's app.storage.user.
@@ -658,11 +672,14 @@ async def _auth_middleware(request: Request, call_next):
                 return blocked
         return await call_next(request)
 
+    if trigger_token_authorizes(request.url.path, request.headers, config.server.trigger_token):
+        return await call_next(request)
+
     if config.auth.provider == "header":
         _try_header_auth(request, config.auth)
 
     if not app.storage.user.get("authenticated"):
-        return RedirectResponse("/login", status_code=307)
+        return _unauthenticated_response(request.url.path)
 
     expired = _check_session_ttl(config.auth.session_ttl_hours)
     if expired:

--- a/src/immich_memories/ui/auth.py
+++ b/src/immich_memories/ui/auth.py
@@ -10,7 +10,7 @@ import ipaddress
 import logging
 import secrets
 import threading
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from datetime import UTC, datetime
 
 import nicegui
@@ -105,6 +105,52 @@ def verify_credentials(username: str, password: str, auth_config: AuthConfig) ->
     username_ok = secrets.compare_digest(username, auth_config.username)
     password_ok = secrets.compare_digest(password, auth_config.password)
     return username_ok and password_ok
+
+
+# The HTTP trigger API. Not a bypass path: a caller without a valid token still
+# has to be a logged-in session, which is what the auth middleware decides.
+_TRIGGER_PREFIX = "/api/trigger"
+
+
+def is_trigger_path(path: str) -> bool:
+    """Whether a path belongs to the HTTP trigger API."""
+    return path == _TRIGGER_PREFIX or path.startswith(f"{_TRIGGER_PREFIX}/")
+
+
+def presented_trigger_token(headers: Mapping[str, str]) -> str:
+    """The trigger token a caller offered, from either header the API accepts.
+
+    `x-api-key` is what Immich's own API takes, so a workflow calling us looks
+    like a workflow calling Immich; `Authorization: Bearer` is what everything
+    else reaches for. Anything else counts as no offer at all.
+    """
+    if api_key := headers.get("x-api-key", ""):
+        return api_key
+    scheme, _, value = headers.get("authorization", "").partition(" ")
+    return value.strip() if scheme.lower() == "bearer" else ""
+
+
+def trigger_token_matches(presented: str, configured: str) -> bool:
+    """Constant-time comparison that refuses an unset token.
+
+    Without the emptiness guard an operator who never set `server.trigger_token`
+    would be authorizing every caller who also sends nothing.
+    """
+    if not configured or not presented:
+        return False
+    return secrets.compare_digest(presented, configured)
+
+
+def trigger_token_authorizes(path: str, headers: Mapping[str, str], configured_token: str) -> bool:
+    """Whether a trigger token lets this request skip the session check.
+
+    The middleware asks this before anything reads `app.storage.user`: a headless
+    caller sends no session cookie, so touching NiceGUI's user store for one would
+    both fail and mint a session file per request.
+    """
+    if not is_trigger_path(path):
+        return False
+    return trigger_token_matches(presented_trigger_token(headers), configured_token)
 
 
 def _parse_proxy_networks(

--- a/src/immich_memories/ui/pages/settings_config.py
+++ b/src/immich_memories/ui/pages/settings_config.py
@@ -22,6 +22,7 @@ _SENSITIVE_KEYS = {
     "password",
     "secret",
     "token",
+    "trigger_token",
     "urls",
 }
 

--- a/src/immich_memories/ui/trigger_api.py
+++ b/src/immich_memories/ui/trigger_api.py
@@ -1,0 +1,193 @@
+"""The HTTP trigger API: one POST that runs the decision `auto run` would make.
+
+Immich's Workflows can call an external URL when something happens in the library.
+This is the URL. It takes no parameters on purpose — the server decides what to
+generate, through exactly the machinery the nightly timer and the CLI already use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from immich_memories.automation.models import AutoOutcome
+from immich_memories.automation.runner import (
+    AutomationAlreadyRunningError,
+    AutoRunner,
+    StartedAutoRun,
+)
+from immich_memories.automation.state_store import AutomationStateStore
+from immich_memories.config import get_config
+from immich_memories.tracking.run_database import RunDatabase
+from immich_memories.ui.auth import (
+    is_auth_enabled,
+    presented_trigger_token,
+    trigger_token_matches,
+)
+
+if TYPE_CHECKING:
+    from immich_memories.config_loader import Config
+
+logger = logging.getLogger(__name__)
+
+TRIGGER_PATH = "/api/trigger"
+
+# What the attempt history records for a run somebody asked for over HTTP, so
+# `auto status` and /health can tell it apart from the nightly wake.
+TRIGGER_REASON = "http trigger"
+
+# The run fields a caller polling for its artifact actually needs. The full record
+# carries host paths and person names that this contract has no reason to promise.
+_RUN_FIELDS = (
+    "run_id",
+    "status",
+    "created_at",
+    "completed_at",
+    "last_phase",
+    "output_duration_seconds",
+    "delivery_status",
+    "immich_asset_id",
+)
+
+# asyncio keeps only a weak reference to a bare task, so a fire-and-forget
+# generation can be collected mid-run. These are the strong ones.
+_running: set[asyncio.Task[Any]] = set()
+
+
+def trigger_enabled(config: Config) -> bool:
+    """Whether anything at all authenticates a caller of the trigger API.
+
+    With neither authentication nor a token the routes answer 404: this process
+    holds an Immich API key, and nobody who merely reached the port may spend it.
+    """
+    return is_auth_enabled(config.auth) or bool(config.server.trigger_token)
+
+
+def _authorized(request: Request, config: Config) -> bool:
+    """Whether this request may start work, by token or by the session behind it."""
+    if presented := presented_trigger_token(request.headers):
+        return trigger_token_matches(presented, config.server.trigger_token)
+    # Nothing offered. With auth on, the middleware has already proven a session
+    # got this far; with auth off, a token was the only thing that could have.
+    return is_auth_enabled(config.auth)
+
+
+def _submit_to_background(started: StartedAutoRun) -> None:
+    """Run the accepted decision off the request path.
+
+    A generation blocks for up to two hours, so it goes to a worker thread the
+    same way the in-process daily timer sends its own.
+    """
+    task = asyncio.create_task(asyncio.to_thread(_execute, started))
+    _running.add(task)
+    task.add_done_callback(_running.discard)
+
+
+def _execute(started: StartedAutoRun) -> None:
+    """Execute one accepted decision, leaving its record to the runner."""
+    result = started.execute()
+    logger.info("Triggered automation: %s (%s)", result.outcome.value, result.reason)
+
+
+def _start(config: Config) -> StartedAutoRun | None:
+    """Take the automation lease, or None when another run already holds it."""
+    try:
+        return AutoRunner(config).start_one(reason=TRIGGER_REASON)
+    except AutomationAlreadyRunningError:
+        return None
+
+
+def _active_attempt_id(config: Config) -> str | None:
+    """The id of the run holding the lease, as far as durable history can tell."""
+    last = AutomationStateStore(config.cache.database_path).get_last_attempt()
+    return last.id if last is not None and last.outcome is AutoOutcome.RUNNING else None
+
+
+def _attempt_payload(config: Config, attempt_id: str) -> dict[str, Any] | None:
+    """One attempt's live state, plus its run record once generation produced one."""
+    attempt = AutomationStateStore(config.cache.database_path).get_attempt(attempt_id)
+    if attempt is None:
+        return None
+    return {
+        "attempt_id": attempt.id,
+        "state": attempt.outcome.value,
+        "reason": attempt.reason,
+        "started_at": attempt.started_at.isoformat(),
+        "finished_at": attempt.finished_at.isoformat() if attempt.finished_at else None,
+        # The generation subprocess reports its pipeline phase back to this row,
+        # so a caller polling mid-run sees where it is rather than just "running".
+        "phase": attempt.last_phase.value if attempt.last_phase else None,
+        "memory_type": attempt.memory_type,
+        # Already sanitized by the runner before it was persisted.
+        "error": attempt.error,
+        "run": _run_payload(config, attempt.run_id),
+    }
+
+
+def _run_payload(config: Config, run_id: str | None) -> dict[str, Any] | None:
+    if run_id is None:
+        return None
+    run = RunDatabase(db_path=config.cache.database_path).get_run(run_id)
+    if run is None:
+        return None
+    record = run.to_dict()
+    return {field: record[field] for field in _RUN_FIELDS}
+
+
+def _refused(config: Config, request: Request) -> JSONResponse | None:
+    """The response an ineligible caller gets, or None to let the request through."""
+    if not trigger_enabled(config):
+        return JSONResponse({"detail": "trigger API is not enabled"}, status_code=404)
+    if not _authorized(request, config):
+        return JSONResponse({"detail": "invalid trigger token"}, status_code=401)
+    return None
+
+
+def register_trigger_routes(
+    server: Any,
+    *,
+    submit: Callable[[StartedAutoRun], None] = _submit_to_background,
+) -> None:
+    """Attach the trigger API to a server, with `submit` running accepted decisions."""
+
+    async def trigger(request: Request) -> JSONResponse:
+        config = get_config()
+        if refused := _refused(config, request):
+            return refused
+
+        started = await asyncio.to_thread(_start, config)
+        if started is None:
+            active = await asyncio.to_thread(_active_attempt_id, config)
+            return JSONResponse(
+                {"detail": "a run is already active", "attempt_id": active},
+                status_code=409,
+            )
+
+        submit(started)
+        return JSONResponse(
+            {
+                "status": "accepted",
+                "attempt_id": started.attempt.id,
+                "status_url": f"{TRIGGER_PATH}/{started.attempt.id}",
+            },
+            status_code=202,
+        )
+
+    async def trigger_status(request: Request) -> JSONResponse:
+        config = get_config()
+        if refused := _refused(config, request):
+            return refused
+
+        attempt_id = request.path_params["attempt_id"]
+        payload = await asyncio.to_thread(_attempt_payload, config, attempt_id)
+        if payload is None:
+            return JSONResponse({"detail": "unknown attempt"}, status_code=404)
+        return JSONResponse(payload)
+
+    server.add_api_route(TRIGGER_PATH, trigger, methods=["POST"])
+    server.add_api_route(f"{TRIGGER_PATH}/{{attempt_id}}", trigger_status, methods=["GET"])

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -23,6 +23,7 @@ from immich_memories.automation.candidate_scorer import score_and_rank
 from immich_memories.automation.candidates import CandidateCategory, MemoryCandidate
 from immich_memories.automation.models import AutoOutcome, ProcessResult
 from immich_memories.automation.runner import (
+    AutomationAlreadyRunningError,
     AutoRunner,
     _build_generate_command,
     _execute_generate,
@@ -1783,3 +1784,47 @@ class TestFailedCandidateBackoff:
         target, after = self._suggest_with_failures(config, failures=1)
 
         assert target in {c.memory_key for c in after}
+
+
+class TestStartedAutoRun:
+    """The seam the HTTP trigger needs: an id now, the generation afterwards."""
+
+    def test_started_attempt_is_durable_before_the_run_executes(self, config: Config) -> None:
+        runner = AutoRunner(config)
+
+        started = runner.start_one(reason="http trigger")
+        try:
+            stored = runner.state.get_attempt(started.attempt.id)
+        finally:
+            started.execute(force=True, dry_run=True)
+
+        assert stored is not None
+        assert stored.outcome is AutoOutcome.RUNNING
+        assert stored.reason == "http trigger"
+
+    def test_a_held_lease_refuses_a_second_start(self, config: Config) -> None:
+        """One automation decision at a time, whoever asked for it."""
+        started = AutoRunner(config).start_one(reason="http trigger")
+        try:
+            with pytest.raises(AutomationAlreadyRunningError):
+                AutoRunner(config).start_one(reason="daily wake")
+        finally:
+            started.execute(force=True, dry_run=True)
+
+    def test_executing_releases_the_lease_for_the_next_caller(self, config: Config) -> None:
+        AutoRunner(config).start_one(reason="http trigger").execute(force=True, dry_run=True)
+
+        AutoRunner(config).start_one(reason="daily wake").execute(force=True, dry_run=True)
+
+    def test_run_one_still_skips_rather_than_raising_when_the_lease_is_held(
+        self, config: Config
+    ) -> None:
+        """The CLI and the daily timer keep their old, non-raising contract."""
+        started = AutoRunner(config).start_one(reason="http trigger")
+        try:
+            result = AutoRunner(config).run_one()
+        finally:
+            started.execute(force=True, dry_run=True)
+
+        assert result.outcome is AutoOutcome.SKIPPED
+        assert result.reason == "automation already running"

--- a/tests/test_trigger_endpoint.py
+++ b/tests/test_trigger_endpoint.py
@@ -1,0 +1,344 @@
+"""The HTTP trigger: one POST that runs the decision `auto run` would make."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from immich_memories.automation.runner import StartedAutoRun
+from immich_memories.config_loader import Config
+from immich_memories.security import configured_secret_values
+
+TOKEN = "workflow-token"  # noqa: S105
+
+
+def _config(tmp_path: Path, **server: object) -> Config:
+    return Config(
+        immich={"url": "http://immich.test", "api_key": "immich-key"},
+        cache={"database": str(tmp_path / "runs.db"), "directory": str(tmp_path / "cache")},
+        server={"trigger_token": TOKEN, **server},
+    )
+
+
+@contextmanager
+def _serving(config: Config) -> Iterator[None]:
+    """Answer requests from *config* rather than from whatever this machine has."""
+    # WHY: replaces the on-disk config file the server reads on every request.
+    with patch("immich_memories.ui.trigger_api.get_config", return_value=config):
+        yield
+
+
+class _RecordingWorker:
+    """The background worker, replaced by one that only hands the lease back.
+
+    Executing for real would run a generation subprocess for up to two hours;
+    everything up to the handover — lease, attempt row, response — stays real.
+    """
+
+    def __init__(self) -> None:
+        self.submitted: list[StartedAutoRun] = []
+
+    def __call__(self, started: StartedAutoRun) -> None:
+        self.submitted.append(started)
+        started.lease.release()
+
+
+@pytest.fixture
+def worker() -> _RecordingWorker:
+    return _RecordingWorker()
+
+
+@pytest.fixture
+def client(worker: _RecordingWorker) -> TestClient:
+    """A bare app carrying only the trigger routes, wired to the fake worker."""
+    from immich_memories.ui.trigger_api import register_trigger_routes
+
+    app = FastAPI()
+    register_trigger_routes(app, submit=worker)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestTriggerTokenIsASecret:
+    def test_configured_token_joins_the_redacted_credential_inventory(self) -> None:
+        """Anything that can start a run must never reach a log or /health verbatim."""
+        config = Config(server={"trigger_token": "workflow-token-secret"})
+
+        assert "workflow-token-secret" in configured_secret_values(config)
+
+    def test_the_config_viewer_masks_it_like_every_other_secret(self) -> None:
+        from immich_memories.ui.pages.settings_config import redact_config
+
+        redacted = redact_config({"server": {"trigger_token": "workflow-token-secret"}})
+
+        assert redacted["server"]["trigger_token"] == "***"  # noqa: S105
+
+
+class TestTriggerIsOffUntilSomethingAuthenticatesIt:
+    """This process holds an Immich API key; an anonymous caller cannot spend it."""
+
+    @pytest.mark.parametrize(
+        ("auth", "server", "expected"),
+        [
+            ({}, {}, False),
+            ({}, {"trigger_token": "workflow-token"}, True),
+            ({"enabled": True, "username": "u", "password": "p"}, {}, True),
+            (
+                {"enabled": True, "username": "u", "password": "p"},
+                {"trigger_token": "workflow-token"},
+                True,
+            ),
+        ],
+    )
+    def test_endpoint_requires_auth_or_a_token(
+        self, auth: dict, server: dict, expected: bool
+    ) -> None:
+        from immich_memories.ui.trigger_api import trigger_enabled
+
+        assert trigger_enabled(Config(auth=auth, server=server)) is expected
+
+
+class TestTokenPresentation:
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {"x-api-key": "workflow-token"},
+            {"X-API-Key": "workflow-token"},
+            {"authorization": "Bearer workflow-token"},
+            {"authorization": "bearer workflow-token"},
+        ],
+    )
+    def test_either_header_carries_the_token(self, headers: dict) -> None:
+        """Immich's own API speaks x-api-key; everything else speaks Bearer."""
+        from starlette.datastructures import Headers
+
+        from immich_memories.ui.auth import presented_trigger_token
+
+        assert presented_trigger_token(Headers(headers)) == "workflow-token"
+
+    @pytest.mark.parametrize(
+        "headers", [{}, {"authorization": "Basic dXNlcjpwYXNz"}, {"x-api-key": ""}]
+    )
+    def test_nothing_else_counts_as_an_offer(self, headers: dict) -> None:
+        from starlette.datastructures import Headers
+
+        from immich_memories.ui.auth import presented_trigger_token
+
+        assert presented_trigger_token(Headers(headers)) == ""
+
+    @pytest.mark.parametrize(
+        ("presented", "configured", "expected"),
+        [
+            ("workflow-token", "workflow-token", True),
+            ("workflow-toke", "workflow-token", False),
+            ("", "", False),
+            ("anything", "", False),
+        ],
+    )
+    def test_an_unset_token_authorizes_nobody(
+        self, presented: str, configured: str, expected: bool
+    ) -> None:
+        """A blank config value must not turn a blank header into a valid caller."""
+        from immich_memories.ui.auth import trigger_token_matches
+
+        assert trigger_token_matches(presented, configured) is expected
+
+
+class TestPostEnqueuesOneDecision:
+    def test_accepted_call_answers_with_the_attempt_it_started(
+        self, client: TestClient, worker: _RecordingWorker, tmp_path: Path
+    ) -> None:
+        """A workflow gets an id back immediately; the generation is still ahead of it."""
+        from immich_memories.automation.models import AutoOutcome
+        from immich_memories.automation.state_store import AutomationStateStore
+
+        config = _config(tmp_path)
+        with _serving(config):
+            response = client.post("/api/trigger", headers={"x-api-key": TOKEN})
+
+        body = response.json()
+        assert response.status_code == 202
+        assert body["status"] == "accepted"
+        assert body["status_url"] == f"/api/trigger/{body['attempt_id']}"
+        assert [started.attempt.id for started in worker.submitted] == [body["attempt_id"]]
+
+        stored = AutomationStateStore(config.cache.database_path).get_attempt(body["attempt_id"])
+        assert stored is not None
+        assert stored.outcome is AutoOutcome.RUNNING
+        assert stored.reason == "http trigger"
+
+    def test_a_second_call_while_a_run_is_active_reports_the_active_one(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Single-flight is the existing lease, so a CLI run blocks a trigger too."""
+        from immich_memories.automation.runner import AutoRunner
+
+        config = _config(tmp_path)
+        active = AutoRunner(config).start_one(reason="daily wake")
+        try:
+            with _serving(config):
+                response = client.post("/api/trigger", headers={"x-api-key": TOKEN})
+        finally:
+            active.lease.release()
+
+        assert response.status_code == 409
+        assert response.json()["attempt_id"] == active.attempt.id
+
+    @pytest.mark.parametrize(
+        "headers", [{}, {"x-api-key": "wrong-token"}, {"authorization": "Bearer wrong-token"}]
+    )
+    def test_a_caller_without_the_token_starts_nothing(
+        self, client: TestClient, worker: _RecordingWorker, tmp_path: Path, headers: dict
+    ) -> None:
+        config = _config(tmp_path)
+        with _serving(config):
+            response = client.post("/api/trigger", headers=headers)
+
+        assert response.status_code == 401
+        assert worker.submitted == []
+
+    def test_the_routes_are_absent_when_nothing_authenticates_them(
+        self, client: TestClient, worker: _RecordingWorker, tmp_path: Path
+    ) -> None:
+        """No auth and no token: this process holds an Immich key, so there is no endpoint."""
+        config = _config(tmp_path, trigger_token="")
+        with _serving(config):
+            response = client.post("/api/trigger")
+
+        assert response.status_code == 404
+        assert worker.submitted == []
+
+
+class TestStatusReportsWhatTheRunIsDoing:
+    def _get(self, client: TestClient, config: Config, attempt_id: str):
+        with _serving(config):
+            return client.get(f"/api/trigger/{attempt_id}", headers={"x-api-key": TOKEN})
+
+    def test_an_id_nobody_started_is_a_404(self, client: TestClient, tmp_path: Path) -> None:
+        response = self._get(client, _config(tmp_path), "never-started")
+
+        assert response.status_code == 404
+
+    def test_a_running_attempt_reports_the_phase_the_generation_reached(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """The generation subprocess writes its phase to this row, so polling shows progress."""
+        from immich_memories.automation.state_store import AutomationStateStore
+        from immich_memories.operations.phases import OperationalPhase, PhaseEvent
+
+        config = _config(tmp_path)
+        store = AutomationStateStore(config.cache.database_path)
+        attempt = store.start_attempt(reason="http trigger")
+        store.update_phase(attempt.id, PhaseEvent(OperationalPhase.ANALYSIS, 3, 10, "scoring", 0.3))
+
+        body = self._get(client, config, attempt.id).json()
+
+        assert body["state"] == "running"
+        assert body["phase"] == OperationalPhase.ANALYSIS.value
+        assert body["run"] is None
+
+    def test_a_completed_attempt_carries_its_record_from_the_run_database(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from immich_memories.automation.models import AutoOutcome
+        from immich_memories.automation.state_store import AutomationStateStore
+        from immich_memories.tracking.models import RunMetadata
+        from immich_memories.tracking.run_database import RunDatabase
+
+        config = _config(tmp_path)
+        RunDatabase(db_path=config.cache.database_path).save_run(
+            RunMetadata(
+                run_id="20260824_120000_abcd",
+                created_at=datetime.now(tz=UTC),
+                completed_at=datetime.now(tz=UTC),
+                status="completed",
+                source="auto",
+                output_duration_seconds=182.5,
+            )
+        )
+        store = AutomationStateStore(config.cache.database_path)
+        attempt = store.start_attempt(reason="http trigger")
+        store.finish_attempt(
+            attempt.id,
+            AutoOutcome.COMPLETED,
+            "generation completed",
+            run_id="20260824_120000_abcd",
+        )
+
+        body = self._get(client, config, attempt.id).json()
+
+        assert body["state"] == "completed"
+        assert body["run"]["run_id"] == "20260824_120000_abcd"
+        assert body["run"]["status"] == "completed"
+        assert body["run"]["output_duration_seconds"] == 182.5
+
+    def test_status_needs_the_same_token_the_post_did(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        config = _config(tmp_path)
+        with _serving(config):
+            response = client.get("/api/trigger/anything")
+
+        assert response.status_code == 401
+
+
+class TestTheAuthMiddlewareKnowsAboutHeadlessCallers:
+    @pytest.mark.asyncio
+    async def test_a_valid_token_is_not_sent_to_the_login_page(self, tmp_path: Path) -> None:
+        """A workflow has no session cookie; reading NiceGUI's user storage for it fails."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from starlette.datastructures import Headers
+
+        from immich_memories.ui.app import _auth_middleware
+
+        config = _config(tmp_path)
+        config.auth.enabled = True
+        config.auth.username = "operator"
+        config.auth.password = "operator-password"  # noqa: S105
+        request = MagicMock()
+        request.url.path = "/api/trigger"
+        request.headers = Headers({"x-api-key": TOKEN})
+        response = MagicMock(name="trigger_response")
+        call_next = AsyncMock(return_value=response)
+
+        # WHY: replaces the on-disk config the middleware loads for every request.
+        with patch("immich_memories.ui.app.get_config", return_value=config):
+            actual = await _auth_middleware(request, call_next)
+
+        assert actual is response
+
+    def test_an_api_caller_without_credentials_gets_a_status_it_can_act_on(self) -> None:
+        from immich_memories.ui.app import _unauthenticated_response
+
+        assert _unauthenticated_response("/api/trigger").status_code == 401
+
+    def test_a_browser_still_goes_to_the_login_page(self) -> None:
+        from immich_memories.ui.app import _unauthenticated_response
+
+        response = _unauthenticated_response("/step2")
+
+        assert response.status_code == 307
+        assert response.headers["location"] == "/login"
+
+    def test_the_server_users_actually_run_serves_the_trigger_route(self, tmp_path: Path) -> None:
+        """A disabled trigger says so; a route that was never registered would not."""
+        from immich_memories.ui.app import app as server
+
+        config = _config(tmp_path, trigger_token="")
+        # WHY: the same on-disk config boundary, reached by middleware and route alike.
+        with (
+            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.trigger_api.get_config", return_value=config),
+        ):
+            response = TestClient(server, raise_server_exceptions=False).post("/api/trigger")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "trigger API is not enabled"


### PR DESCRIPTION
Closes #682.

Immich shipped Workflows + Plugins — event-driven automation that can make external HTTP calls,
which their maintainer publicly blessed for "external calls to trigger things like this". We had
no URL for it to call. Now we do.

## What this adds

`POST /api/trigger` runs **exactly what `auto run` decides**. No body, no parameters, no way to
pick a memory: the caller chooses *when*, the server chooses *what*. It answers `202` with the
durable automation attempt id and a status URL, because a generation takes minutes to hours.

```console
$ curl -X POST https://memories.example.com/api/trigger -H "x-api-key: $TOKEN"
{"status":"accepted","attempt_id":"6f1c…","status_url":"/api/trigger/6f1c…"}

$ curl -s https://memories.example.com/api/trigger/6f1c… -H "x-api-key: $TOKEN"
{"state":"running","reason":"http trigger","phase":"analysis","memory_type":"monthly_highlights",…}
```

`GET /api/trigger/{attempt_id}` reports live state. `phase` is real progress, not a spinner — the
generation subprocess already writes each pipeline stage back to the attempt row, so polling shows
`discovery` → `analysis` → `assembly`. Once a run exists, the response carries its record from the
run database.

A second POST while a run is active gets `409` naming the active attempt. Single-flight is the
**existing** `.auto.lock` lease, so a trigger, a `docker exec … auto run`, and the in-process daily
timer cannot overlap — the trigger did not get its own lock to disagree with.

## Auth

| `auth.enabled` | `server.trigger_token` | `POST /api/trigger` |
|---|---|---|
| off | unset | **404 — not served** |
| off | set | token required |
| on | unset | logged-in session required |
| on | set | token **or** session |

This process holds an Immich API key, so "no authentication configured" means the routes do not
exist rather than "the routes are open". `server.trigger_token` (new, Tier 2) is compared with
`secrets.compare_digest`, joins `CREDENTIAL_FIELD_NAMES` so it is redacted from logs, `/health`,
and the config viewer, and supports `${VAR}` / `IMMICH_MEMORIES_SERVER__TRIGGER_TOKEN` like every
other secret. `x-api-key` (what Immich's own API speaks) or `Authorization: Bearer`.

The auth middleware learned two things: a valid trigger token short-circuits the session check
*before* anything reads `app.storage.user` (a headless caller has no session cookie, and touching
NiceGUI's user store for one would both fail and mint a session file per request), and an
unauthenticated API caller gets `401 JSON` instead of a `307` to a login page it cannot use.

## Reused, not reimplemented

- `AutoRunner` — the whole decision, unchanged. `run_one` is now `start_one().execute()`; the new
  `start_one` takes the lease and opens the durable attempt so an HTTP caller can be answered
  before the generation runs, and `execute` releases the lease on whatever thread finishes it.
  `run_one`'s contract (skip, don't raise, on a held lease) is unchanged and covered by a test.
- `AutomationStateStore` — one new read, `get_attempt(id)`.
- `RunMetadata.to_dict()` — the status endpoint projects a bounded subset of it rather than
  building a second serializer (or leaking host paths and person names into an API contract).
- `ui/auth.py` — token parsing and comparison sit next to `verify_credentials`, same shape.

## Tests

31 new, one behaviour per cycle: token redaction, the enable/disable matrix, header parsing
(including "a blank configured token authorizes nobody"), 202/409/401/404, live phase, the run
record, the middleware, and one test through the app users actually run to prove the routes are
wired. The route tests run against a bare FastAPI app with an injected fake worker, so the lease,
the attempt row, and the responses are all real — only the two-hour generation is not.

WHY-ratchet unchanged at 906. `make ci` green, `make docs-check` clean.

## Docs

New page: **Trigger from Immich or Anything Else** (`create/recipes/trigger-endpoint.md`), wired
into the sidebar, with the curl example, the enable/disable table, the Immich-workflow note, and
the two things that surprise people — the cooldown still applies (a workflow firing on every
upload will mostly get `skipped` back, which is correct), and the server picks the memory, so a
workflow that fires on a trip album does not generate *that* album.

## Out of scope

Choosing what to generate from the request body, webhook signatures/replay protection, and
anything in `cli/generate.py`.

On the 800-line rule that landed in #684 while this was in flight: `ui/app.py` was already at 874
before this PR and this adds 17 lines to it (the middleware branch, the 401-vs-redirect helper,
and the route registration) — the trigger's own ~190 lines went into a new module rather than
into `app.py`. `ui/app.py` is already on the list in #685; this PR does not cross the threshold,
so it does not open the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
