### PR TITLE
feat(generate): generate the day the catalogue found

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -920,256 +920,252 @@
       {
         "name": "register_generate_commands",
         "complexity": 163,
-        "line_start": 47,
-        "line_end": 592,
+        "line_start": 49,
+        "line_end": 602,
         "line_complexities": [
           {
-            "line": 134,
+            "line": 137,
             "complexity": 0
           },
           {
-            "line": 135,
+            "line": 138,
             "complexity": 0
           },
           {
-            "line": 142,
+            "line": 145,
             "complexity": 2
-          },
-          {
-            "line": 143,
-            "complexity": 0
-          },
-          {
-            "line": 144,
-            "complexity": 0
           },
           {
             "line": 146,
+            "complexity": 0
+          },
+          {
+            "line": 147,
+            "complexity": 0
+          },
+          {
+            "line": 149,
             "complexity": 2
           },
           {
-            "line": 148,
+            "line": 151,
             "complexity": 3
-          },
-          {
-            "line": 152,
-            "complexity": 3
-          },
-          {
-            "line": 153,
-            "complexity": 0
           },
           {
             "line": 155,
-            "complexity": 0
-          },
-          {
-            "line": 156,
-            "complexity": 2
-          },
-          {
-            "line": 157,
-            "complexity": 1
-          },
-          {
-            "line": 162,
             "complexity": 3
           },
           {
-            "line": 163,
+            "line": 156,
             "complexity": 0
           },
           {
-            "line": 167,
+            "line": 158,
             "complexity": 0
           },
           {
-            "line": 168,
+            "line": 159,
+            "complexity": 2
+          },
+          {
+            "line": 160,
             "complexity": 1
           },
           {
-            "line": 169,
+            "line": 165,
+            "complexity": 3
+          },
+          {
+            "line": 166,
+            "complexity": 0
+          },
+          {
+            "line": 170,
             "complexity": 0
           },
           {
             "line": 171,
-            "complexity": 2
+            "complexity": 1
           },
           {
-            "line": 187,
+            "line": 172,
             "complexity": 0
           },
           {
-            "line": 198,
+            "line": 174,
+            "complexity": 2
+          },
+          {
+            "line": 190,
+            "complexity": 0
+          },
+          {
+            "line": 201,
             "complexity": 3
           },
           {
-            "line": 202,
+            "line": 205,
             "complexity": 3
           },
           {
-            "line": 206,
+            "line": 209,
             "complexity": 4
           },
           {
-            "line": 210,
+            "line": 213,
             "complexity": 3
           },
           {
-            "line": 214,
+            "line": 217,
             "complexity": 3
           },
           {
-            "line": 222,
+            "line": 226,
             "complexity": 0
           },
           {
-            "line": 239,
+            "line": 227,
+            "complexity": 0
+          },
+          {
+            "line": 231,
+            "complexity": 0
+          },
+          {
+            "line": 249,
             "complexity": 2
           },
           {
-            "line": 240,
+            "line": 250,
             "complexity": 0
           },
           {
-            "line": 241,
+            "line": 251,
             "complexity": 1
-          },
-          {
-            "line": 243,
-            "complexity": 0
-          },
-          {
-            "line": 244,
-            "complexity": 1
-          },
-          {
-            "line": 245,
-            "complexity": 0
           },
           {
             "line": 253,
-            "complexity": 2
-          },
-          {
-            "line": 258,
             "complexity": 0
           },
           {
-            "line": 261,
-            "complexity": 0
-          },
-          {
-            "line": 267,
+            "line": 254,
             "complexity": 1
           },
           {
-            "line": 270,
-            "complexity": 3
+            "line": 255,
+            "complexity": 0
+          },
+          {
+            "line": 263,
+            "complexity": 2
+          },
+          {
+            "line": 268,
+            "complexity": 0
           },
           {
             "line": 271,
-            "complexity": 3
+            "complexity": 0
           },
           {
-            "line": 273,
-            "complexity": 0
+            "line": 277,
+            "complexity": 1
           },
           {
             "line": 280,
-            "complexity": 0
-          },
-          {
-            "line": 284,
             "complexity": 3
           },
           {
-            "line": 285,
-            "complexity": 0
-          },
-          {
-            "line": 286,
+            "line": 281,
             "complexity": 3
           },
           {
-            "line": 287,
+            "line": 283,
             "complexity": 0
           },
           {
-            "line": 289,
+            "line": 290,
             "complexity": 0
           },
           {
-            "line": 313,
+            "line": 294,
+            "complexity": 3
+          },
+          {
+            "line": 295,
+            "complexity": 0
+          },
+          {
+            "line": 296,
+            "complexity": 3
+          },
+          {
+            "line": 297,
+            "complexity": 0
+          },
+          {
+            "line": 299,
+            "complexity": 0
+          },
+          {
+            "line": 323,
             "complexity": 1
           },
           {
-            "line": 314,
+            "line": 324,
             "complexity": 2
           },
           {
-            "line": 318,
+            "line": 328,
             "complexity": 1
           },
           {
-            "line": 329,
+            "line": 339,
             "complexity": 3
           },
           {
-            "line": 330,
+            "line": 340,
             "complexity": 0
           },
           {
-            "line": 331,
+            "line": 341,
             "complexity": 0
           },
           {
-            "line": 333,
+            "line": 343,
             "complexity": 0
           },
           {
-            "line": 335,
+            "line": 345,
             "complexity": 0
           },
           {
-            "line": 337,
+            "line": 347,
             "complexity": 0
           },
           {
-            "line": 344,
+            "line": 354,
             "complexity": 5
           },
           {
-            "line": 386,
+            "line": 396,
             "complexity": 6
           },
           {
-            "line": 430,
+            "line": 440,
             "complexity": 0
           },
           {
-            "line": 431,
+            "line": 441,
             "complexity": 5
           },
           {
-            "line": 432,
+            "line": 442,
             "complexity": 6
-          },
-          {
-            "line": 433,
-            "complexity": 0
-          },
-          {
-            "line": 434,
-            "complexity": 0
-          },
-          {
-            "line": 435,
-            "complexity": 7
           },
           {
             "line": 443,
-            "complexity": 6
+            "complexity": 0
           },
           {
             "line": 444,
@@ -1180,55 +1176,63 @@
             "complexity": 7
           },
           {
-            "line": 446,
-            "complexity": 0
-          },
-          {
-            "line": 448,
-            "complexity": 1
-          },
-          {
             "line": 453,
-            "complexity": 7
+            "complexity": 6
           },
           {
             "line": 454,
             "complexity": 0
           },
           {
-            "line": 467,
+            "line": 455,
             "complexity": 7
           },
           {
-            "line": 468,
+            "line": 456,
             "complexity": 0
           },
           {
-            "line": 469,
-            "complexity": 0
-          },
-          {
-            "line": 472,
+            "line": 458,
             "complexity": 1
           },
           {
-            "line": 473,
+            "line": 463,
+            "complexity": 7
+          },
+          {
+            "line": 464,
             "complexity": 0
           },
           {
-            "line": 474,
-            "complexity": 0
+            "line": 477,
+            "complexity": 7
           },
           {
             "line": 478,
-            "complexity": 7
+            "complexity": 0
           },
           {
             "line": 479,
             "complexity": 0
           },
           {
+            "line": 482,
+            "complexity": 1
+          },
+          {
+            "line": 483,
+            "complexity": 0
+          },
+          {
+            "line": 484,
+            "complexity": 0
+          },
+          {
             "line": 488,
+            "complexity": 7
+          },
+          {
+            "line": 489,
             "complexity": 0
           },
           {
@@ -1236,67 +1240,71 @@
             "complexity": 0
           },
           {
-            "line": 499,
-            "complexity": 5
-          },
-          {
-            "line": 500,
+            "line": 508,
             "complexity": 0
           },
           {
-            "line": 505,
-            "complexity": 6
+            "line": 509,
+            "complexity": 5
           },
           {
-            "line": 508,
-            "complexity": 6
-          },
-          {
-            "line": 513,
+            "line": 510,
             "complexity": 0
           },
           {
             "line": 515,
-            "complexity": 5
+            "complexity": 6
           },
           {
-            "line": 517,
-            "complexity": 5
+            "line": 518,
+            "complexity": 6
           },
           {
-            "line": 521,
-            "complexity": 5
-          },
-          {
-            "line": 524,
-            "complexity": 1
-          },
-          {
-            "line": 526,
+            "line": 523,
             "complexity": 0
           },
           {
-            "line": 528,
+            "line": 525,
+            "complexity": 5
+          },
+          {
+            "line": 527,
+            "complexity": 5
+          },
+          {
+            "line": 531,
+            "complexity": 5
+          },
+          {
+            "line": 534,
+            "complexity": 1
+          },
+          {
+            "line": 536,
             "complexity": 0
           },
           {
-            "line": 575,
-            "complexity": 1
-          },
-          {
-            "line": 578,
-            "complexity": 1
-          },
-          {
-            "line": 581,
-            "complexity": 1
-          },
-          {
-            "line": 582,
+            "line": 538,
             "complexity": 0
           },
           {
-            "line": 583,
+            "line": 585,
+            "complexity": 1
+          },
+          {
+            "line": 588,
+            "complexity": 1
+          },
+          {
+            "line": 591,
+            "complexity": 1
+          },
+          {
+            "line": 592,
+            "complexity": 0
+          },
+          {
+            "line": 593,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -28,7 +28,7 @@ immich-memories generate [OPTIONS]
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
-| `--memory-type` | — | choice | — | `year_in_review`, `season`, `person_spotlight`, `multi_person`, `monthly_highlights`, `on_this_day`, `trip`, `holiday`, `then_and_now` |
+| `--memory-type` | — | choice | — | `year_in_review`, `season`, `person_spotlight`, `multi_person`, `monthly_highlights`, `on_this_day`, `trip`, `holiday`, `then_and_now`, `special_day` |
 | `--holiday` | — | text | — | Holiday name or `MM-DD` (with `--memory-type holiday`) |
 | `--from-album` | — | string | — | Generate from an Immich album (name or ID) instead of a date range. See [Album Memories](../memory-types/album-memories). Cannot be combined with any time-period or person flag |
 | `--person` | `-p` | string | — | Person name from Immich face recognition (repeatable: `--person "Alice" --person "Bob"`) |
@@ -164,6 +164,7 @@ have not set explicitly; the flags below still win. Persistent form: `preset: fa
 | `--trip-index` | — | int | — | Select a specific trip by index (use with `--memory-type trip`) |
 | `--all-trips` | — | flag | — | Generate a video for every detected trip (use with `--memory-type trip`) |
 | `--near-date` | — | string | — | Select trip closest to this date (`YYYY-MM-DD`, use with `--memory-type trip`) |
+| `--day` | — | datetime | — | The catalogued day to generate (`YYYY-MM-DD`, use with `--memory-type special_day`) |
 
 ## Examples
 
@@ -265,6 +266,38 @@ contrast is the point and a two-day window a decade ago is usually empty.
 
 Without `--duration` this runs 45 seconds — two years side by side, not the ten
 that separate them.
+
+### A day the catalogue found
+
+[`discover-days`](./discover-days) walks the library and writes down the days
+something happened on. `--day` generates one of them:
+
+```bash
+immich-memories generate --memory-type special_day --day 2016-06-12
+```
+
+The flag carries a **date, not a title**. The title and subtitle come from the
+catalogue, which this command re-reads — because argv is logged by the automation
+runner and is readable in `ps` and in launchd's logs, and the catalogue's titles
+name real people and places. `immich-memories days-due` lists what it holds.
+
+Three things are refused rather than faked:
+
+- `--memory-type special_day` with no `--day`
+- a `--day` the catalogue has never heard of — the error names the file it read
+- a catalogued day with neither a title nor a description of what it was
+
+There is no generic "Memories from 12 June 2016" card. A day the model could not
+name is a day that should not be rendered.
+
+Scope is the window the catalogue recorded for the day, when it recorded one:
+`discover-days` only writes a window when trimming to it drops a meaningful slice
+of the day, so it means "the memory starts at the circuit, not at the cat on the
+balcony that morning". A day with no window covers the whole calendar day.
+
+Without `--duration` the length comes from how long the day stayed awake —
+roughly a minute plus six seconds an hour, held between 60 and 180 seconds.
+`--title` and `--subtitle` still override the catalogue's naming.
 
 ### Trip closest to a date
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -263,7 +263,7 @@ immich-memories generate [OPTIONS]
 | `--birthday`, `-b` | text | - | Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15) |
 | `--from-album` | text | - | Generate from an Immich album (name or ID) instead of a date range |
 | `--person`, `-p` | text | - | Person name (repeatable) |
-| `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` \| `holiday` \| `then_and_now` | - | Memory type preset |
+| `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` \| `holiday` \| `then_and_now` \| `special_day` | - | Memory type preset |
 | `--holiday` | text | - | Holiday name or MM-DD (use with --memory-type holiday) |
 | `--season` | choice: `spring` \| `summer` \| `fall` \| `autumn` \| `winter` | - | Season (use with --memory-type season) |
 | `--month` | integer | - | Month 1-12 (with --year, generates that month; selects trip by month) |
@@ -301,6 +301,7 @@ immich-memories generate [OPTIONS]
 | `--all-trips` | boolean | false | Generate a video for every detected trip (use with --memory-type trip) |
 | `--years-back` | integer | - | Years to look back for on_this_day, holiday or then_and_now |
 | `--near-date` | text | - | Select trip closest to this date (YYYY-MM-DD, use with --memory-type trip) |
+| `--day` | datetime | - | The catalogued day to generate (YYYY-MM-DD, use with --memory-type special_day). Its title comes from the catalogue, not from here: run `immich-memories days-due` to see which days are in it |
 | `--quiet` | boolean | false | Suppress interactive progress, emit log lines |
 
 ## `hardware`

--- a/src/immich_memories/automation/catalogue.py
+++ b/src/immich_memories/automation/catalogue.py
@@ -70,6 +70,18 @@ def entries_from(path: Path) -> list[DiscoveredDay]:
     ]
 
 
+def hours_awake(entry: DiscoveredDay) -> float:
+    """How long the day the catalogue found actually lasted.
+
+    `active_hours` counts distinct hours touched, so it saturates at 24 -- and
+    a run keyed by the date it began can span 45 hours. Where the extent was
+    recorded it is the only reading that survives midnight.
+    """
+    if entry.run_start is not None and entry.run_end is not None:
+        return (entry.run_end - entry.run_start).total_seconds() / 3600.0
+    return float(entry.active_hours)
+
+
 def _moment_in(raw: object) -> datetime | None:
     """One end of the run a catalogue entry recorded, if it recorded any."""
     if not isinstance(raw, str):

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -121,12 +121,16 @@ def resolve_date_range(
     years_back: int | None = None,
     on_this_day_target: date | None = None,
     holiday: str | None = None,
+    preset_params: dict | None = None,
 ) -> DateRange | list[DateRange]:
     """Resolve date range from command line options.
 
     When --memory-type is set, delegates to preset date builders.
     --start/--end can override the preset's default date range.
     Otherwise falls through to manual date range options.
+
+    ``preset_params`` carries what a memory type cannot spell as date flags: a
+    special day's window comes out of the catalogue, not off the command line.
     """
     if memory_type:
         default_range = _resolve_memory_type_dates(
@@ -138,6 +142,7 @@ def resolve_date_range(
             years_back,
             on_this_day_target,
             holiday,
+            preset_params,
         )
         manual_range = _resolve_manual_dates(start, end, period)
         if manual_range:
@@ -180,9 +185,13 @@ def _resolve_memory_type_dates(
     years_back: int | None = None,
     on_this_day_target: date | None = None,
     holiday: str | None = None,
+    preset_params: dict | None = None,
 ) -> DateRange | list[DateRange]:
     """Resolve date ranges from memory type preset."""
     from immich_memories.memory_types.date_builders import build_month, build_season
+
+    if memory_type == "special_day":
+        return _special_day_scope(preset_params or {})
 
     if memory_type == "season":
         if not season:
@@ -211,6 +220,19 @@ def _resolve_memory_type_dates(
         return build_month(month, year)
 
     return calendar_year(year)
+
+
+def _special_day_scope(preset_params: dict) -> DateRange:
+    """The window the catalogue recorded for one day, or the calendar day."""
+    from immich_memories.memory_types.date_builders import build_special_day
+
+    day = preset_params.get("day")
+    if day is None:
+        raise click.UsageError(
+            "--day is required with --memory-type special_day. Run "
+            "`immich-memories days-due` to see which days the catalogue holds."
+        )
+    return build_special_day(day, preset_params.get("window"))
 
 
 def duration_from_date_range(date_range: DateRange) -> float:

--- a/src/immich_memories/cli/_flags.py
+++ b/src/immich_memories/cli/_flags.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+
 import click
 
 _ORIENTATIONS = ("landscape", "portrait", "square")
+
+
+def calendar_day(ctx: click.Context, param: click.Parameter, value: datetime | None) -> date | None:
+    """Read a `YYYY-MM-DD` flag as the day it names.
+
+    click.DateTime hands back a datetime at midnight, and a datetime never
+    equals the date a catalogue entry is keyed by, so the truncation belongs
+    here rather than at every place the value is compared.
+    """
+    del ctx, param
+    return value.date() if value else None
 
 
 def output_path(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -36,8 +36,10 @@ from immich_memories.cli.generate_resolution import (
     _arm_selection_trace,
     _reject_album_scope_conflicts,
     _resolve_generation_scope,
+    name_from_catalogue,
     resolve_inclusion,
     resolve_short_form,
+    resolve_special_day,
 )
 from immich_memories.filename_builder import build_memory_output_path, normalize_output_path
 from immich_memories.processing.encoding_plan import resolve_output_selection
@@ -103,6 +105,7 @@ def register_generate_commands(main: click.Group) -> None:
         all_trips: bool,
         years_back: int | None,
         near_date: str | None,
+        day: date | None,
         source: str,
         memory_key: str | None,
         memory_category: str | None,
@@ -219,6 +222,12 @@ def register_generate_commands(main: click.Group) -> None:
             print_error("--years-back requires --memory-type on_this_day, holiday or then_and_now")
             sys.exit(1)
 
+        # The catalogue, not the command line, knows what the day was called.
+        special_day = resolve_special_day(day, memory_type)
+        title_override, subtitle_override = name_from_catalogue(
+            special_day, title_override, subtitle_override
+        )
+
         date_range, date_ranges = _resolve_generation_scope(
             from_album=from_album,
             year=year,
@@ -233,6 +242,7 @@ def register_generate_commands(main: click.Group) -> None:
             years_back=years_back,
             on_this_day_target=exact_on_this_day,
             holiday=holiday,
+            preset_params=special_day,
         )
 
         # Determine output path
@@ -282,7 +292,7 @@ def register_generate_commands(main: click.Group) -> None:
         # Resolve duration: CLI --duration > memory type default > date-range scaling
         # Album mode defers to the pipeline, which sizes it from the album's media.
         if duration is None and not from_album:
-            duration = default_duration_for_type(memory_type, date_range)
+            duration = default_duration_for_type(memory_type, date_range, special_day)
             if duration is None:
                 duration = duration_from_date_range(date_range)
 

--- a/src/immich_memories/cli/generate_options.py
+++ b/src/immich_memories/cli/generate_options.py
@@ -14,7 +14,7 @@ from typing import Any, TypeVar
 
 import click
 
-from immich_memories.cli._flags import output_path
+from immich_memories.cli._flags import calendar_day, output_path
 from immich_memories.cli.generate_resolution import SHORT_FORM_SECONDS
 
 FC = TypeVar("FC", bound=Callable[..., Any])
@@ -70,6 +70,7 @@ def scope_options(command: FC) -> FC:
                     "trip",
                     "holiday",
                     "then_and_now",
+                    "special_day",
                 ]
             ),
             default=None,
@@ -329,6 +330,17 @@ def per_memory_type_options(command: FC) -> FC:
             type=str,
             default=None,
             help="Select trip closest to this date (YYYY-MM-DD, use with --memory-type trip)",
+        ),
+        click.option(
+            "--day",
+            type=click.DateTime(formats=["%Y-%m-%d"]),
+            callback=calendar_day,
+            default=None,
+            help=(
+                "The catalogued day to generate (YYYY-MM-DD, use with --memory-type "
+                "special_day). Its title comes from the catalogue, not from here: run "
+                "`immich-memories days-due` to see which days are in it"
+            ),
         ),
     ]
     return _apply(command, options)

--- a/src/immich_memories/cli/generate_resolution.py
+++ b/src/immich_memories/cli/generate_resolution.py
@@ -24,6 +24,77 @@ if TYPE_CHECKING:
     from immich_memories.config_loader import Config
 
 
+def resolve_special_day(day: date | None, memory_type: str | None) -> dict | None:
+    """What the catalogue records about one day, as preset parameters.
+
+    ``--day`` carries a date and the catalogue is re-read here rather than
+    having the title passed in, because the runner logs the whole argv and argv
+    is readable in `ps` and in launchd's logs. The catalogue's titles name real
+    people and places; a date is the most a scheduled run should say out loud.
+
+    Refuse over fake throughout: a day the catalogue never found, or one the
+    model could not name, is a day with nothing truthful to put on its title
+    card, so it errors rather than rendering "Memories from 12 June 2016".
+    """
+    from immich_memories.automation.catalogue import (
+        default_catalogue_path,
+        entries_from,
+        hours_awake,
+    )
+
+    if day is None:
+        # The missing half of the pair is reported where the scope is resolved,
+        # beside --season's and --holiday's identical rule.
+        return None
+    if memory_type != "special_day":
+        raise click.UsageError("--day requires --memory-type special_day")
+
+    path = default_catalogue_path()
+    entry = next((e for e in entries_from(path) if e.day == day), None)
+    if entry is None:
+        raise click.UsageError(
+            f"{day.isoformat()} is not one of the days in {path}. Run "
+            "`immich-memories days-due` to see which days it holds, or "
+            "`immich-memories discover-days` to look for more."
+        )
+
+    name = (entry.title or "").strip() or (entry.what or "").strip()
+    if not name:
+        raise click.UsageError(
+            f"{path} has neither a title nor a 'what' for {day.isoformat()}, so there "
+            "is nothing truthful to call the memory. Re-run `immich-memories "
+            "discover-days --rescan` to name it."
+        )
+
+    return {
+        "day": entry.day,
+        "window": entry.window,
+        "title": name,
+        "subtitle": entry.subtitle,
+        "active_hours": hours_awake(entry),
+    }
+
+
+def name_from_catalogue(
+    special_day: dict | None,
+    title_override: str | None,
+    subtitle_override: str | None,
+) -> tuple[str | None, str | None]:
+    """Let the catalogue name the memory, unless the run named it itself.
+
+    The catalogue's title is the point of a special day and also the one thing
+    that must never travel on the command line, so it is picked up from the
+    file rather than passed in. --title and --subtitle still win: this fills a
+    gap, it does not argue.
+    """
+    if special_day is None:
+        return title_override, subtitle_override
+    return (
+        title_override or special_day["title"],
+        subtitle_override or special_day["subtitle"] or None,
+    )
+
+
 def _resolve_generation_scope(
     *,
     from_album: str | None,
@@ -39,6 +110,7 @@ def _resolve_generation_scope(
     years_back: int | None,
     on_this_day_target: date | None,
     holiday: str | None = None,
+    preset_params: dict | None = None,
 ) -> tuple[DateRange, list[DateRange]]:
     """Resolve what a memory covers: date range(s), or an album that defines its own.
 
@@ -65,6 +137,7 @@ def _resolve_generation_scope(
         years_back=years_back,
         on_this_day_target=on_this_day_target,
         holiday=holiday,
+        preset_params=preset_params,
     )
 
     # Normalize to single DateRange for display (multi-range for on_this_day)

--- a/tests/test_generate_special_day.py
+++ b/tests/test_generate_special_day.py
@@ -1,0 +1,265 @@
+"""Generating the day the catalogue found.
+
+The flag carries a date, never a title. `runner.py` logs the whole argv, and
+argv is readable in `ps` and in launchd's own logs, so the one thing a scheduled
+run says out loud is a date; the child re-reads the catalogue for the name.
+Every day here is invented -- the real catalogue names real people and places.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from immich_memories.cli.generate_resolution import name_from_catalogue, resolve_special_day
+from immich_memories.memory_types.factory import create_preset
+from immich_memories.memory_types.registry import MemoryType
+
+# An invented day, in the style the docs already use. Nothing real belongs here.
+DAY_ISO = "2016-06-12"
+DAY = date(2016, 6, 12)
+TITLE = "An afternoon at the track"
+ENTRY = {
+    "day": DAY_ISO,
+    "title": TITLE,
+    "subtitle": "Somebody's first race",
+    "what": "A long day out",
+    "photos": 210,
+    "active_hours": 9,
+}
+
+
+def _configured(tmp_path: Path) -> Path:
+    """A config with just enough Immich for `generate` to get past its own gate."""
+    path = tmp_path / "config.yaml"
+    path.write_text("immich:\n  url: http://immich.invalid\n  api_key: not-a-real-key\n")
+    return path
+
+
+@pytest.fixture
+def run_generate(tmp_path: Path):
+    """Invoke `generate` the way a person or the runner does: through argv."""
+    from immich_memories.cli import main
+
+    config = _configured(tmp_path)
+
+    def _invoke(*args: str):
+        # WHY: init_config_dir writes to the real home directory, which a unit
+        # test must not touch. Nothing else about the command is replaced.
+        with patch("immich_memories.cli.init_config_dir"):
+            return CliRunner().invoke(main, ["-c", str(config), "generate", *args])
+
+    return _invoke
+
+
+class _RecordingImmich:
+    """Stands in for the Immich HTTP API, keeping the windows it was asked for."""
+
+    def __init__(self) -> None:
+        self.windows: list = []
+
+    def get_videos_for_date_range(self, date_range) -> list:
+        self.windows.append(date_range)
+        return []
+
+    def __enter__(self) -> _RecordingImmich:
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+@pytest.fixture
+def windows_asked_for(run_generate, monkeypatch: pytest.MonkeyPatch):
+    """Run `generate` to the point of the query, and hand back what it asked for."""
+
+    def _run(*args: str) -> list:
+        client = _RecordingImmich()
+        # WHY: the Immich HTTP API is the boundary this run would cross. It
+        # records the window instead of answering it; every step that decides
+        # the window -- catalogue, preset, date resolution -- is the real one.
+        monkeypatch.setattr("immich_memories.api.immich.SyncImmichClient", lambda **_kwargs: client)
+        run_generate("--no-photos", "--no-live-photos", *args)
+        return client.windows
+
+    return _run
+
+
+def _immich_payload_for(date_range) -> dict:
+    """The body Immich actually receives for a window.
+
+    A DateRange is not the contract -- what survives the timezone round trip
+    into takenAfter/takenBefore is, and that is where a window recorded with an
+    offset either keeps its clock times or silently shifts.
+    """
+    import asyncio
+
+    from immich_memories.api.search_service import SearchService
+
+    recorded: dict = {}
+
+    # WHY: the same Immich HTTP boundary, one layer lower, so the assertion can
+    # be about the request body rather than the object that produced it.
+    async def request(_method: str, _path: str, *, json: dict) -> dict:
+        recorded.update(json)
+        return {}
+
+    asyncio.run(SearchService(request).get_videos_for_date_range(date_range))
+    return recorded
+
+
+@pytest.fixture
+def catalogue_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the shared catalogue reader at a file this test wrote.
+
+    The path resolves from the home directory, which is the one thing a test
+    has to move; the reader itself is the real one.
+    """
+
+    def _install(*entries: dict) -> Path:
+        path = tmp_path / "special-days.json"
+        path.write_text(json.dumps(list(entries)))
+        monkeypatch.setattr(
+            "immich_memories.automation.catalogue.default_catalogue_path", lambda: path
+        )
+        return path
+
+    return _install
+
+
+class TestFlagPairing:
+    """--day and --memory-type special_day mean nothing apart."""
+
+    def test_a_special_day_without_a_day_names_the_flag_it_wants(self, run_generate) -> None:
+        result = run_generate("--memory-type", "special_day")
+
+        assert result.exit_code != 0
+        assert "--day" in result.output
+
+    def test_a_day_on_any_other_memory_type_is_refused(self, run_generate) -> None:
+        """A date scoped to one occasion says nothing about a yearly review."""
+        result = run_generate("--memory-type", "year_in_review", "--year", "2016", "--day", DAY_ISO)
+
+        assert result.exit_code != 0
+        assert "--day requires --memory-type special_day" in result.output
+
+
+class TestRefuseOverFake:
+    """A day the catalogue cannot name is a day that must not be rendered."""
+
+    def test_a_day_that_is_not_in_the_catalogue_names_the_file_it_looked_in(
+        self, run_generate, catalogue_at
+    ) -> None:
+        path = catalogue_at({**ENTRY, "day": "2019-12-31"})
+
+        result = run_generate("--memory-type", "special_day", "--day", DAY_ISO)
+
+        assert result.exit_code != 0
+        assert str(path) in result.output
+        assert DAY_ISO in result.output
+
+    def test_a_catalogued_day_with_no_name_at_all_is_refused(
+        self, run_generate, catalogue_at
+    ) -> None:
+        catalogue_at({"day": DAY_ISO, "title": "  ", "what": "", "photos": 210})
+
+        result = run_generate("--memory-type", "special_day", "--day", DAY_ISO)
+
+        assert result.exit_code != 0
+        assert "nothing truthful" in result.output
+
+
+class TestTheWindowIsTheScope:
+    """What the catalogue recorded is what Immich gets asked for."""
+
+    def test_a_recorded_window_reaches_immich_with_its_clock_times_intact(
+        self, windows_asked_for, catalogue_at
+    ) -> None:
+        # The catalogue writes the window with the offset Immich returned, and
+        # only a window that keeps that offset scopes the memory to the hours
+        # the day actually happened in.
+        catalogue_at(
+            {**ENTRY, "window": ["2016-06-12T13:45:00+02:00", "2016-06-12T16:03:00+02:00"]}
+        )
+
+        windows = windows_asked_for("--memory-type", "special_day", "--day", DAY_ISO)
+
+        assert len(windows) == 1
+        payload = _immich_payload_for(windows[0])
+        assert payload["takenAfter"] == "2016-06-12T11:45:00+00:00"
+        assert payload["takenBefore"] == "2016-06-12T14:03:00+00:00"
+
+    def test_a_day_with_no_window_is_scoped_to_the_whole_calendar_day(
+        self, windows_asked_for, catalogue_at
+    ) -> None:
+        catalogue_at(ENTRY)
+
+        windows = windows_asked_for("--memory-type", "special_day", "--day", DAY_ISO)
+
+        payload = _immich_payload_for(windows[0])
+        assert payload["takenAfter"] == "2016-06-12T00:00:00+00:00"
+        assert payload["takenBefore"] == "2016-06-12T23:59:59+00:00"
+
+
+class TestTheTitleNeverTravelsOnTheCommandLine:
+    """The privacy contract: a date on argv, the name out of the catalogue."""
+
+    def test_a_day_alone_is_enough_for_the_catalogue_to_name_the_memory(
+        self, windows_asked_for, catalogue_at
+    ) -> None:
+        catalogue_at(ENTRY)
+        argv = ("--memory-type", "special_day", "--day", DAY_ISO)
+
+        assert windows_asked_for(*argv), "the run never reached Immich"
+
+        # Everything a runner logs, and everything `ps` shows, is in argv.
+        assert TITLE not in " ".join(argv)
+        preset = create_preset(MemoryType.SPECIAL_DAY, **resolve_special_day(DAY, "special_day"))
+        assert preset.name == TITLE
+
+    def test_a_typed_title_still_outranks_the_catalogues(self, catalogue_at) -> None:
+        catalogue_at(ENTRY)
+        special_day = resolve_special_day(DAY, "special_day")
+
+        assert name_from_catalogue(special_day, "Our own name for it", None) == (
+            "Our own name for it",
+            ENTRY["subtitle"],
+        )
+        assert name_from_catalogue(special_day, None, None) == (TITLE, ENTRY["subtitle"])
+
+
+class TestHowLongTheDayLasted:
+    """Length comes from the day's own evidence, and the evidence has a trap."""
+
+    def test_a_run_that_outlasted_the_calendar_day_is_not_read_as_24_hours(
+        self, catalogue_at
+    ) -> None:
+        # active_hours counts distinct hours touched, so it saturates at 24 --
+        # which a 45-hour run reaches before lunch on its second day. The
+        # recorded extent is the only reading that survives midnight.
+        catalogue_at(
+            {
+                **ENTRY,
+                "active_hours": 24,
+                "run_start": "2016-06-12T09:00:00+02:00",
+                "run_end": "2016-06-14T06:00:00+02:00",
+            }
+        )
+
+        special_day = resolve_special_day(DAY, "special_day")
+
+        assert special_day["active_hours"] == pytest.approx(45.0)
+
+    def test_a_day_with_no_recorded_extent_falls_back_to_the_hours_it_counted(
+        self, catalogue_at
+    ) -> None:
+        catalogue_at(ENTRY)
+
+        special_day = resolve_special_day(DAY, "special_day")
+
+        assert special_day["active_hours"] == pytest.approx(9.0)

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -54,6 +54,10 @@ class MemorySpec:
     trip_end: date | None = None
     location_name: str | None = None
     people: tuple[Person, ...] = ()
+    day: date | None = None
+    window: tuple[datetime, datetime] | None = None
+    title: str | None = None
+    active_hours: float | None = None
 
     def as_preset_params(self) -> dict:
         """The spec as the UI's ``memory_preset_params`` bag."""
@@ -69,8 +73,24 @@ class MemorySpec:
             "trip_start": self.trip_start,
             "trip_end": self.trip_end,
             "location_name": self.location_name,
+            **self.as_cli_preset_params(),
         }
         return {key: value for key, value in params.items() if value is not None}
+
+    def as_cli_preset_params(self) -> dict:
+        """What ``generate`` forwards to the preset factory, beside the flags.
+
+        Only a special day has inputs the CLI cannot spell as date flags: the
+        window and the title come out of the catalogue that ``--day`` names, so
+        they travel as preset parameters on both surfaces alike.
+        """
+        catalogued = {
+            "day": self.day,
+            "window": self.window,
+            "title": self.title,
+            "active_hours": self.active_hours,
+        }
+        return {key: value for key, value in catalogued.items() if value is not None}
 
 
 # The people a spec can name, as the wizard would have picked them.
@@ -94,19 +114,20 @@ SPECS: dict[MemoryType, MemorySpec] = {
         trip_end=date(2024, 7, 10),
         location_name="Rome",
     ),
+    # An invented day, as the docs' fixtures name them. The catalogue that
+    # feeds this on both surfaces names real people and places.
+    MemoryType.SPECIAL_DAY: MemorySpec(
+        day=date(2016, 6, 12),
+        window=(datetime(2016, 6, 12, 10, 20), datetime(2016, 6, 12, 19, 50)),
+        title="An afternoon at the track",
+        active_hours=12.0,
+    ),
 }
 
 # An album brings its own assets, so neither surface resolves a window for it:
 # --from-album on the CLI, the Album card in the wizard, and both take the span
 # from what the album holds. Registering a preset for it must fail this file.
 ALBUM_HAS_NO_PRESET = MemoryType.ALBUM
-
-# A special day now has one surface: the wizard's Surprise me card reads the
-# catalogue and hands the preset a day, a window and a title. The CLI has no
-# `--day` yet, and a MemorySpec is a request phrased for *both* surfaces, so
-# there is still nothing to compare. This exception goes when `generate --day`
-# lands, in the PR that adds it.
-SPECIAL_DAY_HAS_NO_SURFACE_YET = MemoryType.SPECIAL_DAY
 
 # --memory-type's choices, copied from cli/generate_options.py so a type added to the
 # registry and not to the flag is caught here rather than by a user.
@@ -121,6 +142,7 @@ CLI_MEMORY_TYPE_CHOICES = frozenset(
         "trip",
         "holiday",
         "then_and_now",
+        "special_day",
     }
 )
 
@@ -188,6 +210,7 @@ def _cli_resolution(memory_type: MemoryType, spec: MemorySpec) -> DateRange | li
         years_back=spec.years_back,
         on_this_day_target=spec.on_this_day_target,
         holiday=spec.holiday,
+        preset_params=spec.as_cli_preset_params() or None,
     )
 
 
@@ -205,7 +228,9 @@ def cli_duration(memory_type: MemoryType, spec: MemorySpec) -> float | None:
     resolved = _cli_resolution(memory_type, spec)
     if isinstance(resolved, list):
         resolved = DateRange(start=resolved[-1].start, end=resolved[0].end)
-    return default_duration_for_type(str(memory_type), resolved)
+    return default_duration_for_type(
+        str(memory_type), resolved, spec.as_cli_preset_params() or None
+    )
 
 
 def ui_windows(memory_type: MemoryType, spec: MemorySpec) -> list[tuple[datetime, datetime]]:
@@ -240,7 +265,7 @@ class TestRegistryCoverage:
     """A new memory type cannot ship without declaring what parity means for it."""
 
     def test_every_memory_type_has_parity_data(self) -> None:
-        declared = set(SPECS) | {ALBUM_HAS_NO_PRESET, SPECIAL_DAY_HAS_NO_SURFACE_YET}
+        declared = set(SPECS) | {ALBUM_HAS_NO_PRESET}
         missing = set(MemoryType) - declared
         assert not missing, (
             f"Memory types with no parity data: {sorted(str(m) for m in missing)}. "


### PR DESCRIPTION
`immich-memories generate --memory-type special_day --day 2016-06-12` renders one
day the catalogue found, scoped to the hours it actually happened in.

PR 4 of the surprise-me program. PR 3 (#695) built the memory type; this is the
way to reach it from a command line, and it is what PR 5's automation will shell
out to.

## The flag carries a date, not a title

The catalogue's `title` and `subtitle` are the point of the whole feature and
they name real people and places. `automation/runner.py` logs the whole argv
(`logger.info("Running: %s", " ".join(cmd))`), and argv is readable in `ps`, in
launchd's and systemd's logs, and in the attempt row.

So `--day` takes a **date** and the child process re-reads the catalogue for the
name. Nothing about a memory's content ever appears on a command line:

```
generate --memory-type special_day --day 2016-06-12
```

`resolve_special_day()` loads it through `automation/catalogue.py`'s shared
reader — the same `entries_from` the wizard's Surprise me card and `days-due`
use, never a private second parse. `test_generate_special_day.py` asserts the
built preset carries the catalogue's title when `--day` alone was passed, and
that the title is absent from the argv that produced it.

`--day` is **public, not hidden**: automation and a human type the same thing,
and somebody can regenerate what arrived overnight. That is also why this does
not follow the `--automation-target-date` pattern — no guard to extend, no
`memory_category == memory_type` triple-check, nothing hidden.

`--title` / `--subtitle` still win. `name_from_catalogue()` fills the gap and
does not argue, the same rule `resolve_short_form` already states one function
above it; precedence itself stays in `_llm_title.resolve_cli_title`, unchanged.

## Refuse over fake

Four ways to not get a video, all of them naming what to do next:

| Situation | What happens |
|---|---|
| `--memory-type special_day`, no `--day` | UsageError naming `--day`, beside `--season`'s and `--holiday`'s identical rule |
| `--day` on any other memory type | UsageError |
| a `--day` the catalogue never found | UsageError naming **the file it read** |
| a catalogued day with neither `title` nor `what` | UsageError — "nothing truthful to call the memory" |

No generic "Memories from 12 June 2016" card anywhere. A day the model could not
name is a day that should not be rendered.

## How long the day lasted

Length comes from the day's own evidence, and the evidence has a trap:
`active_hours` counts *distinct hours touched*, so it saturates at 24 — which a
45-hour activity run reaches before lunch on its second day (`_NIGHT_GAP_HOURS`
is 5, and the scan's own docstring cites a run that long).

Effective hours, computed at the call site rather than by changing the factory's
signature:

1. the window's span, when the catalogue recorded one;
2. otherwise `run_end - run_start`, when the extent was recorded;
3. otherwise `active_hours`.

Steps 2 and 3 are `automation/catalogue.hours_awake()`, next to the reader that
parses those fields; step 1 is the factory's existing rule, untouched. The
helper is public and lives in the shared module deliberately: the wizard's card
(#702) still passes raw `active_hours`, which only differs on a windowless day
with a recorded extent, and it can adopt `hours_awake` the next time that file
is opened rather than being dragged into this diff.

## The surface-parity exception is gone

#695 added `SPECIAL_DAY_HAS_NO_SURFACE_YET` to `tests/test_surface_parity.py`
with a comment saying it had to be deleted in the PR that adds `--day`. This is
that PR, so it is deleted and replaced with real parity data:

- `MemorySpec` gains `day` / `window` / `title` / `active_hours` and an
  `as_cli_preset_params()` — what `generate` forwards to the preset factory
  beside the flags, because a special day is the one type whose window and name
  cannot be spelled as date flags.
- `SPECS[SPECIAL_DAY]` is an invented windowed day, and `special_day` joins
  `CLI_MEMORY_TYPE_CHOICES`.
- Both surfaces resolve it through the same `build_special_day`, so the window
  and the 87-second target match exactly — no new `DOCUMENTED_DURATION_SPLIT`
  entry and no new xfail.

## Notes

- `resolve_date_range` / `_resolve_memory_type_dates` gain the same optional
  `preset_params` #695 gave `default_duration_for_type`, and `generate` now
  passes it to both. Additive; every existing call is byte-identical.
- `--day` uses `click.DateTime` with a `calendar_day` callback in `cli/_flags.py`
  that truncates to a `date`. A datetime never equals the date a catalogue entry
  is keyed by, and doing it at parse time keeps the truncation out of
  `register_generate_commands`, which the cognitive-complexity ratchet watches.
- Tests run `generate` through `CliRunner` and argv. The window assertions go
  one layer further and check the **`takenAfter`/`takenBefore` payload** rather
  than the `DateRange` — a window recorded at `+02:00` has to arrive as
  `11:45:00+00:00`, and the timezone round trip is the thing that can silently
  shift it.
- Fixture days are invented, in the style the docs already use. No catalogue
  content in the diff.
- `make ci` green; `make docs-cli-check` and `make docs-build` pass.

Part of the surprise-me program (#326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
