### PR TITLE
refactor(ui): split app.py below the 800-line cap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -309,6 +309,7 @@ src/immich_memories/
 │   ├── app.py                  # App setup & routing
 │   ├── auth.py                 # Auth middleware, credential verification, session helpers
 │   ├── auth_oidc.py            # OIDC client (authlib starlette integration, singleton)
+│   ├── health_api.py           # GET /health, /health/live, /health/ready — probe payloads + snapshot cache
 │   ├── trigger_api.py          # POST /api/trigger — runs what `auto run` decides, 202 + status URL
 │   ├── reverse_proxy.py        # Secure cookie + trusted X-Forwarded-* kwargs for ui.run
 │   ├── state.py                # Shared UI state

--- a/src/immich_memories/ui/app.py
+++ b/src/immich_memories/ui/app.py
@@ -9,28 +9,19 @@ import os
 import secrets
 import socket
 import sys
-import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from immich_memories.config_loader import Config
     from immich_memories.config_models_auth import AuthConfig
 
-import httpx
 from nicegui import app, ui
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
-from immich_memories import __version__
 from immich_memories.automation.in_process_scheduler import automation_scheduler
 from immich_memories.config import get_config, init_config_dir
-from immich_memories.security import (
-    configured_secret_values,
-    sanitize_error_message,
-    write_secret_file,
-)
+from immich_memories.security import write_secret_file
 from immich_memories.ui.auth import (
     clear_session,
     client_ip_for_rate_limit,
@@ -43,6 +34,7 @@ from immich_memories.ui.auth import (
     set_session,
     trigger_token_authorizes,
 )
+from immich_memories.ui.health_api import register_health_routes
 from immich_memories.ui.reverse_proxy import reverse_proxy_run_kwargs
 from immich_memories.ui.state import ensure_config, get_app_state
 from immich_memories.ui.theme import apply_theme, render_theme_toggle
@@ -330,265 +322,11 @@ def cache_page() -> None:
 
 
 # ============================================================================
-# Health Endpoint
+# Operational Routes
 # ============================================================================
 
-
-@dataclass(frozen=True)
-class _ImmichDependency:
-    """Sanitized result of the dependency probe used by health responses."""
-
-    status: Literal[
-        "ready",
-        "missing_configuration",
-        "unreachable",
-        "authentication_failed",
-        "unsupported_version",
-    ]
-    reachable: bool
-    resolved_api_version: str | None = None
-
-
-async def _check_immich_dependency(config) -> _ImmichDependency:
-    """Resolve the configured API policy and authenticate within a bounded time."""
-    from immich_memories.api.compatibility import UnsupportedImmichVersion
-    from immich_memories.api.immich import ImmichAPIError, ImmichAuthError, ImmichClient
-
-    try:
-        async with ImmichClient(
-            base_url=config.immich.url,
-            api_key=config.immich.api_key,
-            api_version=config.immich.api_version,
-            timeout=2.0,
-        ) as client:
-
-            async def resolve_and_authenticate() -> str:
-                resolved = await client.get_api_version()
-                await client.get_current_user()
-                return resolved.value
-
-            resolved_api_version = await asyncio.wait_for(resolve_and_authenticate(), timeout=5.0)
-        return _ImmichDependency(
-            status="ready",
-            reachable=True,
-            resolved_api_version=resolved_api_version,
-        )
-    except UnsupportedImmichVersion:
-        return _ImmichDependency(status="unsupported_version", reachable=True)
-    except ImmichAuthError:
-        return _ImmichDependency(status="authentication_failed", reachable=True)
-    except (ImmichAPIError, TimeoutError, httpx.HTTPError, OSError, ValueError):
-        return _ImmichDependency(status="unreachable", reachable=False)
-
-
-def _get_last_successful_run(config) -> str | None:
-    """Return ISO timestamp of last completed run, or None."""
-    from immich_memories.tracking.run_database import RunDatabase
-
-    db = RunDatabase(db_path=config.cache.database_path)
-    runs = db.list_runs(limit=1, status="completed")
-    if runs and runs[0].completed_at:
-        return runs[0].completed_at.isoformat()
-    return None
-
-
-def _get_automation_status(config) -> dict[str, Any]:
-    """Return the durable, read-only smart automation status contract."""
-    from immich_memories.automation.runner import AutoRunner
-
-    return AutoRunner(config).status().to_dict()
-
-
-def _automation_field(automation: dict[str, Any] | None, name: str) -> Any:
-    """Project one optional automation field without branching in readiness logic."""
-    return automation.get(name) if automation is not None else None
-
-
-def _sanitize_health_text(value: object, secrets_to_redact: tuple[str, ...]) -> str:
-    """Apply structural and config-aware sanitization before exposing health text."""
-    safe = sanitize_error_message(str(value))
-    for secret in secrets_to_redact:
-        safe = safe.replace(secret, "***")
-    return safe
-
-
-def _redact_health_value(value: Any, secrets_to_redact: tuple[str, ...]) -> Any:
-    """Recursively sanitize operational state with the shared text redactor."""
-    if isinstance(value, str):
-        return _sanitize_health_text(value, secrets_to_redact)
-    if isinstance(value, dict):
-        return {key: _redact_health_value(item, secrets_to_redact) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_redact_health_value(item, secrets_to_redact) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_redact_health_value(item, secrets_to_redact) for item in value)
-    return value
-
-
-def _health_detail_allowed(config: Config) -> bool:
-    """Return whether the current request may see automation/run detail."""
-    if not is_auth_enabled(config.auth):
-        return True
-    try:
-        return bool(app.storage.user.get("authenticated"))
-    except RuntimeError:
-        # No request/session context (e.g. called outside an HTTP request).
-        return False
-
-
-def _operational_detail(
-    config: Config, secrets_to_redact: tuple[str, ...]
-) -> tuple[dict[str, Any] | None, str | None]:
-    """Return (automation status, last successful run) for the health payload.
-
-    WHY: /health is public so probes work, but automation detail carries person
-    names (memory keys) and host paths. With auth on, only a logged-in session
-    gets the detail; probes and other LAN devices get status + version.
-    """
-    if not _health_detail_allowed(config):
-        return None, None
-
-    automation: dict[str, Any] | None = None
-    try:
-        automation = _get_automation_status(config)
-    except Exception as exc:
-        logger.warning(
-            "Could not read automation status for readiness (%s)",
-            type(exc).__name__,
-        )
-
-    last_successful_run: str | None = None
-    try:
-        last_successful_run = _get_last_successful_run(config)
-    except Exception as exc:
-        logger.warning(
-            "Could not read run status for readiness (%s)",
-            type(exc).__name__,
-        )
-
-    if automation is not None:
-        automation = _redact_health_value(automation, secrets_to_redact)
-    return automation, last_successful_run
-
-
-# /health and /health/ready are unauthenticated so probes work without
-# credentials, and each build costs a network round trip to Immich plus ~12
-# SQLite connections. Serving repeats from a short-lived snapshot keeps a flood
-# of requests from turning into a flood of work, while staying well inside the
-# 15s readiness period so a scheduled probe still reports current truth.
-_HEALTH_SNAPSHOT_TTL_SECONDS = 10.0
-_health_snapshot_cache: tuple[float, dict[str, Any]] | None = None
-
-
-async def _build_health_snapshot() -> dict[str, Any]:
-    """Build the shared detailed health payload, reusing a recent one if fresh."""
-    global _health_snapshot_cache
-
-    cached = _health_snapshot_cache
-    if cached is not None and time.monotonic() - cached[0] < _HEALTH_SNAPSHOT_TTL_SECONDS:
-        return cached[1]
-
-    snapshot = await _compute_health_snapshot()
-    _health_snapshot_cache = (time.monotonic(), snapshot)
-    return snapshot
-
-
-async def _compute_health_snapshot() -> dict[str, Any]:
-    """Build the shared detailed health payload for readiness and compatibility."""
-    try:
-        config = get_config()
-    except Exception:
-        return {
-            "status": "degraded",
-            "configuration": "unavailable",
-            "immich_reachable": False,
-            "immich": {
-                "status": "missing_configuration",
-                "reachable": False,
-                "api_version_policy": None,
-                "resolved_api_version": None,
-            },
-            "automation": None,
-            "last_automation_attempt": None,
-            "last_successful_auto_run": None,
-            "pending_delivery_count": None,
-            "oldest_pending_delivery": None,
-            "notification_health": None,
-            "last_successful_run": None,
-            "in_process_scheduler": None,
-            "version": __version__,
-        }
-
-    secrets_to_redact = configured_secret_values(config)
-    configured = bool(config.immich.url and config.immich.api_key)
-    if configured:
-        try:
-            immich = await _check_immich_dependency(config)
-        except Exception:
-            immich = _ImmichDependency(status="unreachable", reachable=False)
-    else:
-        immich = _ImmichDependency(status="missing_configuration", reachable=False)
-
-    # Synchronous SQLite: on the event loop each open waits on the write lock
-    # while a pipeline run holds it, which stalls every other session.
-    automation, last_successful_run = await asyncio.to_thread(
-        _operational_detail, config, secrets_to_redact
-    )
-
-    ready = configured and immich.status == "ready"
-    api_version_policy = getattr(config.immich.api_version, "value", config.immich.api_version)
-    return {
-        "status": "ready" if ready else "degraded",
-        "configuration": "configured" if configured else "missing",
-        "immich_reachable": immich.reachable,
-        "immich": {
-            "status": immich.status,
-            "reachable": immich.reachable,
-            "api_version_policy": api_version_policy,
-            "resolved_api_version": immich.resolved_api_version,
-        },
-        "automation": automation,
-        "last_automation_attempt": automation.get("last_attempt") if automation else None,
-        "last_successful_auto_run": (
-            automation.get("last_completed_auto_run") if automation else None
-        ),
-        "pending_delivery_count": (
-            automation.get("pending_delivery_count") if automation else None
-        ),
-        "oldest_pending_delivery": (
-            automation.get("oldest_pending_delivery") if automation else None
-        ),
-        "notification_health": _automation_field(automation, "notification_health"),
-        "last_successful_run": last_successful_run,
-        "in_process_scheduler": (
-            automation_scheduler.snapshot().to_dict() if _health_detail_allowed(config) else None
-        ),
-        "version": __version__,
-    }
-
-
-async def _liveness_handler(request: Request) -> JSONResponse:  # noqa: ARG001
-    """Report only that the web process is alive."""
-    return JSONResponse({"status": "alive", "version": __version__})
-
-
-async def _readiness_handler(request: Request) -> JSONResponse:  # noqa: ARG001
-    """Report whether configuration and Immich can support useful work."""
-    snapshot = await _build_health_snapshot()
-    return JSONResponse(snapshot, status_code=200 if snapshot["status"] == "ready" else 503)
-
-
-async def _health_handler(request: Request) -> JSONResponse:  # noqa: ARG001
-    """Keep the detailed compatibility payload without readiness status codes."""
-    snapshot = await _build_health_snapshot()
-    if snapshot["status"] == "ready":
-        snapshot["status"] = "ok"
-    return JSONResponse(snapshot)
-
-
-app.add_api_route("/health", _health_handler, methods=["GET"])
-app.add_api_route("/health/live", _liveness_handler, methods=["GET"])
-app.add_api_route("/health/ready", _readiness_handler, methods=["GET"])
+# /health, /health/live and /health/ready — see ui/health_api.py.
+register_health_routes(app)
 
 # The URL an Immich workflow (or anything else) POSTs to. Off unless authentication
 # or `server.trigger_token` is configured — see ui/trigger_api.py.

--- a/src/immich_memories/ui/health_api.py
+++ b/src/immich_memories/ui/health_api.py
@@ -1,0 +1,290 @@
+"""The health API: the three routes a probe or an operator can ask about this server.
+
+`/health/live` says the process is up, `/health/ready` says configuration and Immich
+can support real work, and `/health` keeps the older detailed payload without the
+readiness status codes. All three are unauthenticated so a container runtime can
+reach them, which is also why the detail in those payloads is gated below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import httpx
+from nicegui import app
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from immich_memories import __version__
+from immich_memories.automation.in_process_scheduler import automation_scheduler
+from immich_memories.config import get_config
+from immich_memories.security import configured_secret_values, sanitize_error_message
+from immich_memories.ui.auth import is_auth_enabled
+
+if TYPE_CHECKING:
+    from immich_memories.config_loader import Config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ImmichDependency:
+    """Sanitized result of the dependency probe used by health responses."""
+
+    status: Literal[
+        "ready",
+        "missing_configuration",
+        "unreachable",
+        "authentication_failed",
+        "unsupported_version",
+    ]
+    reachable: bool
+    resolved_api_version: str | None = None
+
+
+async def _check_immich_dependency(config) -> _ImmichDependency:
+    """Resolve the configured API policy and authenticate within a bounded time."""
+    from immich_memories.api.compatibility import UnsupportedImmichVersion
+    from immich_memories.api.immich import ImmichAPIError, ImmichAuthError, ImmichClient
+
+    try:
+        async with ImmichClient(
+            base_url=config.immich.url,
+            api_key=config.immich.api_key,
+            api_version=config.immich.api_version,
+            timeout=2.0,
+        ) as client:
+
+            async def resolve_and_authenticate() -> str:
+                resolved = await client.get_api_version()
+                await client.get_current_user()
+                return resolved.value
+
+            resolved_api_version = await asyncio.wait_for(resolve_and_authenticate(), timeout=5.0)
+        return _ImmichDependency(
+            status="ready",
+            reachable=True,
+            resolved_api_version=resolved_api_version,
+        )
+    except UnsupportedImmichVersion:
+        return _ImmichDependency(status="unsupported_version", reachable=True)
+    except ImmichAuthError:
+        return _ImmichDependency(status="authentication_failed", reachable=True)
+    except (ImmichAPIError, TimeoutError, httpx.HTTPError, OSError, ValueError):
+        return _ImmichDependency(status="unreachable", reachable=False)
+
+
+def _get_last_successful_run(config) -> str | None:
+    """Return ISO timestamp of last completed run, or None."""
+    from immich_memories.tracking.run_database import RunDatabase
+
+    db = RunDatabase(db_path=config.cache.database_path)
+    runs = db.list_runs(limit=1, status="completed")
+    if runs and runs[0].completed_at:
+        return runs[0].completed_at.isoformat()
+    return None
+
+
+def _get_automation_status(config) -> dict[str, Any]:
+    """Return the durable, read-only smart automation status contract."""
+    from immich_memories.automation.runner import AutoRunner
+
+    return AutoRunner(config).status().to_dict()
+
+
+def _automation_field(automation: dict[str, Any] | None, name: str) -> Any:
+    """Project one optional automation field without branching in readiness logic."""
+    return automation.get(name) if automation is not None else None
+
+
+def _sanitize_health_text(value: object, secrets_to_redact: tuple[str, ...]) -> str:
+    """Apply structural and config-aware sanitization before exposing health text."""
+    safe = sanitize_error_message(str(value))
+    for secret in secrets_to_redact:
+        safe = safe.replace(secret, "***")
+    return safe
+
+
+def _redact_health_value(value: Any, secrets_to_redact: tuple[str, ...]) -> Any:
+    """Recursively sanitize operational state with the shared text redactor."""
+    if isinstance(value, str):
+        return _sanitize_health_text(value, secrets_to_redact)
+    if isinstance(value, dict):
+        return {key: _redact_health_value(item, secrets_to_redact) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_health_value(item, secrets_to_redact) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_health_value(item, secrets_to_redact) for item in value)
+    return value
+
+
+def _health_detail_allowed(config: Config) -> bool:
+    """Return whether the current request may see automation/run detail."""
+    if not is_auth_enabled(config.auth):
+        return True
+    try:
+        return bool(app.storage.user.get("authenticated"))
+    except RuntimeError:
+        # No request/session context (e.g. called outside an HTTP request).
+        return False
+
+
+def _operational_detail(
+    config: Config, secrets_to_redact: tuple[str, ...]
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return (automation status, last successful run) for the health payload.
+
+    WHY: /health is public so probes work, but automation detail carries person
+    names (memory keys) and host paths. With auth on, only a logged-in session
+    gets the detail; probes and other LAN devices get status + version.
+    """
+    if not _health_detail_allowed(config):
+        return None, None
+
+    automation: dict[str, Any] | None = None
+    try:
+        automation = _get_automation_status(config)
+    except Exception as exc:
+        logger.warning(
+            "Could not read automation status for readiness (%s)",
+            type(exc).__name__,
+        )
+
+    last_successful_run: str | None = None
+    try:
+        last_successful_run = _get_last_successful_run(config)
+    except Exception as exc:
+        logger.warning(
+            "Could not read run status for readiness (%s)",
+            type(exc).__name__,
+        )
+
+    if automation is not None:
+        automation = _redact_health_value(automation, secrets_to_redact)
+    return automation, last_successful_run
+
+
+# /health and /health/ready are unauthenticated so probes work without
+# credentials, and each build costs a network round trip to Immich plus ~12
+# SQLite connections. Serving repeats from a short-lived snapshot keeps a flood
+# of requests from turning into a flood of work, while staying well inside the
+# 15s readiness period so a scheduled probe still reports current truth.
+_HEALTH_SNAPSHOT_TTL_SECONDS = 10.0
+_health_snapshot_cache: tuple[float, dict[str, Any]] | None = None
+
+
+async def _build_health_snapshot() -> dict[str, Any]:
+    """Build the shared detailed health payload, reusing a recent one if fresh."""
+    global _health_snapshot_cache
+
+    cached = _health_snapshot_cache
+    if cached is not None and time.monotonic() - cached[0] < _HEALTH_SNAPSHOT_TTL_SECONDS:
+        return cached[1]
+
+    snapshot = await _compute_health_snapshot()
+    _health_snapshot_cache = (time.monotonic(), snapshot)
+    return snapshot
+
+
+async def _compute_health_snapshot() -> dict[str, Any]:
+    """Build the shared detailed health payload for readiness and compatibility."""
+    try:
+        config = get_config()
+    except Exception:
+        return {
+            "status": "degraded",
+            "configuration": "unavailable",
+            "immich_reachable": False,
+            "immich": {
+                "status": "missing_configuration",
+                "reachable": False,
+                "api_version_policy": None,
+                "resolved_api_version": None,
+            },
+            "automation": None,
+            "last_automation_attempt": None,
+            "last_successful_auto_run": None,
+            "pending_delivery_count": None,
+            "oldest_pending_delivery": None,
+            "notification_health": None,
+            "last_successful_run": None,
+            "in_process_scheduler": None,
+            "version": __version__,
+        }
+
+    secrets_to_redact = configured_secret_values(config)
+    configured = bool(config.immich.url and config.immich.api_key)
+    if configured:
+        try:
+            immich = await _check_immich_dependency(config)
+        except Exception:
+            immich = _ImmichDependency(status="unreachable", reachable=False)
+    else:
+        immich = _ImmichDependency(status="missing_configuration", reachable=False)
+
+    # Synchronous SQLite: on the event loop each open waits on the write lock
+    # while a pipeline run holds it, which stalls every other session.
+    automation, last_successful_run = await asyncio.to_thread(
+        _operational_detail, config, secrets_to_redact
+    )
+
+    ready = configured and immich.status == "ready"
+    api_version_policy = getattr(config.immich.api_version, "value", config.immich.api_version)
+    return {
+        "status": "ready" if ready else "degraded",
+        "configuration": "configured" if configured else "missing",
+        "immich_reachable": immich.reachable,
+        "immich": {
+            "status": immich.status,
+            "reachable": immich.reachable,
+            "api_version_policy": api_version_policy,
+            "resolved_api_version": immich.resolved_api_version,
+        },
+        "automation": automation,
+        "last_automation_attempt": automation.get("last_attempt") if automation else None,
+        "last_successful_auto_run": (
+            automation.get("last_completed_auto_run") if automation else None
+        ),
+        "pending_delivery_count": (
+            automation.get("pending_delivery_count") if automation else None
+        ),
+        "oldest_pending_delivery": (
+            automation.get("oldest_pending_delivery") if automation else None
+        ),
+        "notification_health": _automation_field(automation, "notification_health"),
+        "last_successful_run": last_successful_run,
+        "in_process_scheduler": (
+            automation_scheduler.snapshot().to_dict() if _health_detail_allowed(config) else None
+        ),
+        "version": __version__,
+    }
+
+
+async def _liveness_handler(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Report only that the web process is alive."""
+    return JSONResponse({"status": "alive", "version": __version__})
+
+
+async def _readiness_handler(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Report whether configuration and Immich can support useful work."""
+    snapshot = await _build_health_snapshot()
+    return JSONResponse(snapshot, status_code=200 if snapshot["status"] == "ready" else 503)
+
+
+async def _health_handler(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Keep the detailed compatibility payload without readiness status codes."""
+    snapshot = await _build_health_snapshot()
+    if snapshot["status"] == "ready":
+        snapshot["status"] = "ok"
+    return JSONResponse(snapshot)
+
+
+def register_health_routes(server: Any) -> None:
+    """Attach the liveness, readiness, and compatibility health routes to a server."""
+    server.add_api_route("/health", _health_handler, methods=["GET"])
+    server.add_api_route("/health/live", _liveness_handler, methods=["GET"])
+    server.add_api_route("/health/ready", _readiness_handler, methods=["GET"])

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -40,11 +40,11 @@ def _fresh_health_snapshot():
 
     Tests would otherwise read each other's snapshots, so each starts cold.
     """
-    from immich_memories.ui import app as app_module
+    from immich_memories.ui import health_api as health_module
 
-    app_module._health_snapshot_cache = None
+    health_module._health_snapshot_cache = None
     yield
-    app_module._health_snapshot_cache = None
+    health_module._health_snapshot_cache = None
 
 
 class TestHealthEndpoint:
@@ -60,7 +60,7 @@ class TestHealthEndpoint:
         expected_diagnostic: str,
     ) -> None:
         """Optional status failures retain class diagnostics without their sensitive message."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = _config_with_every_secret_class()
         sensitive_values = (config.immich.url, *configured_secret_values(config))
@@ -73,10 +73,10 @@ class TestHealthEndpoint:
             last_run.side_effect = failure
 
         with (
-            caplog.at_level(logging.WARNING, logger="immich_memories.ui.app"),
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            caplog.at_level(logging.WARNING, logger="immich_memories.ui.health_api"),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(
                     status="ready",
@@ -84,8 +84,8 @@ class TestHealthEndpoint:
                     resolved_api_version="v3",
                 ),
             ),
-            patch("immich_memories.ui.app._get_automation_status", automation),
-            patch("immich_memories.ui.app._get_last_successful_run", last_run),
+            patch("immich_memories.ui.health_api._get_automation_status", automation),
+            patch("immich_memories.ui.health_api._get_last_successful_run", last_run),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -101,7 +101,7 @@ class TestHealthEndpoint:
 
         client = TestClient(app, raise_server_exceptions=False)
         with patch(
-            "immich_memories.ui.app.get_config",
+            "immich_memories.ui.health_api.get_config",
             side_effect=RuntimeError("configuration unavailable"),
         ):
             live = client.get("/health/live")
@@ -117,7 +117,8 @@ class TestHealthEndpoint:
 
     def test_readiness_reports_the_in_process_automation_timer(self, tmp_path: Path):
         """Docker users check /health to see when the in-app daily run will fire (#305)."""
-        from immich_memories.ui.app import _ImmichDependency, app
+        from immich_memories.ui.app import app
+        from immich_memories.ui.health_api import _ImmichDependency
 
         config = Config(
             immich={"url": "http://immich.test", "api_key": "health-secret"},
@@ -134,13 +135,13 @@ class TestHealthEndpoint:
         client = TestClient(app, raise_server_exceptions=False)
         with (
             # WHY: /health must not reach out to a real Immich in a unit test.
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(status="ready", reachable=True),
             ),
-            patch("immich_memories.ui.app.automation_scheduler", scheduler),
+            patch("immich_memories.ui.health_api.automation_scheduler", scheduler),
         ):
             response = client.get("/health/ready")
 
@@ -152,14 +153,17 @@ class TestHealthEndpoint:
 
     def test_registered_readiness_uses_one_configuration_snapshot(self):
         """A real detailed request cannot reload config while reading run history."""
-        from immich_memories.ui.app import _ImmichDependency, app
+        from immich_memories.ui.app import app
+        from immich_memories.ui.health_api import _ImmichDependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         client = TestClient(app, raise_server_exceptions=False)
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config) as get_config_mock,
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api.get_config", return_value=config
+            ) as get_config_mock,
+            patch(
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(
                     status="ready",
@@ -167,7 +171,7 @@ class TestHealthEndpoint:
                     resolved_api_version="v3",
                 ),
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
             patch("immich_memories.tracking.run_database.RunDatabase") as database,
         ):
             database.return_value.list_runs.return_value = []
@@ -194,16 +198,16 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_readiness_projects_real_automation_delivery_defaults(self, tmp_path: Path):
         """The detailed endpoint consumes delivery fields from the real status producer."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = Config(
             immich={"url": "http://immich.test", "api_key": "health-secret"},
             cache={"database": str(tmp_path / "health.db"), "directory": str(tmp_path / "cache")},
         )
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(
                     status="ready",
@@ -211,7 +215,7 @@ class TestHealthEndpoint:
                     resolved_api_version="v3",
                 ),
             ),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -226,7 +230,7 @@ class TestHealthEndpoint:
             NotificationFailureCategory,
             NotificationStateStore,
         )
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = Config(
             immich={"url": "http://immich.test", "api_key": "health-secret"},
@@ -237,15 +241,15 @@ class TestHealthEndpoint:
             NotificationFailureCategory.QUOTA
         )
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(
                     status="ready", reachable=True, resolved_api_version="v3"
                 ),
             ),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -257,17 +261,17 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_liveness_is_process_only(self):
         """Liveness must stay green without consulting config, Immich, or SQLite."""
-        from immich_memories.ui.app import _liveness_handler
+        from immich_memories.ui.health_api import _liveness_handler
 
         config = MagicMock(name="get_config")
         immich = MagicMock(name="check_immich_dependency")
         automation = MagicMock(name="get_automation_status")
         last_run = MagicMock(name="get_last_successful_run")
         with (
-            patch("immich_memories.ui.app.get_config", config),
-            patch("immich_memories.ui.app._check_immich_dependency", immich),
-            patch("immich_memories.ui.app._get_automation_status", automation),
-            patch("immich_memories.ui.app._get_last_successful_run", last_run),
+            patch("immich_memories.ui.health_api.get_config", config),
+            patch("immich_memories.ui.health_api._check_immich_dependency", immich),
+            patch("immich_memories.ui.health_api._get_automation_status", automation),
+            patch("immich_memories.ui.health_api._get_last_successful_run", last_run),
         ):
             response = await _liveness_handler(MagicMock())
 
@@ -292,7 +296,7 @@ class TestHealthEndpoint:
         failing_boundary,
     ):
         """Database diagnostics must be sanitized before response or logging boundaries."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = _config_with_every_secret_class()
         secrets = configured_secret_values(config)
@@ -304,11 +308,11 @@ class TestHealthEndpoint:
         else:
             last_run.side_effect = failure
 
-        caplog.set_level(logging.WARNING, logger="immich_memories.ui.app")
+        caplog.set_level(logging.WARNING, logger="immich_memories.ui.health_api")
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(
                     status="ready",
@@ -316,8 +320,8 @@ class TestHealthEndpoint:
                     resolved_api_version="v3",
                 ),
             ),
-            patch("immich_memories.ui.app._get_automation_status", automation),
-            patch("immich_memories.ui.app._get_last_successful_run", last_run),
+            patch("immich_memories.ui.health_api._get_automation_status", automation),
+            patch("immich_memories.ui.health_api._get_last_successful_run", last_run),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -330,16 +334,16 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_readiness_is_503_when_configuration_is_missing(self):
         """A default config cannot generate memories and must not be reported ready."""
-        from immich_memories.ui.app import _readiness_handler
+        from immich_memories.ui.health_api import _readiness_handler
 
         with (
-            patch("immich_memories.ui.app.get_config", return_value=Config()),
+            patch("immich_memories.ui.health_api.get_config", return_value=Config()),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 side_effect=AssertionError("missing config should not contact Immich"),
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -353,19 +357,19 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_readiness_is_503_when_immich_is_unreachable(self):
         """An unreachable configured server must fail the readiness gate."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         dependency = _ImmichDependency(status="unreachable", reachable=False)
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=dependency,
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -375,19 +379,19 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_readiness_is_503_for_unsupported_immich(self):
         """Auto-detecting an unsupported major must fail the readiness gate."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         dependency = _ImmichDependency(status="unsupported_version", reachable=True)
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=dependency,
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -397,7 +401,7 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_ready_snapshot_exposes_policy_version_and_automation_without_secrets(self):
         """Operators get actionable state, while configured credentials never enter JSON."""
-        from immich_memories.ui.app import _ImmichDependency, _readiness_handler
+        from immich_memories.ui.health_api import _ImmichDependency, _readiness_handler
 
         secret = "never-serialize-this-key"  # noqa: S105
         config = Config(immich={"url": "http://immich.test", "api_key": secret})
@@ -418,15 +422,15 @@ class TestHealthEndpoint:
             },
         }
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=dependency,
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=automation),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=automation),
             patch(
-                "immich_memories.ui.app._get_last_successful_run",
+                "immich_memories.ui.health_api._get_last_successful_run",
                 return_value="2026-08-11T06:15:00+00:00",
             ),
         ):
@@ -457,19 +461,19 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_legacy_health_keeps_detailed_payload_and_http_200_when_degraded(self):
         """Compatibility clients retain details without inheriting readiness status codes."""
-        from immich_memories.ui.app import _health_handler, _ImmichDependency
+        from immich_memories.ui.health_api import _health_handler, _ImmichDependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         dependency = _ImmichDependency(status="unreachable", reachable=False)
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=dependency,
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _health_handler(MagicMock())
 
@@ -481,19 +485,19 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_legacy_health_keeps_ok_status_when_dependency_is_healthy(self):
         """Compatibility health keeps its established healthy status label."""
-        from immich_memories.ui.app import _health_handler, _ImmichDependency
+        from immich_memories.ui.health_api import _health_handler, _ImmichDependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         dependency = _ImmichDependency(status="ready", reachable=True, resolved_api_version="v3")
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=dependency,
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _health_handler(MagicMock())
 
@@ -503,15 +507,15 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_health_handler_returns_json(self):
         """Health handler should return valid JSON with expected keys."""
-        from immich_memories.ui.app import _health_handler
+        from immich_memories.ui.health_api import _health_handler
 
         mock_request = MagicMock()
 
         # WHY: detailed health reads both disk configuration and SQLite status.
         with (
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
-            patch("immich_memories.ui.app.get_config", return_value=Config()),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api.get_config", return_value=Config()),
         ):
             response = await _health_handler(mock_request)
 
