### PR TITLE
feat(ui): the Surprise me card

### DIFF
--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -163,6 +163,10 @@ simply have none of it, and still read.
 Anniversaries either side of New Year are found: a day at the end of December is due in
 early January.
 
+Once a catalogue exists, the wizard's **Surprise me** card offers what is in it — due
+anniversaries first, then every other day it holds. See
+[Step 1: Configuration](../web-ui/step1-configuration.mdx#surprise-me).
+
 ## What you need
 
 An LLM configured under `llm:` — see [Configuration](/docs/deploy/configuration/config-file).

--- a/docs-site/docs/create/web-ui/step1-configuration.mdx
+++ b/docs-site/docs/create/web-ui/step1-configuration.mdx
@@ -19,7 +19,7 @@ The rest of the page (Memory Type, Options, Next) only appears after a successfu
 
 ## Memory Type
 
-Pick one of the 11 cards: **Year in Review**, **Season**, **Person Spotlight**, **Multi-Person**, **Monthly Highlights**, **On This Day**, **Holiday**, **Then and Now**, **Trip**, **Album**, or **Custom**.
+Pick one of the 12 cards: **Year in Review**, **Season**, **Person Spotlight**, **Multi-Person**, **Monthly Highlights**, **On This Day**, **Holiday**, **Then and Now**, **Trip**, **Album**, **Surprise me**, or **Custom**.
 
 <ThemedScreenshot name="step1-preset-cards" alt="Memory type preset cards" />
 
@@ -37,6 +37,7 @@ Each preset sets the date range and a default target duration, then shows the pa
 | Then and Now | Now (year), Years back (1–20) | 45 s |
 | Trip | Year, then "Select a trip" from the trips detected in your GPS data | auto: 30 s + 10 s per active day, bounded 60–300 s |
 | Album | "Select an album" from your Immich albums | auto: 4 s per item in the album, bounded 30 s–10 min |
+| Surprise me | "Pick a day" from the days [`discover-days`](../cli/discover-days.md) found | auto: 30 s + 6 s per active hour, bounded 60–180 s |
 | Custom | date range tabs and person filter (below) | ~1 min per month of range |
 
 ### Memory types that span several years
@@ -56,6 +57,32 @@ that holiday rather than the five years between them.
   title names both ("2016 & 2026").
 
 The presets also drive the output filename and title screen. A Multi-Person preset with Alice and Bob for March 2025 produces `alice_bob_march_2025_memories.mp4` with "Alice & Bob" as the title subtitle.
+
+### Surprise me
+
+The other eleven cards ask you what the memory is about. This one asks the
+library. `immich-memories discover-days` walks the years a month at a time and
+asks the local model which days stand out on their own — a day that ran long,
+shot a lot, and was not a holiday or part of a trip — and writes what it found
+to `~/.immich-memories/special-days.json`. The card offers those days and
+nothing else.
+
+The list is ordered anniversaries first, labelled *"10 years ago — A long
+evening out"*, then every other catalogued day by how round its anniversary is
+and how recent it is. This is deliberately not what
+[automation](../cli/auto.md) does: a scheduled run only proposes a day on its
+anniversary, because it arrives unannounced and the round number is what earns
+the interruption. You clicked the card, so you get the whole catalogue.
+
+Choosing a day scopes the memory to **the hours it happened in** rather than to
+midnight-to-midnight, when the scan recorded a window for it, and the day's own
+title and subtitle carry through to the title screen in Step 3 — the catalogue
+named it from that day's photos, so the title LLM is not asked for a second
+opinion. A special day is one occasion, so it gets a single opening card and no
+month dividers.
+
+If there is no catalogue yet, the card says which file it looked for and which
+command builds one, and Step 1 stays incomplete. It will not offer a random day.
 
 <ThemedScreenshot name="step1-preset-selected" alt="Year in Review preset selected" />
 

--- a/src/immich_memories/automation/catalogue.py
+++ b/src/immich_memories/automation/catalogue.py
@@ -1,0 +1,96 @@
+"""Reading the catalogue `discover-days` writes.
+
+More than one reader wants this file -- `days-due` prints from it and the
+wizard's Surprise me card offers from it -- and they have to agree on where it
+lives and on what a half-written entry means, so the reading happens once here.
+
+Nothing raises. A scan of twenty years is not something to ask anybody to run
+again for a field they can live without, so every key falls back and an
+unreadable file reads as an empty catalogue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from immich_memories.automation.special_day_scan import DiscoveredDay
+
+logger = logging.getLogger(__name__)
+
+
+def default_catalogue_path() -> Path:
+    """Where the catalogue lives when nobody said otherwise.
+
+    Resolved per call rather than at import: the home directory is the one
+    thing a test, a container, or a service account changes underneath us.
+    """
+    return Path.home() / ".immich-memories" / "special-days.json"
+
+
+def load_catalogue(path: Path) -> list[dict]:
+    """What an earlier run already found, or nothing readable.
+
+    A scan runs for hours across twenty years. Starting from scratch every
+    time is the difference between a command you can interrupt and one you
+    have to babysit.
+    """
+    if not path.exists():
+        return []
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("%s is not readable as a catalogue; starting fresh", path)
+        return []
+    return loaded if isinstance(loaded, list) else []
+
+
+def entries_from(path: Path) -> list[DiscoveredDay]:
+    """The catalogue as discovered days, skipping anything without a date."""
+    from immich_memories.automation.special_day_scan import DiscoveredDay
+
+    return [
+        DiscoveredDay(
+            day=date.fromisoformat(raw["day"]),
+            title=raw.get("title", ""),
+            subtitle=raw.get("subtitle", ""),
+            what=raw.get("what", ""),
+            photos=raw.get("photos", 0),
+            window=_window_in(raw.get("window")),
+            active_hours=raw.get("active_hours", 0),
+            run_start=_moment_in(raw.get("run_start")),
+            run_end=_moment_in(raw.get("run_end")),
+        )
+        for raw in load_catalogue(path)
+        if raw.get("day")
+    ]
+
+
+def _moment_in(raw: object) -> datetime | None:
+    """One end of the run a catalogue entry recorded, if it recorded any."""
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        logger.warning("Ignoring an unreadable time in the catalogue: %r", raw)
+        return None
+
+
+def _window_in(raw: object) -> tuple[datetime, datetime] | None:
+    """The hours a catalogue entry recorded for its event, if it recorded any.
+
+    Entries written before the scan looked for one have no window, and a scan
+    of twenty years is not something to ask anybody to run again.
+    """
+    if not isinstance(raw, list) or len(raw) != 2:
+        return None
+    try:
+        return (datetime.fromisoformat(raw[0]), datetime.fromisoformat(raw[1]))
+    except (TypeError, ValueError):
+        logger.warning("Ignoring an unreadable window in the catalogue: %r", raw)
+        return None

--- a/src/immich_memories/cli/special_days_cmd.py
+++ b/src/immich_memories/cli/special_days_cmd.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import calendar
 import json
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
 
+from immich_memories.automation.catalogue import (
+    default_catalogue_path,
+    entries_from,
+    load_catalogue,
+)
 from immich_memories.cli._helpers import console, print_success
-
-if TYPE_CHECKING:
-    from immich_memories.automation.special_day_scan import DiscoveredDay
 
 
 def register_special_day_commands(main: click.Group) -> None:
@@ -36,7 +37,7 @@ def _register_discover(main: click.Group) -> None:
     @click.option(
         "--out",
         type=click.Path(dir_okay=False, path_type=Path),
-        default=Path.home() / ".immich-memories" / "special-days.json",
+        default=default_catalogue_path(),
         help="Where to write the catalogue",
     )
     @click.option(
@@ -82,14 +83,14 @@ def _register_due(main: click.Group) -> None:
     @click.option(
         "--catalogue",
         type=click.Path(exists=True, dir_okay=False, path_type=Path),
-        default=Path.home() / ".immich-memories" / "special-days.json",
+        default=default_catalogue_path(),
     )
     def days_due(on: object, catalogue: Path) -> None:
         """Show which discovered days have an anniversary about now."""
         from immich_memories.automation.special_day_scan import anniversaries_due
 
         when = on.date() if on is not None else date.today()  # type: ignore[attr-defined]
-        entries = _entries_in(catalogue)
+        entries = entries_from(catalogue)
 
         for entry, years in anniversaries_due(entries, when):
             line = f"[bold]{years} years ago[/bold]  {entry.day}  {entry.title or entry.what}"
@@ -102,76 +103,6 @@ def _register_due(main: click.Group) -> None:
             if entry.subtitle:
                 console.print(f"                {entry.subtitle}")
         print_success(f"{len(entries)} days in the catalogue, checked against {when}")
-
-
-def _entries_in(path: Path) -> list[DiscoveredDay]:
-    """The catalogue as discovered days, skipping anything without a date.
-
-    Every field the scan learned to record arrived after some entry in a real
-    catalogue was written, so each one falls back instead of failing the
-    load: twenty years of scanning is not something to ask anybody to run
-    again for a field they can live without.
-    """
-    from immich_memories.automation.special_day_scan import DiscoveredDay
-
-    return [
-        DiscoveredDay(
-            day=date.fromisoformat(raw["day"]),
-            title=raw.get("title", ""),
-            subtitle=raw.get("subtitle", ""),
-            what=raw.get("what", ""),
-            photos=raw.get("photos", 0),
-            window=_window_in(raw.get("window")),
-            active_hours=raw.get("active_hours", 0),
-            run_start=_moment_in(raw.get("run_start")),
-            run_end=_moment_in(raw.get("run_end")),
-        )
-        for raw in _load_catalogue(path)
-        if raw.get("day")
-    ]
-
-
-def _moment_in(raw: object) -> datetime | None:
-    """One end of the run a catalogue entry recorded, if it recorded any."""
-    if not isinstance(raw, str):
-        return None
-    try:
-        return datetime.fromisoformat(raw)
-    except ValueError:
-        console.print(f"[yellow]Ignoring an unreadable time in the catalogue: {raw!r}[/yellow]")
-        return None
-
-
-def _window_in(raw: object) -> tuple[datetime, datetime] | None:
-    """The hours a catalogue entry recorded for its event, if it recorded any.
-
-    Entries written before the scan looked for one have no window, and a scan
-    of twenty years is not something to ask anybody to run again.
-    """
-    if not isinstance(raw, list) or len(raw) != 2:
-        return None
-    try:
-        return (datetime.fromisoformat(raw[0]), datetime.fromisoformat(raw[1]))
-    except (TypeError, ValueError):
-        console.print(f"[yellow]Ignoring an unreadable window in the catalogue: {raw!r}[/yellow]")
-        return None
-
-
-def _load_catalogue(path: Path) -> list[dict]:
-    """What an earlier run already found, or nothing readable.
-
-    A scan runs for hours across twenty years. Starting from scratch every
-    time is the difference between a command you can interrupt and one you
-    have to babysit.
-    """
-    if not path.exists():
-        return []
-    try:
-        loaded = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        console.print(f"[yellow]{path} is not readable as a catalogue; starting fresh[/yellow]")
-        return []
-    return loaded if isinstance(loaded, list) else []
 
 
 def _years_in(catalogue: list[dict]) -> set[int]:
@@ -193,7 +124,7 @@ def _write_catalogue(path: Path, found: list[dict], *, rescan: bool) -> None:
     swallowed an unreachable Immich wrote [] over twenty years of scanning
     and called it a success.
     """
-    if not found and not rescan and _load_catalogue(path):
+    if not found and not rescan and load_catalogue(path):
         console.print(
             f"[yellow]Found nothing; leaving {path} as it was. "
             f"Pass --rescan to replace it.[/yellow]"
@@ -236,7 +167,7 @@ def _scan_library(
 
     config = get_config()
     home = _homebase(config)
-    found: list[dict] = [] if rescan else _load_catalogue(out)
+    found: list[dict] = [] if rescan else load_catalogue(out)
     already = set() if rescan else _years_in(found)
 
     with SyncImmichClient(base_url=config.immich.url, api_key=config.immich.api_key) as client:

--- a/src/immich_memories/filename_builder.py
+++ b/src/immich_memories/filename_builder.py
@@ -288,6 +288,11 @@ def _build_when_part(
     if memory_type == "monthly_highlights":
         return _when_monthly(preset_params)
 
+    # A special day is one day, and the range slug below rounds it up to its
+    # month -- which is the name that month's highlights already write to.
+    if memory_type == "special_day" and date_start:
+        return date_start.isoformat()
+
     # On This Day: month + day (no year, it spans years)
     if memory_type == "on_this_day" and date_start:
         month_name = calendar.month_name[date_start.month].lower()

--- a/src/immich_memories/ui/pages/pipeline_title.py
+++ b/src/immich_memories/ui/pages/pipeline_title.py
@@ -84,7 +84,7 @@ def _occasion_title(
         # The catalogue named this day from the day's own photos, months before
         # anybody asked for a video of it.
         entry = preset_params or {}
-        name = (entry.get("title") or entry.get("what") or "").strip()
+        name = (entry.get("title") or "").strip() or (entry.get("what") or "").strip()
         if name:
             return name, (entry.get("subtitle") or "").strip() or None
 

--- a/src/immich_memories/ui/pages/pipeline_title.py
+++ b/src/immich_memories/ui/pages/pipeline_title.py
@@ -15,6 +15,8 @@ from immich_memories.memory_types.registry import MemoryType
 from immich_memories.titles.llm_titles import generate_title_with_llm
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from immich_memories.ui.state import AppState
 
 logger = logging.getLogger(__name__)
@@ -51,6 +53,42 @@ def _detect_season(start_month: int) -> str:
         if start_month in months:
             return name
     return "Memories"
+
+
+def _occasion_title(
+    memory_type: str | None,
+    start: date,
+    end: date,
+    preset_params: dict | None,
+) -> tuple[str, str | None] | None:
+    """Titles that name an occasion rather than the span it happens to cover.
+
+    The span of five Christmases is five years and the span of a special day is
+    a few hours; naming either by its ends describes none of what happened.
+    Returns None for the types whose span *is* the answer.
+    """
+    if memory_type == "on_this_day":
+        return f"On This Day — {_MONTH_NAMES[start.month]} {start.day}", None
+
+    if memory_type == "holiday":
+        from immich_memories.memory_types.factory import holiday_label
+
+        holiday = (preset_params or {}).get("holiday", "christmas")
+        return holiday_label(holiday, end.year), "Through the Years"
+
+    if memory_type == "then_and_now":
+        # Both ends, in the order the memory plays them.
+        return f"{start.year} & {end.year}", "Then and Now"
+
+    if memory_type == "special_day":
+        # The catalogue named this day from the day's own photos, months before
+        # anybody asked for a video of it.
+        entry = preset_params or {}
+        name = (entry.get("title") or entry.get("what") or "").strip()
+        if name:
+            return name, (entry.get("subtitle") or "").strip() or None
+
+    return None
 
 
 def generate_template_title(
@@ -95,20 +133,9 @@ def generate_template_title(
     if memory_type == "trip":
         return f"{_MONTH_NAMES[start.month]} {year} Trip", f"{start_date} \u2013 {end_date}"
 
-    if memory_type == "on_this_day":
-        return f"On This Day \u2014 {_MONTH_NAMES[start.month]} {start.day}", None
-
-    if memory_type == "holiday":
-        # The span of five Christmases is five years; naming it by either end
-        # describes none of them. The occasion is the title.
-        from immich_memories.memory_types.factory import holiday_label
-
-        holiday = (preset_params or {}).get("holiday", "christmas")
-        return holiday_label(holiday, end.year), "Through the Years"
-
-    if memory_type == "then_and_now":
-        # Both ends, in the order the memory plays them.
-        return f"{start.year} & {end.year}", "Then and Now"
+    occasion = _occasion_title(memory_type, start, end, preset_params)
+    if occasion is not None:
+        return occasion
 
     # Fallback for unknown types
     span_months = (end.year - start.year) * 12 + (end.month - start.month)
@@ -274,6 +301,12 @@ async def generate_title_after_pipeline(state: AppState) -> None:
         # Matches the CLI, where the album name is a title_override: a name the
         # user typed themselves outranks anything the LLM would invent. Step 3
         # still lets them edit it.
+        return
+
+    if state.memory_type == MemoryType.SPECIAL_DAY and template_title:
+        # Same rule, different author: the catalogue named this day months ago
+        # from the day's own photos. The title LLM sees a handful of clip
+        # descriptions, and asking it would rename the occasion.
         return
 
     # Step 2: Try LLM (overwrites template on success)

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import calendar as cal
 import logging
+from datetime import date
+from typing import TYPE_CHECKING
 
 from nicegui import ui
 
@@ -12,6 +14,11 @@ from immich_memories.memory_types.registry import MemoryType
 from immich_memories.ui.components import im_card
 from immich_memories.ui.nicegui_compat import io_bound_result
 from immich_memories.ui.state import get_app_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from immich_memories.automation.special_day_scan import DiscoveredDay
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +35,12 @@ _PRESET_CARDS: list[tuple[str, str, str, str]] = [
     (MemoryType.THEN_AND_NOW, "compare_arrows", "Then and Now", "An early year beside this one"),
     (MemoryType.TRIP, "flight_takeoff", "Trip", "Auto-detect trips from GPS data"),
     (MemoryType.ALBUM, "photo_album", "Album", "Everything from one Immich album"),
+    (
+        MemoryType.SPECIAL_DAY,
+        "auto_awesome",
+        "Surprise me",
+        "A day your library says something happened on",
+    ),
     ("custom", "tune", "Custom", "Full control over date range"),
 ]
 
@@ -135,6 +148,8 @@ def _render_params(key: str) -> None:
             _render_trip_params()
         elif memory_type == MemoryType.ALBUM:
             _render_album_picker()
+        elif memory_type == MemoryType.SPECIAL_DAY:
+            _render_special_day_params()
 
 
 def _render_holiday_params() -> None:
@@ -651,6 +666,110 @@ def _render_trip_params() -> None:
         ui.timer(0.1, lambda: _detect_trips_for_year(current_year), once=True)
 
 
+def _day_name(entry: DiscoveredDay) -> str:
+    """What the catalogue calls this day, if it managed to call it anything."""
+    return (entry.title or entry.what).strip()
+
+
+def _anniversary_rank(years: int) -> int:
+    """How round an anniversary is, ranked the way `anniversaries_due` sorts."""
+    if years < 1:
+        return 3
+    return 0 if years % 10 == 0 else 1 if years % 5 == 0 else 2
+
+
+def _special_day_options(
+    entries: list[DiscoveredDay], today: date
+) -> list[tuple[DiscoveredDay, str]]:
+    """The catalogue as picker rows: anniversaries due first, then the rest.
+
+    This is where the wizard honestly diverges from automation. A scheduled
+    run only proposes a day on its anniversary, because it arrives unannounced
+    and the round number is what earns the interruption. Somebody who just
+    clicked Surprise me wants a memory now, so every other catalogued day is
+    offered below the due ones -- same days, same evidence, different trigger.
+
+    A day the model could not name is left out: there is nothing truthful to
+    put on its title card, so offering it would be offering a dead end.
+    """
+    from immich_memories.automation.special_day_scan import anniversaries_due
+
+    rows = [
+        (entry, f"{years} years ago — {_day_name(entry)}")
+        for entry, years in anniversaries_due(entries, today)
+        if _day_name(entry)
+    ]
+    due = {entry.day for entry, _ in rows}
+    rest = sorted(
+        (entry for entry in entries if entry.day not in due and _day_name(entry)),
+        key=lambda entry: (_anniversary_rank(today.year - entry.day.year), -entry.day.toordinal()),
+    )
+    return rows + [(entry, f"{entry.day} — {_day_name(entry)}") for entry in rest]
+
+
+def _empty_catalogue_message(path: Path) -> str:
+    """What to say when no day has been found yet."""
+    return (
+        f"No catalogue at {path}. Run  immich-memories discover-days  to build one: it "
+        "walks the library a year at a time and asks the local model which days stood "
+        "out. Surprise me offers those days and nothing else."
+    )
+
+
+def _choose_special_day(entry: DiscoveredDay) -> None:
+    """Scope the wizard to one catalogued day, under the name it was found by."""
+    state = get_app_state()
+    state.memory_preset_params = {
+        "day": entry.day,
+        "window": entry.window,
+        "title": _day_name(entry),
+        "subtitle": entry.subtitle,
+        "photos": entry.photos,
+        "active_hours": entry.active_hours,
+    }
+    _apply_preset_to_state(MemoryType.SPECIAL_DAY)
+    # Step 3 opens on the day's own name instead of asking the title LLM to
+    # invent one for an occasion it never saw.
+    state.title_suggestion_title = _day_name(entry)
+    state.title_suggestion_subtitle = entry.subtitle or None
+
+
+def _render_special_day_params() -> None:
+    """The days the catalogue found, read on mount."""
+    state = get_app_state()
+    container = ui.column().classes("w-full mt-2")
+
+    def _offer_the_catalogue() -> None:
+        from immich_memories.automation.catalogue import default_catalogue_path, entries_from
+
+        path = default_catalogue_path()
+        rows = _special_day_options(entries_from(path), date.today())
+        container.clear()
+        with container:
+            if not rows:
+                # Refuse over fake: with no catalogue there is no day to offer,
+                # and a random one would be the tool inventing an occasion.
+                ui.label(_empty_catalogue_message(path)).style(
+                    "color: var(--im-text-secondary)"
+                ).classes("text-sm italic")
+                return
+
+            ui.label(
+                "Anniversaries first, then the rest. A scheduled run only proposes a day "
+                "on its anniversary; here you can pick any day the catalogue holds."
+            ).style("color: var(--im-text-secondary)").classes("text-sm mb-1")
+            chosen = state.memory_preset_params.get("day")
+            ui.select(
+                options={i: label for i, (_, label) in enumerate(rows)},
+                label="Pick a day",
+                value=next((i for i, (e, _) in enumerate(rows) if e.day == chosen), None),
+                on_change=lambda e: _choose_special_day(rows[e.value][0]),
+            ).classes("w-full")
+
+    # A local file rather than an Immich query, so a frame is the whole wait.
+    ui.timer(0.1, _offer_the_catalogue, once=True)
+
+
 def _apply_preset_to_state(memory_type: MemoryType) -> None:
     """Create a preset and write its date_range + duration into app state."""
     from immich_memories.timeperiod import custom_range
@@ -660,8 +779,6 @@ def _apply_preset_to_state(memory_type: MemoryType) -> None:
 
     # "All Time" → wide date range covering all years
     if params.get("year") == 0:
-        from datetime import date
-
         state.date_ranges = [custom_range(date(2000, 1, 1), date.today())]
         state.target_duration = 10
         return

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -667,8 +667,12 @@ def _render_trip_params() -> None:
 
 
 def _day_name(entry: DiscoveredDay) -> str:
-    """What the catalogue calls this day, if it managed to call it anything."""
-    return (entry.title or entry.what).strip()
+    """What the catalogue calls this day, if it managed to call it anything.
+
+    Falls back to `what` exactly the way the preset factory does, so the picker
+    offers precisely the days the factory will accept and no others.
+    """
+    return entry.title.strip() or entry.what.strip()
 
 
 def _anniversary_rank(years: int) -> int:

--- a/tests/test_special_day_scan.py
+++ b/tests/test_special_day_scan.py
@@ -16,15 +16,14 @@ from unittest.mock import patch
 import pytest
 
 from immich_memories.api.models import AssetType
+from immich_memories.automation.catalogue import entries_from, load_catalogue
 from immich_memories.automation.special_day_scan import (
     DiscoveredDay,
     anniversaries_due,
     scan_year,
 )
 from immich_memories.cli.special_days_cmd import (
-    _entries_in,
     _homebase,
-    _load_catalogue,
     _write_catalogue,
     _year_of_assets,
     _years_in,
@@ -373,7 +372,7 @@ def test_the_night_a_run_ended_survives_the_trip_through_the_catalogue(tmp_path)
         )
     )
 
-    entry = _entries_in(catalogue)[0]
+    entry = entries_from(catalogue)[0]
 
     assert (entry.run_start, entry.run_end) == (
         datetime(2015, 6, 12, 21, 0, tzinfo=UTC),
@@ -393,7 +392,7 @@ def test_a_catalogue_written_before_the_hours_existed_still_loads(tmp_path) -> N
         json.dumps([{"day": "2015-06-12", "title": "A long evening out", "photos": 133}])
     )
 
-    entry = _entries_in(catalogue)[0]
+    entry = entries_from(catalogue)[0]
 
     assert (entry.active_hours, entry.run_start, entry.run_end) == (0, None, None)
     printed = _days_due(catalogue, "2025-06-12")
@@ -532,7 +531,7 @@ def test_a_catalogue_nobody_can_read_is_not_a_catalogue(tmp_path) -> None:
     catalogue = tmp_path / "special-days.json"
     catalogue.write_text('[{"day": "2014-12-31"')
 
-    assert _load_catalogue(catalogue) == []
+    assert load_catalogue(catalogue) == []
 
 
 def test_media_the_camera_never_shot_is_gone_before_the_day_is_counted(monkeypatch) -> None:

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -101,11 +101,11 @@ SPECS: dict[MemoryType, MemorySpec] = {
 # from what the album holds. Registering a preset for it must fail this file.
 ALBUM_HAS_NO_PRESET = MemoryType.ALBUM
 
-# A special day has a preset but nothing to reach it with yet. Its scope comes
-# from a catalogue entry -- the day, its window, its title -- and no flag or
-# card carries one, so there is no spec either surface could be handed. It
-# joins SPECS when `generate --day` and the Surprise me card land, and this
-# exception has to be deleted in the same PR.
+# A special day now has one surface: the wizard's Surprise me card reads the
+# catalogue and hands the preset a day, a window and a title. The CLI has no
+# `--day` yet, and a MemorySpec is a request phrased for *both* surfaces, so
+# there is still nothing to compare. This exception goes when `generate --day`
+# lands, in the PR that adds it.
 SPECIAL_DAY_HAS_NO_SURFACE_YET = MemoryType.SPECIAL_DAY
 
 # --memory-type's choices, copied from cli/generate_options.py so a type added to the

--- a/tests/test_ui_special_day.py
+++ b/tests/test_ui_special_day.py
@@ -255,3 +255,23 @@ def test_a_day_the_model_could_not_name_is_not_offered() -> None:
     )
 
     assert [entry.day for entry, _ in rows] == [date(2019, 2, 2)]
+
+
+def test_a_blank_title_falls_back_to_what_the_day_was() -> None:
+    """The picker and the preset have to agree on which days are nameable.
+
+    `create_preset` falls back from an empty title to `what`; a picker that
+    did not would hide a day the factory would happily have built.
+    """
+    blank_titled = DiscoveredDay(
+        day=date(2019, 2, 2),
+        title="   ",
+        subtitle="",
+        what="A very long walk",
+        photos=44,
+        window=None,
+    )
+
+    rows = step1_presets._special_day_options([blank_titled], date(2026, 6, 12))
+
+    assert [label for _, label in rows] == ["2019-02-02 — A very long walk"]

--- a/tests/test_ui_special_day.py
+++ b/tests/test_ui_special_day.py
@@ -1,0 +1,257 @@
+"""The wizard can reach a day the catalogue found.
+
+Fixture days are invented. A real catalogue names real people and places, and
+none of that belongs in a test file.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from immich_memories.automation.special_day_scan import DiscoveredDay
+from immich_memories.memory_types.registry import MemoryType
+from immich_memories.ui.pages import step1_presets
+from immich_memories.ui.pages.step1_presets import _PRESET_CARDS
+from immich_memories.ui.state import AppState
+
+BRUSSELS = timezone(timedelta(hours=2))
+
+_A_LONG_EVENING = {
+    "day": "2016-06-12",
+    "title": "A long evening out",
+    "subtitle": "The one that ran past midnight",
+    "what": "a street party",
+    "photos": 289,
+    "window": ["2016-06-12T18:30:00+02:00", "2016-06-13T01:15:00+02:00"],
+    "active_hours": 9,
+}
+
+
+def _catalogue(home: Path, *entries: dict) -> None:
+    """Write a catalogue where `discover-days` would have left one."""
+    folder = home / ".immich-memories"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "special-days.json").write_text(json.dumps(list(entries)))
+
+
+def _render_card(monkeypatch, home: Path, pick: int | None = None) -> tuple[AppState, MagicMock]:
+    """Drive the card the way a browser does: mount it, then choose a row.
+
+    The catalogue is read from the user's home, so pointing HOME at a tmp
+    directory is enough to hand the card a library's worth of days -- or none.
+    """
+    monkeypatch.setenv("HOME", str(home))
+    state = AppState(memory_type=MemoryType.SPECIAL_DAY)
+    ui_stub = MagicMock()
+    # WHY: the wizard reads its state through a per-session accessor.
+    with (
+        patch.object(step1_presets, "get_app_state", return_value=state),
+        # WHY: NiceGUI widgets need a live client slot; the card's catalogue
+        # reading and option building do not. These two stand in for the whole
+        # widget layer, and recording what was drawn is how the test reads it.
+        patch.object(step1_presets, "ui", ui_stub),
+        patch.object(step1_presets, "im_card", MagicMock()),
+    ):
+        step1_presets._render_params(MemoryType.SPECIAL_DAY)
+        ui_stub.timer.call_args.args[1]()
+        if pick is not None:
+            ui_stub.select.call_args.kwargs["on_change"](SimpleNamespace(value=pick))
+    return state, ui_stub
+
+
+def _discovered(day: str, title: str) -> DiscoveredDay:
+    return DiscoveredDay(
+        day=date.fromisoformat(day),
+        title=title,
+        subtitle="",
+        what="",
+        photos=44,
+        window=None,
+    )
+
+
+def _drawn_text(ui_stub: MagicMock) -> str:
+    return " ".join(str(call) for call in ui_stub.label.call_args_list)
+
+
+def test_the_catalogue_is_offered_as_a_card() -> None:
+    keys = [card[0] for card in _PRESET_CARDS]
+
+    assert MemoryType.SPECIAL_DAY in keys
+
+
+def test_choosing_a_day_scopes_the_wizard_to_the_hours_it_happened_in(
+    monkeypatch, tmp_path
+) -> None:
+    """The window is the scope, offsets and all.
+
+    Trimming to the hours the day was awake is the whole point of recording a
+    window; a memory scoped to midnight-to-midnight would put the cat on the
+    balcony that morning beside the fireworks.
+    """
+    _catalogue(tmp_path, _A_LONG_EVENING)
+
+    state, _ = _render_card(monkeypatch, tmp_path, pick=0)
+
+    assert [(r.start, r.end) for r in state.date_ranges] == [
+        (
+            datetime(2016, 6, 12, 18, 30, tzinfo=BRUSSELS),
+            datetime(2016, 6, 13, 1, 15, tzinfo=BRUSSELS),
+        )
+    ]
+    assert state.scope_is_selected
+    assert state.memory_preset_params["day"] == date(2016, 6, 12)
+    assert state.memory_preset_params["photos"] == 289
+    assert state.memory_preset_params["active_hours"] == 9
+
+
+def test_choosing_a_day_carries_its_own_name_to_the_title(monkeypatch, tmp_path) -> None:
+    """The catalogue already named this day, from the day's own photos."""
+    _catalogue(tmp_path, _A_LONG_EVENING)
+
+    state, _ = _render_card(monkeypatch, tmp_path, pick=0)
+
+    assert state.title_suggestion_title == "A long evening out"
+    assert state.title_suggestion_subtitle == "The one that ran past midnight"
+
+
+def test_with_no_catalogue_the_card_asks_for_one_instead_of_picking_a_day(
+    monkeypatch, tmp_path
+) -> None:
+    """Refuse over fake.
+
+    A library nobody has scanned has no special days, and offering a random
+    one would be the tool inventing an occasion. Step 1 stays incomplete and
+    the card says which file was missing and what builds it.
+    """
+    state, ui_stub = _render_card(monkeypatch, tmp_path)
+
+    assert not state.scope_is_selected
+    assert not state.memory_preset_params
+    ui_stub.select.assert_not_called()
+    drawn = _drawn_text(ui_stub)
+    assert "discover-days" in drawn
+    assert str(tmp_path / ".immich-memories" / "special-days.json") in drawn
+
+
+def test_the_title_is_the_day_the_catalogue_named_not_its_span() -> None:
+    """One occasion, one name.
+
+    The generic fallback describes a span, and a special day's span is a few
+    hours: it comes out as "June - June 2016", which names nothing that
+    happened.
+    """
+    from immich_memories.ui.pages.pipeline_title import generate_template_title
+
+    title, subtitle = generate_template_title(
+        memory_type="special_day",
+        start_date="2016-06-12",
+        end_date="2016-06-13",
+        preset_params={
+            "title": "A long evening out",
+            "subtitle": "The one that ran past midnight",
+        },
+    )
+
+    assert title == "A long evening out"
+    assert subtitle == "The one that ran past midnight"
+
+
+async def test_the_title_llm_is_never_asked_to_rename_the_day() -> None:
+    """The catalogue's name outranks a second opinion.
+
+    It was written by a model that looked at this day's own photos, months
+    before anybody asked for a video of it. The title LLM sees a handful of
+    clip descriptions and would rename the occasion from them.
+    """
+    from immich_memories.timeperiod import DateRange
+    from immich_memories.ui.pages.pipeline_title import generate_title_after_pipeline
+
+    state = AppState(
+        memory_type=MemoryType.SPECIAL_DAY,
+        memory_preset_params={"day": date(2016, 6, 12), "title": "A long evening out"},
+    )
+    state.date_ranges = [DateRange(start=datetime(2016, 6, 12, 18, 30), end=datetime(2016, 6, 13))]
+    # WHY: Config is a wide tree of pydantic sections and this path reads three
+    # leaves of it; a configured title model is what makes the LLM call live.
+    state.config = MagicMock(title_llm=None, **{"llm.model": "omlx"})
+
+    # WHY: the title LLM is a network call to a model server.
+    with patch(
+        "immich_memories.ui.pages.pipeline_title.generate_title_with_llm", new_callable=AsyncMock
+    ) as llm:
+        await generate_title_after_pipeline(state)
+
+    llm.assert_not_called()
+    assert state.title_suggestion_title == "A long evening out"
+
+
+def test_the_file_is_named_after_the_day_and_nobody_in_it() -> None:
+    """The date is the only part of a special day that is safe in a filename.
+
+    The generic slug rounds a single day up to its month, so a special day in
+    June 2016 and that month's Monthly Highlights would write the same file.
+    The catalogue's own title stays out: it names real people and places, and
+    a filename travels further than a title card.
+    """
+    from immich_memories.filename_builder import build_output_filename
+
+    name = build_output_filename(
+        memory_type="special_day",
+        preset_params={"day": date(2016, 6, 12), "title": "A long evening out"},
+        person_name=None,
+        date_start=date(2016, 6, 12),
+        date_end=date(2016, 6, 13),
+    )
+
+    assert name == "everyone_2016-06-12_memories.mp4"
+    assert "evening" not in name
+
+
+def test_one_occasion_gets_one_title_card_and_no_dividers() -> None:
+    """A day is not a span to divide.
+
+    Nothing special-cases this -- a one-day range is already too short for
+    dividers -- so the pin is here to catch the day somebody widens the rule.
+    """
+    from immich_memories.filename_builder import get_divider_mode
+
+    assert get_divider_mode("special_day", date(2016, 6, 12), date(2016, 6, 13)) == "none"
+
+
+def test_the_picker_puts_anniversaries_first_and_still_offers_the_rest() -> None:
+    """The wizard triggers differently from automation, on purpose.
+
+    A scheduled run only proposes a day on its anniversary -- it arrives
+    unannounced, and the round number is what earns the interruption. Somebody
+    who clicked Surprise me wants a memory now, so the whole catalogue is
+    offered, due days first.
+    """
+    a_decade_ago = _discovered("2016-06-12", "A long evening out")
+    nowhere_near_today = _discovered("2019-02-02", "Somebody's leap day")
+
+    rows = step1_presets._special_day_options([nowhere_near_today, a_decade_ago], date(2026, 6, 12))
+
+    assert [label for _, label in rows] == [
+        "10 years ago — A long evening out",
+        "2019-02-02 — Somebody's leap day",
+    ]
+
+
+def test_a_day_the_model_could_not_name_is_not_offered() -> None:
+    """Refuse over fake, one row at a time.
+
+    A day with no title and no description has nothing truthful to put on a
+    title card, so the preset refuses it. Listing it would be offering a row
+    that clears itself when clicked.
+    """
+    rows = step1_presets._special_day_options(
+        [_discovered("2016-06-12", ""), _discovered("2019-02-02", "Somebody's leap day")],
+        date(2026, 6, 12),
+    )
+
+    assert [entry.day for entry, _ in rows] == [date(2019, 2, 2)]


### PR DESCRIPTION
The twelfth Step 1 card. The other eleven ask you what the memory is about;
this one asks the library, and offers the days `discover-days` already found.

## Kin to the Trip card

Trip is the one existing card whose parameters are *discovered* rather than
typed, so this follows it: a `ui.timer(..., once=True)` mount, a picker built
from what was found, and a `_apply_preset_to_state` call once a row is chosen.
The difference is the source — a local JSON file rather than GPS clustering
over an Immich query — so there is no spinner and no network path to fail.

## The UI/automation divergence, said out loud

Automation will only propose a day on its **anniversary**: it arrives
unannounced, and the round number is what earns the interruption. Somebody who
just clicked *Surprise me* wants a memory **now**. So the picker lists
anniversaries due first (`10 years ago — A long evening out`, using the
existing `anniversaries_due` roundness sort), then every other catalogued day
by roundness and recency. Same days, same evidence, different trigger — and the
card's help line says so rather than pretending the two surfaces agree.

## Refuse over fake

With no catalogue there is no day to offer. The card renders the path it looked
at and the `immich-memories discover-days` command that builds one, and leaves
`scope_is_selected` false so Step 1 stays incomplete. It never falls back to a
random day. Same rule one row down: a day the model could not name is not
listed, because there would be nothing truthful to put on its title card.

## One catalogue reader

`_load_catalogue` / `_window_in` / `_moment_in` / `_entries_in` were private to
`days-due`. They move to `automation/catalogue.py` as `load_catalogue` /
`entries_from`, unchanged apart from logging instead of printing to the CLI
console, and the default path moves with them — so the card and the command
cannot drift about where the file lives. Loading only; no other refactor.

## Companion naming

A special day's span is a few hours, and both generic fallbacks describe spans:

- the title came out `June – June 2016`, so `generate_template_title` now
  returns the catalogue's own title and subtitle;
- the filename rounded the day up to its month
  (`everyone_june_2016_memories.mp4`), colliding with that month's Monthly
  Highlights, so `build_output_filename` now writes the ISO day. The
  catalogue's title stays out of it — filenames travel further than title
  cards.

Dividers already resolved to `none` for a one-day range, which is the right
answer (one occasion, one opening card), so that one is **pinned by a test
rather than coded**. `titles/text_builder.py` needed nothing: the title reaches
it as a `title_override`.

`generate_template_title` grew a fifth "the span names none of this" branch and
went to Xenon rank D, so `_occasion_title` splits out along that boundary —
on-this-day, holiday, then-and-now and special-day together.

The title LLM is also skipped for a special day, the way it already is for a
hand-named album: the catalogue named this day months ago from the day's own
photos, and a second opinion drawn from a handful of clip descriptions would
rename the occasion.

## Parity

`SPECIAL_DAY_HAS_NO_SURFACE_YET` stays in `tests/test_surface_parity.py`. A
`MemorySpec` is a request phrased for *both* surfaces and `generate --day` is a
later PR, so there is still nothing to compare — the comment now says the card
exists and only the flag is missing. No CLI choice added here.

## Tests

`tests/test_ui_special_day.py`, state-level as UI pages are coverage-excluded.
Fixture days are invented (`A long evening out`, `Somebody's leap day`); no real
catalogue content anywhere.

Part of the surprise-me program (#326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
