### PR TITLE
feat(auto): the library proposes the day, not just the calendar

### DIFF
--- a/docs-site/docs/create/cli/auto.md
+++ b/docs-site/docs/create/cli/auto.md
@@ -9,7 +9,7 @@ Scans your Immich library, detects what's worth turning into a memory video, and
 
 ## How selection works
 
-The system runs 8 detectors against your library, applies hard rotation rules, then scores the candidates that remain. The top eligible candidate gets generated.
+The system runs 9 detectors against your library, applies hard rotation rules, then scores the candidates that remain. The top eligible candidate gets generated.
 
 A suggestion list can look like this:
 
@@ -139,6 +139,25 @@ the floor is what the detector's own admission rules allow through.
 | **PersonSpotlightDetector** | Top 5 people by asset count | 0.12-0.6 | that person's share of the top person's asset count, floored at 0.2 |
 | **MultiPersonDetector** | Pairs who appear together frequently | 0.06-0.55 | estimated shared assets up to 500 (50 minimum to qualify) |
 | **OnThisDayDetector** | Dates with content across 5+ years | 0.18-0.35 | how many years the date has content in, up to 10 |
+| **SpecialDayDetector** | Catalogued days whose anniversary is within 3 days | 0.48-0.8 | roundness of the anniversary (decade / half-decade / other) |
+
+### The anniversary that would otherwise score lowest
+
+`SpecialDayDetector` reads the catalogue `discover-days` writes and proposes a day when its anniversary comes round. Base score 0.8, multiplied by how round the anniversary is: 1.0 for a decade, 0.85 for a half-decade, 0.6 for anything else.
+
+The scoring adjustments then land it where the ladder wants it. For a 200-photo day, never generated, with no same-type cooldown: never-generated ×1.2, recency ×1.0 (the anniversary is within 3 days by construction), richness ×(0.7 + 0.3 × log(200)/log(1000)) = ×0.930.
+
+| Anniversary | Roundness | Raw | Final |
+|---|---|---|---|
+| 10, 20, 30 years | 1.00 | 0.80 | **0.893** (`0.80 × 1.2 × 1.0 × 0.930`) |
+| 5, 15, 25 years | 0.85 | 0.68 | **0.759** (`0.68 × 1.2 × 1.0 × 0.930`) |
+| anything else | 0.60 | 0.48 | **0.536** (`0.48 × 1.2 × 1.0 × 0.930`) |
+
+Against the rest of the ladder — monthly 0.776, birthday 0.700, yearly 0.672, multi-person 0.514, trip 0.449, on-this-day 0.349 — a decade goes first, a half-decade sits between monthly and birthday, and a seventh anniversary competes rather than pre-empts.
+
+Recency is the reason this detector needs a rule of its own. The scorer decays a candidate from the end of what it covers, so a ten-year-old day would take the 0.5 floor: the memory most worth arriving would be punished hardest by a rule meant to prefer fresh content. `OnThisDayDetector` avoids that by reporting today as its date range and putting the real years in its reason, which makes `auto suggest` print a period the memory does not cover. A special day instead reports its real date and tells the scorer separately when it is timely, so what you see in the table is what gets generated.
+
+One per run, and the title never travels: automation passes `--day 2016-06-12` and the generate command re-reads the catalogue for the name, because argv is logged in full and readable in `ps`.
 
 ### Scoring adjustments
 
@@ -149,7 +168,7 @@ After detectors assign raw scores, the scorer applies:
 - **Recency**: recent content scores higher (linear decay over 365 days, floor 0.5x)
 - **Content richness**: more assets = higher score (log scale)
 - **Same-type cooldown**: 0.3x for 7 days, 0.7x for 30 days after generating the same type
-- **Per-type caps**: max 3 per type, except on_this_day (1) and multi_person (2)
+- **Per-type caps**: max 3 per type, except on_this_day (1), special_day (1), and multi_person (2)
 - **Dedup by memory key**: if two detectors propose the same memory, the higher-scoring one wins
 
 ## auto run

--- a/src/immich_memories/automation/candidate_discovery.py
+++ b/src/immich_memories/automation/candidate_discovery.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 
 from immich_memories.automation.candidate_scorer import score_and_rank
 from immich_memories.automation.candidates import MemoryCandidate
+from immich_memories.automation.catalogue import default_catalogue_path, entries_from
 from immich_memories.automation.failure_backoff import drop_backed_off
 from immich_memories.automation.state_store import FailureStreak
 from immich_memories.automation.trip_input_cache import load_or_fetch_trip_assets
@@ -97,6 +98,7 @@ def _build_last_runs_by_type(db: MemoryHistoryReader) -> dict[str, date]:
         "person_spotlight",
         "trip",
         "multi_person",
+        "special_day",
     ):
         run = db.get_last_run_of_type(mem_type, source="auto")
         if run and run.created_at:
@@ -129,6 +131,7 @@ def _run_all_detectors(
     today: date,
     person_asset_counts: dict[str, int],
     gps_assets: list | None,
+    catalogue: list | None,
 ) -> list[MemoryCandidate]:
     """Run all enabled detectors and collect candidates."""
     from immich_memories.automation.calendar_detectors import (
@@ -143,6 +146,7 @@ def _run_all_detectors(
         MultiPersonDetector,
         TripDetector,
     )
+    from immich_memories.automation.special_day_detector import SpecialDayDetector
 
     all_candidates: list[MemoryCandidate] = []
 
@@ -220,6 +224,17 @@ def _run_all_detectors(
             )
         )
 
+    all_candidates.extend(
+        SpecialDayDetector().detect(
+            assets_by_month,
+            people,
+            generated_keys,
+            config,
+            today,
+            catalogue=catalogue,
+        )
+    )
+
     return all_candidates
 
 
@@ -259,6 +274,9 @@ class CandidateDiscovery:
             today,
             snapshot.person_asset_counts,
             snapshot.gps_assets,
+            # Read here rather than in _LibrarySnapshot: that exists to bundle
+            # the live Immich reads into one session, and this is a local file.
+            entries_from(default_catalogue_path()),
         )
 
         all_candidates, backoff_skips = drop_backed_off(

--- a/src/immich_memories/automation/candidate_scorer.py
+++ b/src/immich_memories/automation/candidate_scorer.py
@@ -12,6 +12,7 @@ _MAX_PER_TYPE = 3
 _TYPE_CAPS = {
     "on_this_day": 1,  # At most 1 per run — can't verify day-level content quality
     "multi_person": 2,  # At most 2 pair suggestions per run
+    "special_day": 1,  # One surprise per run — a queue of them is not a surprise
 }
 
 
@@ -43,8 +44,14 @@ def _adjust_score(
     if candidate.memory_key not in generated_keys:
         score *= 1.2
 
-    # Recency: linear decay from date_range_end, floor 0.5
-    days_ago = (today - candidate.date_range_end).days
+    # Recency: linear decay from when the memory is timely, floor 0.5.
+    # For nearly every detector that is the end of what it covers. An
+    # anniversary is the exception: the content is ten years old and the
+    # arrival is today, and reading the content's age would penalise hardest
+    # exactly the memory most worth arriving. A detector that knows better
+    # says so in extra_params rather than lying about its date range.
+    timely_on = candidate.extra_params.get("recency_date") or candidate.date_range_end
+    days_ago = (today - timely_on).days
     score *= max(0.5, 1.0 - days_ago / 365.0)
 
     # Content richness: log-scaled, 30% weight

--- a/src/immich_memories/automation/candidates.py
+++ b/src/immich_memories/automation/candidates.py
@@ -19,6 +19,11 @@ class CandidateCategory(StrEnum):
     MULTI_PERSON = "multi_person"
     ON_THIS_DAY = "on_this_day"
     TRIP = "trip"
+    # Named for the family rather than for the catalogue: what makes this kind
+    # of proposal different is that the library volunteered it, not that it is
+    # a day. A recurring subject aggregated out of the analysis corpus is the
+    # same thing at another granularity and reads as this member's sibling.
+    EMERGENT_DAY = "emergent_day"
 
 
 @dataclass
@@ -42,11 +47,22 @@ def make_memory_key(
     date_range_start: date,
     date_range_end: date,
     person_names: list[str] | None = None,
+    discriminator: str | None = None,
 ) -> str:
     """Build a deterministic dedup fingerprint for a memory.
 
-    Format: {type}:{start}:{end}:{sorted,lowered,persons}
+    Format: {type}:{start}:{end}:{sorted,lowered,persons}[:{discriminator}]
     Same inputs always produce the same key, regardless of person order or case.
+
+    The discriminator is for a memory that is allowed to come back: the same
+    day proposed on its tenth anniversary and again on its fifteenth is two
+    memories, and without it the second could never fire. Keys already written
+    carry no discriminator and no trailing colon, so every one of them still
+    matches the run that wrote it.
     """
     persons = ",".join(sorted(n.lower() for n in (person_names or [])))
-    return f"{memory_type}:{date_range_start.isoformat()}:{date_range_end.isoformat()}:{persons}"
+    suffix = f":{discriminator}" if discriminator else ""
+    return (
+        f"{memory_type}:{date_range_start.isoformat()}:"
+        f"{date_range_end.isoformat()}:{persons}{suffix}"
+    )

--- a/src/immich_memories/automation/generation_request.py
+++ b/src/immich_memories/automation/generation_request.py
@@ -47,6 +47,8 @@ class GenerationRequest:
                 memory_type = "on_this_day"
             case CandidateCategory.TRIP:
                 memory_type = "trip"
+            case CandidateCategory.EMERGENT_DAY:
+                memory_type = "special_day"
             case _:
                 raise ValueError(f"Unsupported automation category: {candidate.category!r}")
 
@@ -97,6 +99,11 @@ class GenerationRequest:
                         self.end.isoformat(),
                     ]
                 )
+            case CandidateCategory.EMERGENT_DAY:
+                # A date, and nothing else. The child re-reads the catalogue for
+                # the day's name: this argv is logged in full and is readable in
+                # `ps`, and the catalogue's titles name real people and places.
+                argv.extend(["--day", self.start.isoformat()])
             case _:
                 raise ValueError(f"Unsupported automation category: {self.category!r}")
 

--- a/src/immich_memories/automation/special_day_detector.py
+++ b/src/immich_memories/automation/special_day_detector.py
@@ -1,0 +1,90 @@
+"""Proposing the days the catalogue already decided were worth something.
+
+The other detectors read the calendar or a bulk statistic. This one reads a
+judgement that was made in advance and written down, which is what makes the
+result feel unrequested rather than scheduled.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+from immich_memories.automation.candidates import (
+    CandidateCategory,
+    MemoryCandidate,
+    make_memory_key,
+)
+from immich_memories.automation.catalogue import hours_awake
+from immich_memories.automation.special_day_scan import anniversaries_due, same_day_in
+
+if TYPE_CHECKING:
+    from immich_memories.automation.special_day_scan import DiscoveredDay
+
+# Ten years reads louder than nine, and five louder than seven. The ladder is
+# what puts a decade above every other detector and leaves a seventh
+# anniversary competing rather than pre-empting.
+_DECADE = 1.00
+_HALF_DECADE = 0.85
+_ORDINARY = 0.60
+
+
+def _roundness(years: int) -> float:
+    if years % 10 == 0:
+        return _DECADE
+    return _HALF_DECADE if years % 5 == 0 else _ORDINARY
+
+
+class SpecialDayDetector:
+    """Propose a catalogued day when its anniversary comes round."""
+
+    BASE_SCORE = 0.8
+    WINDOW_DAYS = 3
+
+    def detect(
+        self,
+        assets_by_month: dict[str, int],
+        people: list[Any],
+        generated_keys: set[str],
+        config: Any,
+        today: date,
+        catalogue: list[DiscoveredDay] | None = None,
+    ) -> list[MemoryCandidate]:
+        """Emit one candidate per catalogued day with an anniversary near today."""
+        if not catalogue:
+            return []
+
+        candidates: list[MemoryCandidate] = []
+        for entry, years in anniversaries_due(catalogue, today, window_days=self.WINDOW_DAYS):
+            # Keyed by the anniversary as well as the day, so a day that got
+            # its memory at ten can still get one at fifteen.
+            key = make_memory_key("special_day", entry.day, entry.day, discriminator=f"{years}y")
+            if key in generated_keys:
+                continue
+            candidates.append(
+                MemoryCandidate(
+                    memory_type="special_day",
+                    category=CandidateCategory.EMERGENT_DAY,
+                    date_range_start=entry.day,
+                    date_range_end=entry.day,
+                    person_names=[],
+                    memory_key=key,
+                    score=self.BASE_SCORE * _roundness(years),
+                    # Evidence, never the title. This string reaches
+                    # `auto suggest --json`, the attempt row, and the
+                    # notification payload, and the title names real people.
+                    reason=(
+                        f"{years} years ago today · {entry.photos} photos "
+                        f"over {round(hours_awake(entry))} hours"
+                    ),
+                    asset_count=entry.photos,
+                    extra_params={
+                        # The dates above are the day itself, honestly. What is
+                        # timely is the anniversary, and the scorer is told so
+                        # here instead of being handed a doctored date range.
+                        "recency_date": same_day_in(entry.day, entry.day.year + years),
+                        "source": "special-days catalogue",
+                    },
+                )
+            )
+        return candidates

--- a/src/immich_memories/automation/special_day_scan.py
+++ b/src/immich_memories/automation/special_day_scan.py
@@ -238,7 +238,7 @@ def _thumbnails_for(items: list, thumbnail_for: Any) -> list[tuple[Any, bytes]]:
     return tiles
 
 
-def _same_day_in(day: date, year: int) -> date:
+def same_day_in(day: date, year: int) -> date:
     """The same calendar day in another year; 29 February falls back to the 28th."""
     try:
         return day.replace(year=year)
@@ -270,7 +270,7 @@ def anniversaries_due(
             years = year - entry.day.year
             if years < 1:
                 continue
-            if abs((_same_day_in(entry.day, year) - on).days) <= window_days:
+            if abs((same_day_in(entry.day, year) - on).days) <= window_days:
                 due.append((entry, years))
                 break
     return sorted(

--- a/src/immich_memories/cli/auto_cmd.py
+++ b/src/immich_memories/cli/auto_cmd.py
@@ -31,13 +31,19 @@ def _print_candidates_table(candidates: list) -> None:
         label = c.memory_type
         if c.person_names:
             label += f"\n({', '.join(c.person_names)})"
+        reason = c.reason
+        source = c.extra_params.get("source")
+        if source:
+            # A proposal that came from something other than the calendar has
+            # to say so, or its arrival reads as a coincidence.
+            reason += f"\nvia {source}"
         table.add_row(
             str(i),
             label,
             c.category.value,
             f"{c.date_range_start} to {c.date_range_end}",
             f"{c.score:.3f}",
-            c.reason,
+            reason,
             str(c.asset_count),
         )
 
@@ -55,6 +61,9 @@ def _candidates_to_json(candidates: list) -> str:
             "asset_count": c.asset_count,
             "person_names": c.person_names,
             "memory_key": c.memory_key,
+            # Always present, so a consumer never has to tell "the calendar
+            # proposed this" from "field missing".
+            "source": c.extra_params.get("source"),
         }
         for c in candidates
     ]

--- a/tests/test_special_day_detector.py
+++ b/tests/test_special_day_detector.py
@@ -1,0 +1,343 @@
+"""The catalogue's own days, proposed on their anniversaries.
+
+Every day here is invented. Real catalogue entries name real people and real
+places, and this file is public.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+from immich_memories.automation.candidate_discovery import _run_all_detectors
+from immich_memories.automation.candidate_scorer import score_and_rank
+from immich_memories.automation.candidates import (
+    CandidateCategory,
+    MemoryCandidate,
+    make_memory_key,
+)
+from immich_memories.automation.catalogue import entries_from
+from immich_memories.automation.generation_request import GenerationRequest
+from immich_memories.automation.special_day_detector import SpecialDayDetector
+from immich_memories.automation.special_day_scan import DiscoveredDay
+from immich_memories.cli.auto_cmd import _candidates_to_json, _print_candidates_table
+from immich_memories.config_models_automation import AutomationConfig
+
+
+def _a_day(
+    day: date,
+    *,
+    title: str = "A long evening out",
+    photos: int = 200,
+    active_hours: int = 8,
+    window: tuple[datetime, datetime] | None = None,
+) -> DiscoveredDay:
+    return DiscoveredDay(
+        day=day,
+        title=title,
+        subtitle="",
+        what="people were out late",
+        photos=photos,
+        window=window,
+        active_hours=active_hours,
+    )
+
+
+def _detect(catalogue: list[DiscoveredDay] | None, today: date):
+    return SpecialDayDetector().detect(
+        {},
+        [],
+        set(),
+        None,
+        today,
+        catalogue=catalogue,
+    )
+
+
+class TestAnniversaryTrigger:
+    def test_a_day_whose_anniversary_is_today_is_proposed(self):
+        candidates = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))
+
+        assert len(candidates) == 1
+        assert candidates[0].category is CandidateCategory.EMERGENT_DAY
+        assert candidates[0].memory_type == "special_day"
+
+    def test_a_day_four_months_away_is_not_proposed(self):
+        assert _detect([_a_day(date(2016, 6, 12))], date(2026, 2, 12)) == []
+
+
+def _final_score(day: date, today: date) -> float:
+    """What a 200-photo catalogued day is worth once the scorer has had it."""
+    ranked = score_and_rank(
+        _detect([_a_day(day, photos=200)], today),
+        generated_keys=set(),
+        today=today,
+        last_runs_by_type={},
+    )
+    return round(ranked[0].score, 3)
+
+
+class TestRoundnessLadder:
+    """A decade outranks a half-decade outranks an ordinary year (design 2.5)."""
+
+    def test_a_decade_scores_highest_of_all_detectors(self):
+        # Above the monthly review's 0.776, which is the whole product claim.
+        assert _final_score(date(2016, 6, 12), date(2026, 6, 12)) == 0.893
+
+    def test_a_half_decade_sits_between_monthly_and_birthday(self):
+        assert _final_score(date(2011, 6, 12), date(2026, 6, 12)) == 0.759
+
+    def test_an_ordinary_anniversary_sits_between_multi_person_and_trip(self):
+        assert _final_score(date(2019, 6, 12), date(2026, 6, 12)) == 0.536
+
+
+# One candidate per existing detector, and what the scorer paid it before
+# `recency_date` existed. Recorded by running origin/main's scorer, not by
+# re-deriving its formula here: a pin that recomputes the implementation
+# agrees with any change to it, which is the opposite of a pin.
+_PINNED_TODAY = date(2026, 8, 24)
+_PINNED_SCORES = {
+    "monthly_highlights:monthly_review": 0.7717730044828872,
+    "monthly_highlights:activity_burst": 0.6420805109650133,
+    "person_spotlight:birthday": 0.5005479452054794,
+    "year_in_review:year_in_review": 0.432,
+    "on_this_day:on_this_day": 0.3897076512400188,
+    "person_spotlight:person_spotlight": 0.36,
+    "trip:trip": 0.2241019891817383,
+    "multi_person:multi_person": 0.09899999999999999,
+}
+# category value -> (memory_type, start, end, raw detector score, assets)
+_PINNED_INPUTS = {
+    "monthly_review": ("monthly_highlights", "2026-07-01", "2026-07-31", 0.70, 683),
+    "activity_burst": ("monthly_highlights", "2026-05-01", "2026-05-31", 0.70, 921),
+    "year_in_review": ("year_in_review", "2025-01-01", "2025-12-31", 0.72, 13151),
+    "person_spotlight": ("person_spotlight", "2025-01-01", "2025-12-31", 0.60, 16464),
+    "birthday": ("person_spotlight", "2026-01-01", "2026-03-15", 0.75, 4210),
+    "multi_person": ("multi_person", "2025-01-01", "2025-12-31", 0.55, 2564),
+    "on_this_day": ("on_this_day", "2026-08-24", "2026-08-24", 0.35, 190),
+    "trip": ("trip", "2025-07-26", "2025-08-10", 0.449, 960),
+}
+
+
+class TestExistingDetectorsAreUntouched:
+    def test_a_candidate_without_a_recency_date_scores_exactly_as_before(self):
+        """The eight detectors that never heard of `recency_date` must not move."""
+        candidates = [
+            MemoryCandidate(
+                memory_type=memory_type,
+                category=CandidateCategory(detector),
+                date_range_start=date.fromisoformat(start),
+                date_range_end=date.fromisoformat(end),
+                person_names=[],
+                memory_key=f"{memory_type}:{detector}",
+                score=raw,
+                reason="r",
+                asset_count=assets,
+            )
+            for detector, (memory_type, start, end, raw, assets) in _PINNED_INPUTS.items()
+        ]
+
+        ranked = score_and_rank(
+            candidates,
+            generated_keys={"trip:trip"},
+            today=_PINNED_TODAY,
+            last_runs_by_type={"multi_person": date(2026, 8, 20)},
+        )
+
+        assert {c.memory_key: c.score for c in ranked} == _PINNED_SCORES
+
+
+class TestMemoryKeyFormat:
+    """`generated_keys` is durable history: a key that changes shape un-dedups it."""
+
+    def test_a_key_without_a_discriminator_is_unchanged(self):
+        assert (
+            make_memory_key("monthly_highlights", date(2026, 7, 1), date(2026, 7, 31))
+            == "monthly_highlights:2026-07-01:2026-07-31:"
+        )
+        assert (
+            make_memory_key(
+                "person_spotlight", date(2025, 1, 1), date(2025, 12, 31), ["Bea", "alex"]
+            )
+            == "person_spotlight:2025-01-01:2025-12-31:alex,bea"
+        )
+
+    def test_a_discriminator_appends_exactly_one_segment(self):
+        assert (
+            make_memory_key(
+                "special_day", date(2016, 6, 12), date(2016, 6, 12), discriminator="10y"
+            )
+            == "special_day:2016-06-12:2016-06-12::10y"
+        )
+
+    def test_a_day_can_come_back_on_a_later_round_anniversary(self):
+        """Ten years and fifteen years are two memories, not one already spent."""
+        at_ten = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+        at_fifteen = _detect([_a_day(date(2016, 6, 12))], date(2031, 6, 12))[0]
+
+        assert at_ten.memory_key != at_fifteen.memory_key
+        assert _detect([_a_day(date(2016, 6, 12))], date(2031, 6, 12)) != []
+        assert (
+            SpecialDayDetector().detect(
+                {},
+                [],
+                {at_ten.memory_key},
+                None,
+                date(2026, 6, 12),
+                catalogue=[_a_day(date(2016, 6, 12))],
+            )
+            == []
+        )
+
+
+class TestGenerationRequest:
+    def test_an_emergent_day_generates_a_special_day_from_its_date(self):
+        candidate = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+
+        argv = GenerationRequest.from_candidate(candidate, upload=False).to_argv()
+
+        assert argv[argv.index("--memory-type") + 1] == "special_day"
+        assert argv[argv.index("--day") + 1] == "2016-06-12"
+
+    def test_the_catalogue_title_never_reaches_the_command_line(self):
+        """argv is readable in `ps` and in launchd's logs; the title names people."""
+        title = "A long evening out"
+        candidate = _detect([_a_day(date(2016, 6, 12), title=title)], date(2026, 6, 12))[0]
+
+        rendered = " ".join(GenerationRequest.from_candidate(candidate, upload=False).to_argv())
+
+        assert title not in rendered
+        assert "evening" not in rendered
+        assert "people were out late" not in rendered
+
+
+class TestOneSurprisePerRun:
+    def test_two_due_days_leave_one_candidate(self):
+        """A night gets one unrequested memory, and it is the rounder one."""
+        today = date(2026, 6, 12)
+        catalogue = [
+            _a_day(date(2019, 6, 11), title="A morning at the lake"),
+            _a_day(date(2016, 6, 13), title="The day the kitchen flooded"),
+        ]
+
+        ranked = score_and_rank(
+            _detect(catalogue, today),
+            generated_keys=set(),
+            today=today,
+            last_runs_by_type={},
+        )
+
+        assert len(ranked) == 1
+        assert ranked[0].date_range_start == date(2016, 6, 13)
+
+
+class TestNoCatalogue:
+    """Nobody has to run a twenty-year scan for the other eight to work."""
+
+    def test_no_catalogue_at_all_yields_nothing(self):
+        assert _detect(None, date(2026, 6, 12)) == []
+
+    def test_an_empty_catalogue_yields_nothing(self):
+        assert _detect([], date(2026, 6, 12)) == []
+
+    def test_an_unreadable_file_reads_as_an_empty_catalogue(self, tmp_path):
+        unreadable = tmp_path / "special-days.json"
+        unreadable.write_text("{ this was half-written when the scan was killed")
+
+        assert entries_from(unreadable) == []
+        assert _detect(entries_from(unreadable), date(2026, 6, 12)) == []
+
+    def test_discovery_still_runs_the_other_detectors(self):
+        """A missing catalogue costs the emergent day and nothing else."""
+        # WHY: Config is a large pydantic tree the detectors only read flags off;
+        # the other eight detectors in this call are the real subject.
+        config = MagicMock()
+        today = date(2026, 8, 24)
+
+        def run(catalogue):
+            return _run_all_detectors(
+                AutomationConfig(),
+                {"2026-07": 683},
+                [],
+                set(),
+                config,
+                today,
+                {},
+                None,
+                catalogue,
+            )
+
+        without = run(None)
+        with_a_due_day = run([_a_day(date(2016, 8, 24))])
+
+        assert [c.category for c in without] != []
+        assert [c.category for c in with_a_due_day] == [
+            *[c.category for c in without],
+            CandidateCategory.EMERGENT_DAY,
+        ]
+
+
+class TestWhereItCameFrom:
+    """A proposal has to say what volunteered it, or it reads as a coincidence."""
+
+    def test_the_candidate_names_its_source(self):
+        candidate = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+
+        assert candidate.extra_params["source"] == "special-days catalogue"
+
+    def test_suggest_renders_the_source_in_json(self):
+        candidate = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+
+        rows = json.loads(_candidates_to_json([candidate]))
+
+        assert rows[0]["source"] == "special-days catalogue"
+
+    def test_suggest_renders_the_source_in_the_table(self, capsys):
+        candidate = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+
+        _print_candidates_table([candidate])
+
+        # Rich wraps the cell to the terminal, so "special-days" can arrive
+        # hyphenated; "catalogue" is the word that survives any width.
+        assert "catalogue" in capsys.readouterr().out
+
+    def test_a_candidate_with_no_source_renders_a_null_not_a_missing_key(self):
+        rows = json.loads(
+            _candidates_to_json(
+                [
+                    MemoryCandidate(
+                        memory_type="trip",
+                        category=CandidateCategory.TRIP,
+                        date_range_start=date(2025, 7, 26),
+                        date_range_end=date(2025, 8, 10),
+                        person_names=[],
+                        memory_key="trip:x",
+                        score=0.4,
+                        reason="16-day trip",
+                        asset_count=960,
+                    )
+                ]
+            )
+        )
+
+        assert rows[0]["source"] is None
+
+
+class TestEvidenceNotTitle:
+    def test_the_reason_is_evidence_and_never_the_catalogue_title(self):
+        """`reason` reaches suggest --json, the attempt row, and notifications."""
+        title = "The day the kitchen flooded"
+        candidate = _detect(
+            [_a_day(date(2016, 6, 12), title=title, photos=289, active_hours=18)],
+            date(2026, 6, 12),
+        )[0]
+
+        assert candidate.reason == "10 years ago today · 289 photos over 18 hours"
+        assert title not in candidate.reason
+
+    def test_no_real_name_enters_durable_run_history(self):
+        """person_names lands in RunMetadata.memory_people, which is kept."""
+        candidate = _detect([_a_day(date(2016, 6, 12))], date(2026, 6, 12))[0]
+
+        assert candidate.person_names == []