@@ -524,7 +528,7 @@ class TestHealthEndpoint:
     async def test_dependency_probe_resolves_version_and_authenticates(self):
         """A usable connection reports the selected API compatibility version."""
         from immich_memories.api.compatibility import ResolvedApiVersion
-        from immich_memories.ui.app import _check_immich_dependency
+        from immich_memories.ui.health_api import _check_immich_dependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         client = AsyncMock()
@@ -543,7 +547,7 @@ class TestHealthEndpoint:
     async def test_dependency_probe_accepts_a_supported_v2_server(self):
         """A configured v2 server is just as ready as the existing v3 path."""
         from immich_memories.api.compatibility import ResolvedApiVersion
-        from immich_memories.ui.app import _check_immich_dependency
+        from immich_memories.ui.health_api import _check_immich_dependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         client = AsyncMock()
@@ -561,7 +565,7 @@ class TestHealthEndpoint:
         """A rejected key means the server answered, but it is not ready for work."""
         from immich_memories.api.compatibility import ResolvedApiVersion
         from immich_memories.api.immich import ImmichAuthError
-        from immich_memories.ui.app import _check_immich_dependency
+        from immich_memories.ui.health_api import _check_immich_dependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         client = AsyncMock()
@@ -578,7 +582,7 @@ class TestHealthEndpoint:
     @pytest.mark.asyncio
     async def test_readiness_timeout_returns_503_and_closes_cancelled_client(self):
         """A cancelled dependency probe releases its client and degrades readiness."""
-        from immich_memories.ui.app import _readiness_handler
+        from immich_memories.ui.health_api import _readiness_handler
 
         async def cancelled_wait_for(operation, timeout):  # noqa: ARG001
             task = asyncio.create_task(operation)
@@ -591,11 +595,11 @@ class TestHealthEndpoint:
         client = AsyncMock()
         client.__aenter__.return_value = client
         with (
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch("immich_memories.api.immich.ImmichClient", return_value=client),
-            patch("immich_memories.ui.app.asyncio.wait_for", new=cancelled_wait_for),
-            patch("immich_memories.ui.app._get_automation_status", return_value=None),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value=None),
+            patch("immich_memories.ui.health_api.asyncio.wait_for", new=cancelled_wait_for),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=None),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value=None),
         ):
             response = await _readiness_handler(MagicMock())
 
@@ -607,7 +611,7 @@ class TestHealthEndpoint:
     async def test_dependency_probe_distinguishes_an_unsupported_server(self):
         """A responding unsupported major is different from a network outage."""
         from immich_memories.api.compatibility import UnsupportedImmichVersion
-        from immich_memories.ui.app import _check_immich_dependency
+        from immich_memories.ui.health_api import _check_immich_dependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         client = AsyncMock()
@@ -621,7 +625,7 @@ class TestHealthEndpoint:
 
     def test_get_last_successful_run_returns_none_when_no_runs(self):
         """Should return None when no completed runs exist."""
