### PR TITLE
refactor(titles): lift backend probing out of the kernel module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,7 +259,8 @@ src/immich_memories/
 │   ├── taichi_particles.py     # ParticleField: bokeh drift / fireworks physics
 │   ├── taichi_text.py          # TitleTextRenderer: SDF + PIL text compositing
 │   ├── renderer_ffmpeg.py      # FFmpeg-based renderer
-│   ├── taichi_kernels.py       # Taichi GPU kernels
+│   ├── taichi_kernels.py       # Taichi GPU kernels + lazy compilation (init_taichi)
+│   ├── taichi_backend_probe.py # Which Taichi arch can dispatch here (isolated child probe)
 │   ├── taichi_video.py         # Taichi video creation
 │   ├── ffmpeg_pipe.py          # Feed raw frames to FFmpeg without deadlocking on an unread stderr
 │   ├── safe_zones.py           # Keep vertical titles clear of the Reels/Shorts/TikTok button rail

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -3769,12 +3769,388 @@
       {
         "name": "_compile_kernels",
         "complexity": 130,
-        "line_start": 342,
-        "line_end": 779,
+        "line_start": 168,
+        "line_end": 605,
         "line_complexities": [
           {
-            "line": 346,
+            "line": 172,
             "complexity": 2
+          },
+          {
+            "line": 189,
+            "complexity": 0
+          },
+          {
+            "line": 190,
+            "complexity": 0
+          },
+          {
+            "line": 192,
+            "complexity": 2
+          },
+          {
+            "line": 193,
+            "complexity": 0
+          },
+          {
+            "line": 194,
+            "complexity": 0
+          },
+          {
+            "line": 195,
+            "complexity": 0
+          },
+          {
+            "line": 196,
+            "complexity": 0
+          },
+          {
+            "line": 197,
+            "complexity": 0
+          },
+          {
+            "line": 198,
+            "complexity": 0
+          },
+          {
+            "line": 199,
+            "complexity": 0
+          },
+          {
+            "line": 215,
+            "complexity": 0
+          },
+          {
+            "line": 216,
+            "complexity": 0
+          },
+          {
+            "line": 217,
+            "complexity": 0
+          },
+          {
+            "line": 219,
+            "complexity": 2
+          },
+          {
+            "line": 220,
+            "complexity": 0
+          },
+          {
+            "line": 221,
+            "complexity": 0
+          },
+          {
+            "line": 222,
+            "complexity": 0
+          },
+          {
+            "line": 223,
+            "complexity": 0
+          },
+          {
+            "line": 224,
+            "complexity": 0
+          },
+          {
+            "line": 225,
+            "complexity": 0
+          },
+          {
+            "line": 226,
+            "complexity": 0
+          },
+          {
+            "line": 227,
+            "complexity": 0
+          },
+          {
+            "line": 228,
+            "complexity": 0
+          },
+          {
+            "line": 238,
+            "complexity": 0
+          },
+          {
+            "line": 239,
+            "complexity": 0
+          },
+          {
+            "line": 241,
+            "complexity": 2
+          },
+          {
+            "line": 242,
+            "complexity": 3
+          },
+          {
+            "line": 243,
+            "complexity": 0
+          },
+          {
+            "line": 244,
+            "complexity": 4
+          },
+          {
+            "line": 245,
+            "complexity": 0
+          },
+          {
+            "line": 246,
+            "complexity": 0
+          },
+          {
+            "line": 247,
+            "complexity": 0
+          },
+          {
+            "line": 257,
+            "complexity": 0
+          },
+          {
+            "line": 258,
+            "complexity": 0
+          },
+          {
+            "line": 260,
+            "complexity": 2
+          },
+          {
+            "line": 261,
+            "complexity": 3
+          },
+          {
+            "line": 262,
+            "complexity": 0
+          },
+          {
+            "line": 263,
+            "complexity": 4
+          },
+          {
+            "line": 264,
+            "complexity": 0
+          },
+          {
+            "line": 265,
+            "complexity": 0
+          },
+          {
+            "line": 266,
+            "complexity": 0
+          },
+          {
+            "line": 276,
+            "complexity": 0
+          },
+          {
+            "line": 277,
+            "complexity": 0
+          },
+          {
+            "line": 278,
+            "complexity": 2
+          },
+          {
+            "line": 279,
+            "complexity": 0
+          },
+          {
+            "line": 280,
+            "complexity": 0
+          },
+          {
+            "line": 281,
+            "complexity": 0
+          },
+          {
+            "line": 282,
+            "complexity": 0
+          },
+          {
+            "line": 283,
+            "complexity": 3
+          },
+          {
+            "line": 284,
+            "complexity": 0
+          },
+          {
+            "line": 297,
+            "complexity": 2
+          },
+          {
+            "line": 298,
+            "complexity": 0
+          },
+          {
+            "line": 299,
+            "complexity": 0
+          },
+          {
+            "line": 300,
+            "complexity": 0
+          },
+          {
+            "line": 301,
+            "complexity": 0
+          },
+          {
+            "line": 302,
+            "complexity": 3
+          },
+          {
+            "line": 303,
+            "complexity": 0
+          },
+          {
+            "line": 304,
+            "complexity": 0
+          },
+          {
+            "line": 305,
+            "complexity": 0
+          },
+          {
+            "line": 306,
+            "complexity": 0
+          },
+          {
+            "line": 307,
+            "complexity": 0
+          },
+          {
+            "line": 308,
+            "complexity": 0
+          },
+          {
+            "line": 309,
+            "complexity": 0
+          },
+          {
+            "line": 310,
+            "complexity": 0
+          },
+          {
+            "line": 311,
+            "complexity": 0
+          },
+          {
+            "line": 312,
+            "complexity": 0
+          },
+          {
+            "line": 313,
+            "complexity": 4
+          },
+          {
+            "line": 314,
+            "complexity": 0
+          },
+          {
+            "line": 315,
+            "complexity": 0
+          },
+          {
+            "line": 316,
+            "complexity": 0
+          },
+          {
+            "line": 317,
+            "complexity": 0
+          },
+          {
+            "line": 318,
+            "complexity": 0
+          },
+          {
+            "line": 319,
+            "complexity": 0
+          },
+          {
+            "line": 321,
+            "complexity": 3
+          },
+          {
+            "line": 322,
+            "complexity": 0
+          },
+          {
+            "line": 323,
+            "complexity": 0
+          },
+          {
+            "line": 324,
+            "complexity": 0
+          },
+          {
+            "line": 325,
+            "complexity": 1
+          },
+          {
+            "line": 326,
+            "complexity": 0
+          },
+          {
+            "line": 327,
+            "complexity": 0
+          },
+          {
+            "line": 328,
+            "complexity": 0
+          },
+          {
+            "line": 329,
+            "complexity": 0
+          },
+          {
+            "line": 340,
+            "complexity": 2
+          },
+          {
+            "line": 341,
+            "complexity": 0
+          },
+          {
+            "line": 342,
+            "complexity": 0
+          },
+          {
+            "line": 343,
+            "complexity": 0
+          },
+          {
+            "line": 344,
+            "complexity": 0
+          },
+          {
+            "line": 345,
+            "complexity": 3
+          },
+          {
+            "line": 346,
+            "complexity": 0
+          },
+          {
+            "line": 347,
+            "complexity": 0
+          },
+          {
+            "line": 359,
+            "complexity": 2
+          },
+          {
+            "line": 360,
+            "complexity": 0
+          },
+          {
+            "line": 361,
+            "complexity": 0
+          },
+          {
+            "line": 362,
+            "complexity": 0
           },
           {
             "line": 363,
@@ -3782,11 +4158,15 @@
           },
           {
             "line": 364,
+            "complexity": 3
+          },
+          {
+            "line": 365,
             "complexity": 0
           },
           {
             "line": 366,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 367,
@@ -3817,20 +4197,48 @@
             "complexity": 0
           },
           {
-            "line": 389,
+            "line": 374,
             "complexity": 0
           },
           {
-            "line": 390,
+            "line": 375,
             "complexity": 0
           },
           {
-            "line": 391,
+            "line": 376,
+            "complexity": 3
+          },
+          {
+            "line": 377,
+            "complexity": 0
+          },
+          {
+            "line": 378,
+            "complexity": 0
+          },
+          {
+            "line": 379,
+            "complexity": 0
+          },
+          {
+            "line": 380,
+            "complexity": 1
+          },
+          {
+            "line": 381,
+            "complexity": 0
+          },
+          {
+            "line": 382,
+            "complexity": 0
+          },
+          {
+            "line": 383,
             "complexity": 0
           },
           {
             "line": 393,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 394,
@@ -3838,7 +4246,7 @@
           },
           {
             "line": 395,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 396,
@@ -3846,26 +4254,18 @@
           },
           {
             "line": 397,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 398,
             "complexity": 0
           },
           {
-            "line": 399,
+            "line": 410,
             "complexity": 0
           },
           {
-            "line": 400,
-            "complexity": 0
-          },
-          {
-            "line": 401,
-            "complexity": 0
-          },
-          {
-            "line": 402,
+            "line": 411,
             "complexity": 0
           },
           {
@@ -3877,24 +4277,28 @@
             "complexity": 0
           },
           {
-            "line": 415,
+            "line": 414,
             "complexity": 2
           },
           {
+            "line": 415,
+            "complexity": 0
+          },
+          {
             "line": 416,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 417,
-            "complexity": 0
-          },
-          {
-            "line": 418,
             "complexity": 4
           },
           {
-            "line": 419,
+            "line": 418,
             "complexity": 0
+          },
+          {
+            "line": 419,
+            "complexity": 4
           },
           {
             "line": 420,
@@ -3905,20 +4309,28 @@
             "complexity": 0
           },
           {
-            "line": 431,
+            "line": 422,
+            "complexity": 1
+          },
+          {
+            "line": 423,
+            "complexity": 4
+          },
+          {
+            "line": 424,
             "complexity": 0
           },
           {
-            "line": 432,
+            "line": 433,
             "complexity": 0
           },
           {
             "line": 434,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 435,
-            "complexity": 3
+            "complexity": 2
           },
           {
             "line": 436,
@@ -3926,7 +4338,7 @@
           },
           {
             "line": 437,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 438,
@@ -3941,39 +4353,51 @@
             "complexity": 0
           },
           {
-            "line": 450,
+            "line": 441,
             "complexity": 0
           },
           {
-            "line": 451,
+            "line": 442,
             "complexity": 0
           },
           {
-            "line": 452,
-            "complexity": 2
-          },
-          {
-            "line": 453,
+            "line": 443,
             "complexity": 0
           },
           {
-            "line": 454,
+            "line": 444,
             "complexity": 0
           },
           {
-            "line": 455,
+            "line": 445,
             "complexity": 0
           },
           {
-            "line": 456,
+            "line": 446,
             "complexity": 0
           },
           {
-            "line": 457,
-            "complexity": 3
+            "line": 447,
+            "complexity": 0
           },
           {
-            "line": 458,
+            "line": 448,
+            "complexity": 0
+          },
+          {
+            "line": 466,
+            "complexity": 0
+          },
+          {
+            "line": 467,
+            "complexity": 0
+          },
+          {
+            "line": 468,
+            "complexity": 0
+          },
+          {
+            "line": 469,
             "complexity": 0
           },
           {
@@ -3986,7 +4410,7 @@
           },
           {
             "line": 473,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 474,
@@ -3998,7 +4422,7 @@
           },
           {
             "line": 476,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 477,
@@ -4021,10 +4445,6 @@
             "complexity": 0
           },
           {
-            "line": 482,
-            "complexity": 0
-          },
-          {
             "line": 483,
             "complexity": 0
           },
@@ -4034,7 +4454,7 @@
           },
           {
             "line": 485,
-            "complexity": 0
+            "complexity": 5
           },
           {
             "line": 486,
@@ -4042,11 +4462,11 @@
           },
           {
             "line": 487,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 488,
-            "complexity": 0
+            "complexity": 6
           },
           {
             "line": 489,
@@ -4070,11 +4490,11 @@
           },
           {
             "line": 495,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 496,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 497,
@@ -4086,75 +4506,47 @@
           },
           {
             "line": 499,
-            "complexity": 1
-          },
-          {
-            "line": 500,
             "complexity": 0
           },
           {
-            "line": 501,
-            "complexity": 0
-          },
-          {
-            "line": 502,
-            "complexity": 0
-          },
-          {
-            "line": 503,
-            "complexity": 0
-          },
-          {
-            "line": 514,
+            "line": 508,
             "complexity": 2
           },
           {
-            "line": 515,
+            "line": 509,
+            "complexity": 3
+          },
+          {
+            "line": 510,
             "complexity": 0
           },
           {
             "line": 516,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 517,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 518,
             "complexity": 0
           },
           {
-            "line": 519,
-            "complexity": 3
-          },
-          {
-            "line": 520,
-            "complexity": 0
-          },
-          {
-            "line": 521,
-            "complexity": 0
-          },
-          {
-            "line": 533,
+            "line": 527,
             "complexity": 2
           },
           {
-            "line": 534,
-            "complexity": 0
+            "line": 528,
+            "complexity": 3
           },
           {
-            "line": 535,
-            "complexity": 0
-          },
-          {
-            "line": 536,
+            "line": 529,
             "complexity": 0
           },
           {
             "line": 537,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 538,
@@ -4169,71 +4561,35 @@
             "complexity": 0
           },
           {
-            "line": 541,
-            "complexity": 0
-          },
-          {
-            "line": 542,
-            "complexity": 0
-          },
-          {
-            "line": 543,
-            "complexity": 0
-          },
-          {
-            "line": 544,
-            "complexity": 0
-          },
-          {
-            "line": 545,
-            "complexity": 0
-          },
-          {
-            "line": 546,
-            "complexity": 0
-          },
-          {
-            "line": 547,
-            "complexity": 0
-          },
-          {
             "line": 548,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 549,
-            "complexity": 0
+            "complexity": 3
           },
           {
             "line": 550,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 551,
             "complexity": 0
           },
           {
-            "line": 552,
+            "line": 563,
             "complexity": 0
           },
           {
-            "line": 553,
+            "line": 564,
             "complexity": 0
           },
           {
-            "line": 554,
-            "complexity": 1
+            "line": 565,
+            "complexity": 2
           },
           {
-            "line": 555,
-            "complexity": 0
-          },
-          {
-            "line": 556,
-            "complexity": 0
-          },
-          {
-            "line": 557,
+            "line": 566,
             "complexity": 0
           },
           {
@@ -4246,18 +4602,50 @@
           },
           {
             "line": 569,
-            "complexity": 2
-          },
-          {
-            "line": 570,
             "complexity": 0
           },
           {
             "line": 571,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 572,
+            "complexity": 3
+          },
+          {
+            "line": 573,
+            "complexity": 0
+          },
+          {
+            "line": 574,
+            "complexity": 0
+          },
+          {
+            "line": 575,
+            "complexity": 0
+          },
+          {
+            "line": 576,
+            "complexity": 0
+          },
+          {
+            "line": 578,
+            "complexity": 3
+          },
+          {
+            "line": 579,
+            "complexity": 0
+          },
+          {
+            "line": 580,
+            "complexity": 0
+          },
+          {
+            "line": 581,
+            "complexity": 0
+          },
+          {
+            "line": 582,
             "complexity": 0
           },
           {
@@ -4278,7 +4666,7 @@
           },
           {
             "line": 588,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 589,
@@ -4290,7 +4678,7 @@
           },
           {
             "line": 591,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 592,
@@ -4298,7 +4686,7 @@
           },
           {
             "line": 593,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 594,
@@ -4310,428 +4698,40 @@
           },
           {
             "line": 596,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 597,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 598,
             "complexity": 0
           },
           {
-            "line": 607,
+            "line": 599,
             "complexity": 0
           },
           {
-            "line": 608,
+            "line": 600,
             "complexity": 0
           },
           {
-            "line": 609,
-            "complexity": 2
-          },
-          {
-            "line": 610,
-            "complexity": 0
-          },
-          {
-            "line": 611,
-            "complexity": 0
-          },
-          {
-            "line": 612,
-            "complexity": 0
-          },
-          {
-            "line": 613,
-            "complexity": 0
-          },
-          {
-            "line": 614,
-            "complexity": 0
-          },
-          {
-            "line": 615,
-            "complexity": 0
-          },
-          {
-            "line": 616,
-            "complexity": 0
-          },
-          {
-            "line": 617,
-            "complexity": 0
-          },
-          {
-            "line": 618,
-            "complexity": 0
-          },
-          {
-            "line": 619,
-            "complexity": 0
-          },
-          {
-            "line": 620,
-            "complexity": 0
-          },
-          {
-            "line": 621,
-            "complexity": 0
-          },
-          {
-            "line": 622,
-            "complexity": 0
-          },
-          {
-            "line": 640,
-            "complexity": 0
-          },
-          {
-            "line": 641,
-            "complexity": 0
-          },
-          {
-            "line": 642,
-            "complexity": 0
-          },
-          {
-            "line": 643,
-            "complexity": 0
-          },
-          {
-            "line": 645,
-            "complexity": 2
-          },
-          {
-            "line": 646,
-            "complexity": 0
-          },
-          {
-            "line": 647,
-            "complexity": 3
-          },
-          {
-            "line": 648,
-            "complexity": 0
-          },
-          {
-            "line": 649,
-            "complexity": 0
-          },
-          {
-            "line": 650,
-            "complexity": 0
-          },
-          {
-            "line": 651,
-            "complexity": 0
-          },
-          {
-            "line": 652,
-            "complexity": 0
-          },
-          {
-            "line": 653,
-            "complexity": 0
-          },
-          {
-            "line": 654,
-            "complexity": 0
-          },
-          {
-            "line": 655,
-            "complexity": 0
-          },
-          {
-            "line": 657,
-            "complexity": 0
-          },
-          {
-            "line": 658,
-            "complexity": 0
-          },
-          {
-            "line": 659,
-            "complexity": 5
-          },
-          {
-            "line": 660,
-            "complexity": 0
-          },
-          {
-            "line": 661,
-            "complexity": 0
-          },
-          {
-            "line": 662,
-            "complexity": 6
-          },
-          {
-            "line": 663,
-            "complexity": 0
-          },
-          {
-            "line": 664,
-            "complexity": 0
-          },
-          {
-            "line": 665,
-            "complexity": 0
-          },
-          {
-            "line": 666,
-            "complexity": 0
-          },
-          {
-            "line": 667,
-            "complexity": 0
-          },
-          {
-            "line": 669,
-            "complexity": 0
-          },
-          {
-            "line": 670,
-            "complexity": 3
-          },
-          {
-            "line": 671,
-            "complexity": 0
-          },
-          {
-            "line": 672,
-            "complexity": 0
-          },
-          {
-            "line": 673,
-            "complexity": 0
-          },
-          {
-            "line": 682,
-            "complexity": 2
-          },
-          {
-            "line": 683,
-            "complexity": 3
-          },
-          {
-            "line": 684,
-            "complexity": 0
-          },
-          {
-            "line": 690,
-            "complexity": 2
-          },
-          {
-            "line": 691,
-            "complexity": 3
-          },
-          {
-            "line": 692,
-            "complexity": 0
-          },
-          {
-            "line": 701,
-            "complexity": 2
-          },
-          {
-            "line": 702,
-            "complexity": 3
-          },
-          {
-            "line": 703,
-            "complexity": 0
-          },
-          {
-            "line": 711,
-            "complexity": 2
-          },
-          {
-            "line": 712,
-            "complexity": 3
-          },
-          {
-            "line": 713,
-            "complexity": 0
-          },
-          {
-            "line": 714,
-            "complexity": 0
-          },
-          {
-            "line": 722,
-            "complexity": 2
-          },
-          {
-            "line": 723,
-            "complexity": 3
-          },
-          {
-            "line": 724,
-            "complexity": 0
-          },
-          {
-            "line": 725,
-            "complexity": 0
-          },
-          {
-            "line": 737,
-            "complexity": 0
-          },
-          {
-            "line": 738,
-            "complexity": 0
-          },
-          {
-            "line": 739,
-            "complexity": 2
-          },
-          {
-            "line": 740,
-            "complexity": 0
-          },
-          {
-            "line": 741,
-            "complexity": 0
-          },
-          {
-            "line": 742,
-            "complexity": 0
-          },
-          {
-            "line": 743,
-            "complexity": 0
-          },
-          {
-            "line": 745,
-            "complexity": 0
-          },
-          {
-            "line": 746,
-            "complexity": 3
-          },
-          {
-            "line": 747,
-            "complexity": 0
-          },
-          {
-            "line": 748,
-            "complexity": 0
-          },
-          {
-            "line": 749,
-            "complexity": 0
-          },
-          {
-            "line": 750,
-            "complexity": 0
-          },
-          {
-            "line": 752,
-            "complexity": 3
-          },
-          {
-            "line": 753,
-            "complexity": 0
-          },
-          {
-            "line": 754,
-            "complexity": 0
-          },
-          {
-            "line": 755,
-            "complexity": 0
-          },
-          {
-            "line": 756,
-            "complexity": 0
-          },
-          {
-            "line": 758,
-            "complexity": 0
-          },
-          {
-            "line": 759,
-            "complexity": 0
-          },
-          {
-            "line": 760,
-            "complexity": 0
-          },
-          {
-            "line": 761,
-            "complexity": 0
-          },
-          {
-            "line": 762,
-            "complexity": 0
-          },
-          {
-            "line": 763,
-            "complexity": 0
-          },
-          {
-            "line": 764,
-            "complexity": 0
-          },
-          {
-            "line": 765,
-            "complexity": 0
-          },
-          {
-            "line": 766,
-            "complexity": 0
-          },
-          {
-            "line": 767,
-            "complexity": 0
-          },
-          {
-            "line": 768,
-            "complexity": 0
-          },
-          {
-            "line": 769,
-            "complexity": 0
-          },
-          {
-            "line": 770,
-            "complexity": 0
-          },
-          {
-            "line": 771,
-            "complexity": 0
-          },
-          {
-            "line": 772,
-            "complexity": 0
-          },
-          {
-            "line": 773,
-            "complexity": 0
-          },
-          {
-            "line": 774,
-            "complexity": 0
-          },
-          {
-            "line": 775,
+            "line": 601,
             "complexity": 0
           },
           {
-            "line": 776,
+            "line": 602,
             "complexity": 0
           },
           {
-            "line": 778,
+            "line": 604,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 194
+    "complexity": 169
   },
   {
     "path": "src/immich_memories/tracking/run_database.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -454,6 +454,7 @@ module = [
     "immich_memories.titles.renderer_taichi",
     "immich_memories.titles.taichi_text",
     "immich_memories.titles.sdf_font",
+    "immich_memories.titles.taichi_backend_probe",
     "immich_memories.titles.taichi_kernels",
     "immich_memories.titles.sdf_font_rendering",
     "immich_memories.titles.taichi_video",

--- a/src/immich_memories/titles/taichi_backend_probe.py
+++ b/src/immich_memories/titles/taichi_backend_probe.py
@@ -1,0 +1,207 @@
+"""Taichi backend availability: which arch can actually dispatch a kernel here.
+
+Owns the `taichi` import guard, so importing this module (directly or via
+taichi_kernels) is what sets the banner-suppression env vars before Taichi's
+C++ runtime loads. Nothing here knows about title kernels; taichi_kernels
+drives the selection loop with `_candidate_backends` and `_backend_dispatches`.
+
+Note: This module does NOT use 'from __future__ import annotations'
+because Taichi kernels require actual type objects, not string annotations.
+"""
+
+import contextlib
+import logging
+import os
+import queue
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# WHY: Taichi's C++ runtime prints to stdout, corrupting Rich Live display.
+# ENABLE_TAICHI_HEADER_PRINT="0" — suppresses import-time version banner (taichi#8334)
+# TI_LOG_LEVEL — belt-and-suspenders for C++ log messages
+# These must be set before `import taichi` below, and before any sibling module
+# that imports Taichi is loaded.
+# The main fix is verbose=False on ti.init() calls (see init_taichi and _check_taichi)
+os.environ.setdefault("ENABLE_TAICHI_HEADER_PRINT", "0")
+os.environ.setdefault("TI_LOG_LEVEL", "error")
+
+try:
+    import taichi as ti
+
+    TAICHI_AVAILABLE = True
+except ImportError:
+    TAICHI_AVAILABLE = False
+    ti = None
+
+_TAICHI_PROBE_TIMEOUT_SECONDS = 10.0
+_TAICHI_PROBE_STOP_TIMEOUT_SECONDS = 1.0
+
+
+class TaichiProbeOutcome(StrEnum):
+    """Bounded outcomes from an isolated backend dispatch probe."""
+
+    SUCCESS = "success"
+    DISPATCH_FAILED = "dispatch_failed"
+    CHILD_CRASHED = "child_crashed"
+    TIMED_OUT = "timed_out"
+
+
+@dataclass(frozen=True)
+class TaichiProbeResult:
+    """Small picklable result sent from the probe child to its parent."""
+
+    outcome: TaichiProbeOutcome
+    detail: str | None = None
+
+
+@contextlib.contextmanager
+def _silence_output_fds():
+    """Temporarily redirect process stdout/stderr to the null device."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    saved_stdout = os.dup(1)
+    saved_stderr = os.dup(2)
+    try:
+        os.dup2(devnull_fd, 1)
+        os.dup2(devnull_fd, 2)
+        yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_stdout, 1)
+        os.dup2(saved_stderr, 2)
+        os.close(saved_stdout)
+        os.close(saved_stderr)
+        os.close(devnull_fd)
+
+
+def _silent_init(**kwargs) -> None:
+    """Call ti.init() with stdout/stderr silenced at the OS file descriptor level.
+
+    WHY: Taichi's C++ runtime prints "[Taichi] Starting on arch=metal"
+    directly to file descriptor 1, bypassing Python's sys.stdout, all
+    env vars (TI_LOG_LEVEL, ENABLE_TAICHI_HEADER_PRINT), and all Python
+    API flags (verbose=False, log_level). The ONLY way to suppress it is
+    to redirect the raw OS file descriptors during the call.
+    """
+    with _silence_output_fds():
+        ti.init(**kwargs)
+
+
+def _taichi_probe_worker(backend_name: str, result_queue) -> None:
+    """Initialize one backend and dispatch a real kernel inside a child process."""
+    try:
+        with _silence_output_fds():
+            backend = getattr(ti, backend_name)
+            ti.init(arch=backend, offline_cache=True)
+
+            @ti.kernel
+            def increment(values: ti.types.ndarray(dtype=ti.i32, ndim=1)):
+                for index in values:
+                    values[index] += 1
+
+            values = np.zeros(1, dtype=np.int32)
+            increment(values)
+        if values[0] != 1:
+            result = TaichiProbeResult(
+                TaichiProbeOutcome.DISPATCH_FAILED,
+                "unexpected_kernel_result",
+            )
+        else:
+            result = TaichiProbeResult(TaichiProbeOutcome.SUCCESS)
+    except Exception as exc:
+        result = TaichiProbeResult(
+            TaichiProbeOutcome.DISPATCH_FAILED,
+            type(exc).__name__,
+        )
+    result_queue.put(result)
+
+
+def _stop_probe_process(process) -> None:
+    """Stop a stuck probe, escalating from terminate to kill."""
+    process.terminate()
+    process.join(_TAICHI_PROBE_STOP_TIMEOUT_SECONDS)
+    if process.is_alive():
+        process.kill()
+        process.join(_TAICHI_PROBE_STOP_TIMEOUT_SECONDS)
+
+
+def _probe_taichi_backend(
+    backend_name: str,
+    timeout: float = _TAICHI_PROBE_TIMEOUT_SECONDS,
+) -> TaichiProbeResult:
+    """Probe one non-CPU backend without changing parent Taichi state."""
+    import multiprocessing
+
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue(maxsize=1)
+    process = context.Process(
+        target=_taichi_probe_worker,
+        args=(backend_name, result_queue),
+        name=f"taichi-{backend_name}-probe",
+        daemon=True,
+    )
+    started = False
+    try:
+        process.start()
+        started = True
+        process.join(timeout)
+        if process.is_alive():
+            _stop_probe_process(process)
+            return TaichiProbeResult(TaichiProbeOutcome.TIMED_OUT)
+        try:
+            result = result_queue.get(timeout=0.25)
+        except queue.Empty:
+            return TaichiProbeResult(
+                TaichiProbeOutcome.CHILD_CRASHED,
+                f"exitcode={process.exitcode}",
+            )
+        if not isinstance(result, TaichiProbeResult):
+            return TaichiProbeResult(TaichiProbeOutcome.CHILD_CRASHED, "invalid_result")
+        return result
+    except (OSError, RuntimeError, TypeError) as exc:
+        return TaichiProbeResult(TaichiProbeOutcome.CHILD_CRASHED, type(exc).__name__)
+    finally:
+        if started and process.is_alive():
+            _stop_probe_process(process)
+        result_queue.close()
+        result_queue.join_thread()
+        if started and not process.is_alive():
+            process.close()
+
+
+def _candidate_backends(
+    *, force_cpu: bool, operating_system: str
+) -> list[tuple[object, str, str | None]]:
+    """Return parent architecture objects and child-safe probe names in priority order."""
+    if force_cpu:
+        return [(ti.cpu, "CPU", None)]
+    if operating_system == "Darwin":
+        return [(ti.metal, "Metal", "metal"), (ti.cpu, "CPU", None)]
+    return [
+        (ti.cuda, "CUDA", "cuda"),
+        (ti.vulkan, "Vulkan", "vulkan"),
+        (ti.cpu, "CPU", None),
+    ]
+
+
+def _backend_dispatches(name: str, probe_name: str | None) -> bool:
+    """Prove a GPU backend can dispatch, while allowing CPU to bypass the probe."""
+    if probe_name is None:
+        return True
+    probe = _probe_taichi_backend(probe_name)
+    if probe.outcome is TaichiProbeOutcome.SUCCESS:
+        return True
+    logger.debug(
+        "Taichi %s dispatch probe failed (%s: %s)",
+        name,
+        probe.outcome.value,
+        probe.detail or "no detail",
+    )
+    return False

--- a/src/immich_memories/titles/taichi_kernels.py
+++ b/src/immich_memories/titles/taichi_kernels.py
@@ -1,28 +1,28 @@
 """Taichi GPU kernel definitions, initialization, and helper functions.
 
+Backend selection lives in taichi_backend_probe.py; this module owns the
+kernels themselves and the lazy compilation that init_taichi() drives.
+
 Note: This module does NOT use 'from __future__ import annotations'
 because Taichi kernels require actual type objects, not string annotations.
 """
 
 import contextlib
 import logging
-import os
-import queue
-import sys
-from dataclasses import dataclass
-from enum import StrEnum
 from pathlib import Path
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
-
-# WHY: Taichi's C++ runtime prints to stdout, corrupting Rich Live display.
-# ENABLE_TAICHI_HEADER_PRINT="0" — suppresses import-time version banner (taichi#8334)
-# TI_LOG_LEVEL — belt-and-suspenders for C++ log messages
-# The main fix is verbose=False on ti.init() calls (see init_taichi and _check_taichi)
-os.environ.setdefault("ENABLE_TAICHI_HEADER_PRINT", "0")
-os.environ.setdefault("TI_LOG_LEVEL", "error")
+# WHY: importing this first is what sets ENABLE_TAICHI_HEADER_PRINT/TI_LOG_LEVEL
+# before any module in this package pulls in Taichi's C++ runtime — including
+# the SDF modules below, which import Taichi themselves.
+from .taichi_backend_probe import (
+    TAICHI_AVAILABLE,
+    _backend_dispatches,
+    _candidate_backends,
+    _silent_init,
+    ti,
+)
 
 try:
     from .sdf_atlas_gen import get_cached_atlas
@@ -37,185 +37,11 @@ except ImportError:
     init_sdf_kernels = None
     layout_text = None
 
-try:
-    import taichi as ti
-
-    TAICHI_AVAILABLE = True
-except ImportError:
-    TAICHI_AVAILABLE = False
-    ti = None
+logger = logging.getLogger(__name__)
 
 _taichi_initialized = False
 _taichi_backend = None
 _kernels_compiled = False
-
-_TAICHI_PROBE_TIMEOUT_SECONDS = 10.0
-_TAICHI_PROBE_STOP_TIMEOUT_SECONDS = 1.0
-
-
-class TaichiProbeOutcome(StrEnum):
-    """Bounded outcomes from an isolated backend dispatch probe."""
-
-    SUCCESS = "success"
-    DISPATCH_FAILED = "dispatch_failed"
-    CHILD_CRASHED = "child_crashed"
-    TIMED_OUT = "timed_out"
-
-
-@dataclass(frozen=True)
-class TaichiProbeResult:
-    """Small picklable result sent from the probe child to its parent."""
-
-    outcome: TaichiProbeOutcome
-    detail: str | None = None
-
-
-@contextlib.contextmanager
-def _silence_output_fds():
-    """Temporarily redirect process stdout/stderr to the null device."""
-    sys.stdout.flush()
-    sys.stderr.flush()
-    devnull_fd = os.open(os.devnull, os.O_WRONLY)
-    saved_stdout = os.dup(1)
-    saved_stderr = os.dup(2)
-    try:
-        os.dup2(devnull_fd, 1)
-        os.dup2(devnull_fd, 2)
-        yield
-    finally:
-        sys.stdout.flush()
-        sys.stderr.flush()
-        os.dup2(saved_stdout, 1)
-        os.dup2(saved_stderr, 2)
-        os.close(saved_stdout)
-        os.close(saved_stderr)
-        os.close(devnull_fd)
-
-
-def _silent_init(**kwargs) -> None:
-    """Call ti.init() with stdout/stderr silenced at the OS file descriptor level.
-
-    WHY: Taichi's C++ runtime prints "[Taichi] Starting on arch=metal"
-    directly to file descriptor 1, bypassing Python's sys.stdout, all
-    env vars (TI_LOG_LEVEL, ENABLE_TAICHI_HEADER_PRINT), and all Python
-    API flags (verbose=False, log_level). The ONLY way to suppress it is
-    to redirect the raw OS file descriptors during the call.
-    """
-    with _silence_output_fds():
-        ti.init(**kwargs)
-
-
-def _taichi_probe_worker(backend_name: str, result_queue) -> None:
-    """Initialize one backend and dispatch a real kernel inside a child process."""
-    try:
-        with _silence_output_fds():
-            backend = getattr(ti, backend_name)
-            ti.init(arch=backend, offline_cache=True)
-
-            @ti.kernel
-            def increment(values: ti.types.ndarray(dtype=ti.i32, ndim=1)):
-                for index in values:
-                    values[index] += 1
-
-            values = np.zeros(1, dtype=np.int32)
-            increment(values)
-        if values[0] != 1:
-            result = TaichiProbeResult(
-                TaichiProbeOutcome.DISPATCH_FAILED,
-                "unexpected_kernel_result",
-            )
-        else:
-            result = TaichiProbeResult(TaichiProbeOutcome.SUCCESS)
-    except Exception as exc:
-        result = TaichiProbeResult(
-            TaichiProbeOutcome.DISPATCH_FAILED,
-            type(exc).__name__,
-        )
-    result_queue.put(result)
-
-
-def _stop_probe_process(process) -> None:
-    """Stop a stuck probe, escalating from terminate to kill."""
-    process.terminate()
-    process.join(_TAICHI_PROBE_STOP_TIMEOUT_SECONDS)
-    if process.is_alive():
-        process.kill()
-        process.join(_TAICHI_PROBE_STOP_TIMEOUT_SECONDS)
-
-
-def _probe_taichi_backend(
-    backend_name: str,
-    timeout: float = _TAICHI_PROBE_TIMEOUT_SECONDS,
-) -> TaichiProbeResult:
-    """Probe one non-CPU backend without changing parent Taichi state."""
-    import multiprocessing
-
-    context = multiprocessing.get_context("spawn")
-    result_queue = context.Queue(maxsize=1)
-    process = context.Process(
-        target=_taichi_probe_worker,
-        args=(backend_name, result_queue),
-        name=f"taichi-{backend_name}-probe",
-        daemon=True,
-    )
-    started = False
-    try:
-        process.start()
-        started = True
-        process.join(timeout)
-        if process.is_alive():
-            _stop_probe_process(process)
-            return TaichiProbeResult(TaichiProbeOutcome.TIMED_OUT)
-        try:
-            result = result_queue.get(timeout=0.25)
-        except queue.Empty:
-            return TaichiProbeResult(
-                TaichiProbeOutcome.CHILD_CRASHED,
-                f"exitcode={process.exitcode}",
-            )
-        if not isinstance(result, TaichiProbeResult):
-            return TaichiProbeResult(TaichiProbeOutcome.CHILD_CRASHED, "invalid_result")
-        return result
-    except (OSError, RuntimeError, TypeError) as exc:
-        return TaichiProbeResult(TaichiProbeOutcome.CHILD_CRASHED, type(exc).__name__)
-    finally:
-        if started and process.is_alive():
-            _stop_probe_process(process)
-        result_queue.close()
-        result_queue.join_thread()
-        if started and not process.is_alive():
-            process.close()
-
-
-def _candidate_backends(
-    *, force_cpu: bool, operating_system: str
-) -> list[tuple[object, str, str | None]]:
-    """Return parent architecture objects and child-safe probe names in priority order."""
-    if force_cpu:
-        return [(ti.cpu, "CPU", None)]
-    if operating_system == "Darwin":
-        return [(ti.metal, "Metal", "metal"), (ti.cpu, "CPU", None)]
-    return [
-        (ti.cuda, "CUDA", "cuda"),
-        (ti.vulkan, "Vulkan", "vulkan"),
-        (ti.cpu, "CPU", None),
-    ]
-
-
-def _backend_dispatches(name: str, probe_name: str | None) -> bool:
-    """Prove a GPU backend can dispatch, while allowing CPU to bypass the probe."""
-    if probe_name is None:
-        return True
-    probe = _probe_taichi_backend(probe_name)
-    if probe.outcome is TaichiProbeOutcome.SUCCESS:
-        return True
-    logger.debug(
-        "Taichi %s dispatch probe failed (%s: %s)",
-        name,
-        probe.outcome.value,
-        probe.detail or "no detail",
-    )
-    return False
 
 
 def init_taichi() -> str | None:

--- a/tests/test_taichi_backend_probe.py
+++ b/tests/test_taichi_backend_probe.py
@@ -21,6 +21,9 @@ class _FakeQueue:
             raise queue.Empty
         return self.items.pop(0)
 
+    def put(self, item: object) -> None:
+        self.items.append(item)
+
     def close(self) -> None:
         self.closed = True
 
@@ -89,8 +92,108 @@ def _install_context(
     return context
 
 
+class _FakeTaichi:
+    """Stand-in for the `taichi` module inside the probe child.
+
+    The worker only ever touches four things on it: an arch attribute, init(),
+    the @kernel decorator, and the ndarray type annotation.
+    """
+
+    def __init__(self, *, effect, init_error: Exception | None = None) -> None:
+        self.metal = object()
+        self.cuda = object()
+        self.vulkan = object()
+        self.cpu = object()
+        self.i32 = "i32"
+        self.types = SimpleNamespace(ndarray=lambda **kwargs: object())  # noqa: ARG005
+        self._effect = effect
+        self._init_error = init_error
+        self.init_calls: list[dict[str, object]] = []
+
+    def init(self, **kwargs: object) -> None:
+        if self._init_error is not None:
+            raise self._init_error
+        self.init_calls.append(kwargs)
+
+    def kernel(self, _fn):
+        return self._effect
+
+
+def _run_worker(monkeypatch: pytest.MonkeyPatch, fake_ti: _FakeTaichi) -> object:
+    from immich_memories.titles import taichi_backend_probe
+
+    # WHY: the worker's whole job is driving the Taichi runtime — the one
+    # external boundary here. A real ti.init() would claim the GPU in-process,
+    # which is exactly what running the probe in a child process avoids.
+    monkeypatch.setattr(taichi_backend_probe, "ti", fake_ti)
+    result_queue = _FakeQueue()
+    taichi_backend_probe._taichi_probe_worker("metal", result_queue)
+    assert len(result_queue.items) == 1
+    return result_queue.items[0]
+
+
+def test_worker_reports_success_when_the_kernel_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from immich_memories.titles.taichi_backend_probe import TaichiProbeOutcome
+
+    def increments(values) -> None:
+        values[0] += 1
+
+    fake_ti = _FakeTaichi(effect=increments)
+
+    result = _run_worker(monkeypatch, fake_ti)
+
+    assert result.outcome is TaichiProbeOutcome.SUCCESS
+    assert fake_ti.init_calls == [{"arch": fake_ti.metal, "offline_cache": True}]
+
+
+def test_worker_rejects_a_backend_that_dispatches_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend that accepts the launch but leaves memory untouched is a failure.
+
+    This is the case the probe exists for: init() succeeding proves nothing,
+    only the written-back value does.
+    """
+    from immich_memories.titles.taichi_backend_probe import TaichiProbeOutcome
+
+    result = _run_worker(monkeypatch, _FakeTaichi(effect=lambda _values: None))
+
+    assert result.outcome is TaichiProbeOutcome.DISPATCH_FAILED
+    assert result.detail == "unexpected_kernel_result"
+
+
+def test_worker_names_the_exception_a_failing_backend_raised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from immich_memories.titles.taichi_backend_probe import TaichiProbeOutcome
+
+    fake_ti = _FakeTaichi(effect=lambda _values: None, init_error=RuntimeError("no device"))
+
+    result = _run_worker(monkeypatch, fake_ti)
+
+    assert result.outcome is TaichiProbeOutcome.DISPATCH_FAILED
+    assert result.detail == "RuntimeError"
+
+
+def test_non_apple_hosts_try_cuda_then_vulkan_then_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    from immich_memories.titles import taichi_backend_probe
+
+    fake_ti = _FakeTaichi(effect=lambda _values: None)
+    # WHY: the arch objects are Taichi runtime singletons; identity is what
+    # init_taichi passes through to ti.init().
+    monkeypatch.setattr(taichi_backend_probe, "ti", fake_ti)
+
+    candidates = taichi_backend_probe._candidate_backends(force_cpu=False, operating_system="Linux")
+
+    assert candidates == [
+        (fake_ti.cuda, "CUDA", "cuda"),
+        (fake_ti.vulkan, "Vulkan", "vulkan"),
+        (fake_ti.cpu, "CPU", None),
+    ]
+
+
 def test_probe_returns_success_and_closes_resources(monkeypatch: pytest.MonkeyPatch) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         TaichiProbeResult,
         _probe_taichi_backend,
@@ -118,7 +221,7 @@ def test_probe_returns_success_and_closes_resources(monkeypatch: pytest.MonkeyPa
 
 
 def test_probe_preserves_dispatch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         TaichiProbeResult,
         _probe_taichi_backend,
@@ -137,7 +240,7 @@ def test_probe_preserves_dispatch_failure(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_probe_reports_child_crash_without_a_result(monkeypatch: pytest.MonkeyPatch) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         _probe_taichi_backend,
     )
@@ -155,8 +258,24 @@ def test_probe_reports_child_crash_without_a_result(monkeypatch: pytest.MonkeyPa
     assert result_queue.joined
 
 
+def test_probe_distrusts_a_result_it_did_not_recognise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anything but a TaichiProbeResult means the child was not ours to trust."""
+    from immich_memories.titles.taichi_backend_probe import (
+        TaichiProbeOutcome,
+        _probe_taichi_backend,
+    )
+
+    result_queue = _FakeQueue("something else entirely")
+    _install_context(monkeypatch, result_queue, _FakeProcess())
+
+    result = _probe_taichi_backend("metal")
+
+    assert result.outcome is TaichiProbeOutcome.CHILD_CRASHED
+    assert result.detail == "invalid_result"
+
+
 def test_probe_terminates_then_kills_a_hung_child(monkeypatch: pytest.MonkeyPatch) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         _probe_taichi_backend,
     )
@@ -177,31 +296,38 @@ def test_probe_terminates_then_kills_a_hung_child(monkeypatch: pytest.MonkeyPatc
 
 
 def _prepare_parent_init(monkeypatch: pytest.MonkeyPatch):
-    from immich_memories.titles import taichi_kernels
+    """Stub both namespaces init_taichi() spans: the kernels module and the probe.
+
+    `init_taichi` resolves TAICHI_AVAILABLE and the module-level init flags in
+    `taichi_kernels`, but `_candidate_backends` and `_backend_dispatches` read
+    `ti` and `_probe_taichi_backend` from `taichi_backend_probe`. Patching one
+    module for both would leave the real Taichi arch objects in play.
+    """
+    from immich_memories.titles import taichi_backend_probe, taichi_kernels
 
     fake_ti = SimpleNamespace(metal=object(), cpu=object())
     monkeypatch.setattr(taichi_kernels, "TAICHI_AVAILABLE", True)
-    monkeypatch.setattr(taichi_kernels, "ti", fake_ti)
+    monkeypatch.setattr(taichi_backend_probe, "ti", fake_ti)
     monkeypatch.setattr(taichi_kernels, "_taichi_initialized", False)
     monkeypatch.setattr(taichi_kernels, "_taichi_backend", None)
     monkeypatch.setattr(taichi_kernels, "SDF_AVAILABLE", False)
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.delenv("IMMICH_FORCE_CPU", raising=False)
-    return taichi_kernels, fake_ti
+    return taichi_kernels, taichi_backend_probe, fake_ti
 
 
 def test_successful_gpu_probe_initializes_parent_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         TaichiProbeResult,
     )
 
-    taichi_kernels, fake_ti = _prepare_parent_init(monkeypatch)
+    taichi_kernels, probe_module, fake_ti = _prepare_parent_init(monkeypatch)
     probes: list[str] = []
     parent_inits: list[dict[str, object]] = []
     compile_calls: list[bool] = []
     monkeypatch.setattr(
-        taichi_kernels,
+        probe_module,
         "_probe_taichi_backend",
         lambda backend: probes.append(backend) or TaichiProbeResult(TaichiProbeOutcome.SUCCESS),
     )
@@ -229,15 +355,15 @@ def test_successful_gpu_probe_initializes_parent_once(monkeypatch: pytest.Monkey
 def test_failed_gpu_probe_skips_parent_gpu_init(
     monkeypatch: pytest.MonkeyPatch, outcome: str
 ) -> None:
-    from immich_memories.titles.taichi_kernels import (
+    from immich_memories.titles.taichi_backend_probe import (
         TaichiProbeOutcome,
         TaichiProbeResult,
     )
 
-    taichi_kernels, fake_ti = _prepare_parent_init(monkeypatch)
+    taichi_kernels, probe_module, fake_ti = _prepare_parent_init(monkeypatch)
     parent_inits: list[dict[str, object]] = []
     monkeypatch.setattr(
-        taichi_kernels,
+        probe_module,
         "_probe_taichi_backend",
         lambda _backend: TaichiProbeResult(TaichiProbeOutcome(outcome)),
     )
@@ -251,11 +377,11 @@ def test_failed_gpu_probe_skips_parent_gpu_init(
 
 
 def test_forced_cpu_never_spawns_a_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-    taichi_kernels, fake_ti = _prepare_parent_init(monkeypatch)
+    taichi_kernels, probe_module, fake_ti = _prepare_parent_init(monkeypatch)
     parent_inits: list[dict[str, object]] = []
     monkeypatch.setenv("IMMICH_FORCE_CPU", "true")
     monkeypatch.setattr(
-        taichi_kernels,
+        probe_module,
         "_probe_taichi_backend",
         lambda _backend: pytest.fail("CPU fallback must not spawn a child"),
     )


### PR DESCRIPTION
Refs #685 — the `titles/taichi_kernels.py` entry in the split wave. No `Closes`: six modules on that list are still over the line.

`taichi_kernels.py` was **896 lines** carrying two unrelated jobs. One decides which Taichi arch can dispatch on this machine — the `taichi` import guard, an fd-level stdout silencer, and a spawn-child probe that proves a backend before the parent commits to it. The other defines the title kernels. The first knows nothing about the second, and it already had its own test file (`tests/test_taichi_backend_probe.py`), which is what makes this a cohesion seam rather than a line-count cut.

| | before | after |
|---|---:|---:|
| `taichi_kernels.py` | 896 | **722** |
| `taichi_backend_probe.py` | — | 207 |

## Why the kernels did not move, and could not

This is the constraint the file carries in its own comments, so it is worth being explicit. Consumers reach kernels as **module attributes at call time** — `taichi_kernels._render_sdf_text`, never `from .taichi_kernels import _render_sdf_text` — because the names are `None` until `init_taichi()` compiles them. A from-import would capture the `None`.

Splitting the kernels across modules by family (SDF/text vs particles/effects) would therefore have meant a `_compile_*` function, a block of `None` globals and an `init_taichi()` hook **per module**. The compile wiring is exactly what couples them. Backend selection has no such coupling — it is one call, `init_taichi()` → `_compile_kernels()`, in one direction — so that is where the seam is.

Every kernel keeps the module attribute it had, so `renderer_taichi.py` and `taichi_text.py` — the two consumers split out recently, whose import style is the spec here — needed **no change at all**. Shown rather than claimed:

```
before init: all five kernel attrs are None    -> True
backend: Metal
after init : all five kernel attrs are set     -> True
renderer_taichi sees taichi_kernels._apply_vignette_and_noise -> True
taichi_text     sees taichi_kernels._render_sdf_text          -> True
```

`tests/test_gpu_buffers.py` is the standing CI-side guard on this: it calls `init_taichi()` and *then* imports the kernels, so it fails outright if the globals stop being populated. It passes untouched, as do the 143 tests in `make test-integration-titles`.

## The patch-target audit

`init_taichi()` now spans two namespaces, so the existing test was repointed name by name rather than by search-replace. `from x import y` binds `y` in the *importing* module, which cuts both ways here:

| patched name | resolves in | patched on |
|---|---|---|
| `TAICHI_AVAILABLE`, `_taichi_initialized`, `_taichi_backend`, `SDF_AVAILABLE` | `init_taichi` body | `taichi_kernels` (unchanged) |
| `_silent_init`, `_compile_kernels` | `init_taichi` body | `taichi_kernels` (unchanged) |
| `ti` | `_candidate_backends` | **`taichi_backend_probe`** |
| `_probe_taichi_backend` | `_backend_dispatches` | **`taichi_backend_probe`** |

Patching either of the last two on the wrong module fails silently — the test would go green with the real Taichi arch objects still in play. That distinction is the whole risk surface of this PR.

## The env guard keeps its ordering

`ENABLE_TAICHI_HEADER_PRINT` / `TI_LOG_LEVEL` have to be set before Taichi's C++ runtime loads, and `sdf_font.py` / `sdf_font_rendering.py` import Taichi themselves. So the new module sets them beside its own `import taichi`, and `taichi_kernels` imports it **above** the SDF try-block. Verified in a fresh interpreter with both vars unset: `taichi_backend_probe` loads, then `taichi`, then `sdf_font`, with both vars set.

## One thing that is not just a move

`_taichi_probe_worker` had **no test** — it only ever ran inside a spawned child, so nothing exercised it, and diff-cover noticed the moment the lines counted as changed. Four tests now drive it against a fake Taichi module, including the case the probe exists for at all: `init()` succeeding while nothing is actually dispatched. Plus the Linux CUDA→Vulkan→CPU candidate order, which had no coverage either. Module coverage **76% → 90%**; the remainder is the `ImportError` fallback and two `except` arms.

## Housekeeping

- `os`, `sys`, `queue`, `dataclass`, `StrEnum` dropped from `taichi_kernels` — they went with the probe (ruff caught them).
- `taichi_backend_probe` joins `taichi_kernels` in the existing mypy override for modules using Taichi's untyped APIs.
- `ARCHITECTURE.md` updated with both modules.
- complexipy snapshot: pure line renumbering, plus the file total for `taichi_kernels.py` dropping **194 → 169**. `_compile_kernels` (130) is unchanged and still its only entry; the new module needs no entry, so every function in it is under the ≤15 gate on its own.

`make ci` green: **5669 passed**, 9 skipped. `make test-integration-titles` green: **143 passed** — recommended as post-merge validation too, since the GPU paths do not run in public CI.

## Noted while mapping, deliberately not fixed here

`taichi_kernels` re-exports `find_font`, `get_cached_atlas` and `layout_text` purely for `taichi_text.py` — it uses only `init_sdf_kernels` itself. That is a genuine shim and CLAUDE.md forbids it, but unwinding it changes `taichi_text`'s fallback behaviour when SDF is unavailable, which is a behaviour question and not a file split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
