### PR TITLE
refactor(cli): split the pipeline runner below the 800-line cap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,7 +298,9 @@ src/immich_memories/
 │   ├── _generation_preview.py  # Plain-text summary for read-only generation planning (--dry-run)
 │   ├── _config_errors.py       # Config error formatting
 │   ├── _flags.py               # Shared validation for flags more than one command takes
-│   ├── _pipeline_runner.py     # Fetch assets + run SmartPipeline + generate
+│   ├── _pipeline_runner.py     # Run SmartPipeline over the fetched assets + generate
+│   ├── _asset_fetch.py         # What a memory asks Immich for: videos, Live Photos, stills
+│   ├── _candidate_pool.py      # Videos + photos merged into one pool, then filtered
 │   ├── _album_generation.py    # Album mode: an Immich album is the candidate pool
 │   ├── _llm_title.py           # Opt-in LLM title on the CLI path (the wizard's default differs)
 │   ├── _trip_generation.py     # Trip detection, selection, per-trip generation

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -920,112 +920,120 @@
       {
         "name": "register_generate_commands",
         "complexity": 163,
-        "line_start": 50,
-        "line_end": 595,
+        "line_start": 47,
+        "line_end": 592,
         "line_complexities": [
           {
-            "line": 137,
+            "line": 134,
             "complexity": 0
           },
           {
-            "line": 138,
+            "line": 135,
             "complexity": 0
           },
           {
-            "line": 145,
+            "line": 142,
             "complexity": 2
+          },
+          {
+            "line": 143,
+            "complexity": 0
+          },
+          {
+            "line": 144,
+            "complexity": 0
           },
           {
             "line": 146,
-            "complexity": 0
-          },
-          {
-            "line": 147,
-            "complexity": 0
-          },
-          {
-            "line": 149,
             "complexity": 2
           },
           {
-            "line": 151,
+            "line": 148,
             "complexity": 3
+          },
+          {
+            "line": 152,
+            "complexity": 3
+          },
+          {
+            "line": 153,
+            "complexity": 0
           },
           {
             "line": 155,
-            "complexity": 3
+            "complexity": 0
           },
           {
             "line": 156,
-            "complexity": 0
-          },
-          {
-            "line": 158,
-            "complexity": 0
-          },
-          {
-            "line": 159,
             "complexity": 2
           },
           {
-            "line": 160,
+            "line": 157,
             "complexity": 1
           },
           {
-            "line": 165,
+            "line": 162,
             "complexity": 3
           },
           {
-            "line": 166,
+            "line": 163,
             "complexity": 0
           },
           {
-            "line": 170,
+            "line": 167,
+            "complexity": 0
+          },
+          {
+            "line": 168,
+            "complexity": 1
+          },
+          {
+            "line": 169,
             "complexity": 0
           },
           {
             "line": 171,
-            "complexity": 1
-          },
-          {
-            "line": 172,
-            "complexity": 0
-          },
-          {
-            "line": 174,
             "complexity": 2
           },
           {
-            "line": 190,
+            "line": 187,
             "complexity": 0
           },
           {
-            "line": 201,
+            "line": 198,
             "complexity": 3
           },
           {
-            "line": 205,
+            "line": 202,
             "complexity": 3
           },
           {
-            "line": 209,
+            "line": 206,
             "complexity": 4
           },
           {
-            "line": 213,
+            "line": 210,
             "complexity": 3
           },
           {
-            "line": 217,
+            "line": 214,
             "complexity": 3
           },
           {
-            "line": 225,
+            "line": 222,
             "complexity": 0
           },
           {
-            "line": 242,
+            "line": 239,
             "complexity": 2
+          },
+          {
+            "line": 240,
+            "complexity": 0
+          },
+          {
+            "line": 241,
+            "complexity": 1
           },
           {
             "line": 243,
@@ -1036,111 +1044,115 @@
             "complexity": 1
           },
           {
-            "line": 246,
+            "line": 245,
             "complexity": 0
           },
           {
-            "line": 247,
-            "complexity": 1
-          },
-          {
-            "line": 248,
-            "complexity": 0
-          },
-          {
-            "line": 256,
+            "line": 253,
             "complexity": 2
+          },
+          {
+            "line": 258,
+            "complexity": 0
           },
           {
             "line": 261,
             "complexity": 0
           },
           {
-            "line": 264,
-            "complexity": 0
-          },
-          {
-            "line": 270,
+            "line": 267,
             "complexity": 1
           },
           {
+            "line": 270,
+            "complexity": 3
+          },
+          {
+            "line": 271,
+            "complexity": 3
+          },
+          {
             "line": 273,
-            "complexity": 3
-          },
-          {
-            "line": 274,
-            "complexity": 3
-          },
-          {
-            "line": 276,
             "complexity": 0
           },
           {
-            "line": 283,
+            "line": 280,
             "complexity": 0
+          },
+          {
+            "line": 284,
+            "complexity": 3
+          },
+          {
+            "line": 285,
+            "complexity": 0
+          },
+          {
+            "line": 286,
+            "complexity": 3
           },
           {
             "line": 287,
-            "complexity": 3
-          },
-          {
-            "line": 288,
             "complexity": 0
           },
           {
             "line": 289,
-            "complexity": 3
-          },
-          {
-            "line": 290,
             "complexity": 0
           },
           {
-            "line": 292,
-            "complexity": 0
-          },
-          {
-            "line": 316,
+            "line": 313,
             "complexity": 1
           },
           {
-            "line": 317,
+            "line": 314,
             "complexity": 2
           },
           {
-            "line": 321,
+            "line": 318,
             "complexity": 1
           },
           {
-            "line": 332,
+            "line": 329,
             "complexity": 3
+          },
+          {
+            "line": 330,
+            "complexity": 0
+          },
+          {
+            "line": 331,
+            "complexity": 0
           },
           {
             "line": 333,
             "complexity": 0
           },
           {
-            "line": 334,
+            "line": 335,
             "complexity": 0
           },
           {
-            "line": 336,
+            "line": 337,
             "complexity": 0
           },
           {
-            "line": 338,
-            "complexity": 0
-          },
-          {
-            "line": 340,
-            "complexity": 0
-          },
-          {
-            "line": 347,
+            "line": 344,
             "complexity": 5
           },
           {
-            "line": 389,
+            "line": 386,
+            "complexity": 6
+          },
+          {
+            "line": 430,
+            "complexity": 0
+          },
+          {
+            "line": 431,
+            "complexity": 5
+          },
+          {
+            "line": 432,
             "complexity": 6
           },
           {
@@ -1149,135 +1161,127 @@
           },
           {
             "line": 434,
-            "complexity": 5
+            "complexity": 0
           },
           {
             "line": 435,
+            "complexity": 7
+          },
+          {
+            "line": 443,
             "complexity": 6
           },
           {
-            "line": 436,
+            "line": 444,
             "complexity": 0
           },
           {
-            "line": 437,
-            "complexity": 0
-          },
-          {
-            "line": 438,
+            "line": 445,
             "complexity": 7
           },
           {
             "line": 446,
-            "complexity": 6
-          },
-          {
-            "line": 447,
             "complexity": 0
           },
           {
             "line": 448,
-            "complexity": 7
-          },
-          {
-            "line": 449,
-            "complexity": 0
-          },
-          {
-            "line": 451,
             "complexity": 1
           },
           {
-            "line": 456,
+            "line": 453,
             "complexity": 7
           },
           {
-            "line": 457,
+            "line": 454,
             "complexity": 0
           },
           {
-            "line": 470,
+            "line": 467,
             "complexity": 7
           },
           {
-            "line": 471,
+            "line": 468,
+            "complexity": 0
+          },
+          {
+            "line": 469,
             "complexity": 0
           },
           {
             "line": 472,
-            "complexity": 0
-          },
-          {
-            "line": 475,
             "complexity": 1
           },
           {
-            "line": 476,
+            "line": 473,
             "complexity": 0
           },
           {
-            "line": 477,
+            "line": 474,
             "complexity": 0
           },
           {
-            "line": 481,
+            "line": 478,
             "complexity": 7
           },
           {
-            "line": 482,
+            "line": 479,
             "complexity": 0
           },
           {
-            "line": 491,
+            "line": 488,
             "complexity": 0
           },
           {
-            "line": 501,
+            "line": 498,
             "complexity": 0
           },
           {
-            "line": 502,
+            "line": 499,
             "complexity": 5
           },
           {
-            "line": 503,
+            "line": 500,
             "complexity": 0
+          },
+          {
+            "line": 505,
+            "complexity": 6
           },
           {
             "line": 508,
             "complexity": 6
           },
           {
-            "line": 511,
-            "complexity": 6
-          },
-          {
-            "line": 516,
+            "line": 513,
             "complexity": 0
           },
           {
-            "line": 518,
+            "line": 515,
             "complexity": 5
           },
           {
-            "line": 520,
+            "line": 517,
+            "complexity": 5
+          },
+          {
+            "line": 521,
             "complexity": 5
           },
           {
             "line": 524,
-            "complexity": 5
-          },
-          {
-            "line": 527,
             "complexity": 1
           },
           {
-            "line": 529,
+            "line": 526,
             "complexity": 0
           },
           {
-            "line": 531,
+            "line": 528,
             "complexity": 0
+          },
+          {
+            "line": 575,
+            "complexity": 1
           },
           {
             "line": 578,
@@ -1288,15 +1292,11 @@
             "complexity": 1
           },
           {
-            "line": 584,
-            "complexity": 1
-          },
-          {
-            "line": 585,
+            "line": 582,
             "complexity": 0
           },
           {
-            "line": 586,
+            "line": 583,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/pipeline/pipeline-overview.md
+++ b/docs-site/docs/create/pipeline/pipeline-overview.md
@@ -112,7 +112,7 @@ flowchart TB
 
 ### 1. Discovery
 
-`fetch_videos_and_live_photos()` in `cli/_pipeline_runner.py` runs one Immich
+`fetch_videos_and_live_photos()` in `cli/_asset_fetch.py` runs one Immich
 search per date range, then dedups by asset id. Live Photos are fetched
 separately and their video components are removed from the plain video list so
 the same footage is not considered twice.

--- a/src/immich_memories/cli/_asset_fetch.py
+++ b/src/immich_memories/cli/_asset_fetch.py
@@ -1,0 +1,112 @@
+"""What a memory asks Immich for, given its windows and the people in it.
+
+The rules here answer to the API rather than to the pipeline: one person
+filters by ``person_id``, several ask for the moments holding all of them, and
+windows that touch must not hand the same asset over twice. Live Photos arrive
+as clips and take their own video out of the plain video list, so nothing is
+offered to selection in both forms.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from immich_memories.cli._helpers import print_success
+from immich_memories.timeperiod import DateRange
+
+if TYPE_CHECKING:
+    from immich_memories.api.immich import SyncImmichClient
+    from immich_memories.cli._live_display import ProgressDisplay
+    from immich_memories.config_loader import Config
+
+
+def fetch_photos(
+    *,
+    client: SyncImmichClient,
+    date_ranges: list[DateRange],
+    person_ids: list[str],
+) -> list:
+    """Fetch still photos for the memory's windows, honouring the person filter.
+
+    Several people means the photos holding all of them, the same rule videos
+    and Live Photos already follow.
+    """
+    photos: list = []
+    seen: set[str] = set()
+    for dr in date_ranges:
+        batch = client.get_photos_for_date_range(
+            dr,
+            person_id=person_ids[0] if len(person_ids) == 1 else None,
+            person_ids=person_ids if len(person_ids) > 1 else None,
+        )
+        for photo in batch:
+            if photo.id not in seen:
+                seen.add(photo.id)
+                photos.append(photo)
+    return photos
+
+
+def fetch_videos_and_live_photos(
+    *,
+    client: SyncImmichClient,
+    config: Config,
+    progress: ProgressDisplay,
+    date_ranges: list[DateRange],
+    person_ids: list[str],
+    use_live_photos: bool,
+) -> tuple[list, list]:
+    """Fetch video assets and optionally live photo clips.
+
+    Returns (assets, live_photo_clips).
+    """
+    task = progress.add_task("Fetching videos...", total=None)
+
+    all_assets = []
+    for dr in date_ranges:
+        if len(person_ids) > 1:
+            # Naming several people asks for the moments that hold all of them,
+            # not the union of their solo reels. Live photos already intersect.
+            batch = client.get_videos_for_all_persons(person_ids, dr)
+        elif len(person_ids) == 1:
+            batch = client.get_videos_for_person_and_date_range(person_ids[0], dr)
+        else:
+            batch = client.get_videos_for_date_range(dr)
+        all_assets.extend(batch)
+
+    # Deduplicate across date ranges
+    seen: dict[str, object] = {}
+    assets = []
+    for a in all_assets:
+        if a.id not in seen:
+            seen[a.id] = True
+            assets.append(a)
+
+    progress.update(task, completed=True)
+    print_success(f"Found {len(assets)} videos")
+
+    live_photo_clips: list = []
+    if use_live_photos:
+        from immich_memories.analysis.live_photo_pipeline import fetch_live_photo_clips
+
+        lp_task = progress.add_task("Fetching live photos...", total=None)
+        all_lp_clips: list = []
+        all_lp_video_ids: set[str] = set()
+        for dr in date_ranges:
+            lp_clips, lp_vid_ids = fetch_live_photo_clips(
+                client,
+                dr,
+                person_id=person_ids[0] if len(person_ids) == 1 else None,
+                person_ids=person_ids if len(person_ids) > 1 else None,
+                config=config,
+            )
+            all_lp_clips.extend(lp_clips)
+            all_lp_video_ids.update(lp_vid_ids)
+
+        if all_lp_video_ids:
+            assets = [a for a in assets if a.id not in all_lp_video_ids]
+        live_photo_clips = all_lp_clips
+        progress.update(lp_task, completed=True)
+        if live_photo_clips:
+            print_success(f"Found {len(live_photo_clips)} live photo clips")
+
+    return assets, live_photo_clips

--- a/src/immich_memories/cli/_candidate_pool.py
+++ b/src/immich_memories/cli/_candidate_pool.py
@@ -1,0 +1,210 @@
+"""The pool that selection actually chooses from.
+
+Analysis hands over video candidates; this merges the memory's still photos in
+so both compete on one scale, then drops what should never have been in the
+running: messaging re-encodes, stills a clip from the same moment already
+shows, and more animals or objects than the runtime can spare.
+
+The CLI runner and the UI's clip pipeline both build their pool here. That is
+the point — a rule added on one path used to miss the other.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from immich_memories.api.immich import SyncImmichClient
+    from immich_memories.config_loader import Config
+
+
+def _merge_photos_into_pool(
+    analyzed_videos: list,
+    *,
+    live_photo_clips: list | None = None,
+    photo_assets: list | None,
+    include_photos: bool,
+    config: Config,
+    client: SyncImmichClient,
+    work_dir: Path,
+    provider_circuit=None,
+    dry_run: bool = False,
+    thumbnail_cache=None,
+) -> list:
+    """Score photos and merge them as ClipWithSegment into the video pool.
+
+    Returns the combined list of video + photo candidates for unified selection.
+    When photos are disabled or absent, returns the video list unchanged.
+    """
+    if not include_photos or not photo_assets:
+        return analyzed_videos
+
+    import logging
+
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+    from immich_memories.analysis.source_filter import from_the_camera_roll
+    from immich_memories.api.models import VideoClipInfo
+    from immich_memories.photos.photo_pipeline import (
+        score_photos,
+        video_count_for_photo_budget,
+    )
+    from immich_memories.photos.scoring import score_photo
+
+    _logger = logging.getLogger(__name__)
+
+    # Before anything is fetched or scored: this is the pool both the CLI and
+    # the UI actually build, and the rule used to live only on the path
+    # neither of them takes.
+    photo_assets = from_the_camera_roll(photo_assets, config)
+    if not photo_assets:
+        return analyzed_videos
+
+    photo_assets = _drop_photos_already_shown_as_motion(
+        photo_assets,
+        analyzed_videos,
+        config=config,
+        client=client,
+        thumbnail_cache=thumbnail_cache,
+    )
+    if not photo_assets:
+        return analyzed_videos
+
+    photo_duration = config.photos.duration
+    if dry_run:
+        scored = [(asset, score_photo(asset, config.photos)) for asset in photo_assets]
+    else:
+        photo_dir = work_dir / "photos"
+        photo_dir.mkdir(parents=True, exist_ok=True)
+        scored = score_photos(
+            assets=photo_assets,
+            config=config.photos,
+            video_clip_count=video_count_for_photo_budget(
+                len(analyzed_videos), len(live_photo_clips or [])
+            ),
+            work_dir=photo_dir,
+            download_fn=client.download_asset,
+            db_path=config.cache.database_path,
+            app_config=config,
+            thumbnail_fn=client.get_asset_thumbnail,
+            provider_circuit=provider_circuit,
+            thumbnail_cache=thumbnail_cache,
+        )
+
+    # What the VLM said about each photo, so the holistic review can read a
+    # photograph the way it reads a video. Without it every still arrived as a
+    # bare line and survived on the rule that protects unanalysed material.
+    from immich_memories.analysis.cache_projection import apply_semantic_payload
+    from immich_memories.photos.scoring import semantic_payloads_for
+
+    payloads = semantic_payloads_for(
+        config.cache.database_path, [asset.id for asset, _ in scored], config.llm.model
+    )
+
+    photo_candidates = []
+    for asset, photo_score in scored:
+        clip = VideoClipInfo(
+            asset=asset,
+            duration_seconds=photo_duration,
+            width=asset.width,
+            height=asset.height,
+        )
+        apply_semantic_payload(clip, payloads.get(asset.id))
+        photo_candidates.append(
+            ClipWithSegment(
+                clip=clip,
+                start_time=0.0,
+                end_time=photo_duration,
+                score=photo_score,
+            )
+        )
+
+    _logger.info(
+        f"Unified pool: {len(analyzed_videos)} video + {len(photo_candidates)} photo candidates"
+    )
+
+    return analyzed_videos + photo_candidates
+
+
+def _drop_reencoded_sources(candidates: list, *, config: Config) -> list:
+    """Drop messaging re-encodes: small, and with no camera EXIF to vouch for them."""
+    from immich_memories.analysis.source_quality import is_usable_source
+
+    floor = config.analysis.min_source_short_side
+    if floor <= 0:
+        return candidates
+
+    kept = [
+        c
+        for c in candidates
+        if is_usable_source(
+            width=c.clip.width or c.clip.asset.width or 0,
+            height=c.clip.height or c.clip.asset.height or 0,
+            has_camera_exif=_has_camera_exif(c.clip.asset),
+            min_short_side=floor,
+        )
+    ]
+    if len(kept) < len(candidates):
+        logger.info(
+            "Source quality: dropped %d clips under %dp with no camera EXIF",
+            len(candidates) - len(kept),
+            floor,
+        )
+    return kept
+
+
+def _has_camera_exif(asset) -> bool:
+    exif = getattr(asset, "exif_info", None)
+    return bool(exif and (exif.make or exif.model))
+
+
+def _apply_subject_policy(
+    candidates: list,
+    *,
+    config: Config,
+    content_budget_seconds: float,
+    photo_assets: list | None = None,
+) -> list:
+    """Prefer clips of people, and ration animals and objects by share of runtime."""
+    if not config.analysis.subject_policy_enabled:
+        return candidates
+
+    from immich_memories.analysis.subject_policy import filter_candidates_by_subject
+
+    return filter_candidates_by_subject(
+        candidates,
+        animal_ratio=config.analysis.max_animal_ratio,
+        object_ratio=config.analysis.max_object_ratio,
+        content_budget_seconds=content_budget_seconds,
+        photo_asset_ids={a.id for a in photo_assets or []},
+    )
+
+
+def _drop_photos_already_shown_as_motion(
+    photo_assets: list,
+    analyzed_videos: list,
+    *,
+    config: Config,
+    client: SyncImmichClient,
+    thumbnail_cache=None,
+) -> list:
+    """Remove photos a selected clip from the same moment already shows.
+
+    Runs before scoring so the removed photos never reach the LLM.
+    """
+    from immich_memories.photos.moment_suppression import filter_photos_covered_by_motion
+
+    motion_clips = [c.clip for c in analyzed_videos if getattr(c, "clip", None) is not None]
+    if not motion_clips:
+        return photo_assets
+
+    return filter_photos_covered_by_motion(
+        photo_assets,
+        motion_clips,
+        config=config.photos,
+        thumbnail_cache=thumbnail_cache,
+        thumbnail_fn=client.get_asset_thumbnail,
+    )

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -1,7 +1,8 @@
 """Pipeline orchestration for the generate command.
 
-Bridges CLI to SmartPipeline + generate_memory: fetches assets from
-Immich, runs analysis, and generates the final video.
+Bridges CLI to SmartPipeline + generate_memory: runs analysis over the assets
+the CLI fetched, selects from the candidate pool, and generates the final
+video.
 """
 
 from __future__ import annotations
@@ -15,6 +16,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from immich_memories.analysis import llm_metrics
+from immich_memories.cli._candidate_pool import (
+    _apply_subject_policy,
+    _drop_reencoded_sources,
+    _merge_photos_into_pool,
+)
 from immich_memories.cli._helpers import console, print_error, print_success
 from immich_memories.cli._pool_coverage import report_pool_coverage
 from immich_memories.cli._run_inputs import ResolvedRunInputs
@@ -657,145 +663,6 @@ def _send_notification(
         logging.getLogger(__name__).debug("Notification failed", exc_info=True)
 
 
-def _merge_photos_into_pool(
-    analyzed_videos: list,
-    *,
-    live_photo_clips: list | None = None,
-    photo_assets: list | None,
-    include_photos: bool,
-    config: Config,
-    client: SyncImmichClient,
-    work_dir: Path,
-    provider_circuit=None,
-    dry_run: bool = False,
-    thumbnail_cache=None,
-) -> list:
-    """Score photos and merge them as ClipWithSegment into the video pool.
-
-    Returns the combined list of video + photo candidates for unified selection.
-    When photos are disabled or absent, returns the video list unchanged.
-    """
-    if not include_photos or not photo_assets:
-        return analyzed_videos
-
-    import logging
-
-    from immich_memories.analysis.smart_pipeline import ClipWithSegment
-    from immich_memories.analysis.source_filter import from_the_camera_roll
-    from immich_memories.api.models import VideoClipInfo
-    from immich_memories.photos.photo_pipeline import (
-        score_photos,
-        video_count_for_photo_budget,
-    )
-    from immich_memories.photos.scoring import score_photo
-
-    _logger = logging.getLogger(__name__)
-
-    # Before anything is fetched or scored: this is the pool both the CLI and
-    # the UI actually build, and the rule used to live only on the path
-    # neither of them takes.
-    photo_assets = from_the_camera_roll(photo_assets, config)
-    if not photo_assets:
-        return analyzed_videos
-
-    photo_assets = _drop_photos_already_shown_as_motion(
-        photo_assets,
-        analyzed_videos,
-        config=config,
-        client=client,
-        thumbnail_cache=thumbnail_cache,
-    )
-    if not photo_assets:
-        return analyzed_videos
-
-    photo_duration = config.photos.duration
-    if dry_run:
-        scored = [(asset, score_photo(asset, config.photos)) for asset in photo_assets]
-    else:
-        photo_dir = work_dir / "photos"
-        photo_dir.mkdir(parents=True, exist_ok=True)
-        scored = score_photos(
-            assets=photo_assets,
-            config=config.photos,
-            video_clip_count=video_count_for_photo_budget(
-                len(analyzed_videos), len(live_photo_clips or [])
-            ),
-            work_dir=photo_dir,
-            download_fn=client.download_asset,
-            db_path=config.cache.database_path,
-            app_config=config,
-            thumbnail_fn=client.get_asset_thumbnail,
-            provider_circuit=provider_circuit,
-            thumbnail_cache=thumbnail_cache,
-        )
-
-    # What the VLM said about each photo, so the holistic review can read a
-    # photograph the way it reads a video. Without it every still arrived as a
-    # bare line and survived on the rule that protects unanalysed material.
-    from immich_memories.analysis.cache_projection import apply_semantic_payload
-    from immich_memories.photos.scoring import semantic_payloads_for
-
-    payloads = semantic_payloads_for(
-        config.cache.database_path, [asset.id for asset, _ in scored], config.llm.model
-    )
-
-    photo_candidates = []
-    for asset, photo_score in scored:
-        clip = VideoClipInfo(
-            asset=asset,
-            duration_seconds=photo_duration,
-            width=asset.width,
-            height=asset.height,
-        )
-        apply_semantic_payload(clip, payloads.get(asset.id))
-        photo_candidates.append(
-            ClipWithSegment(
-                clip=clip,
-                start_time=0.0,
-                end_time=photo_duration,
-                score=photo_score,
-            )
-        )
-
-    _logger.info(
-        f"Unified pool: {len(analyzed_videos)} video + {len(photo_candidates)} photo candidates"
-    )
-
-    return analyzed_videos + photo_candidates
-
-
-def _drop_reencoded_sources(candidates: list, *, config: Config) -> list:
-    """Drop messaging re-encodes: small, and with no camera EXIF to vouch for them."""
-    from immich_memories.analysis.source_quality import is_usable_source
-
-    floor = config.analysis.min_source_short_side
-    if floor <= 0:
-        return candidates
-
-    kept = [
-        c
-        for c in candidates
-        if is_usable_source(
-            width=c.clip.width or c.clip.asset.width or 0,
-            height=c.clip.height or c.clip.asset.height or 0,
-            has_camera_exif=_has_camera_exif(c.clip.asset),
-            min_short_side=floor,
-        )
-    ]
-    if len(kept) < len(candidates):
-        logger.info(
-            "Source quality: dropped %d clips under %dp with no camera EXIF",
-            len(candidates) - len(kept),
-            floor,
-        )
-    return kept
-
-
-def _has_camera_exif(asset) -> bool:
-    exif = getattr(asset, "exif_info", None)
-    return bool(exif and (exif.make or exif.model))
-
-
 def _name_after_recipe(
     output_path: Path,
     *,
@@ -826,144 +693,3 @@ def _name_after_recipe(
         clips=clips,
     )
     return apply_recipe_hash(output_path, digest)
-
-
-def _apply_subject_policy(
-    candidates: list,
-    *,
-    config: Config,
-    content_budget_seconds: float,
-    photo_assets: list | None = None,
-) -> list:
-    """Prefer clips of people, and ration animals and objects by share of runtime."""
-    if not config.analysis.subject_policy_enabled:
-        return candidates
-
-    from immich_memories.analysis.subject_policy import filter_candidates_by_subject
-
-    return filter_candidates_by_subject(
-        candidates,
-        animal_ratio=config.analysis.max_animal_ratio,
-        object_ratio=config.analysis.max_object_ratio,
-        content_budget_seconds=content_budget_seconds,
-        photo_asset_ids={a.id for a in photo_assets or []},
-    )
-
-
-def _drop_photos_already_shown_as_motion(
-    photo_assets: list,
-    analyzed_videos: list,
-    *,
-    config: Config,
-    client: SyncImmichClient,
-    thumbnail_cache=None,
-) -> list:
-    """Remove photos a selected clip from the same moment already shows.
-
-    Runs before scoring so the removed photos never reach the LLM.
-    """
-    from immich_memories.photos.moment_suppression import filter_photos_covered_by_motion
-
-    motion_clips = [c.clip for c in analyzed_videos if getattr(c, "clip", None) is not None]
-    if not motion_clips:
-        return photo_assets
-
-    return filter_photos_covered_by_motion(
-        photo_assets,
-        motion_clips,
-        config=config.photos,
-        thumbnail_cache=thumbnail_cache,
-        thumbnail_fn=client.get_asset_thumbnail,
-    )
-
-
-def fetch_photos(
-    *,
-    client: SyncImmichClient,
-    date_ranges: list[DateRange],
-    person_ids: list[str],
-) -> list:
-    """Fetch still photos for the memory's windows, honouring the person filter.
-
-    Several people means the photos holding all of them, the same rule videos
-    and Live Photos already follow.
-    """
-    photos: list = []
-    seen: set[str] = set()
-    for dr in date_ranges:
-        batch = client.get_photos_for_date_range(
-            dr,
-            person_id=person_ids[0] if len(person_ids) == 1 else None,
-            person_ids=person_ids if len(person_ids) > 1 else None,
-        )
-        for photo in batch:
-            if photo.id not in seen:
-                seen.add(photo.id)
-                photos.append(photo)
-    return photos
-
-
-def fetch_videos_and_live_photos(
-    *,
-    client: SyncImmichClient,
-    config: Config,
-    progress: ProgressDisplay,
-    date_ranges: list[DateRange],
-    person_ids: list[str],
-    use_live_photos: bool,
-) -> tuple[list, list]:
-    """Fetch video assets and optionally live photo clips.
-
-    Returns (assets, live_photo_clips).
-    """
-    task = progress.add_task("Fetching videos...", total=None)
-
-    all_assets = []
-    for dr in date_ranges:
-        if len(person_ids) > 1:
-            # Naming several people asks for the moments that hold all of them,
-            # not the union of their solo reels. Live photos already intersect.
-            batch = client.get_videos_for_all_persons(person_ids, dr)
-        elif len(person_ids) == 1:
-            batch = client.get_videos_for_person_and_date_range(person_ids[0], dr)
-        else:
-            batch = client.get_videos_for_date_range(dr)
-        all_assets.extend(batch)
-
-    # Deduplicate across date ranges
-    seen: dict[str, object] = {}
-    assets = []
-    for a in all_assets:
-        if a.id not in seen:
-            seen[a.id] = True
-            assets.append(a)
-
-    progress.update(task, completed=True)
-    print_success(f"Found {len(assets)} videos")
-
-    live_photo_clips: list = []
-    if use_live_photos:
-        from immich_memories.analysis.live_photo_pipeline import fetch_live_photo_clips
-
-        lp_task = progress.add_task("Fetching live photos...", total=None)
-        all_lp_clips: list = []
-        all_lp_video_ids: set[str] = set()
-        for dr in date_ranges:
-            lp_clips, lp_vid_ids = fetch_live_photo_clips(
-                client,
-                dr,
-                person_id=person_ids[0] if len(person_ids) == 1 else None,
-                person_ids=person_ids if len(person_ids) > 1 else None,
-                config=config,
-            )
-            all_lp_clips.extend(lp_clips)
-            all_lp_video_ids.update(lp_vid_ids)
-
-        if all_lp_video_ids:
-            assets = [a for a in assets if a.id not in all_lp_video_ids]
-        live_photo_clips = all_lp_clips
-        progress.update(lp_task, completed=True)
-        if live_photo_clips:
-            print_success(f"Found {len(live_photo_clips)} live photo clips")
-
-    return assets, live_photo_clips

--- a/src/immich_memories/cli/_trip_generation.py
+++ b/src/immich_memories/cli/_trip_generation.py
@@ -14,11 +14,9 @@ from typing import TYPE_CHECKING
 import click
 
 from immich_memories.analysis.trip_detection import DetectedTrip, haversine_km
+from immich_memories.cli._asset_fetch import fetch_videos_and_live_photos
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
-from immich_memories.cli._pipeline_runner import (
-    fetch_videos_and_live_photos,
-    run_pipeline_and_generate,
-)
+from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
 from immich_memories.processing.encoding_plan import resolve_output_selection
 from immich_memories.timeperiod import DateRange
 

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 
+from immich_memories.cli._asset_fetch import fetch_photos, fetch_videos_and_live_photos
 from immich_memories.cli._date_resolution import (
     BIRTHDAY_FLAG_FORMAT,
     default_duration_for_type,
@@ -20,11 +21,7 @@ from immich_memories.cli._generate_display import (
     _print_generation_result,
 )
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
-from immich_memories.cli._pipeline_runner import (
-    fetch_photos,
-    fetch_videos_and_live_photos,
-    run_pipeline_and_generate,
-)
+from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
 from immich_memories.cli._trip_generation import handle_trip_generation, resolve_music_arg
 from immich_memories.cli.generate_options import (
     automation_options,

--- a/src/immich_memories/ui/pages/clip_pipeline.py
+++ b/src/immich_memories/ui/pages/clip_pipeline.py
@@ -316,7 +316,7 @@ def _run_pipeline_blocking(
             if state.include_photos and photos:
                 from pathlib import Path
 
-                from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+                from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
                 all_candidates = _merge_photos_into_pool(
                     analyzed,

--- a/tests/integration/cli/test_generate.py
+++ b/tests/integration/cli/test_generate.py
@@ -869,7 +869,7 @@ class TestCLIGenerate:
 
 
 class TestPipelineRunner:
-    """Tests for _pipeline_runner functions with mocked assembly.
+    """Tests for the fetch and runner functions with mocked assembly.
 
     WHY mock assembly: These functions run SmartPipeline + generate_memory.
     Assembly is FFmpeg-heavy; we mock it to test the pipeline wiring.
@@ -877,7 +877,7 @@ class TestPipelineRunner:
 
     def test_fetch_videos_returns_assets(self, tmp_path):
         """fetch_videos_and_live_photos returns deduped assets."""
-        from immich_memories.cli._pipeline_runner import fetch_videos_and_live_photos
+        from immich_memories.cli._asset_fetch import fetch_videos_and_live_photos
         from immich_memories.timeperiod import DateRange
 
         mock_client = MagicMock()
@@ -907,7 +907,7 @@ class TestPipelineRunner:
 
     def test_fetch_videos_person_filter(self, tmp_path):
         """fetch with single person_id calls person-specific API."""
-        from immich_memories.cli._pipeline_runner import fetch_videos_and_live_photos
+        from immich_memories.cli._asset_fetch import fetch_videos_and_live_photos
         from immich_memories.timeperiod import DateRange
 
         mock_client = MagicMock()
@@ -931,7 +931,7 @@ class TestPipelineRunner:
 
     def test_fetch_videos_multi_person(self, tmp_path):
         """fetch with multiple person_ids asks for the videos holding all of them."""
-        from immich_memories.cli._pipeline_runner import fetch_videos_and_live_photos
+        from immich_memories.cli._asset_fetch import fetch_videos_and_live_photos
         from immich_memories.timeperiod import DateRange
 
         mock_client = MagicMock()

--- a/tests/integration/pipeline/test_mega_flows.py
+++ b/tests/integration/pipeline/test_mega_flows.py
@@ -77,7 +77,7 @@ def test_twelve_day_auto_trip_deeply_analyzes_the_manageable_pool(tmp_path: Path
     from immich_memories.analysis.smart_pipeline import ClipWithSegment, SmartPipeline
     from immich_memories.api.models import Asset, AssetType, VideoClipInfo
     from immich_memories.cache.thumbnail_cache import ThumbnailCache
-    from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+    from immich_memories.cli._candidate_pool import _merge_photos_into_pool
     from immich_memories.config_loader import Config
     from immich_memories.ui.pages.clip_pipeline import (
         _build_pipeline_config,

--- a/tests/test_clip_pipeline_ui.py
+++ b/tests/test_clip_pipeline_ui.py
@@ -142,7 +142,7 @@ def test_blocking_pipeline_cannot_reintroduce_unchecked_photos() -> None:
         patch("immich_memories.analysis.smart_pipeline.SmartPipeline", return_value=pipeline),
         patch("immich_memories.config.get_config", return_value=state.config),
         patch(
-            "immich_memories.cli._pipeline_runner._merge_photos_into_pool",
+            "immich_memories.cli._candidate_pool._merge_photos_into_pool",
             return_value=[],
         ) as merge_photos,
     ):
@@ -198,7 +198,7 @@ def test_blocking_pipeline_hands_the_photo_merge_its_thumbnail_cache() -> None:
         patch("immich_memories.config.get_config", return_value=state.config),
         # WHY: the seam under inspection — captures the arguments, runs nothing.
         patch(
-            "immich_memories.cli._pipeline_runner._merge_photos_into_pool",
+            "immich_memories.cli._candidate_pool._merge_photos_into_pool",
             return_value=[],
         ) as merge_photos,
     ):

--- a/tests/test_multi_person_selection.py
+++ b/tests/test_multi_person_selection.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from immich_memories.cli._pipeline_runner import fetch_photos, fetch_videos_and_live_photos
+from immich_memories.cli._asset_fetch import fetch_photos, fetch_videos_and_live_photos
 from immich_memories.config_loader import Config
 from immich_memories.timeperiod import DateRange
 

--- a/tests/test_photo_pipeline.py
+++ b/tests/test_photo_pipeline.py
@@ -235,7 +235,7 @@ def test_the_pool_the_cli_and_ui_build_drops_what_the_camera_did_not_shoot(tmp_p
     """
     from datetime import UTC, datetime
 
-    from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+    from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
     when = datetime(2019, 6, 12, 12, tzinfo=UTC)
     forwarded = make_asset(

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -26,8 +26,8 @@ from datetime import date, datetime
 import pytest
 
 from immich_memories.api.models import Person
+from immich_memories.cli._asset_fetch import fetch_photos, fetch_videos_and_live_photos
 from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
-from immich_memories.cli._pipeline_runner import fetch_photos, fetch_videos_and_live_photos
 from immich_memories.memory_types.factory import create_preset
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import DateRange
@@ -341,7 +341,7 @@ class SilentProgress:
 def cli_fetch_calls(
     windows: list[DateRange], people: tuple[Person, ...], *, include_photos: bool
 ) -> list:
-    """What ``cli/_pipeline_runner`` asks Immich for, given windows and people."""
+    """What ``cli/_asset_fetch`` asks Immich for, given windows and people."""
     client = RecordingClient()
     person_ids = [person.id for person in people]
     fetch_videos_and_live_photos(

--- a/tests/test_unified_selection.py
+++ b/tests/test_unified_selection.py
@@ -251,7 +251,7 @@ class TestUnifiedPool:
 
 
 class TestPipelineRunnerUnifiedFlow:
-    """_pipeline_runner merges photos into the selection pool."""
+    """_candidate_pool merges photos into the selection pool."""
 
     def test_photos_converted_to_clip_with_segment(self):
         """score_photos results should be convertible to ClipWithSegment."""
@@ -291,10 +291,10 @@ class TestPipelineRunnerUnifiedFlow:
 
 
 class TestMergePhotosIntoPool:
-    """Tests for _merge_photos_into_pool helper in _pipeline_runner."""
+    """Tests for _merge_photos_into_pool helper in _candidate_pool."""
 
     def test_returns_unchanged_when_photos_disabled(self):
-        from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+        from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
         mock_client = MagicMock()
         analyzed = [MagicMock(), MagicMock()]
@@ -311,7 +311,7 @@ class TestMergePhotosIntoPool:
         assert result is analyzed
 
     def test_returns_unchanged_when_no_photo_assets(self):
-        from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+        from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
         mock_client = MagicMock()
         analyzed = [MagicMock(), MagicMock()]
@@ -330,7 +330,7 @@ class TestMergePhotosIntoPool:
     def test_merges_scored_photos_with_videos(self, tmp_path):
         from unittest.mock import patch
 
-        from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+        from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
         mock_client = MagicMock()
         mock_client.download_asset = MagicMock()
@@ -383,7 +383,7 @@ class TestMergePhotosIntoPool:
     def test_open_provider_circuit_skips_photo_llm_requests(self, tmp_path):
         """A video-side provider failure also suppresses photo-side requests."""
         from immich_memories.analysis.provider_health import ProviderCircuit
-        from immich_memories.cli._pipeline_runner import _merge_photos_into_pool
+        from immich_memories.cli._candidate_pool import _merge_photos_into_pool
 
         circuit = ProviderCircuit()
         circuit.disable("configured model unavailable")


### PR DESCRIPTION
Part of #685 — the last of the seven, so this **closes out the >800 split wave**.

`cli/_pipeline_runner.py` was **969 lines** on `main`. The urgency is not the soft cap: open PR **#661** adds ~40 lines to this exact file, which lands it at **1008** and fails `make file-length` on the 1000-line hard gate for a reason unrelated to its own change. **Unblocks #661.**

## The seams: the fetch layer, and the pool layer

| file | before | after |
|---|---:|---:|
| `cli/_pipeline_runner.py` | 969 | **695** |
| `cli/_asset_fetch.py` | — | 112 |
| `cli/_candidate_pool.py` | — | 210 |

**`cli/_asset_fetch.py`** — `fetch_photos` + `fetch_videos_and_live_photos`. These are the module's *other* public entry points, and they sit on the far side of the pipeline from everything else in it: `cli/generate.py` and `cli/_trip_generation.py` call them **before** `run_pipeline_and_generate`, with a client and a list of windows, and hand the result in. Coupling audit: neither function calls anything defined in `_pipeline_runner.py` (their only cross-module dependency is `print_success` from `_helpers`), and nothing left in `_pipeline_runner.py` calls either of them. Their rules answer to the Immich API rather than to the pipeline — one person filters by `person_id`, several ask for the moments holding *all* of them, windows that touch must not hand the same asset over twice, and a Live Photo's video component is removed from the plain video list so nothing reaches selection in two forms.

**`cli/_candidate_pool.py`** — `_merge_photos_into_pool`, `_drop_reencoded_sources`, `_has_camera_exif`, `_apply_subject_policy`, `_drop_photos_already_shown_as_motion`. The strongest cohesion in the file, and it is not a judgement call: **two of the five were already private to the group** (`_drop_photos_already_shown_as_motion` is called only by `_merge_photos_into_pool`, `_has_camera_exif` only by `_drop_reencoded_sources`), so the seam already existed — it just had no file. The other three are called from four consecutive statements in the orchestrator, all with the same shape: take a candidate list plus config, return a candidate list. None of them touch `progress`, the task handle, the timeline, or any pipeline object.

The second signal is that this is not CLI-only code. `ui/pages/clip_pipeline.py` reaches into `_pipeline_runner` at call time for `_merge_photos_into_pool` — the module already had an outside consumer for exactly this one function, and the WHY comment inside it says why ("this is the pool both the CLI and the UI actually build, and the rule used to live only on the path neither of them takes"). The import now points at the honest module. The direction of the dependency is unchanged and still permitted — `import-linter` forbids core→CLI and core→UI, not ui→cli.

## Where #661 lands

**Per-window reporting from #661 belongs in `cli/_asset_fetch.py`.** That is not a guess: its `_report_per_window` is called from inside `fetch_videos_and_live_photos`, immediately after `print_success(f"Found {len(assets)} videos")`, and `_window_label` is its only helper. Both functions and the `print_info` / `print_warning` additions to the import block move to `_asset_fetch.py` unchanged, and **`_pipeline_runner.py` stops being touched by #661 at all** — its 40 lines land in a 112-line file instead of a 1008-line one. None of #661's content is in this PR.

## Seams evaluated and not taken

- **Run reporting / display — rejected, it is already gone.** There is no reporting module left to extract: `render_run_summary` lives in `_run_summary.py`, `report_pool_coverage` in `_pool_coverage.py`, the preview in `_generation_preview.py`, the params table in `_generate_display.py`. What remains in the runner is four `logger.info` calls and one `console.print(render_run_summary(...))` — call sites interleaved with the orchestration they narrate, not a layer. Extracting them would mean *writing* a function, not moving one, which breaks the behaviour-neutrality rule this wave runs under. And #661's reporting is per-*window*, which belongs with the fetch loop that has the windows, not with the run summary that does not.
- **`_configure_timeline` — rejected, it is half a concern.** The timeline is resolved in two places: `_configure_timeline` before selection, and `finalize_selected_timeline` + its two log branches inline after it. Moving the first without the second cuts *through* the concern rather than along it, and the second half is inline statements, not a function to move. It is also a matched pair with `_configure_output_canvas` right above it — same shape, same job of writing a resolved decision back into `pipeline_config` — and separating those two would be arbitrary.
- **Arithmetic that settles it:** the three candidate seams could not have done the job anyway. 169 lines had to leave to clear 800. Fetch is 91 and `_configure_timeline` is 47; reporting is ~0. **All three together are 138** — the file would still have been at 831, over the cap, with #661 still blocked.

## Behaviour-neutral, and shown rather than asserted

- **Every moved body is byte-identical to `main`.** Verified by list comparison against `git show origin/main:…/_pipeline_runner.py`, not by eye: lines 660–796 → `_candidate_pool.py` 25–161, lines 831–877 → `_candidate_pool.py` 164–210, lines 880–969 → `_asset_fetch.py` 23–112. All three exact.
- **Everything that stayed is byte-identical too.** `main`'s lines 24–657 plus 797–828 equal the new `_pipeline_runner.py` from `logger = …` to EOF — 666 lines, exact match. The two deletion seams rejoined with the correct two-blank-line separation and nothing else shifted.
- **The complete `+` side of the runner's diff is 8 lines** (`git diff --numstat` → `8  282`): three docstring lines, because the file no longer fetches anything and the docstring said it did, and the five-line import of the three pool functions. No other addition anywhere in the file.
- **The module-level `logger` stayed** rather than being moved with `_drop_reencoded_sources` — `_resolve_requested_duration` also uses it, and it is not going anywhere.

## Import-site audit

Every reference to a moved symbol across `src/`, `tests/`, `scripts/`, `docs/` and `docs-site/`, site by site:

| site | verdict |
|---|---|
| `cli/generate.py`, `cli/_trip_generation.py` — `from …_pipeline_runner import fetch_*, run_pipeline_and_generate` | **Split into two imports.** Both still bind `fetch_videos_and_live_photos` in their own namespace and still call it as a bare name, so every patch target that goes *through* them resolves exactly as before: 13 × `immich_memories.cli.generate.fetch_videos_and_live_photos` and 12 × `…cli.generate.run_pipeline_and_generate` across five test files, plus 3 on `…cli._trip_generation.…`. **28 sites, nothing to repoint.** |
| `ui/pages/clip_pipeline.py:319` — function-local import of `_merge_photos_into_pool` | **Repointed** to `_candidate_pool`. |
| `tests/test_clip_pipeline_ui.py` — 2 × `patch("immich_memories.cli._pipeline_runner._merge_photos_into_pool")` | **Repointed — mandatory.** The UI imports the name *inside* the function, so the patch has to target the module the name now lives in; left alone it would have patched an attribute that no longer exists and failed loudly. |
| `tests/test_unified_selection.py` (4), `tests/test_photo_pipeline.py`, `tests/integration/pipeline/test_mega_flows.py` — direct imports of `_merge_photos_into_pool` | **Repointed** to `_candidate_pool`. |
| `tests/test_multi_person_selection.py`, `tests/test_surface_parity.py` — `import fetch_photos, fetch_videos_and_live_photos` | **Repointed** to `_asset_fetch`. |
| `tests/integration/cli/test_generate.py` — 3 × `import fetch_videos_and_live_photos` | **Repointed** to `_asset_fetch`. The three `run_pipeline_and_generate` imports in the same file were left alone. |
| `patch("…_pipeline_runner.print_error")`, `patch("…_pipeline_runner.sys.exit")` in `tests/test_trip_photo_gps.py` | **Untouched, and checked.** Both names are used only by code that stayed. |
| Docstrings pointing at the old module — `test_surface_parity.py:344`, `test_unified_selection.py` ×2, `test_generate.py:872` | **Updated.** They assert nothing about module paths; a stale pointer just sends the next reader to the wrong file. |
| `docs-site/docs/create/pipeline/pipeline-overview.md:115` — "`fetch_videos_and_live_photos()` in `cli/_pipeline_runner.py`" | **Updated** to `cli/_asset_fetch.py`. |
| `docs/superpowers/plans/*.md` — 12 hits | **Left alone.** Dated plan documents describing work already done; they are a record of what was true then. |

No re-export shims — every consumer imports from the source, and `cli/__init__.py` is untouched.

## Gates

`make ci` green locally (5729 passed, 9 skipped, 6 xfailed), plus the ones this change could plausibly have broken:

- `make file-length` — 695 / 210 / 112, all under the **soft** limit, not just the hard one. With #661's 40 lines applied on top, `_asset_fetch.py` reaches ~152 and the runner does not move.
- `make arch-check` (import-linter) — the ui→cli import moved between two `cli` modules; both contracts still pass.
- `make dead-code` (Vulture) — `_has_camera_exif` and `_drop_photos_already_shown_as_motion` are now referenced only from inside their new module, which is the point; Vulture is satisfied they are live.
- `make cognitive-complexity` — snapshot regenerated (never hand-edited). The **only** change is line numbers for `register_generate_commands`, shifted −3 because `generate.py`'s import of the fetch functions collapsed from five lines to two. Its complexity is **163 before and after**, and no entry exists for any of the three files in this split.
- `make critique` — the WHY ratchet is unmoved: no `patch()` call was added or removed, only retargeted.
- `make docs-build` — passes.

`ARCHITECTURE.md` updated with both new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