-        from immich_memories.ui.app import _get_last_successful_run
+        from immich_memories.ui.health_api import _get_last_successful_run
 
         # WHY: RunDatabase reads from SQLite file (lazy import inside function)
         with patch("immich_memories.tracking.run_database.RunDatabase") as mock_db_cls:
@@ -636,7 +640,8 @@ class TestHealthDisclosure:
 
     @pytest.mark.parametrize("path", ["/health", "/health/ready"])
     def test_unauthenticated_health_omits_automation_detail_when_auth_enabled(self, path: str):
-        from immich_memories.ui.app import _ImmichDependency, app
+        from immich_memories.ui.app import app
+        from immich_memories.ui.health_api import _ImmichDependency
 
         config = Config(
             immich={"url": "http://immich.test", "api_key": "health-secret"},
@@ -655,14 +660,14 @@ class TestHealthDisclosure:
         client = TestClient(app, raise_server_exceptions=False)
         with (
             # WHY: config and Immich probe are external boundaries; the test is about payload shape.
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(status="ready", reachable=True),
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=automation),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value="run-123"),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=automation),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value="run-123"),
         ):
             response = client.get(path)
 
@@ -676,21 +681,22 @@ class TestHealthDisclosure:
         assert body["last_successful_run"] is None
 
     def test_health_keeps_detail_when_auth_disabled(self):
-        from immich_memories.ui.app import _ImmichDependency, app
+        from immich_memories.ui.app import app
+        from immich_memories.ui.health_api import _ImmichDependency
 
         config = Config(immich={"url": "http://immich.test", "api_key": "health-secret"})
         automation = {"last_attempt": {"memory_key": "year_in_review:2024"}}
         client = TestClient(app, raise_server_exceptions=False)
         with (
             # WHY: same boundaries as above; auth disabled means a trusted LAN deployment.
-            patch("immich_memories.ui.app.get_config", return_value=config),
+            patch("immich_memories.ui.health_api.get_config", return_value=config),
             patch(
-                "immich_memories.ui.app._check_immich_dependency",
+                "immich_memories.ui.health_api._check_immich_dependency",
                 new_callable=AsyncMock,
                 return_value=_ImmichDependency(status="ready", reachable=True),
             ),
-            patch("immich_memories.ui.app._get_automation_status", return_value=automation),
-            patch("immich_memories.ui.app._get_last_successful_run", return_value="run-123"),
+            patch("immich_memories.ui.health_api._get_automation_status", return_value=automation),
+            patch("immich_memories.ui.health_api._get_last_successful_run", return_value="run-123"),
         ):
             response = client.get("/health")
 
@@ -710,9 +716,9 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
     @staticmethod
     def _reset_cache() -> None:
-        from immich_memories.ui import app as app_module
+        from immich_memories.ui import health_api as health_module
 
-        app_module._health_snapshot_cache = None
+        health_module._health_snapshot_cache = None
 
     @staticmethod
     def _configured_config():
@@ -728,55 +734,55 @@ class TestHealthIsCheapUnderRepeatedProbes:
 
     @pytest.mark.asyncio
     async def test_a_burst_of_probes_does_the_work_once(self):
-        from immich_memories.ui import app as app_module
+        from immich_memories.ui import health_api as health_module
 
         self._reset_cache()
         calls = []
 
         async def counted_dependency(config):  # noqa: ARG001
             calls.append(1)
-            return app_module._ImmichDependency(status="ready", reachable=True)
+            return health_module._ImmichDependency(status="ready", reachable=True)
 
         # WHY: the Immich server and the SQLite stores behind the snapshot
         with (
             # WHY: the probe only runs for a configured Immich
-            patch("immich_memories.ui.app.get_config", self._configured_config),
+            patch("immich_memories.ui.health_api.get_config", self._configured_config),
             # WHY: external Immich server
-            patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
+            patch("immich_memories.ui.health_api._check_immich_dependency", counted_dependency),
             # WHY: reads four SQLite databases
-            patch("immich_memories.ui.app._operational_detail", return_value=(None, None)),
+            patch("immich_memories.ui.health_api._operational_detail", return_value=(None, None)),
         ):
             for _ in range(5):
-                await app_module._health_handler(MagicMock())
+                await health_module._health_handler(MagicMock())
 
         assert len(calls) == 1, f"{len(calls)} dependency probes for 5 requests"
 
     @pytest.mark.asyncio
     async def test_the_snapshot_goes_stale_so_readiness_stays_truthful(self, monkeypatch):
         """A cache that never expires would report a dead Immich as ready."""
-        from immich_memories.ui import app as app_module
+        from immich_memories.ui import health_api as health_module
 
         self._reset_cache()
         calls = []
         clock = {"now": 1000.0}
-        monkeypatch.setattr(app_module.time, "monotonic", lambda: clock["now"])
+        monkeypatch.setattr(health_module.time, "monotonic", lambda: clock["now"])
 
         async def counted_dependency(config):  # noqa: ARG001
             calls.append(1)
-            return app_module._ImmichDependency(status="ready", reachable=True)
+            return health_module._ImmichDependency(status="ready", reachable=True)
 
         # WHY: the Immich server and the SQLite stores behind the snapshot
         with (
             # WHY: the probe only runs for a configured Immich
-            patch("immich_memories.ui.app.get_config", self._configured_config),
+            patch("immich_memories.ui.health_api.get_config", self._configured_config),
             # WHY: external Immich server
-            patch("immich_memories.ui.app._check_immich_dependency", counted_dependency),
+            patch("immich_memories.ui.health_api._check_immich_dependency", counted_dependency),
             # WHY: reads four SQLite databases
-            patch("immich_memories.ui.app._operational_detail", return_value=(None, None)),
+            patch("immich_memories.ui.health_api._operational_detail", return_value=(None, None)),
         ):
-            await app_module._health_handler(MagicMock())
+            await health_module._health_handler(MagicMock())
             clock["now"] += 60.0
-            await app_module._health_handler(MagicMock())
+            await health_module._health_handler(MagicMock())
 
         assert len(calls) == 2, "the snapshot never refreshed"
 
@@ -786,7 +792,7 @@ class TestHealthIsCheapUnderRepeatedProbes:
         import asyncio
         import time as time_module
 
-        from immich_memories.ui import app as app_module
+        from immich_memories.ui import health_api as health_module
 
         self._reset_cache()
         ticks = 0
@@ -804,21 +810,21 @@ class TestHealthIsCheapUnderRepeatedProbes:
             return None, None
 
         async def ready_dependency(config):  # noqa: ARG001
