### PR TITLE
feat(discover-days): the catalogue says how long the day stayed awake

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -148,11 +148,16 @@ first — ten years reads louder than nine, which is the whole appeal of arrivin
 unannounced.
 
 ```
-10 years ago  2015-06-12  A long evening out  18:40-23:55
+10 years ago  2015-06-12  A long evening out  18:40-23:55  9h
 ```
 
-The hours on the right are the day's window, when it found one. Catalogues written before
-windows existed simply have none, and still read.
+The clock times are the day's window, when it found one. The `9h` is how many hours of
+the clock the day put pictures in — the number the scan measured to decide the day was
+worth asking about at all, now kept in the catalogue with the times the day's run started
+and ended. A run is grouped by the date it began and ends when the pictures stop for five
+hours, so a night that ran to three in the morning ends on the following date, and its
+extent says so where the date alone cannot. Catalogues written before any of this existed
+simply have none of it, and still read.
 
 `--on YYYY-MM-DD` checks a different date, and `--catalogue PATH` reads a different file.
 Anniversaries either side of New Year are found: a day at the end of December is due in

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -158,8 +158,30 @@ def candidate_days(
         for day, items in _runs_of_activity(assets).items()
         if day not in away_days
         and len(items) >= MIN_PHOTOS
-        and len({a.file_created_at.hour for a in items}) >= MIN_ACTIVE_HOURS
+        and active_hours(items) >= MIN_ACTIVE_HOURS
     }
+
+
+def active_hours(items: Iterable) -> int:
+    """How many hours of the clock a run put pictures in.
+
+    Hours of the clock rather than hours elapsed: the six-hour bar and every
+    number in this module's docstring were measured this way, and counting
+    elapsed hours instead would quietly move the bar on the long runs.
+    """
+    return len({a.file_created_at.hour for a in items})
+
+
+def run_extent(items: Iterable) -> tuple[datetime, datetime] | None:
+    """When a run's first and last pictures were taken.
+
+    Not the calendar day's bounds: the run is the occasion, and one labelled
+    day was a birth that ran 45 continuous hours, from one evening to the
+    afternoon two dates later. Anything that scopes itself to the date the
+    run began stops at midnight, part-way through what happened.
+    """
+    times = [a.file_created_at for a in items]
+    return (min(times), max(times)) if times else None
 
 
 # A day ends when the photographs stop for this long, not at midnight. One

--- a/src/immich_memories/automation/special_day_scan.py
+++ b/src/immich_memories/automation/special_day_scan.py
@@ -18,10 +18,12 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 from immich_memories.analysis.special_day import (
+    active_hours,
     ask_if_special,
     candidate_days,
     days_covered_by_trips,
     event_window,
+    run_extent,
     sample_across_day,
 )
 from immich_memories.analysis.trip_detection import detect_trips, haversine_km
@@ -46,6 +48,12 @@ class DiscoveredDay:
     what: str
     photos: int
     window: tuple[datetime, datetime] | None
+    # How long the day stayed awake, and when it did. The run is keyed by the
+    # date it began and can end on another one, so its extent is the only
+    # honest scope for a memory of it — the calendar day stops at midnight.
+    active_hours: int = 0
+    run_start: datetime | None = None
+    run_end: datetime | None = None
 
 
 def holidays_in(year: int, extra: Iterable[str] = ()) -> set[date]:
@@ -193,6 +201,7 @@ def scan_year(
         verdict = ask_if_special(items, llm_config, thumbnails=thumbnails)
         if not verdict.special or not (verdict.title or verdict.what):
             continue
+        started, ended = run_extent(items) or (None, None)
         found.append(
             DiscoveredDay(
                 day=day,
@@ -203,6 +212,9 @@ def scan_year(
                 # The model read the day's own timestamps and what was in the
                 # frames; event_window only knows where the pictures were.
                 window=verdict.window or event_window(items),
+                active_hours=active_hours(items),
+                run_start=started,
+                run_end=ended,
             )
         )
     return found

--- a/src/immich_memories/cli/special_days_cmd.py
+++ b/src/immich_memories/cli/special_days_cmd.py
@@ -6,10 +6,14 @@ import calendar
 import json
 from datetime import date, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from immich_memories.cli._helpers import console, print_success
+
+if TYPE_CHECKING:
+    from immich_memories.automation.special_day_scan import DiscoveredDay
 
 
 def register_special_day_commands(main: click.Group) -> None:
@@ -82,34 +86,60 @@ def _register_due(main: click.Group) -> None:
     )
     def days_due(on: object, catalogue: Path) -> None:
         """Show which discovered days have an anniversary about now."""
-        from immich_memories.automation.special_day_scan import (
-            DiscoveredDay,
-            anniversaries_due,
-        )
+        from immich_memories.automation.special_day_scan import anniversaries_due
 
         when = on.date() if on is not None else date.today()  # type: ignore[attr-defined]
-        entries = [
-            DiscoveredDay(
-                day=date.fromisoformat(raw["day"]),
-                title=raw.get("title", ""),
-                subtitle=raw.get("subtitle", ""),
-                what=raw.get("what", ""),
-                photos=raw.get("photos", 0),
-                window=_window_in(raw.get("window")),
-            )
-            for raw in _load_catalogue(catalogue)
-            if raw.get("day")
-        ]
+        entries = _entries_in(catalogue)
 
         for entry, years in anniversaries_due(entries, when):
             line = f"[bold]{years} years ago[/bold]  {entry.day}  {entry.title or entry.what}"
             if entry.window:
                 start, end = entry.window
                 line += f"  [dim]{start:%H:%M}-{end:%H:%M}[/dim]"
+            if entry.active_hours:
+                line += f"  [dim]{entry.active_hours}h[/dim]"
             console.print(line)
             if entry.subtitle:
                 console.print(f"                {entry.subtitle}")
         print_success(f"{len(entries)} days in the catalogue, checked against {when}")
+
+
+def _entries_in(path: Path) -> list[DiscoveredDay]:
+    """The catalogue as discovered days, skipping anything without a date.
+
+    Every field the scan learned to record arrived after some entry in a real
+    catalogue was written, so each one falls back instead of failing the
+    load: twenty years of scanning is not something to ask anybody to run
+    again for a field they can live without.
+    """
+    from immich_memories.automation.special_day_scan import DiscoveredDay
+
+    return [
+        DiscoveredDay(
+            day=date.fromisoformat(raw["day"]),
+            title=raw.get("title", ""),
+            subtitle=raw.get("subtitle", ""),
+            what=raw.get("what", ""),
+            photos=raw.get("photos", 0),
+            window=_window_in(raw.get("window")),
+            active_hours=raw.get("active_hours", 0),
+            run_start=_moment_in(raw.get("run_start")),
+            run_end=_moment_in(raw.get("run_end")),
+        )
+        for raw in _load_catalogue(path)
+        if raw.get("day")
+    ]
+
+
+def _moment_in(raw: object) -> datetime | None:
+    """One end of the run a catalogue entry recorded, if it recorded any."""
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        console.print(f"[yellow]Ignoring an unreadable time in the catalogue: {raw!r}[/yellow]")
+        return None
 
 
 def _window_in(raw: object) -> tuple[datetime, datetime] | None:
@@ -237,6 +267,9 @@ def _scan_library(
                         "what": day.what,
                         "photos": day.photos,
                         "window": [w.isoformat() for w in day.window] if day.window else None,
+                        "active_hours": day.active_hours,
+                        "run_start": day.run_start.isoformat() if day.run_start else None,
+                        "run_end": day.run_end.isoformat() if day.run_end else None,
                     }
                 )
                 console.print(f"  [green]{day.day}[/green]  {day.title or day.what}")

--- a/tests/test_special_day_scan.py
+++ b/tests/test_special_day_scan.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, date, datetime
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -20,6 +22,7 @@ from immich_memories.automation.special_day_scan import (
     scan_year,
 )
 from immich_memories.cli.special_days_cmd import (
+    _entries_in,
     _homebase,
     _load_catalogue,
     _write_catalogue,
@@ -258,6 +261,144 @@ def test_a_picture_that_failed_to_download_takes_its_line_with_it() -> None:
 
     assert missing not in [asset.id for asset, _ in tiles]
     assert len(tiles) == SAMPLE_SIZE - 1
+
+
+def test_the_catalogue_records_how_long_the_day_stayed_awake(monkeypatch) -> None:
+    """Active hours is the signal that separates an occasion from a busy hour.
+
+    The scan measured it to decide whether to ask about the day at all, then
+    threw the number away, so nothing downstream could size a memory by how
+    long the day actually ran.
+    """
+    # WHY: ask_if_special is the LLM call; the day's own hours are the subject.
+    monkeypatch.setattr(
+        "immich_memories.automation.special_day_scan.ask_if_special",
+        lambda *_a, **_k: SimpleNamespace(
+            special=True, title="A long evening out", subtitle="", what="out", window=None
+        ),
+    )
+
+    evening = [_asset(h, m) for h in range(17, 23) for m in (0, 15, 30, 45)]
+
+    found = scan_year(evening, llm_config=None, home=None, ask=1)
+
+    assert [d.active_hours for d in found] == [6]
+
+
+def test_a_run_that_crossed_midnight_is_measured_as_the_one_night_it_was(monkeypatch) -> None:
+    """The catalogue keys a day by the date its run began, and runs run late.
+
+    A night that starts at nine and ends at three belongs to the evening it
+    started, and the calendar disagrees twice over: the first date holds
+    three of its six hours, and a memory scoped to that date ends at
+    midnight, halfway through the thing that happened.
+    """
+    # WHY: ask_if_special is the LLM call; where the night's hours fall is the subject.
+    monkeypatch.setattr(
+        "immich_memories.automation.special_day_scan.ask_if_special",
+        lambda *_a, **_k: SimpleNamespace(
+            special=True, title="A long evening out", subtitle="", what="out", window=None
+        ),
+    )
+    evening = [_asset(h, m, day=13) for h in (21, 22, 23) for m in (0, 15, 30, 45)]
+    small_hours = [_asset(h, m, day=14) for h in (0, 1, 2) for m in (0, 15, 30, 45)]
+
+    found = scan_year(evening + small_hours, llm_config=None, home=None, ask=1)
+
+    assert [(d.day, d.active_hours) for d in found] == [(date(2021, 4, 13), 6)]
+    assert found[0].run_start == datetime(2021, 4, 13, 21, 0, tzinfo=UTC)
+    assert found[0].run_end == datetime(2021, 4, 14, 2, 45, tzinfo=UTC)
+
+
+def _days_due(catalogue: Path, on: str) -> str:
+    from click.testing import CliRunner
+
+    from immich_memories.cli import main
+    from immich_memories.config_loader import Config
+
+    # WHY: the CLI group loads the user's real config directory on startup.
+    with (
+        patch("immich_memories.cli.init_config_dir"),
+        patch("immich_memories.cli.get_config", return_value=Config()),
+    ):
+        result = CliRunner().invoke(
+            main,
+            ["days-due", "--on", on, "--catalogue", str(catalogue)],
+            catch_exceptions=False,
+        )
+    return result.output
+
+
+def test_the_hours_survive_the_trip_through_the_catalogue(tmp_path) -> None:
+    """A number the scan measured and only the scan can see is not a catalogue."""
+    catalogue = tmp_path / "special-days.json"
+    catalogue.write_text(
+        json.dumps(
+            [
+                {
+                    "day": "2015-06-12",
+                    "title": "A long evening out",
+                    "subtitle": "",
+                    "what": "out",
+                    "photos": 133,
+                    "window": None,
+                    "active_hours": 6,
+                }
+            ]
+        )
+    )
+
+    assert "6h" in _days_due(catalogue, "2025-06-12")
+
+
+def test_the_night_a_run_ended_survives_the_trip_through_the_catalogue(tmp_path) -> None:
+    """The extent is the only record that a night ran past its own date.
+
+    Written and never read back is the same as never having measured it, and
+    what will scope a memory to this night is the pair, timezone included.
+    """
+    catalogue = tmp_path / "special-days.json"
+    catalogue.write_text(
+        json.dumps(
+            [
+                {
+                    "day": "2015-06-12",
+                    "title": "A long evening out",
+                    "photos": 133,
+                    "active_hours": 6,
+                    "run_start": "2015-06-12T21:00:00+00:00",
+                    "run_end": "2015-06-13T02:45:00+00:00",
+                }
+            ]
+        )
+    )
+
+    entry = _entries_in(catalogue)[0]
+
+    assert (entry.run_start, entry.run_end) == (
+        datetime(2015, 6, 12, 21, 0, tzinfo=UTC),
+        datetime(2015, 6, 13, 2, 45, tzinfo=UTC),
+    )
+
+
+def test_a_catalogue_written_before_the_hours_existed_still_loads(tmp_path) -> None:
+    """A scan of twenty years is not something to ask anybody to run again.
+
+    Entries from before these fields simply have none of them, and days-due
+    has to go on printing those days rather than reporting an empty
+    catalogue.
+    """
+    catalogue = tmp_path / "special-days.json"
+    catalogue.write_text(
+        json.dumps([{"day": "2015-06-12", "title": "A long evening out", "photos": 133}])
+    )
+
+    entry = _entries_in(catalogue)[0]
+
+    assert (entry.active_hours, entry.run_start, entry.run_end) == (0, None, None)
+    printed = _days_due(catalogue, "2025-06-12")
+    assert "A long evening out" in printed
+    assert "0h" not in printed, "a day nobody measured must not claim it lasted no time"
 
 
 def _entry(day: date) -> DiscoveredDay:


### PR DESCRIPTION
The scan already measured how long a day stayed alive — the ≥6-active-hours
filter is what decides whether a day is worth asking the model about at all —
and then threw the number away. It also recorded nothing about when the day's
run ran, only the date it began.

`DiscoveredDay` now carries three fields, written by `scan_year` and read back
by `days-due`:

- **`active_hours`** — how many hours of the clock the run put pictures in.
  Hours of the clock, not hours elapsed: the six-hour bar and every number in
  the module docstring (18 / 12 / 7 for the labelled positives, 5 / 3 / 1 for
  the negatives) were measured that way, so counting elapsed hours instead
  would quietly move the bar. It therefore saturates at 24 on a very long run,
  which is what the extent is for.
- **`run_start` / `run_end`** — the first and last picture of the run. A run
  ends when the pictures stop for five hours, not at midnight, so it can end on
  another date entirely: the labelled birth ran 45 continuous hours, from one
  evening to the afternoon two dates later.

**What they are for.** The future `special_day` memory type scopes and sizes
itself from the run's real extent. Scoping to the calendar day would stop a
night that ran to three in the morning at midnight, halfway through the thing
that happened, and the duration wants the day's own evidence rather than a span
curve fitted to months.

**Backward compatibility is pinned by a test.** An entry written before these
fields loads with `active_hours == 0` and no extent, and `days-due` still
prints it. A scan of twenty years is not something to ask anybody to run again
for a field they can live without.

`days-due` now prints the hours next to the window: `18:40-23:55  9h`.

The entry construction moved out of the `days-due` body into `_entries_in` so
that fallback can be tested directly. It stays private to the command module —
the shared catalogue reader is a later PR.

Fixtures use invented days only ("A long evening out"); no catalogue content
appears anywhere in the diff.

Part of the surprise-me program (#326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
