### PR TITLE
fix(photos): look once per moment, not a few times per shippable slot

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2459,101 +2459,101 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 634,
-        "line_end": 733,
+        "line_start": 668,
+        "line_end": 767,
         "line_complexities": [
           {
-            "line": 655,
+            "line": 689,
             "complexity": 0
           },
           {
-            "line": 656,
+            "line": 690,
             "complexity": 1
-          },
-          {
-            "line": 658,
-            "complexity": 1
-          },
-          {
-            "line": 659,
-            "complexity": 0
-          },
-          {
-            "line": 660,
-            "complexity": 2
-          },
-          {
-            "line": 661,
-            "complexity": 0
-          },
-          {
-            "line": 668,
-            "complexity": 1
-          },
-          {
-            "line": 672,
-            "complexity": 0
-          },
-          {
-            "line": 673,
-            "complexity": 0
-          },
-          {
-            "line": 674,
-            "complexity": 1
-          },
-          {
-            "line": 675,
-            "complexity": 0
-          },
-          {
-            "line": 676,
-            "complexity": 2
-          },
-          {
-            "line": 677,
-            "complexity": 0
-          },
-          {
-            "line": 684,
-            "complexity": 1
-          },
-          {
-            "line": 688,
-            "complexity": 0
-          },
-          {
-            "line": 691,
-            "complexity": 0
           },
           {
             "line": 692,
-            "complexity": 2
+            "complexity": 1
           },
           {
             "line": 693,
-            "complexity": 3
-          },
-          {
-            "line": 695,
-            "complexity": 1
-          },
-          {
-            "line": 698,
             "complexity": 0
           },
           {
-            "line": 732,
+            "line": 694,
+            "complexity": 2
+          },
+          {
+            "line": 695,
+            "complexity": 0
+          },
+          {
+            "line": 702,
             "complexity": 1
           },
           {
-            "line": 733,
+            "line": 706,
+            "complexity": 0
+          },
+          {
+            "line": 707,
+            "complexity": 0
+          },
+          {
+            "line": 708,
+            "complexity": 1
+          },
+          {
+            "line": 709,
+            "complexity": 0
+          },
+          {
+            "line": 710,
+            "complexity": 2
+          },
+          {
+            "line": 711,
+            "complexity": 0
+          },
+          {
+            "line": 718,
+            "complexity": 1
+          },
+          {
+            "line": 722,
+            "complexity": 0
+          },
+          {
+            "line": 725,
+            "complexity": 0
+          },
+          {
+            "line": 726,
+            "complexity": 2
+          },
+          {
+            "line": 727,
+            "complexity": 3
+          },
+          {
+            "line": 729,
+            "complexity": 1
+          },
+          {
+            "line": 732,
+            "complexity": 0
+          },
+          {
+            "line": 766,
+            "complexity": 1
+          },
+          {
+            "line": 767,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 70
+    "complexity": 77
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -14,6 +14,7 @@ import random
 import subprocess
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -97,14 +98,17 @@ def score_photos(
         metadata_scored, config, thumbnail_cache, thumbnail_fn=thumbnail_fn
     )
 
-    # Cap only the expensive semantic-scoring shortlist.
-    shortlist_size = llm_shortlist_size(video_clip_count, len(metadata_scored), config.max_ratio)
-    shortlist = metadata_scored
-    if len(shortlist) > shortlist_size:
-        shortlist = _select_distributed(shortlist, shortlist_size)
+    # One look per moment, not a few per shippable slot. Sizing the shortlist
+    # from ship-count meant the model only ever saw what metadata had already
+    # picked, so content could confirm that ranking and never overturn it.
+    moments = one_photo_per_moment(metadata_scored, _MOMENT_WINDOW_MINUTES)
+    shortlist = moments
+    if len(shortlist) > LLM_SHORTLIST_CEILING:
+        shortlist = _select_distributed(shortlist, LLM_SHORTLIST_CEILING)
     logger.info(
-        "Photo scoring: %d available -> %d shortlisted for LLM (max %d selectable)",
+        "Photo scoring: %d available -> %d moments -> %d shortlisted for LLM (max %d selectable)",
         len(metadata_scored),
+        len(moments),
         len(shortlist),
         _compute_max_photos(video_clip_count, config.max_ratio),
     )
@@ -322,7 +326,12 @@ def render_photo_clips(
 # determines how long a run takes. A real library produced a 1194-photo
 # shortlist to place a few dozen photos, which ran for hours.
 LLM_SHORTLIST_CEILING = 200
-_LLM_SHORTLIST_HEADROOM = 3
+
+# Undated photos sort first rather than dropping out of the grouping.
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+# What counts as one moment when sampling photos for a content look.
+_MOMENT_WINDOW_MINUTES = 10.0
 
 
 # How much of a photo's score the pixels are allowed to decide. The metadata
@@ -499,14 +508,39 @@ def video_count_for_photo_budget(total_clips: int, live_photo_clips: int) -> int
     return max(0, total_clips - live_photo_clips)
 
 
-def llm_shortlist_size(video_count: int, available: int, max_ratio: float) -> int:
-    """How many photos are worth an LLM call.
+def one_photo_per_moment(scored: list[tuple], window_minutes: float) -> list[tuple]:
+    """One representative per moment, so every moment gets exactly one look.
 
-    Headroom over what can actually be selected, then an absolute ceiling: on a
-    large library the relative bound alone still authorises thousands of calls.
+    The shortlist used to be sized from how many photos the memory could ship,
+    which meant the model only ever saw what metadata had already chosen.
+    Measured on one month: 295 available, 3 shortlisted. Content could only
+    agree with the metadata ranking; a better photo ranked fourth was never
+    looked at, so it could not win.
+
+    Sampling by moment means nothing is skipped at the start. Note this bounds
+    the looking, not the selecting: score_photos still returns every photo, so
+    two members of one moment can still both be selected downstream.
+
+    A favourite represents its moment -- the user already said this one
+    mattered. Otherwise the best metadata score stands in until content can say
+    better.
     """
-    selectable = _compute_max_photos(video_count, max_ratio)
-    return min(available, selectable * _LLM_SHORTLIST_HEADROOM, LLM_SHORTLIST_CEILING)
+    if not scored:
+        return []
+    ordered = sorted(scored, key=lambda item: item[0].file_created_at or _EPOCH)
+    groups: list[list[tuple]] = []
+    for item in ordered:
+        when = item[0].file_created_at
+        opened = groups[-1][0][0].file_created_at if groups else None
+        if (
+            opened is not None
+            and when is not None
+            and (when - opened).total_seconds() <= window_minutes * 60
+        ):
+            groups[-1].append(item)
+            continue
+        groups.append([item])
+    return [max(g, key=lambda item: (bool(item[0].is_favorite), item[1])) for g in groups]
 
 
 def _select_distributed(

--- a/tests/test_moment_shortlist.py
+++ b/tests/test_moment_shortlist.py
@@ -1,0 +1,121 @@
+"""Describe one photo per moment, not three per shippable slot.
+
+Measured on a real 295-photo month:
+
+    Photo scoring: 295 available -> 3 shortlisted for LLM (max 1 selectable)
+
+The shortlist was sized from how many photos the memory could SHIP, so the
+pipeline only ever described what it had already decided it might use — and
+it decided that on metadata alone. Metadata picks the shortlist, the VLM only
+sees the shortlist, so content can only confirm the metadata choice. A better
+photo ranked fourth by metadata was never looked at and could never win.
+
+One per moment breaks that: every moment gets exactly one content look, so
+nothing is skipped at the start.
+
+This bounds the looking, not the selecting — score_photos still returns every
+photo — so it does not by itself make same-moment duplicates impossible. On a
+real month the duplicate pair did disappear, but through better ranking rather
+than by construction.
+
+A favourite is its moment's representative. The user already said this one
+mattered.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from immich_memories.photos.photo_pipeline import one_photo_per_moment
+
+
+def _photo(asset_id: str, minute: int, score: float, favorite: bool = False):
+    return (
+        SimpleNamespace(
+            id=asset_id,
+            is_favorite=favorite,
+            file_created_at=datetime(2020, 1, 1, tzinfo=UTC) + timedelta(minutes=minute),
+        ),
+        score,
+    )
+
+
+def test_a_burst_contributes_one_representative() -> None:
+    """Five shots inside a minute are one moment, so one look."""
+    burst = [_photo(f"burst-{i}", minute=i, score=0.5 + i / 100) for i in range(5)]
+
+    chosen = one_photo_per_moment(burst, window_minutes=10.0)
+
+    assert len(chosen) == 1
+
+
+def test_distinct_moments_each_get_a_look() -> None:
+    """Nothing is skipped at the start — that is the whole point."""
+    spread = [_photo(f"p-{i}", minute=i * 60, score=0.5) for i in range(6)]
+
+    chosen = one_photo_per_moment(spread, window_minutes=10.0)
+
+    assert len(chosen) == 6
+
+
+def test_the_favorite_represents_its_moment() -> None:
+    """The user already told us which one of these mattered."""
+    group = [
+        _photo("plain-high-score", minute=0, score=0.9),
+        _photo("the-favorite", minute=1, score=0.2, favorite=True),
+    ]
+
+    chosen = one_photo_per_moment(group, window_minutes=10.0)
+
+    assert [a.id for a, _ in chosen] == ["the-favorite"]
+
+
+def test_without_a_favorite_the_best_metadata_score_represents() -> None:
+    group = [
+        _photo("weaker", minute=0, score=0.3),
+        _photo("stronger", minute=1, score=0.8),
+    ]
+
+    chosen = one_photo_per_moment(group, window_minutes=10.0)
+
+    assert [a.id for a, _ in chosen] == ["stronger"]
+
+
+def test_a_library_of_moments_is_still_bounded(tmp_path, caplog) -> None:
+    """More moments than the ceiling must not become more calls than the ceiling.
+
+    Sizing by moment removes the old ship-count bound, so the absolute ceiling
+    is now the only thing standing between a large library and thousands of
+    LLM calls. It carries the guarantee the removed llm_shortlist_size used to
+    make, and it is the reason that constant survives.
+    """
+    import logging
+
+    from immich_memories.config_loader import Config
+    from immich_memories.photos.photo_pipeline import LLM_SHORTLIST_CEILING, score_photos
+    from tests.conftest import make_asset
+
+    far_apart = [
+        make_asset(f"m{i}", is_favorite=False, exif_make="Apple", duration=None)
+        for i in range(LLM_SHORTLIST_CEILING + 60)
+    ]
+    for i, asset in enumerate(far_apart):
+        asset.file_created_at = datetime(2020, 1, 1, tzinfo=UTC) + timedelta(hours=i)
+
+    config = Config(
+        cache={"database": str(tmp_path / "cache.db"), "directory": str(tmp_path)},
+        content_analysis={"enabled": False},
+    )
+    with caplog.at_level(logging.INFO):
+        score_photos(
+            far_apart,
+            config.photos,
+            video_clip_count=0,
+            work_dir=tmp_path,
+            download_fn=None,
+            db_path=config.cache.database_path,
+            app_config=config,
+        )
+
+    line = next(m for m in caplog.messages if m.startswith("Photo scoring:"))
+    shortlisted = int(line.split("->")[2].split()[0])
+    assert shortlisted == LLM_SHORTLIST_CEILING

--- a/tests/test_photo_budget.py
+++ b/tests/test_photo_budget.py
@@ -8,7 +8,7 @@ they are derived from.
 
 from __future__ import annotations
 
-from immich_memories.photos.photo_pipeline import _compute_max_photos, llm_shortlist_size
+from immich_memories.photos.photo_pipeline import _compute_max_photos
 
 
 class TestComputeMaxPhotos:
@@ -23,19 +23,6 @@ class TestComputeMaxPhotos:
 
     def test_no_videos_still_bounded(self):
         assert _compute_max_photos(0, 0.5) <= 10
-
-
-class TestLlmShortlistSize:
-    def test_shortlist_is_bounded_absolutely(self):
-        """A huge library must not translate into a huge number of LLM calls."""
-        assert llm_shortlist_size(video_count=400, available=5128, max_ratio=0.5) <= 200
-
-    def test_shortlist_gives_headroom_over_what_is_selectable(self):
-        size = llm_shortlist_size(video_count=20, available=5128, max_ratio=0.5)
-        assert size > _compute_max_photos(20, 0.5)
-
-    def test_never_exceeds_what_is_available(self):
-        assert llm_shortlist_size(video_count=400, available=12, max_ratio=0.5) == 12
 
 
 class TestLivePhotosDoNotInflateThePhotoBudget:

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -655,9 +656,16 @@ def test_a_cold_photo_pass_reports_the_photos_it_had_to_score(tmp_path: Path, ca
         llm={"model": "some-vlm"},
     )
 
+    # Separate days, so these are two moments and both are scored: the
+    # shortlist samples one photo per moment, and make_asset dates every
+    # photo to now.
+    cold = [_photo("cold-1"), _photo("cold-2")]
+    for offset, asset in enumerate(cold):
+        asset.file_created_at = datetime(2020, 1, 1, tzinfo=UTC) + timedelta(days=offset)
+
     with caplog.at_level(logging.INFO):
         score_photos(
-            [_photo("cold-1"), _photo("cold-2")],
+            cold,
             config.photos,
             video_clip_count=0,
             work_dir=tmp_path,

--- a/tests/test_unified_budget.py
+++ b/tests/test_unified_budget.py
@@ -635,5 +635,9 @@ class TestScorePhotos:
                 download_fn=MagicMock(),
             )
 
-        assert len(enhance.call_args.args[0]) == 6
+        # One look per moment, and these 20 photos are an hour apart, so all
+        # 20 are moments. The number is incidental; what this test guards is
+        # the line below — capping the LOOK must never shrink what selection
+        # can choose from.
+        assert len(enhance.call_args.args[0]) == 20
         assert {asset.id for asset, _score in result} == {asset.id for asset in assets}


### PR DESCRIPTION
Closes #704

## The circularity

The VLM shortlist was sized from how many photos the memory could **ship**:

```python
shortlist_size = llm_shortlist_size(video_clip_count, available, max_ratio)
```

Ship-count times a small headroom. On one month of a real library that is:

```
Photo scoring: 295 available -> 3 shortlisted for LLM (max 1 selectable)
```

Three photos of 295 get looked at — and they are the three metadata already
ranked highest. So the model could only ever agree with the ranking that chose
the shortlist. A better photo sitting fourth was never looked at, so it could
not win. The look was spent ratifying a decision already made.

## The change

Size by how many **moments** exist: group into ten-minute moments, look at one
representative each.

```
Photo scoring: 295 available -> 44 moments -> 44 shortlisted for LLM
```

A favourite represents its moment — the user already said that one mattered.
Otherwise the best metadata score stands in until content can say better.

## Measured

Same code both arms, both carrying #701 so the content path actually answers:

| | by ship-count | by moment |
|---|---|---|
| photos looked at | 3 of 295 | 44 of 295 |
| picks changed | — | 9 of 13 (69%) |
| same-moment duplicate pairs shipped | 1 | 0 |

The pair that disappears is two shots of the same group eight minutes apart.

**That duplicate result is emergent, not structural**, and the docstrings say
so. `score_photos` still returns every photo, so this bounds the looking and
not the selecting — better content scores merely reordered the ranking enough
that the second shot no longer placed. Two members of one moment can still
both be selected. Making that impossible means changing what selection draws
from, which is a separate piece of work.

### One caveat worth knowing before merge

Sizing by moment is not universally *more* looking. Where the pool is large
relative to the slots it is far more (295 -> 44 instead of 295 -> 3); where
the pool is already small enough that the old bound covered everything, it is
fewer. One month measured 36 available -> 18 moments, where the old sizing
would have looked at all 36. On such a month this trades coverage for moment
diversity, and the un-sampled half keeps metadata-only scores.

## Dead code, and the constraint that outlives it

`llm_shortlist_size` and `_LLM_SHORTLIST_HEADROOM` lose their only production
caller and go.

Their tests encoded something that does **not** go with them: *a large library
must not authorise a large number of LLM calls*. Removing the old ship-count
bound leaves `LLM_SHORTLIST_CEILING` as the only thing standing between a big
library and thousands of calls, so that guarantee moves to a behavioural test
— 260 moments an hour apart must still shortlist exactly 200 — rather than
being deleted along with the function it used to live on.

## Two existing tests changed

- one asserted the shortlist was `6`, which is the ship-count arithmetic this
  replaces. The assertion the test exists for — capping the *look* must never
  shrink what selection can choose from — is untouched and still passes.
- one built two photos through `make_asset`, which dates everything to `now()`,
  so they arrived as a single moment and only one was scored. That test is
  about the cache report rather than about grouping, so its photos now sit on
  separate days. Worth noting generally: any test using `make_asset` without an
  explicit date now has all its photos in one moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL