### PR TITLE
fix(llm): a non-thinking call must tell the server not to think

### DIFF
--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -284,6 +284,9 @@ llm:
   # thinking_params:               # what the switch looks like on your server
   #   chat_template_kwargs:        # (default: the Qwen dialect, vLLM/mlx)
   #     enable_thinking: true
+  # no_thinking_params:            # how to say "don't reason" to that server
+  #   chat_template_kwargs:        # (default: the Qwen dialect, vLLM/mlx)
+  #     enable_thinking: false
 ```
 
 **The goal of this product is a fully local process** — your photos analyzed
@@ -318,6 +321,18 @@ matches your server's dialect: the default is Qwen's
 the OpenAI API use `{"reasoning_effort": "medium"}`. Leave `thinking` off
 unless you know the server supports your chosen switch — some
 OpenAI-compatible servers reject unknown request fields.
+
+`no_thinking_params` is the other half, and it matters on servers whose chat
+template reasons by default: not asking for reasoning is not the same as
+asking for none, so bulk analysis reasons anyway, at the small token budget
+those calls ask for, and comes back truncated mid-thought with nothing
+parseable in it. This field is sent on every non-thinking call — it hangs off
+the switch, not off `thinking`, because a server that reasons by default does
+so whether or not you turned reasoning on. The default is Qwen's
+`chat_template_kwargs: {"enable_thinking": false}`; set it to `{}` for servers
+that reason only when asked (the `openai` and `zai` presets already do). A
+server that rejects the field is detected from its 400 and asked without it
+from then on.
 
 Parameter dialects are otherwise handled automatically: OpenAI's reasoning
 models (gpt-5 family) reject `max_tokens` and non-default temperatures, and

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -49,6 +49,8 @@ _PARAM_ADAPTATIONS: dict[tuple[str, str], set[str]] = {}
 
 
 def _adaptation_for(message: str) -> str | None:
+    if "chat_template_kwargs" in message:
+        return "no_chat_template_kwargs"
     if "max_tokens" in message and "max_completion_tokens" in message:
         return "max_completion_tokens"
     if "temperature" in message and ("not support" in message or "Unsupported" in message):
@@ -57,6 +59,8 @@ def _adaptation_for(message: str) -> str | None:
 
 
 def _apply_adaptations(payload: dict, adaptations: set[str]) -> None:
+    if "no_chat_template_kwargs" in adaptations:
+        payload.pop("chat_template_kwargs", None)
     if "max_completion_tokens" in adaptations and "max_tokens" in payload:
         payload["max_completion_tokens"] = payload.pop("max_tokens")
     if "default_temperature" in adaptations:
@@ -73,10 +77,12 @@ _PROVIDER_PRESETS: dict[str, dict] = {
     "openai": {
         "base_url": "https://api.openai.com/v1",
         "thinking_params": {"reasoning_effort": "medium"},
+        "no_thinking_params": {},
     },
     "zai": {
         "base_url": "https://api.z.ai/api/paas/v4",
         "thinking_params": {"thinking": {"type": "enabled"}},
+        "no_thinking_params": {},
     },
 }
 
@@ -390,6 +396,13 @@ async def _query_openai(
         payload.update(config.thinking_params)
         payload["max_tokens"] = max(max_tokens, THINKING_MIN_MAX_TOKENS)
         timeout = max(timeout, THINKING_MIN_TIMEOUT_SECONDS)
+    elif config.no_thinking_params:
+        # Not asking to think is not the same as asking not to. On a server
+        # whose template reasons by default, every bulk call reasoned anyway
+        # at the caller's small budget and came back truncated mid-thought.
+        # Gated on the switch itself, never on llm.thinking: a user who turns
+        # reasoning off still has a server that reasons unless it is told.
+        payload.update(config.no_thinking_params)
     _shape_for_provider(payload, config)
     adaptations = _PARAM_ADAPTATIONS.setdefault((base_url, config.model), set())
     _apply_adaptations(payload, adaptations)

--- a/src/immich_memories/config_models_llm.py
+++ b/src/immich_memories/config_models_llm.py
@@ -62,6 +62,16 @@ class LLMConfig(BaseModel):
             "dialect (vLLM/mlx); OpenAI wants {'reasoning_effort': 'medium'}."
         ),
     )
+    no_thinking_params: dict[str, Any] = Field(
+        default_factory=lambda: {"chat_template_kwargs": {"enable_thinking": False}},
+        description=(
+            "Request fields merged into a NON-thinking call on a server whose "
+            "chat template reasons by default. Omitting the enable switch does "
+            "not disable it: bulk analysis then reasons at its small token "
+            "budget, truncates mid-thought and returns nothing parseable. "
+            "Servers that reason only when asked want {}."
+        ),
+    )
     max_tokens_param: str = Field(
         default="max_tokens",
         description=(

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from immich_memories.analysis.llm_query import THINKING_MIN_MAX_TOKENS
 from immich_memories.config_models_llm import LLMConfig
 
 
@@ -129,13 +130,32 @@ class TestThinkingMode:
         assert payload["chat_template_kwargs"] == {"enable_thinking": True}
 
     @pytest.mark.asyncio
-    async def test_config_off_keeps_the_payload_clean_for_any_server(self):
-        """A call may opt in, but only the config knows the server accepts the kwarg."""
+    async def test_config_off_refuses_a_calls_request_to_think(self):
+        """A call may opt in; the config decides, and the server is told.
+
+        `thinking` says whether to reason, `no_thinking_params` says whether
+        the server speaks this dialect — they used to be the same field, which
+        left a config with reasoning off silently reasoning anyway.
+        """
         from immich_memories.analysis.llm_query import query_llm
 
         # WHY: the LLM server is the external boundary this request reaches.
         with patch("httpx.AsyncClient.post", return_value=_openai_response()) as mock_post:
             await query_llm("Judge this cut", _thinking_config(thinking=False), thinking=True)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+        assert payload["max_tokens"] < THINKING_MIN_MAX_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_a_server_that_does_not_speak_the_dialect_stays_clean(self):
+        """Servers that reason only when asked want neither switch."""
+        from immich_memories.analysis.llm_query import query_llm
+
+        config = _thinking_config(thinking=False, no_thinking_params={})
+        # WHY: the LLM server is the external boundary this request reaches.
+        with patch("httpx.AsyncClient.post", return_value=_openai_response()) as mock_post:
+            await query_llm("Judge this cut", config)
 
         assert "chat_template_kwargs" not in mock_post.call_args[1]["json"]
 
@@ -185,8 +205,11 @@ class TestThinkingMode:
             result = await query_llm("Judge this cut", _thinking_config(), thinking=True)
 
         assert result == '{"drop": "B"}'
+        # The retry exists to get a fast answer, so it must say so. Dropping
+        # the switch is not enough on a server that reasons by default: the
+        # retry would reason again and truncate again.
         retry_payload = mock_post.call_args_list[1][1]["json"]
-        assert "chat_template_kwargs" not in retry_payload
+        assert retry_payload["chat_template_kwargs"] == {"enable_thinking": False}
 
     @pytest.mark.asyncio
     async def test_thinking_params_are_configurable_per_server(self):
@@ -438,3 +461,72 @@ class TestQueryLlmWithImages:
         content = mock_post.call_args[1]["json"]["messages"][0]["content"]
         assert content[0]["text"] == "What is this?"
         assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+class TestBulkCallsDoNotThink:
+    """A server that thinks by default thinks on every call it is not told to skip.
+
+    Measured 2026-08-24 against the live endpoint after server-side thinking
+    was switched on: the photo prompt at its 500-token budget came back
+    finish_reason=length, 1800 chars of unterminated reasoning and no JSON,
+    3 times out of 3. The same prompt with the switch sent off parsed 3/3 in
+    1.5s. Omitting the enable switch is not the same as disabling it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_bulk_call_asks_a_thinking_server_not_to_think(self):
+        from immich_memories.analysis.llm_query import query_llm
+
+        # WHY: the LLM server is the external boundary this request reaches.
+        with patch("httpx.AsyncClient.post", return_value=_openai_response()) as mock_post:
+            await query_llm("Describe this photo", _thinking_config(), max_tokens=500)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    @pytest.mark.asyncio
+    async def test_reasoning_turned_off_still_tells_the_server_so(self):
+        """llm.thinking: false says "don't reason", not "this server won't".
+
+        A user who turns reasoning off on a server whose template reasons by
+        default gets the same truncated bulk calls, so the off-switch hangs
+        off the switch itself rather than off the reasoning setting.
+        """
+        from immich_memories.analysis.llm_query import query_llm
+
+        # WHY: the LLM server is the external boundary this request reaches.
+        with patch("httpx.AsyncClient.post", return_value=_openai_response()) as mock_post:
+            await query_llm("Describe this photo", _thinking_config(thinking=False))
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    @pytest.mark.asyncio
+    async def test_a_server_that_rejects_the_switch_is_asked_without_it(self):
+        """Sending the kwarg by default is only safe if a refusal adapts."""
+        import httpx
+
+        from immich_memories.analysis.llm_query import query_llm
+
+        refusal = MagicMock(status_code=400)
+        refusal.json = MagicMock(
+            return_value={
+                "error": {"message": "Unrecognized request argument: chat_template_kwargs"}
+            }
+        )
+        refusal.text = "Unrecognized request argument: chat_template_kwargs"
+        rejected = AsyncMock()
+        rejected.status_code = 400
+        rejected.json = refusal.json
+        rejected.text = refusal.text
+        rejected.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("400", request=MagicMock(), response=refusal)
+        )
+
+        # WHY: the LLM server is the external boundary this request reaches.
+        with patch(
+            "httpx.AsyncClient.post", side_effect=[rejected, _openai_response()]
+        ) as mock_post:
+            await query_llm("Describe this photo", _thinking_config(model="picky"))
+
+        assert "chat_template_kwargs" not in mock_post.call_args_list[-1][1]["json"]


### PR DESCRIPTION
Closes #697

## The bug

`query_llm` only ever *sent* the reasoning switch — `if thinking:` adds it, and
the else branch adds nothing. Not asking to think is not the same as asking not
to, and on a server whose chat template reasons by default that is the whole bug.

Every image call is a non-thinking call by construction:

```python
think = thinking and llm_config.thinking and not images
```

Those callers ask for 500–1024 tokens, well below the floor a reasoning answer
needs. So they reasoned anyway, returned `finish_reason=length` with the
unterminated reasoning sitting in the content channel, and failed to parse. The
fast-answer retry could not rescue them either — it is gated on `if thinking:`,
and they never asked for thinking.

Because failed looks are not cached, the same assets were re-asked on every run.
The photo scorer logged an identical hit/miss split on a cold run and a warm
re-run of the same input, which is what put me onto it.

## Measured

Live endpoint, real photo prompt, three photos:

| request | parses | latency |
|---|---|---|
| reasoning on (as shipped), cap 500 | 0/3, `finish_reason=length`, ~1850 chars of unterminated reasoning | 5.4s |
| reasoning on, cap 4000 | 3/3 | 7.4s |
| reasoning off, cap 500 | 3/3 | 1.5s |

The answer is ~500 chars either way. The budget was never too small for the
answer — only for the reasoning in front of it.

On a real month, model time across a cold run fell from 102s to 30s (median
4.9s → 1.3s per call), and a warm re-run went from an unchanging miss count to
zero misses and zero calls.

## The change

`LLMConfig.no_thinking_params`, defaulting to the Qwen dialect
`{"chat_template_kwargs": {"enable_thinking": false}}`, merged into every
non-thinking call.

Gated on **the switch being non-empty, never on `llm.thinking`**. A user who
turns reasoning off still has a server that reasons unless it is told, so
hanging the off-switch on the reasoning setting would leave precisely that
configuration broken. The `openai` and `zai` presets override it to `{}` since
they reason only when asked, and a server that rejects the field is detected
from its 400 and asked without it thereafter, through the adaptation path that
already handles `max_completion_tokens`.

## Two existing tests changed, because they asserted the defect

- the fallback-retry test required the retry to send **no** switch. On a
  reason-by-default server that retry reasons again and truncates again — which
  is the exact failure the fallback exists to escape.
- `llm.thinking` was doing double duty as both "use reasoning" and "this server
  speaks the dialect". Those are now separate fields, so a call can still be
  refused reasoning while the server is told so.

## Scope

Only the OpenAI-compatible path. The Anthropic adapter takes an explicit
reasoning budget and the Ollama path has its own branch; neither reasons by
default, and neither changes here.

Follow-ups already filed: #698 (a prompt-version bump strands the corpus,
because `asset_scores` keys on `asset_id` alone) and #699 (a failed look is
never cached, so it is re-asked forever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL