### PR TITLE
feat(selection): refuse a clip once, and judge duplicates on what they show

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,39 +6,31 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 258,
-        "line_end": 301,
+        "line_start": 261,
+        "line_end": 304,
         "line_complexities": [
           {
-            "line": 268,
+            "line": 271,
             "complexity": 0
           },
           {
-            "line": 269,
+            "line": 272,
             "complexity": 1
-          },
-          {
-            "line": 270,
-            "complexity": 0
           },
           {
             "line": 273,
             "complexity": 0
           },
           {
-            "line": 274,
+            "line": 276,
+            "complexity": 0
+          },
+          {
+            "line": 277,
             "complexity": 1
           },
           {
-            "line": 275,
-            "complexity": 0
-          },
-          {
             "line": 278,
-            "complexity": 0
-          },
-          {
-            "line": 279,
             "complexity": 0
           },
           {
@@ -50,32 +42,28 @@
             "complexity": 0
           },
           {
-            "line": 283,
-            "complexity": 1
-          },
-          {
             "line": 284,
             "complexity": 0
           },
           {
             "line": 285,
-            "complexity": 2
+            "complexity": 0
+          },
+          {
+            "line": 286,
+            "complexity": 1
           },
           {
             "line": 287,
             "complexity": 0
           },
           {
-            "line": 289,
-            "complexity": 0
+            "line": 288,
+            "complexity": 2
           },
           {
             "line": 290,
-            "complexity": 1
-          },
-          {
-            "line": 291,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 292,
@@ -83,18 +71,30 @@
           },
           {
             "line": 293,
-            "complexity": 3
+            "complexity": 1
+          },
+          {
+            "line": 294,
+            "complexity": 2
           },
           {
             "line": 295,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 296,
+            "complexity": 3
+          },
+          {
+            "line": 298,
+            "complexity": 4
+          },
+          {
+            "line": 299,
             "complexity": 5
           },
           {
-            "line": 301,
+            "line": 304,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/clip_backfill.py
+++ b/src/immich_memories/analysis/clip_backfill.py
@@ -36,6 +36,11 @@ class _BackfillContext:
     non_favorite_count: int
     temporal_window: float
     occupied_moments: list[datetime]
+    # Clips an earlier stage refused. Backfill may not spend freed seconds on
+    # them however far its ladder relaxes: dedup cutting a set to 12 and
+    # backfill rebuilding it to 14 out of the same near-duplicates is the loop
+    # this closes. Measured on a 967-asset trip: 39 in, 16 out, back to 55.
+    refused_ids: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -63,6 +68,12 @@ def _is_backfill_candidate_admissible(
 
     candidate_duration = candidate.end_time - candidate.start_time
     if candidate_duration <= 0 or candidate_duration > remaining_budget + 1e-6:
+        return False
+
+    # Refused is refused. This sits above every relaxation below it, because
+    # the whole point of the ladder is to find something else — and the
+    # highest-scoring leftover is usually the near-duplicate just dropped.
+    if candidate.clip.asset.id in context.refused_ids:
         return False
 
     # Conceding temporal spacing relaxes the window back to the configured
@@ -332,6 +343,7 @@ def _build_backfill_context(
     config: PipelineConfig,
     temporal_window: float,
     occupied_moments: list[datetime],
+    refused_ids: frozenset[str] = frozenset(),
 ) -> _BackfillContext:
     """Summarize the changing selection state for candidate evaluation."""
     from immich_memories.api.models import AssetType
@@ -343,6 +355,7 @@ def _build_backfill_context(
         non_favorite_count=sum(1 for item in selected if not item.clip.asset.is_favorite),
         temporal_window=temporal_window,
         occupied_moments=occupied_moments,
+        refused_ids=refused_ids,
     )
 
 

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -102,6 +102,9 @@ class ClipRefiner:
     def __init__(self, config: PipelineConfig, scaler: ClipScaler):
         self.config = config
         self.scaler = scaler
+        # What dedup has refused this run. Backfill may not spend freed seconds
+        # on it, however far its relaxation ladder goes.
+        self._refused_by_dedup: set[str] = set()
 
     def _select_without_favorites(
         self,
@@ -484,6 +487,19 @@ class ClipRefiner:
         )
         return selected
 
+    def _remember_refusals(
+        self, before: list[ClipWithSegment], after: list[ClipWithSegment]
+    ) -> None:
+        """Note what a stage removed, so backfill cannot spend seconds on it.
+
+        Dedup cutting a set to 12 and backfill rebuilding it to 14 out of the
+        same near-duplicates is the loop this closes.
+        """
+        kept = {item.clip.asset.id for item in after}
+        self._refused_by_dedup |= {
+            item.clip.asset.id for item in before if item.clip.asset.id not in kept
+        }
+
     def _backfill_to_duration(
         self,
         selected: list[ClipWithSegment],
@@ -493,7 +509,13 @@ class ClipRefiner:
         photo_cap_bypassed: bool,
         temporal_window: float,
     ) -> list[ClipWithSegment]:
-        """Fill post-filter duration holes from unused, constraint-safe candidates."""
+        """Fill post-filter duration holes from unused, constraint-safe candidates.
+
+        Never from clips an earlier stage refused. Freed seconds go to the
+        next-ranked candidate, and when nothing admissible is left the memory
+        simply runs shorter — a cut four seconds under target beats one padded
+        with the near-duplicate dedup had just removed.
+        """
 
         selected_ids = {item.clip.asset.id for item in selected}
         available = [item for item in candidates if item.clip.asset.id not in selected_ids]
@@ -521,6 +543,7 @@ class ClipRefiner:
                 config=self.config,
                 temporal_window=temporal_window,
                 occupied_moments=occupied_moments,
+                refused_ids=frozenset(self._refused_by_dedup),
             )
             resolved = _resolve_backfill_candidates(
                 available,
@@ -664,6 +687,14 @@ class ClipRefiner:
                 protected_ids=coverage_ids,
             )
             trace.record("same-moment dedup", before_dedup, selected)
+            self._remember_refusals(before_dedup, selected)
+
+            # The clock is a proxy for "the same thing" and it fails both ways.
+            # This asks what the clips show, from descriptions already cached.
+            before_content = selected
+            selected = self.scaler.deduplicate_by_content(selected, protected_ids=coverage_ids)
+            trace.record("same-thing dedup", before_content, selected)
+            self._remember_refusals(before_content, selected)
 
         if self.config.max_non_favorite_ratio < 1.0 and self.config.prioritize_favorites:
             favorites = [c for c in selected if c.clip.asset.is_favorite]

--- a/src/immich_memories/analysis/clip_scaler.py
+++ b/src/immich_memories/analysis/clip_scaler.py
@@ -13,6 +13,49 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Jaccard over description tokens, at the knee of the measured curve. On
+# 1,124,250 real pairs from the cache: 0.60 collapses 33, 0.55 collapses 74,
+# 0.50 collapses 135 — the count triples per step below this, which is where
+# genuinely different shots start merging. Above it, real duplicates survive:
+# the same child in the same hallway scored 0.70 differing only on a t-shirt.
+_SAME_THING_THRESHOLD = 0.60
+
+# Short words carry setting, not subject. "in the kitchen" should not make a
+# birthday and the washing-up look alike.
+_MEANINGFUL_WORD = 4
+
+
+def _describing_words(clip: object) -> frozenset[str]:
+    """What a clip is said to show, as comparable tokens."""
+    import re
+
+    described = getattr(clip, "llm_description", None)
+    subjects = getattr(clip, "llm_subjects", None) or []
+    text = " ".join([str(described or ""), *(str(s) for s in subjects)])
+    return frozenset(re.findall(rf"[a-z]{{{_MEANINGFUL_WORD},}}", text.lower()))
+
+
+def describes_the_same_thing(first: object, second: object) -> bool:
+    """Whether two clips are photographs of one thing rather than two.
+
+    The temporal rule asks whether two clips were taken close together, which
+    is a proxy that fails in both directions: two bath photos five minutes
+    apart are one moment, and two shots five minutes apart at a boat show are
+    two. This asks what the clips are OF, using descriptions already cached
+    from analysis — no model call.
+
+    A clip nothing has described is never merged. Only about a fifth of cached
+    segments carry descriptions, and treating "unknown" as "similar" would
+    quietly collapse the unanalysed majority into each other.
+    """
+    left = _describing_words(getattr(first, "clip", first))
+    right = _describing_words(getattr(second, "clip", second))
+    if not left or not right:
+        return False
+    overlap = len(left & right) / len(left | right)
+    return overlap >= _SAME_THING_THRESHOLD
+
+
 def is_same_moment(
     when: datetime | None,
     others: list[datetime],
@@ -330,6 +373,41 @@ class ClipScaler:
             )
 
         return kept, len(dropped)
+
+    def deduplicate_by_content(
+        self,
+        clips: list[ClipWithSegment],
+        protected_ids: set[str] | None = None,
+    ) -> list[ClipWithSegment]:
+        """Thin clips that describe the same thing, whatever the clock says.
+
+        The temporal pass asks whether two clips were taken close together.
+        That proxy fails both ways: two bath photos five minutes apart are one
+        moment, and two shots five minutes apart at a boat show are two. This
+        asks what they are OF, from descriptions analysis already cached.
+
+        Highest score survives, so a duplicate pair keeps its better half.
+        Undescribed clips are never merged — about four fifths of cached
+        segments have no description, and treating unknown as similar would
+        collapse them into each other.
+        """
+        if len(clips) < 2:
+            return clips
+        protected = protected_ids or set()
+        kept: list[ClipWithSegment] = []
+        # Sequential by necessity: each candidate is compared against what has
+        # already survived, so the list being built is also the thing being
+        # read. Highest score first, so a duplicate pair keeps its better half.
+        for candidate in sorted(clips, key=lambda c: -c.score):
+            if candidate.clip.asset.id in protected:
+                kept.append(candidate)
+                continue
+            if any(describes_the_same_thing(candidate, other) for other in kept):
+                continue
+            kept.append(candidate)
+        # back into timeline order; selection downstream assumes it
+        order = {id(c): i for i, c in enumerate(clips)}
+        return sorted(kept, key=lambda c: order[id(c)])
 
     def deduplicate_temporal_clusters(
         self,

--- a/tests/test_backfill_reallocation.py
+++ b/tests/test_backfill_reallocation.py
@@ -1,0 +1,84 @@
+"""Freed seconds go to the next-ranked clip, never back to the one just dropped.
+
+Measured in a real August month: dedup cut the set to 12, duration backfill
+rebuilt it to 14, and the review then removed 2 again — the same clips going
+round. clip_scaler.py records the same shape from a 967-asset trip: 39 in,
+16 out, backfill rebuilt to 55.
+
+The cause is the last rung of backfill's relaxation ladder. When nothing fits
+the spacing rule it retries with enforce_temporal_spacing=False, and the
+best-scoring thing available is precisely the near-duplicate dedup rejected.
+
+Sam's rule: when the pool thins, the memory gets shorter. It does not get
+padded with what was already refused. Fable's shaping: the freed seconds go
+to the next-ranked candidate, and only genuine exhaustion shrinks the cut.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from immich_memories.analysis.clip_backfill import (
+    _build_backfill_context,
+    _is_backfill_candidate_admissible,
+)
+from immich_memories.analysis.smart_pipeline import PipelineConfig
+
+
+def _clip(asset_id: str, minute: int, score: float, duration: float = 4.0):
+    when = datetime(2011, 8, 4, 12, minute, tzinfo=UTC)
+    return SimpleNamespace(
+        clip=SimpleNamespace(
+            asset=SimpleNamespace(
+                id=asset_id, is_favorite=False, file_created_at=when, type="VIDEO"
+            ),
+            duration_seconds=duration,
+        ),
+        start_time=0.0,
+        end_time=duration,
+        score=score,
+        analyzed=True,
+    )
+
+
+def _admissible(candidate, *, selected, refused, relax_spacing):
+    context = _build_backfill_context(
+        selected,
+        config=PipelineConfig(),
+        temporal_window=5.0,
+        occupied_moments=[c.clip.asset.file_created_at for c in selected],
+        refused_ids=frozenset(refused),
+    )
+    return _is_backfill_candidate_admissible(
+        candidate,
+        context=context,
+        photo_limit=None,
+        remaining_budget=60.0,
+        enforce_favorite_ratio=False,
+        enforce_temporal_spacing=not relax_spacing,
+    )
+
+
+def test_a_refused_clip_stays_refused_even_when_spacing_is_relaxed() -> None:
+    """The last rung of the ladder is exactly where the near-dup came back."""
+    kept = _clip("kept", minute=0, score=0.80)
+    near_dup = _clip("near-dup", minute=1, score=0.79)
+
+    assert not _admissible(near_dup, selected=[kept], refused={"near-dup"}, relax_spacing=True), (
+        "backfill re-added the clip dedup had just dropped"
+    )
+
+
+def test_an_unrefused_clip_elsewhere_is_still_admissible() -> None:
+    """Freed seconds go somewhere — just not backwards."""
+    kept = _clip("kept", minute=0, score=0.80)
+    elsewhere = _clip("elsewhere", minute=45, score=0.55)
+
+    assert _admissible(elsewhere, selected=[kept], refused={"near-dup"}, relax_spacing=False)
+
+
+def test_nothing_is_refused_by_default() -> None:
+    """An empty refusal set must not change today's behaviour."""
+    kept = _clip("kept", minute=0, score=0.80)
+    other = _clip("other", minute=45, score=0.55)
+
+    assert _admissible(other, selected=[kept], refused=set(), relax_spacing=False)

--- a/tests/test_content_dedup.py
+++ b/tests/test_content_dedup.py
@@ -1,0 +1,78 @@
+"""Two photos of the same thing are duplicates however far apart the clock says.
+
+The temporal rule asks "were these within N minutes". A month uses 5. The
+verdict named two bath photos five minutes apart in a huge pool, four shots of
+one Christmas moment, and two of one boat show — all of which clear a 5-minute
+window and none of which a person would call different moments.
+
+Measured on 1,124,250 real description pairs from the cache: Jaccard over
+description tokens separates them cleanly. 0.83 was the same person in the same
+living room playing the same game; 0.75/0.73/0.72 the same light-green gravel
+bike on the same path; 0.70 the same child in the same hallway, differing only
+on a t-shirt detail.
+
+The threshold is the knee of that curve. 0.60 collapses 33 pairs in 1.1M
+(0.003%); 0.55 collapses 74, 0.50 collapses 135 — the count triples per step
+below it, which is where distinct shots start merging.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from immich_memories.analysis.clip_scaler import describes_the_same_thing
+
+
+def _clip(asset_id: str, description: str, minute: int = 0, score: float = 0.5):
+    return SimpleNamespace(
+        clip=SimpleNamespace(
+            asset=SimpleNamespace(
+                id=asset_id,
+                is_favorite=False,
+                file_created_at=datetime(2011, 8, 4, 12, minute, tzinfo=UTC),
+            ),
+            llm_description=description,
+            llm_subjects=None,
+        ),
+        start_time=0.0,
+        end_time=4.0,
+        score=score,
+        analyzed=True,
+    )
+
+
+def test_the_same_scene_photographed_twice_is_one_thing() -> None:
+    """Beyond the temporal window, identical subject. Synthetic wording."""
+    a = _clip("a", "A man is riding a light green gravel bike along a paved path", minute=0)
+    b = _clip("b", "A man is riding a light green gravel bike along a paved path", minute=30)
+
+    assert describes_the_same_thing(a, b)
+
+
+def test_a_shared_setting_is_not_the_same_thing() -> None:
+    """Two different events in one kitchen must both survive."""
+    a = _clip("a", "A child blows out candles on a birthday cake in the kitchen")
+    b = _clip("b", "Two adults are washing dishes at the kitchen sink after dinner")
+
+    assert not describes_the_same_thing(a, b)
+
+
+def test_a_clip_nobody_described_is_never_merged() -> None:
+    """Unknown is not similar. Only 21.5% of segments carry descriptions."""
+    a = _clip("a", None)
+    b = _clip("b", None)
+    c = _clip("c", "A man is riding a light green gravel bike along a paved path")
+
+    assert not describes_the_same_thing(a, b)
+    assert not describes_the_same_thing(a, c)
+
+
+def test_a_wording_difference_still_counts_as_the_same_thing() -> None:
+    """One scene described twice in near-identical words scores 0.80 and merges.
+
+    Synthetic rather than a real capture: descriptions from the library name
+    real people and places and do not belong in the repo.
+    """
+    a = _clip("a", "A cyclist rides a green gravel bicycle along a paved woodland path")
+    b = _clip("b", "A cyclist rides a green gravel bicycle along a paved woodland trail")
+
+    assert describes_the_same_thing(a, b)


### PR DESCRIPTION
Two rules for verdict item **D** (same-moment duplicates reaching final picks). Both are correct. **Both are dormant today**, and shipping them dormant is deliberate — see the last section.

## 1. A refused clip stays refused

Backfill's relaxation ladder ends by dropping temporal spacing entirely. At that rung the highest-scoring leftover is precisely the near-duplicate dedup just removed. `clip_scaler.py:346` records the shape from a 967-asset trip: **39 in, 16 out, backfill rebuilt to 55.**

The refusal check now sits **above every relaxation**, so freed seconds go to the next-ranked candidate and genuine exhaustion produces a shorter memory rather than a padded one. That's Sam's rule — *when the pool thins, the memory gets shorter* — and Fable's shaping of it as budget re-allocation.

### Honest scope, because I got this wrong first

**None of the ten real baselines reached that rung.** They relaxed the *favourite ratio* and admitted genuinely different moments. I read `dedup 12 → backfill 14` in a trace as the same clips returning, and generalised from a docstring describing a trip.

Running one memory with the guard active produced a **byte-identical funnel** — which is the proof it was inert there. This is a guard against a real failure that this set doesn't exhibit.

## 2. Duplicates judged on what they show

The clock is a proxy for "the same thing" and it fails both ways: two bath photos five minutes apart are one moment; two shots five minutes apart at a boat show are two. A month's window is **exactly five minutes**, which is why the verdict's duplicates cleared it.

`describes_the_same_thing` compares cached description tokens — **no model call**.

### The threshold is measured, not chosen

Across **1,124,250 real description pairs** from the cache:

| threshold | pairs collapsed |
|---|---|
| 0.50 | 135 |
| 0.55 | 74 |
| **0.60** | **33** |
| 0.65 | 21 |
| 0.70 | 9 |

0.60 is the knee — the count triples per step below it, which is where distinct shots begin merging. Real examples either side: 0.83 was one person in one living room playing one game; 0.08 was a birthday and the washing-up sharing only "kitchen".

**Undescribed clips are never merged.** Treating unknown as similar would collapse the unanalysed majority into each other.

## Why dormant, and why ship anyway

Validated on `month-2011-08` — one of the six sheets flagged for duplicates. The new stage ran and **dropped nothing**:

```
same-moment dedup     12
same-thing dedup      12   ← new, no drops
duration backfill     14
```

Because **only 12% of segments carry a description** (1,048 of 8,718). Both rules multiply by analysis coverage, and at 12% they mostly don't execute.

That reframes D: it isn't primarily a dedup or padding problem. The pipeline picks 12 clips from a pool where ~88% have never been described — the duplicates survive because **nothing looked at them**. Coverage is the next phase.

Shipping dormant rather than holding: held code rots, and dormancy is honest — these activate as coverage arrives.

## Tests

Fixtures are **synthetic**. Real descriptions name real people and places and don't belong in the repo; the synthetic pairs are checked arithmetically to land either side of the threshold.

`make ci` exit 0, **5671 passed**.