### PR DESCRIPTION
Automation gains a ninth detector. The other eight read the calendar (this month, last year, your birthday) or a bulk statistic (asset counts, GPS clusters). `SpecialDayDetector` reads the special-days catalogue — the only source where a judgement about *what happened* was made in advance and stored — and proposes a day when its anniversary comes round.

Part of the surprise-me program (#326).

## The recency problem, and why this does not copy OnThisDay

`_adjust_score` decays a candidate from the end of what it covers:

```python
days_ago = (today - candidate.date_range_end).days
score *= max(0.5, 1.0 - days_ago / 365.0)
```

A ten-year anniversary is 3,650 days old, so it takes the 0.5 floor. The memory *most* worth arriving is penalised hardest by a rule meant to prefer fresh content.

`OnThisDayDetector` dodges this by lying about its dates: it sets `date_range_start = date_range_end = today` and puts the real year span in `reason`. `days_ago = 0`, recency `1.0`. The cost is that `auto suggest` and `runs` print a period that is not what the memory covers.

This PR does not copy that. The candidate reports its **real** date, and says separately when it is timely:

```python
timely_on = candidate.extra_params.get("recency_date") or candidate.date_range_end
days_ago = (today - timely_on).days
```

Three lines. Every existing detector omits the key and is byte-identical — **regression-pinned** against `origin/main`'s own numbers, one candidate per detector, exercising the never-generated boost, the recency floor, saturated richness, and the 7-day cooldown. The pin was verified to have teeth: replacing the line with the plausible-looking `extra_params.get("recency_date", today)` fails it.

The special-day candidate carries:

- `date_range_start = date_range_end = the source day` — honest, printable, and what `--day` is built from
- `extra_params["recency_date"] = the anniversary` — when it is timely
- `extra_params["source"] = "special-days catalogue"` — rendered by `auto suggest` in both the table and `--json`

This is also the shape a theme would need (`recency_date` = when a subject last appeared), which is why the fix is about *timeliness* rather than about dates of content.

## Where it lands on the ladder

`BASE_SCORE = 0.8` × roundness. For a 200-photo day, never generated, no cooldown: never-generated ×1.2 → recency ×1.0 (the anniversary is within 3 days by construction) → richness ×0.930.

| Anniversary | Roundness | Raw | Final |
|---|---|---|---|
| 10, 20, 30 years | 1.00 | 0.80 | **0.893** |
| 5, 15, 25 years | 0.85 | 0.68 | **0.759** |
| anything else | 0.60 | 0.48 | **0.536** |

Against the real ladder — monthly 0.776, birthday 0.700, yearly 0.672, multi-person 0.514, trip 0.449, on-this-day 0.349:

- a **decade** goes first, which is the product claim
- a **half-decade** sits between monthly and birthday: it arrives, but a fresher month can still beat it
- **anything else** sits between multi-person and trip, so a seventh anniversary competes rather than pre-empts

`_TYPE_CAPS["special_day"] = 1` — one surprise per run, the same reasoning that capped `on_this_day`. `_build_last_runs_by_type` gains `"special_day"` so the same-type cooldown actually fires. Variety rules apply for free, since they are written against `candidate.category`.

## Recurrence

`make_memory_key("special_day", day, day)` is stable forever, so a day would get a memory once, ever, and its fifteenth anniversary could never fire. `make_memory_key` gains an optional trailing `discriminator`, and the detector passes `f"{years}y"`.

Keys already written carry no discriminator and no trailing colon, so every one of them still matches the run that wrote it. Format-pinned in both directions: without a discriminator, byte-identical to today's output; with one, exactly one appended segment.

## The privacy contract

The catalogue's titles name real people and places, and `runner.py` logs the full argv — readable in `ps` and in launchd's logs.

- **Titles never travel on argv.** `to_argv` emits `--day 2016-06-12` and nothing else; the child re-reads the catalogue for the name (#706). Asserted as an *absence*: the fixture's title, a word from it, and its `what` text must all be missing from the rendered command line.
- **`reason` is evidence, never the title** — `"10 years ago today · 289 photos over 18 hours"`. It reaches `auto suggest --json`, the attempt row, and notification payloads.
- **`person_names` stays empty**, so no real name enters `RunMetadata.memory_people`, which is durable history. Cost: a memory of an occasion does not block a spotlight of the same person the next night. That is the right trade — variety is about shape, and these are different shapes.
- Every fixture day in the test file is **invented** ("A long evening out", "A morning at the lake", "The day the kitchen flooded").

## Robustness

An absent, empty, or unreadable catalogue yields `[]` and does not fail discovery — asserted by running `_run_all_detectors` with and without a catalogue and comparing the category lists. The catalogue is loaded in `discover()` rather than in `_LibrarySnapshot`, which exists to bundle the live Immich reads into one session; this is a local file.

## Tests

22 tests in `tests/test_special_day_detector.py`, written RED-first in the design's order: the anniversary trigger, the score ladder, the eight-detector regression pin, the key format pin, recurrence, the `GenerationRequest` mapping plus the privacy assertion, the type cap, the no-catalogue paths, and the source rendering.

`make ci` green (5799 passed), `make critique` clean, `make docs-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
