### PR TITLE
refactor(cli): move generate's option groups out of the capped file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,6 +280,8 @@ src/immich_memories/
 ├── cli/                        # Command-line interface (Click)
 │   ├── __init__.py             # Main CLI group + `ui` command
 │   ├── generate.py             # `generate`
+│   ├── generate_options.py     # `generate`'s flags, grouped; group order is the --help order
+│   ├── generate_resolution.py  # What those flags mean against the config, presets and conflicts
 │   ├── _analyze_export.py      # `analyze`, `export-project`
 │   ├── config_cmd.py           # `config`, `people`, `years`, `preflight`
 │   ├── scheduler_cmd.py        # `scheduler list/status/start`

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -920,389 +920,389 @@
       {
         "name": "register_generate_commands",
         "complexity": 163,
-        "line_start": 185,
-        "line_end": 995,
+        "line_start": 50,
+        "line_end": 595,
         "line_complexities": [
           {
-            "line": 537,
+            "line": 137,
             "complexity": 0
           },
           {
-            "line": 538,
+            "line": 138,
             "complexity": 0
           },
           {
-            "line": 545,
+            "line": 145,
             "complexity": 2
           },
           {
-            "line": 546,
+            "line": 146,
             "complexity": 0
           },
           {
-            "line": 547,
+            "line": 147,
             "complexity": 0
           },
           {
-            "line": 549,
+            "line": 149,
             "complexity": 2
           },
           {
-            "line": 551,
+            "line": 151,
             "complexity": 3
           },
           {
-            "line": 555,
+            "line": 155,
             "complexity": 3
           },
           {
-            "line": 556,
+            "line": 156,
             "complexity": 0
           },
           {
-            "line": 558,
+            "line": 158,
             "complexity": 0
           },
           {
-            "line": 559,
+            "line": 159,
             "complexity": 2
           },
           {
-            "line": 560,
+            "line": 160,
             "complexity": 1
           },
           {
-            "line": 565,
+            "line": 165,
             "complexity": 3
           },
           {
-            "line": 566,
+            "line": 166,
             "complexity": 0
           },
           {
-            "line": 570,
+            "line": 170,
             "complexity": 0
           },
           {
-            "line": 571,
+            "line": 171,
             "complexity": 1
           },
           {
-            "line": 572,
+            "line": 172,
             "complexity": 0
           },
           {
-            "line": 574,
+            "line": 174,
             "complexity": 2
           },
           {
-            "line": 590,
+            "line": 190,
             "complexity": 0
           },
           {
-            "line": 601,
+            "line": 201,
             "complexity": 3
           },
           {
-            "line": 605,
+            "line": 205,
             "complexity": 3
           },
           {
-            "line": 609,
+            "line": 209,
             "complexity": 4
           },
           {
-            "line": 613,
+            "line": 213,
             "complexity": 3
           },
           {
-            "line": 617,
+            "line": 217,
             "complexity": 3
           },
           {
-            "line": 625,
+            "line": 225,
             "complexity": 0
           },
           {
-            "line": 642,
+            "line": 242,
             "complexity": 2
           },
           {
-            "line": 643,
+            "line": 243,
             "complexity": 0
           },
           {
-            "line": 644,
+            "line": 244,
             "complexity": 1
           },
           {
-            "line": 646,
+            "line": 246,
             "complexity": 0
           },
           {
-            "line": 647,
+            "line": 247,
             "complexity": 1
           },
           {
-            "line": 648,
+            "line": 248,
             "complexity": 0
           },
           {
-            "line": 656,
+            "line": 256,
             "complexity": 2
           },
           {
-            "line": 661,
+            "line": 261,
             "complexity": 0
           },
           {
-            "line": 664,
+            "line": 264,
             "complexity": 0
           },
           {
-            "line": 670,
+            "line": 270,
             "complexity": 1
           },
           {
-            "line": 673,
+            "line": 273,
             "complexity": 3
           },
           {
-            "line": 674,
+            "line": 274,
             "complexity": 3
           },
           {
-            "line": 676,
+            "line": 276,
             "complexity": 0
           },
           {
-            "line": 683,
+            "line": 283,
             "complexity": 0
           },
           {
-            "line": 687,
+            "line": 287,
             "complexity": 3
           },
           {
-            "line": 688,
+            "line": 288,
             "complexity": 0
           },
           {
-            "line": 689,
+            "line": 289,
             "complexity": 3
           },
           {
-            "line": 690,
+            "line": 290,
             "complexity": 0
           },
           {
-            "line": 692,
+            "line": 292,
             "complexity": 0
           },
           {
-            "line": 716,
+            "line": 316,
             "complexity": 1
           },
           {
-            "line": 717,
+            "line": 317,
             "complexity": 2
           },
           {
-            "line": 721,
+            "line": 321,
             "complexity": 1
           },
           {
-            "line": 732,
+            "line": 332,
             "complexity": 3
           },
           {
-            "line": 733,
+            "line": 333,
             "complexity": 0
           },
           {
-            "line": 734,
+            "line": 334,
             "complexity": 0
           },
           {
-            "line": 736,
+            "line": 336,
             "complexity": 0
           },
           {
-            "line": 738,
+            "line": 338,
             "complexity": 0
           },
           {
-            "line": 740,
+            "line": 340,
             "complexity": 0
           },
           {
-            "line": 747,
+            "line": 347,
             "complexity": 5
           },
           {
-            "line": 789,
+            "line": 389,
             "complexity": 6
           },
           {
-            "line": 833,
+            "line": 433,
             "complexity": 0
           },
           {
-            "line": 834,
+            "line": 434,
             "complexity": 5
           },
           {
-            "line": 835,
+            "line": 435,
             "complexity": 6
           },
           {
-            "line": 836,
+            "line": 436,
             "complexity": 0
           },
           {
-            "line": 837,
+            "line": 437,
             "complexity": 0
           },
           {
-            "line": 838,
+            "line": 438,
             "complexity": 7
           },
           {
-            "line": 846,
+            "line": 446,
             "complexity": 6
           },
           {
-            "line": 847,
+            "line": 447,
             "complexity": 0
           },
           {
-            "line": 848,
+            "line": 448,
             "complexity": 7
           },
           {
-            "line": 849,
+            "line": 449,
             "complexity": 0
           },
           {
-            "line": 851,
+            "line": 451,
             "complexity": 1
           },
           {
-            "line": 856,
+            "line": 456,
             "complexity": 7
           },
           {
-            "line": 857,
+            "line": 457,
             "complexity": 0
           },
           {
-            "line": 870,
+            "line": 470,
             "complexity": 7
           },
           {
-            "line": 871,
+            "line": 471,
             "complexity": 0
           },
           {
-            "line": 872,
+            "line": 472,
             "complexity": 0
           },
           {
-            "line": 875,
+            "line": 475,
             "complexity": 1
           },
           {
-            "line": 876,
+            "line": 476,
             "complexity": 0
           },
           {
-            "line": 877,
+            "line": 477,
             "complexity": 0
           },
           {
-            "line": 881,
+            "line": 481,
             "complexity": 7
           },
           {
-            "line": 882,
+            "line": 482,
             "complexity": 0
           },
           {
-            "line": 891,
+            "line": 491,
             "complexity": 0
           },
           {
-            "line": 901,
+            "line": 501,
             "complexity": 0
           },
           {
-            "line": 902,
+            "line": 502,
             "complexity": 5
           },
           {
-            "line": 903,
+            "line": 503,
             "complexity": 0
           },
           {
-            "line": 908,
+            "line": 508,
             "complexity": 6
           },
           {
-            "line": 911,
+            "line": 511,
             "complexity": 6
           },
           {
-            "line": 916,
+            "line": 516,
             "complexity": 0
           },
           {
-            "line": 918,
+            "line": 518,
             "complexity": 5
           },
           {
-            "line": 920,
+            "line": 520,
             "complexity": 5
           },
           {
-            "line": 924,
+            "line": 524,
             "complexity": 5
           },
           {
-            "line": 927,
+            "line": 527,
             "complexity": 1
           },
           {
-            "line": 929,
+            "line": 529,
             "complexity": 0
           },
           {
-            "line": 931,
+            "line": 531,
             "complexity": 0
           },
           {
-            "line": 978,
+            "line": 578,
             "complexity": 1
           },
           {
-            "line": 981,
+            "line": 581,
             "complexity": 1
           },
           {
-            "line": 984,
+            "line": 584,
             "complexity": 1
           },
           {
-            "line": 985,
+            "line": 585,
             "complexity": 0
           },
           {
-            "line": 986,
+            "line": 586,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 174
+    "complexity": 163
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import os
 import sys
-from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
 
@@ -18,7 +15,6 @@ from immich_memories.cli._date_resolution import (
     infer_memory_type,
     resolve_date_range,
 )
-from immich_memories.cli._flags import output_path
 from immich_memories.cli._generate_display import (
     _build_params_table,
     _print_generation_result,
@@ -30,433 +26,37 @@ from immich_memories.cli._pipeline_runner import (
     run_pipeline_and_generate,
 )
 from immich_memories.cli._trip_generation import handle_trip_generation, resolve_music_arg
+from immich_memories.cli.generate_options import (
+    automation_options,
+    output_options,
+    per_memory_type_options,
+    run_options,
+    scope_options,
+    selection_options,
+)
+from immich_memories.cli.generate_resolution import (
+    _apply_scalar_overrides,
+    _arm_selection_trace,
+    _reject_album_scope_conflicts,
+    _resolve_generation_scope,
+    resolve_inclusion,
+    resolve_short_form,
+)
 from immich_memories.filename_builder import build_memory_output_path, normalize_output_path
 from immich_memories.processing.encoding_plan import resolve_output_selection
 from immich_memories.timeperiod import DateRange, parse_date
-
-if TYPE_CHECKING:
-    from immich_memories.config_loader import Config
-
-
-def _resolve_generation_scope(
-    *,
-    from_album: str | None,
-    year: int | None,
-    start: str | None,
-    end: str | None,
-    period: str | None,
-    birthday: str | None,
-    memory_type: str | None,
-    season: str | None,
-    month: int | None,
-    hemisphere: str,
-    years_back: int | None,
-    on_this_day_target: date | None,
-    holiday: str | None = None,
-) -> tuple[DateRange, list[DateRange]]:
-    """Resolve what a memory covers: date range(s), or an album that defines its own.
-
-    Returns the display range plus the ranges to search. Album mode returns no ranges
-    at all — its span comes from the album's assets, which need a connection to read —
-    so the returned range is a stand-in that album mode replaces and never displays.
-    """
-    if from_album:
-        now = datetime.now()
-        return DateRange(start=now, end=now), []
-
-    # WHY: birthday="auto" means detect from Immich later — don't pass to parser
-    initial_birthday = None if birthday == "auto" else birthday
-    date_result = resolve_date_range(
-        year,
-        start,
-        end,
-        period,
-        initial_birthday,
-        memory_type=memory_type,
-        season=season,
-        month=month,
-        hemisphere=hemisphere,
-        years_back=years_back,
-        on_this_day_target=on_this_day_target,
-        holiday=holiday,
-    )
-
-    # Normalize to single DateRange for display (multi-range for on_this_day)
-    if not isinstance(date_result, list):
-        return date_result, [date_result]
-    if not date_result:
-        print_error("No date ranges generated for On This Day")
-        sys.exit(1)
-    return DateRange(start=date_result[-1].start, end=date_result[0].end), date_result
-
-
-def _reject_album_scope_conflicts(
-    *,
-    year: int | None,
-    start: str | None,
-    end: str | None,
-    period: str | None,
-    birthday: str | None,
-    season: str | None,
-    month: int | None,
-    memory_type: str | None,
-    person_names: list[str] | tuple[str, ...],
-) -> None:
-    """Album mode replaces date-range discovery, so date scoping is meaningless."""
-    conflicts = {
-        "--year": year,
-        "--start": start,
-        "--end": end,
-        "--period": period,
-        "--birthday": birthday,
-        "--season": season,
-        "--month": month,
-        "--memory-type": memory_type,
-        "--person": person_names,
-    }
-    used = sorted(flag for flag, value in conflicts.items() if value)
-    if used:
-        raise click.UsageError(f"--from-album selects its own assets; drop {', '.join(used)}")
-
-
-SHORT_FORM_SECONDS = ("15", "30", "60", "90")
-
-
-@dataclass(frozen=True, slots=True)
-class ShortForm:
-    """What a short-form preset resolves to."""
-
-    duration: float | None
-    orientation: str
-
-
-def resolve_short_form(
-    short_form: str | None,
-    *,
-    duration: float | None,
-    orientation: str,
-    orientation_was_given: bool = False,
-) -> ShortForm:
-    """Apply a short-form preset without overruling anything asked for explicitly.
-
-    The preset is vertical because that is the shape Reels, Shorts and TikTok
-    take, but square short-form is real, so an orientation the user actually
-    typed wins. Same for a duration: the preset fills a gap, it does not argue.
-    """
-    if short_form is None:
-        return ShortForm(duration=duration, orientation=orientation)
-    return ShortForm(
-        duration=duration if duration is not None else int(short_form),
-        orientation=orientation if orientation_was_given else "portrait",
-    )
-
-
-def _apply_scalar_overrides(
-    config: Config,
-    *,
-    photo_duration: float | None,
-    refinement_passes: int | None,
-) -> None:
-    """Let a flag outrank the config file for the dials that have both."""
-    if photo_duration is not None:
-        config.photos.duration = photo_duration
-    if refinement_passes is not None:
-        config.analysis.max_refinement_passes = refinement_passes
-
-
-def resolve_inclusion(flag: bool | None, *, config_enabled: bool) -> bool:
-    """Resolve a content-inclusion choice from an optional CLI flag and config.
-
-    `flag or config_enabled` made the flag one-way: with the feature enabled in
-    config there was no way to ask for a run without it. None means "not
-    specified", so the config decides; an explicit True or False wins.
-    """
-    if flag is None:
-        return config_enabled
-    return flag
-
-
-def _arm_selection_trace(path: Path | None) -> None:
-    """Tell run_selection where to write its stage-by-stage report."""
-    if path:
-        os.environ["IMMICH_MEMORIES_SELECTION_TRACE"] = str(path)
 
 
 def register_generate_commands(main: click.Group) -> None:
     """Register the generate command on the main CLI group."""
 
     @main.command()
-    @click.option(
-        "--year", "-y", type=int, help="Year to generate video for (calendar year by default)"
-    )
-    @click.option("--start", type=str, help="Start date (YYYY-MM-DD or DD/MM/YYYY)")
-    @click.option("--end", type=str, help="End date (use with --start)")
-    @click.option("--period", type=str, help="Period from start date (e.g., 6m, 1y, 2w)")
-    @click.option(
-        "--birthday",
-        "-b",
-        is_flag=False,
-        flag_value="auto",
-        default=None,
-        help="Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15)",
-    )
-    @click.option(
-        "--from-album",
-        "from_album",
-        type=str,
-        default=None,
-        help="Generate from an Immich album (name or ID) instead of a date range",
-    )
-    @click.option("--person", "-p", type=str, multiple=True, help="Person name (repeatable)")
-    @click.option(
-        "--memory-type",
-        type=click.Choice(
-            [
-                "year_in_review",
-                "season",
-                "person_spotlight",
-                "multi_person",
-                "monthly_highlights",
-                "on_this_day",
-                "trip",
-                "holiday",
-                "then_and_now",
-            ]
-        ),
-        default=None,
-        help="Memory type preset",
-    )
-    @click.option(
-        "--holiday",
-        type=str,
-        default=None,
-        help="Holiday name or MM-DD (use with --memory-type holiday)",
-    )
-    @click.option(
-        "--season",
-        type=click.Choice(["spring", "summer", "fall", "autumn", "winter"]),
-        default=None,
-        help="Season (use with --memory-type season)",
-    )
-    @click.option(
-        "--month",
-        type=int,
-        default=None,
-        help="Month 1-12 (with --year, generates that month; selects trip by month)",
-    )
-    @click.option(
-        "--hemisphere",
-        type=click.Choice(["north", "south"]),
-        default="north",
-        help="Hemisphere for season calculation",
-    )
-    @click.option(
-        "--duration",
-        "-d",
-        type=int,
-        default=None,
-        help="Target duration in seconds (default: from memory type preset)",
-    )
-    @click.option(
-        "--short-form",
-        type=click.Choice(SHORT_FORM_SECONDS),
-        default=None,
-        help="Short-form preset: sets the duration and makes the video vertical",
-    )
-    @click.option(
-        "--orientation",
-        type=click.Choice(["landscape", "portrait", "square"]),
-        default="landscape",
-        help="Output orientation",
-    )
-    @click.option(
-        "--scale-mode",
-        "-s",
-        type=click.Choice(["fit", "blur"]),
-        default=None,
-        help="How to fill an aspect mismatch: blurred background or black bars "
-        "(default: from config, else blur)",
-    )
-    @click.option(
-        "--transition",
-        "-t",
-        type=click.Choice(["smart", "cut", "crossfade", "none"]),
-        default="smart",
-        help="Transition style (default: smart — mix of fades & cuts)",
-    )
-    @click.option(
-        "--resolution",
-        "-r",
-        type=click.Choice(["auto", "4k", "1080p", "720p"]),
-        default=None,
-        help="Output resolution (default: config value, 'auto' to match source clips)",
-    )
-    @click.option(
-        "--music-volume",
-        type=float,
-        default=0.5,
-        help="Music volume 0.0-1.0 (default: 0.5)",
-    )
-    @click.option(
-        "--format",
-        "output_format",
-        type=click.Choice(["mp4", "h265", "prores"]),
-        default=None,
-        help="Output format override (default: config value)",
-    )
-    @click.option(
-        "--quality",
-        "-q",
-        type=click.Choice(["high", "medium", "low"]),
-        default=None,
-        help="Output quality (default: from config, typically high)",
-    )
-    @click.option(
-        "--output",
-        "-o",
-        "-O",
-        type=click.Path(),
-        callback=output_path,
-        help="Output file path",
-    )
-    @click.option(
-        "--music",
-        "-m",
-        type=str,
-        default=None,
-        help="Music: path to audio file, 'auto' to generate from config, or omit for default behavior",
-    )
-    @click.option(
-        "--no-music",
-        "no_music",
-        is_flag=True,
-        default=False,
-        help="Disable all music (skip both provided files and AI generation)",
-    )
-    @click.option("--dry-run", is_flag=True, help="Show what would be done without generating")
-    @click.option(
-        "--no-render",
-        is_flag=True,
-        help=(
-            "Run the real selection — analysis, verify, judge, review — and stop "
-            "before encoding. Unlike --dry-run, which uses cached analysis only and "
-            "skips the verify pass, this picks the clips it would actually ship"
-        ),
-    )
-    @click.option(
-        "--trace-selection",
-        type=click.Path(dir_okay=False, path_type=Path),
-        help="Write a stage-by-stage report of how the clips were chosen",
-    )
-    @click.option(
-        "--upload-to-immich",
-        is_flag=True,
-        default=False,
-        help="Upload generated video back to Immich",
-    )
-    @click.option("--album", type=str, default=None, help="Immich album name for uploaded video")
-    @click.option("--add-date", is_flag=True, default=False, help="Caption each clip with its date")
-    @click.option(
-        "--add-place", is_flag=True, default=False, help="Caption each clip with its place"
-    )
-    @click.option(
-        "--keep-intermediates",
-        is_flag=True,
-        default=False,
-        help="Keep intermediate files for debugging",
-    )
-    @click.option("--privacy-mode", is_flag=True, default=False, help="Blur faces and mute speech")
-    @click.option(
-        "--title",
-        "title_override",
-        type=str,
-        default=None,
-        help="Override video title text",
-    )
-    @click.option(
-        "--llm-title",
-        is_flag=True,
-        default=False,
-        help="Ask the LLM for the title instead of using a template (--title still wins)",
-    )
-    @click.option(
-        "--subtitle",
-        "subtitle_override",
-        type=str,
-        default=None,
-        help="Override video subtitle text",
-    )
-    @click.option(
-        "--include-live-photos/--no-live-photos",
-        "include_live_photos",
-        default=None,
-        help="Include Live Photo video clips (3s iPhone clips, merged when burst-captured)",
-    )
-    @click.option(
-        "--include-photos/--no-photos",
-        "include_photos",
-        default=None,
-        help="Include photos as animated Ken Burns clips (blur background, face-aware pan)",
-    )
-    @click.option(
-        "--photo-duration",
-        type=float,
-        default=None,
-        help="Duration per photo clip in seconds (default: 4.0)",
-    )
-    @click.option(
-        "--refinement-passes",
-        type=click.IntRange(1, 20),
-        default=None,
-        help=(
-            "How many times selection may verify, judge and review before settling "
-            "(default: 10). The biggest dial on warm-run time, and on the bill when "
-            "llm.base_url points at a paid API"
-        ),
-    )
-    @click.option(
-        "--analysis-depth",
-        type=click.Choice(["auto", "fast", "thorough"]),
-        default=None,
-        help=(
-            "Analysis depth: auto (full analysis for manageable pools), "
-            "fast (favorites first), or thorough (every eligible clip)"
-        ),
-    )
-    @click.option(
-        "--trip-index",
-        type=int,
-        default=None,
-        help="Select a specific trip by index (use with --memory-type trip)",
-    )
-    @click.option(
-        "--all-trips",
-        is_flag=True,
-        default=False,
-        help="Generate a video for every detected trip (use with --memory-type trip)",
-    )
-    @click.option(
-        "--years-back",
-        type=int,
-        default=None,
-        help="Years to look back for on_this_day, holiday or then_and_now",
-    )
-    @click.option(
-        "--near-date",
-        type=str,
-        default=None,
-        help="Select trip closest to this date (YYYY-MM-DD, use with --memory-type trip)",
-    )
-    @click.option(
-        "--source",
-        type=click.Choice(["manual", "scheduled", "auto"]),
-        default="manual",
-        hidden=True,
-    )
-    @click.option("--memory-key", type=str, default=None, hidden=True)
-    @click.option("--memory-category", type=str, default=None, hidden=True)
-    @click.option("--automation-attempt-id", type=str, default=None, hidden=True)
-    @click.option("--automation-target-date", type=str, default=None, hidden=True)
+    @scope_options
+    @output_options
+    @run_options
+    @selection_options
+    @per_memory_type_options
+    @automation_options
     @click.option("--quiet", is_flag=True, help="Suppress interactive progress, emit log lines")
     @click.pass_context
     def generate(

--- a/src/immich_memories/cli/generate_options.py
+++ b/src/immich_memories/cli/generate_options.py
@@ -1,0 +1,351 @@
+"""The flags `generate` takes, grouped by the part of the run each one decides.
+
+Click builds `--help` — and `make docs-cli` builds the CLI reference — from the
+order the options were applied, so each group is a contiguous slice of the stack
+`generate` used to carry and the groups are applied in that same order. Resorting
+them resorts the documentation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import click
+
+from immich_memories.cli._flags import output_path
+from immich_memories.cli.generate_resolution import SHORT_FORM_SECONDS
+
+FC = TypeVar("FC", bound=Callable[..., Any])
+
+
+def _apply(command: Any, options: list[Any]) -> Any:
+    """Apply option decorators so `--help` lists them in the order written here.
+
+    Click reverses `__click_params__` when it builds the command, so decorators
+    read top to bottom. A list read front to back has to be applied backwards to
+    land in the same order.
+    """
+    for option in reversed(options):
+        command = option(command)
+    return command
+
+
+def scope_options(command: FC) -> FC:
+    """What the memory covers: the window to search, and whose memory it is."""
+    options = [
+        click.option(
+            "--year", "-y", type=int, help="Year to generate video for (calendar year by default)"
+        ),
+        click.option("--start", type=str, help="Start date (YYYY-MM-DD or DD/MM/YYYY)"),
+        click.option("--end", type=str, help="End date (use with --start)"),
+        click.option("--period", type=str, help="Period from start date (e.g., 6m, 1y, 2w)"),
+        click.option(
+            "--birthday",
+            "-b",
+            is_flag=False,
+            flag_value="auto",
+            default=None,
+            help="Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15)",
+        ),
+        click.option(
+            "--from-album",
+            "from_album",
+            type=str,
+            default=None,
+            help="Generate from an Immich album (name or ID) instead of a date range",
+        ),
+        click.option("--person", "-p", type=str, multiple=True, help="Person name (repeatable)"),
+        click.option(
+            "--memory-type",
+            type=click.Choice(
+                [
+                    "year_in_review",
+                    "season",
+                    "person_spotlight",
+                    "multi_person",
+                    "monthly_highlights",
+                    "on_this_day",
+                    "trip",
+                    "holiday",
+                    "then_and_now",
+                ]
+            ),
+            default=None,
+            help="Memory type preset",
+        ),
+        click.option(
+            "--holiday",
+            type=str,
+            default=None,
+            help="Holiday name or MM-DD (use with --memory-type holiday)",
+        ),
+        click.option(
+            "--season",
+            type=click.Choice(["spring", "summer", "fall", "autumn", "winter"]),
+            default=None,
+            help="Season (use with --memory-type season)",
+        ),
+        click.option(
+            "--month",
+            type=int,
+            default=None,
+            help="Month 1-12 (with --year, generates that month; selects trip by month)",
+        ),
+        click.option(
+            "--hemisphere",
+            type=click.Choice(["north", "south"]),
+            default="north",
+            help="Hemisphere for season calculation",
+        ),
+    ]
+    return _apply(command, options)
+
+
+def output_options(command: FC) -> FC:
+    """The file that comes out: its shape, its quality, its soundtrack, its path."""
+    options = [
+        click.option(
+            "--duration",
+            "-d",
+            type=int,
+            default=None,
+            help="Target duration in seconds (default: from memory type preset)",
+        ),
+        click.option(
+            "--short-form",
+            type=click.Choice(SHORT_FORM_SECONDS),
+            default=None,
+            help="Short-form preset: sets the duration and makes the video vertical",
+        ),
+        click.option(
+            "--orientation",
+            type=click.Choice(["landscape", "portrait", "square"]),
+            default="landscape",
+            help="Output orientation",
+        ),
+        click.option(
+            "--scale-mode",
+            "-s",
+            type=click.Choice(["fit", "blur"]),
+            default=None,
+            help="How to fill an aspect mismatch: blurred background or black bars "
+            "(default: from config, else blur)",
+        ),
+        click.option(
+            "--transition",
+            "-t",
+            type=click.Choice(["smart", "cut", "crossfade", "none"]),
+            default="smart",
+            help="Transition style (default: smart — mix of fades & cuts)",
+        ),
+        click.option(
+            "--resolution",
+            "-r",
+            type=click.Choice(["auto", "4k", "1080p", "720p"]),
+            default=None,
+            help="Output resolution (default: config value, 'auto' to match source clips)",
+        ),
+        click.option(
+            "--music-volume",
+            type=float,
+            default=0.5,
+            help="Music volume 0.0-1.0 (default: 0.5)",
+        ),
+        click.option(
+            "--format",
+            "output_format",
+            type=click.Choice(["mp4", "h265", "prores"]),
+            default=None,
+            help="Output format override (default: config value)",
+        ),
+        click.option(
+            "--quality",
+            "-q",
+            type=click.Choice(["high", "medium", "low"]),
+            default=None,
+            help="Output quality (default: from config, typically high)",
+        ),
+        click.option(
+            "--output",
+            "-o",
+            "-O",
+            type=click.Path(),
+            callback=output_path,
+            help="Output file path",
+        ),
+        click.option(
+            "--music",
+            "-m",
+            type=str,
+            default=None,
+            help="Music: path to audio file, 'auto' to generate from config, or omit for default behavior",
+        ),
+        click.option(
+            "--no-music",
+            "no_music",
+            is_flag=True,
+            default=False,
+            help="Disable all music (skip both provided files and AI generation)",
+        ),
+    ]
+    return _apply(command, options)
+
+
+def run_options(command: FC) -> FC:
+    """How far the run goes, where the result lands, and what is written over the clips."""
+    options = [
+        click.option("--dry-run", is_flag=True, help="Show what would be done without generating"),
+        click.option(
+            "--no-render",
+            is_flag=True,
+            help=(
+                "Run the real selection — analysis, verify, judge, review — and stop "
+                "before encoding. Unlike --dry-run, which uses cached analysis only and "
+                "skips the verify pass, this picks the clips it would actually ship"
+            ),
+        ),
+        click.option(
+            "--trace-selection",
+            type=click.Path(dir_okay=False, path_type=Path),
+            help="Write a stage-by-stage report of how the clips were chosen",
+        ),
+        click.option(
+            "--upload-to-immich",
+            is_flag=True,
+            default=False,
+            help="Upload generated video back to Immich",
+        ),
+        click.option(
+            "--album", type=str, default=None, help="Immich album name for uploaded video"
+        ),
+        click.option(
+            "--add-date", is_flag=True, default=False, help="Caption each clip with its date"
+        ),
+        click.option(
+            "--add-place", is_flag=True, default=False, help="Caption each clip with its place"
+        ),
+        click.option(
+            "--keep-intermediates",
+            is_flag=True,
+            default=False,
+            help="Keep intermediate files for debugging",
+        ),
+        click.option(
+            "--privacy-mode", is_flag=True, default=False, help="Blur faces and mute speech"
+        ),
+        click.option(
+            "--title",
+            "title_override",
+            type=str,
+            default=None,
+            help="Override video title text",
+        ),
+        click.option(
+            "--llm-title",
+            is_flag=True,
+            default=False,
+            help="Ask the LLM for the title instead of using a template (--title still wins)",
+        ),
+        click.option(
+            "--subtitle",
+            "subtitle_override",
+            type=str,
+            default=None,
+            help="Override video subtitle text",
+        ),
+    ]
+    return _apply(command, options)
+
+
+def selection_options(command: FC) -> FC:
+    """What the candidate pool may hold, and how hard selection works on it."""
+    options = [
+        click.option(
+            "--include-live-photos/--no-live-photos",
+            "include_live_photos",
+            default=None,
+            help="Include Live Photo video clips (3s iPhone clips, merged when burst-captured)",
+        ),
+        click.option(
+            "--include-photos/--no-photos",
+            "include_photos",
+            default=None,
+            help="Include photos as animated Ken Burns clips (blur background, face-aware pan)",
+        ),
+        click.option(
+            "--photo-duration",
+            type=float,
+            default=None,
+            help="Duration per photo clip in seconds (default: 4.0)",
+        ),
+        click.option(
+            "--refinement-passes",
+            type=click.IntRange(1, 20),
+            default=None,
+            help=(
+                "How many times selection may verify, judge and review before settling "
+                "(default: 10). The biggest dial on warm-run time, and on the bill when "
+                "llm.base_url points at a paid API"
+            ),
+        ),
+        click.option(
+            "--analysis-depth",
+            type=click.Choice(["auto", "fast", "thorough"]),
+            default=None,
+            help=(
+                "Analysis depth: auto (full analysis for manageable pools), "
+                "fast (favorites first), or thorough (every eligible clip)"
+            ),
+        ),
+    ]
+    return _apply(command, options)
+
+
+def per_memory_type_options(command: FC) -> FC:
+    """Flags that mean something for one --memory-type only: trip picking, and how far back."""
+    options = [
+        click.option(
+            "--trip-index",
+            type=int,
+            default=None,
+            help="Select a specific trip by index (use with --memory-type trip)",
+        ),
+        click.option(
+            "--all-trips",
+            is_flag=True,
+            default=False,
+            help="Generate a video for every detected trip (use with --memory-type trip)",
+        ),
+        click.option(
+            "--years-back",
+            type=int,
+            default=None,
+            help="Years to look back for on_this_day, holiday or then_and_now",
+        ),
+        click.option(
+            "--near-date",
+            type=str,
+            default=None,
+            help="Select trip closest to this date (YYYY-MM-DD, use with --memory-type trip)",
+        ),
+    ]
+    return _apply(command, options)
+
+
+def automation_options(command: FC) -> FC:
+    """The identity a scheduled or auto run carries so its attempt can be recorded."""
+    options = [
+        click.option(
+            "--source",
+            type=click.Choice(["manual", "scheduled", "auto"]),
+            default="manual",
+            hidden=True,
+        ),
+        click.option("--memory-key", type=str, default=None, hidden=True),
+        click.option("--memory-category", type=str, default=None, hidden=True),
+        click.option("--automation-attempt-id", type=str, default=None, hidden=True),
+        click.option("--automation-target-date", type=str, default=None, hidden=True),
+    ]
+    return _apply(command, options)

--- a/src/immich_memories/cli/generate_resolution.py
+++ b/src/immich_memories/cli/generate_resolution.py
@@ -1,0 +1,168 @@
+"""What `generate`'s flags mean once the config, the presets and the conflicts settle.
+
+`_date_resolution` turns date flags into windows; this is the layer above it —
+which flags outrank the config file, which combinations contradict each other,
+and which presets fill a gap without overruling anything typed explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from immich_memories.cli._date_resolution import resolve_date_range
+from immich_memories.cli._helpers import print_error
+from immich_memories.timeperiod import DateRange
+
+if TYPE_CHECKING:
+    from immich_memories.config_loader import Config
+
+
+def _resolve_generation_scope(
+    *,
+    from_album: str | None,
+    year: int | None,
+    start: str | None,
+    end: str | None,
+    period: str | None,
+    birthday: str | None,
+    memory_type: str | None,
+    season: str | None,
+    month: int | None,
+    hemisphere: str,
+    years_back: int | None,
+    on_this_day_target: date | None,
+    holiday: str | None = None,
+) -> tuple[DateRange, list[DateRange]]:
+    """Resolve what a memory covers: date range(s), or an album that defines its own.
+
+    Returns the display range plus the ranges to search. Album mode returns no ranges
+    at all — its span comes from the album's assets, which need a connection to read —
+    so the returned range is a stand-in that album mode replaces and never displays.
+    """
+    if from_album:
+        now = datetime.now()
+        return DateRange(start=now, end=now), []
+
+    # WHY: birthday="auto" means detect from Immich later — don't pass to parser
+    initial_birthday = None if birthday == "auto" else birthday
+    date_result = resolve_date_range(
+        year,
+        start,
+        end,
+        period,
+        initial_birthday,
+        memory_type=memory_type,
+        season=season,
+        month=month,
+        hemisphere=hemisphere,
+        years_back=years_back,
+        on_this_day_target=on_this_day_target,
+        holiday=holiday,
+    )
+
+    # Normalize to single DateRange for display (multi-range for on_this_day)
+    if not isinstance(date_result, list):
+        return date_result, [date_result]
+    if not date_result:
+        print_error("No date ranges generated for On This Day")
+        sys.exit(1)
+    return DateRange(start=date_result[-1].start, end=date_result[0].end), date_result
+
+
+def _reject_album_scope_conflicts(
+    *,
+    year: int | None,
+    start: str | None,
+    end: str | None,
+    period: str | None,
+    birthday: str | None,
+    season: str | None,
+    month: int | None,
+    memory_type: str | None,
+    person_names: list[str] | tuple[str, ...],
+) -> None:
+    """Album mode replaces date-range discovery, so date scoping is meaningless."""
+    conflicts = {
+        "--year": year,
+        "--start": start,
+        "--end": end,
+        "--period": period,
+        "--birthday": birthday,
+        "--season": season,
+        "--month": month,
+        "--memory-type": memory_type,
+        "--person": person_names,
+    }
+    used = sorted(flag for flag, value in conflicts.items() if value)
+    if used:
+        raise click.UsageError(f"--from-album selects its own assets; drop {', '.join(used)}")
+
+
+SHORT_FORM_SECONDS = ("15", "30", "60", "90")
+
+
+@dataclass(frozen=True, slots=True)
+class ShortForm:
+    """What a short-form preset resolves to."""
+
+    duration: float | None
+    orientation: str
+
+
+def resolve_short_form(
+    short_form: str | None,
+    *,
+    duration: float | None,
+    orientation: str,
+    orientation_was_given: bool = False,
+) -> ShortForm:
+    """Apply a short-form preset without overruling anything asked for explicitly.
+
+    The preset is vertical because that is the shape Reels, Shorts and TikTok
+    take, but square short-form is real, so an orientation the user actually
+    typed wins. Same for a duration: the preset fills a gap, it does not argue.
+    """
+    if short_form is None:
+        return ShortForm(duration=duration, orientation=orientation)
+    return ShortForm(
+        duration=duration if duration is not None else int(short_form),
+        orientation=orientation if orientation_was_given else "portrait",
+    )
+
+
+def _apply_scalar_overrides(
+    config: Config,
+    *,
+    photo_duration: float | None,
+    refinement_passes: int | None,
+) -> None:
+    """Let a flag outrank the config file for the dials that have both."""
+    if photo_duration is not None:
+        config.photos.duration = photo_duration
+    if refinement_passes is not None:
+        config.analysis.max_refinement_passes = refinement_passes
+
+
+def resolve_inclusion(flag: bool | None, *, config_enabled: bool) -> bool:
+    """Resolve a content-inclusion choice from an optional CLI flag and config.
+
+    `flag or config_enabled` made the flag one-way: with the feature enabled in
+    config there was no way to ask for a run without it. None means "not
+    specified", so the config decides; an explicit True or False wins.
+    """
+    if flag is None:
+        return config_enabled
+    return flag
+
+
+def _arm_selection_trace(path: Path | None) -> None:
+    """Tell run_selection where to write its stage-by-stage report."""
+    if path:
+        os.environ["IMMICH_MEMORIES_SELECTION_TRACE"] = str(path)

--- a/tests/test_cli_inclusion_flags.py
+++ b/tests/test_cli_inclusion_flags.py
@@ -7,7 +7,7 @@ video-only memory from the command line.
 
 from __future__ import annotations
 
-from immich_memories.cli.generate import resolve_inclusion
+from immich_memories.cli.generate_resolution import resolve_inclusion
 
 
 class TestResolveInclusion:

--- a/tests/test_cli_short_form.py
+++ b/tests/test_cli_short_form.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from immich_memories.cli.generate import SHORT_FORM_SECONDS, resolve_short_form
+from immich_memories.cli.generate_resolution import SHORT_FORM_SECONDS, resolve_short_form
 
 
 def test_the_preset_sets_the_duration() -> None:

--- a/tests/test_generation_scope.py
+++ b/tests/test_generation_scope.py
@@ -9,7 +9,7 @@ import pytest
 from rich.table import Table
 
 from immich_memories.cli._generate_display import _add_scope_rows, _format_target_duration
-from immich_memories.cli.generate import (
+from immich_memories.cli.generate_resolution import (
     _reject_album_scope_conflicts,
     _resolve_generation_scope,
 )

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -101,7 +101,7 @@ SPECS: dict[MemoryType, MemorySpec] = {
 # from what the album holds. Registering a preset for it must fail this file.
 ALBUM_HAS_NO_PRESET = MemoryType.ALBUM
 
-# --memory-type's choices, copied from cli/generate.py so a type added to the
+# --memory-type's choices, copied from cli/generate_options.py so a type added to the
 # registry and not to the flag is caught here rather than by a user.
 CLI_MEMORY_TYPE_CHOICES = frozenset(
     {


### PR DESCRIPTION
Ticks the first box of #686.

`cli/generate.py` was at **995 lines against a 1000-line hard gate** — five lines of headroom. The next PR that adds a flag to it fails `make file-length` for a reason unrelated to its own change. This is wave PR 0 because it unblocks that.

## What moved

| file | before | after |
|---|---:|---:|
| `cli/generate.py` | 995 | **595** |
| `cli/generate_options.py` | — | 351 |
| `cli/generate_resolution.py` | — | 168 |

**`cli/generate_options.py`** — the ~50-option decorator stack, as six group decorators:

| group | what it decides |
|---|---|
| `scope_options` | `--year … --hemisphere`: the window to search, and whose memory it is |
| `output_options` | `--duration … --no-music`: the file that comes out, its quality, its soundtrack, its path |
| `run_options` | `--dry-run … --subtitle`: how far the run goes, where the result lands, what is written over the clips |
| `selection_options` | `--include-live-photos … --analysis-depth`: what the pool may hold, how hard selection works on it |
| `per_memory_type_options` | `--trip-index … --near-date`: flags that mean something for one `--memory-type` only |
| `automation_options` | the five hidden flags carrying a scheduled run's identity |

Each group is a **contiguous slice of the original stack**, and the groups are applied in the original order. That is load-bearing, not tidiness: Click builds `--help` from `__click_params__`, and `scripts/generate_cli_docs.py` builds `docs-site/docs/create/cli/generate.md` from `cmd.params`. Reordering the groups reorders the documentation and fails `make docs-cli-check`. The module docstring says so.

`--quiet` and `@click.pass_context` stayed inline rather than being forced into a group they don't belong to.

**`cli/generate_resolution.py`** — the flag-resolution helpers (`_resolve_generation_scope`, `_reject_album_scope_conflicts`, `resolve_short_form` + `ShortForm` + `SHORT_FORM_SECONDS`, `_apply_scalar_overrides`, `resolve_inclusion`, `_arm_selection_trace`). This is the layer above `_date_resolution`: that one turns date flags into windows, this one decides which flags outrank the config file and which combinations contradict each other.

## What did not move

`register_generate_commands` itself. Its 163 cognitive-complexity points are a **separate recorded disease** — complexity, not length. Decomposing it here would mix two concerns and make both harder to review. Its complexity is byte-identical after this change (see below), which is the proof the two are actually independent.

## Behaviour-neutral, and shown rather than asserted

The diff to `generate.py` is **deletions plus imports**: the only added lines are the two new import statements and the six decorator lines. Every other line is a deletion of a moved block. `git diff --numstat` on the remaining file confirms it — `23  423`, and all 23 additions are import or decorator lines.

The proof the Click surface is unchanged: dumped `main.commands["generate"].params` on both sides — for every parameter, in order, its `name`, `opts`, `secondary_opts`, `type`, `default`, `required`, `help`, `hidden`, `is_flag`, `flag_value`, `multiple`, `count`, `callback` and `expose_value`, plus the command's `help` text. The two dumps diff to **two lines**, both the heap address inside `<click.types.Path object at 0x…>` (that class has no informative `repr`). Both `Path` instances were then compared attribute by attribute and match: `--output` is `click.Path()`, `--trace-selection` is `click.Path(dir_okay=False, path_type=Path)`.

The moved helper block was diffed line for line against the original — byte-identical.

## Patch-target audit, site by site

Nine references to `immich_memories.cli.generate` across the tree. None broke silently:

| site | verdict |
|---|---|
| `tests/test_generate.py`, `test_cli_smoke.py`, `test_storage_cli_coverage.py`, `test_refinement_passes_config.py`, `tests/integration/cli/test_generate.py` — 20 × `patch("immich_memories.cli.generate.fetch_videos_and_live_photos")` / `.run_pipeline_and_generate` | **Untouched.** Both names are still bound in `generate`'s namespace by the same `from … import` and still called as bare names in the command body, so the patch resolves exactly as before. Nothing to repoint. |
| `tests/test_generation_scope.py` → `_resolve_generation_scope`, `_reject_album_scope_conflicts` | **Repointed** to `generate_resolution`. The old path would still have worked (`generate.py` imports both because it calls both), but these are direct unit tests of the functions and the honest import is their new home, not a module that happens to re-import them. |
| `tests/test_cli_inclusion_flags.py` → `resolve_inclusion` | **Repointed**, same reasoning. |
| `tests/test_cli_short_form.py` → `SHORT_FORM_SECONDS`, `resolve_short_form` | **Repointed — mandatory.** `SHORT_FORM_SECONDS` is now used only by the `--short-form` Choice in `generate_options`; keeping it imported into `generate.py` would be an unused import (`F401`) and a re-export shim for a single consumer, both of which the project forbids. |
| `tests/test_surface_parity.py:104` — comment "copied from `cli/generate.py`" | **Comment updated** to `cli/generate_options.py`, where `--memory-type`'s choices now live. The test asserts nothing about the module path; a stale pointer would just send the next reader to the wrong file. |
| `scripts/simulate-cli-demo.py:22` — `from immich_memories.cli.generate import _build_params_table` | **Left alone.** A pre-existing indirect import through `generate.py` of a symbol that lives in `_generate_display`. `generate.py` still imports it, so the path still resolves. Repointing it is a real cleanup but a different concern from this one, and touching it would put a non-deletion into the shrinking file. |

## Gates

Full `make ci` green locally, including the ones this change could plausibly have broken:

- `make file-length` — 595 / 351 / 168, all under the soft limit.
- `make docs-cli-check` — no drift in the generated CLI reference, which is the independent confirmation that option order survived.
- `make complexity` (Xenon) — moving the low-complexity helpers out could have raised `generate.py`'s module average; it did the opposite. No new branches anywhere; the six group functions are one `for` loop each.
- `make cognitive-complexity` — the snapshot regenerated because line numbers shifted (`register_generate_commands` 185 → 50) and is staged. Its complexity is **163 before and after**; the file total drops 174 → 163 as the helpers leave. The watermark tightened, it did not absorb anything.
- `make critique` — the WHY ratchet is unmoved: no `patch()` calls were added or removed.

`ARCHITECTURE.md` updated with both new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