-            return app_module._ImmichDependency(status="ready", reachable=True)
+            return health_module._ImmichDependency(status="ready", reachable=True)
 
         # WHY: stands in for the Immich server and for a slow SQLite read
         with (
             # WHY: the probe only runs for a configured Immich
-            patch("immich_memories.ui.app.get_config", self._configured_config),
+            patch("immich_memories.ui.health_api.get_config", self._configured_config),
             # WHY: external Immich server
-            patch("immich_memories.ui.app._check_immich_dependency", ready_dependency),
+            patch("immich_memories.ui.health_api._check_immich_dependency", ready_dependency),
             # WHY: a real contended SQLite read, without needing contention
-            patch("immich_memories.ui.app._operational_detail", slow_blocking_detail),
+            patch("immich_memories.ui.health_api._operational_detail", slow_blocking_detail),
         ):
             ticker = asyncio.create_task(tick())
             await asyncio.sleep(0.01)
             before = ticks
-            await app_module._health_handler(MagicMock())
+            await health_module._health_handler(MagicMock())
             # Sampled here, not after awaiting the ticker: once the handler
             # returns the ticker finishes either way, which would make this
             # pass whether or not the loop was ever blocked.


### PR DESCRIPTION
`src/immich_memories/ui/app.py` was 891 lines on `main`, over the 800-line cap. Part of #686.

## The seam: the health API

`app.py` mixes four things that answer to different callers — NiceGUI wizard pages, the auth
middleware and its login/OIDC routes, process startup/shutdown, and the health API. The health
API is the only one of those that answers to a **probe** rather than to a browser:

- three unauthenticated routes (`/health`, `/health/live`, `/health/ready`)
- the bounded Immich dependency probe
- the redaction rules that keep person names and host paths out of a payload anything on the LAN can `GET`
- the TTL'd snapshot cache that stops a probe flood from turning into ~12 SQLite connections per hit

Coupling audit: nothing left in `app.py` calls any of those 16 symbols (`grep -rn` over `src/`,
`tests/`, `docs/`, `docs-site/`, `scripts/` for each name — the only hits outside the two files
were in `tests/test_health.py`). Nothing in the moved block calls anything *defined* in `app.py`
either; its dependencies (`get_config`, `is_auth_enabled`, `automation_scheduler`,
`configured_secret_values`, `sanitize_error_message`, `__version__`) are all third-module imports
that moved with it. Six `app.py` imports became dead and were dropped: `httpx`, `time`,
`dataclass`, `Any`, `Literal`, `__version__`, plus the `Config` TYPE_CHECKING import.

The new module is named and shaped after `ui/trigger_api.py`, which already sits on the adjacent
line doing exactly this: a `register_*_routes(server)` entry point that `app.py` calls.

## Seams rejected

- **Auth middleware + routes (~185 lines).** Not one unit as written: the section wires an
  `@app.middleware("http")` handler, a `@ui.page("/login")` NiceGUI page, and three
  `app.add_api_route` FastAPI routes — three different registration mechanisms with an
  order-sensitive relationship to NiceGUI's own storage middleware. Moving it would either split
  registration away from `app.py` or need the decorator re-applied from a second module. Not worth
  the risk when a cleaner seam clears the cap with room to spare.
- **Sidebar / nav rendering (~150 lines).** A real seam, but a weaker one: `render_sidebar` and
  `page_header` exist *to be called by* the six `@ui.page` handlers directly below them, so the
  cut would leave a module and its only caller staring at each other across a file boundary. It is
  also almost entirely `# pragma: no cover`. Left in place; if `app.py` grows again, this is the
  next one.

## Behaviour-neutral, provably

- **The moved body is byte-identical to `main`.** `git show origin/main:…/app.py | sed -n '337,587p'`
  vs `sed -n '34,284p' health_api.py` → `diff` is empty. No renames, no signature changes, no logic
  edits, no touching the middleware style.
- **Additions to `app.py` are imports plus the registration call.** The complete `+` side of
  `app.py`'s diff is six lines: three collapsed import lines (`from typing import TYPE_CHECKING`,
  `from immich_memories.security import write_secret_file`, the new `register_health_routes`
  import), one section-header comment, one pointer comment, and `register_health_routes(app)` —
  which replaces the three `app.add_api_route(...)` lines at the same point in module execution.
- **Route and middleware order is unchanged**, and not by assertion: imported the module before and
  after and dumped `app.routes` (path, methods, name) and `app.user_middleware`. All 24 route lines
  match exactly; the only diff in the whole dump is the `_auth_middleware` object's memory address.

## Import-site audit

No re-export shims (`app.py` imports from the source; `ui/__init__.py` untouched).
`tests/test_health.py` had ~90 `patch("immich_memories.ui.app.X")` targets repointed to
`immich_memories.ui.health_api`, including the non-obvious ones: the `caplog` logger name, the
`_health_snapshot_cache` reset fixture, `app_module.time.monotonic`, and
`patch("…ui.app.asyncio.wait_for")`. The five `from immich_memories.ui.app import app` lines stayed
— that is the NiceGUI server object for `TestClient`, which does not move. Two of those were
`import _ImmichDependency, app` and were split across the two modules.

`patch("…health_api.get_config")` is still correct for the `TestClient` tests even though
`app.py` has its own `get_config`: `_auth_middleware` short-circuits on `is_health_probe_path`
*before* it calls `get_config()`, so a health request never reaches the `app.py` binding.

## Line counts

| file | before | after |
|---|---|---|
| `src/immich_memories/ui/app.py` | 891 | 629 |
| `src/immich_memories/ui/health_api.py` | — | 290 |
| `tests/test_health.py` | 834 | 840 |
| `ARCHITECTURE.md` | +1 line (ui tree entry) | |

`tests/test_health.py` grew by 6 lines: 2 from the split imports, 4 from `ruff format` reflowing
`patch(...)` calls that got longer with the new module name. Every other changed line in that file
is a repointed string.

## Gates

`make ci` green locally (5704 passed, 9 skipped, 6 xfailed). `make diff-cover` at 97% on changed
lines (`health_api.py` 96.9%, `app.py` 100%). `make critique` clean — no mocks added, so the
WHY-ratchet is unmoved. mypy passes without adding the new module to the
`immich_memories.ui.app` override block in `pyproject.toml`, so that stays as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
