### PR TITLE
docs(pipeline): the curator is the product, so document it first

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@
 
 **Cuts your [Immich](https://immich.app/) library into edited memory videos: title screens, music, and only the good five seconds of each clip.**
 
-It connects to your self-hosted Immich server, scores every video and photo, and assembles the keepers into a real edit: a year in review, a trip with its map, one person across the years.
+It connects to your self-hosted Immich server and runs a real editor over your library: a vision
+model looks at the material and describes what is happening, selection and review judge those
+descriptions, and the keepers become a real edit — a year in review, a trip with its map, one
+person across the years. Always chronological, favourites treated as law, and when it can't name
+a day honestly it refuses rather than faking it. How it decides is documented in
+[The Curator](https://sam-dumont.github.io/immich-video-memory-generator/docs/create/pipeline/the-curator).
 
 > **Full documentation**: [sam-dumont.github.io/immich-video-memory-generator](https://sam-dumont.github.io/immich-video-memory-generator/)
 

--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -5,7 +5,7 @@ title: Clip Selection & Scoring
 
 # Clip Selection & Scoring
 
-The whole point of a memory video is picking the *good* parts. Nobody wants to watch 30 seconds of your pocket recording a sidewalk. The pipeline scores every segment across multiple factors, then picks the winners.
+The whole point of a memory video is picking the *good* parts. Nobody wants to watch 30 seconds of your pocket recording a sidewalk. This page documents the arithmetic — budgets, weights, caps. The judgment those numbers serve — what the model looks at, how the cut is reviewed, and the rules it obeys — is in [The Curator](the-curator).
 
 ## The Density Budget
 

--- a/docs-site/docs/create/pipeline/the-curator.md
+++ b/docs-site/docs/create/pipeline/the-curator.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 0.5
+title: The Curator
+---
+
+# The Curator
+
+Every photo app has an automatic memories feature, and they all work the same
+way: rank the pixels — sharpness, faces, smiles — pick the winners, add music.
+The result is a highlight reel. Technically fine, emotionally random, and
+after the third one you stop watching them.
+
+This pipeline is built on a different premise: **selection is an editing job,
+not a ranking job.** Before anything is scored, a vision model looks at your
+material and describes what is actually happening in it. Every decision after
+that — what makes the cut, what counts as a duplicate, what the title is
+allowed to claim — is made against those descriptions, not against pixel
+statistics. This page explains how that works and the rules it follows. It is
+the core of the product; everything else is delivery.
+
+## It looks before it picks
+
+Candidates are grouped into **moments** — photos and clips taken together —
+and the model looks at one representative per moment rather than a fixed
+handful of metadata winners. Before this worked properly, a month with 295
+photos would get exactly 3 of them in front of the model, chosen by metadata,
+so the model could only confirm what the metadata already decided. Now the
+looking is sized by how many moments the month actually contains.
+
+Two properties of the looking:
+
+- **A favourite fronts its moment.** If you flagged a photo in Immich, it is
+  the one the model sees for that moment. Your flag is the strongest signal in
+  the library — the pipeline treats it as your judgment already made, not as
+  one weight among many.
+- **Every look is paid once, ever.** Descriptions are cached per asset. The
+  first run over a library is the slow one; every later memory reuses what is
+  already known. See [LLM Content Analysis](llm-content-analysis) for the
+  model setup.
+
+## It judges what things show, not how they look
+
+Descriptions do the discriminating work that scores can't:
+
+- **Duplicates are judged on content.** Two clips of the same cake, eight
+  minutes apart, are one moment — keep the better one. Two toasts at the same
+  party are two moments. Perceptual hashing can't tell these apart; a sentence
+  about each can.
+- **The final review sees the whole cut.** After selection, the model reads
+  the full set and removes what weakens it, with a stated reason per drop.
+  These are real reasons from real runs — one clip went because it
+  *"records an object rather than a moment."* That is an editor's sentence,
+  and it is the level the review works at.
+- **Nothing fails silently.** If the reviewer is unreachable, the run says so
+  loudly instead of quietly shipping an unreviewed cut, and every run prints
+  how much of the candidate pool was actually looked at — so "the model chose"
+  and "the model never saw it" are never confused.
+
+## The rules
+
+These are constraints the pipeline obeys, not preferences it weighs.
+
+**Always chronological.** A memory plays in the order things happened. No
+model may resequence a cut for drama: chronology is the one thing you can
+check against your own recollection, and a reordered memory is subtly a lie
+about the day. The editorial decisions are what to include and how long to
+dwell — never when.
+
+**Favourites win their moment.** Where you have flagged a photo, the pipeline
+does not overrule you with a score.
+
+**Titles claim only what the evidence shows.** A title is generated from what
+the model actually saw and is not allowed to invent specifics. If the material
+can't support a claim, the title doesn't make it.
+
+**Refuse over fake.** A day the model could not name does not get a generic
+"Memories of June 12th" card — it doesn't render. An empty special-days
+catalogue produces instructions for building one, not an invented occasion.
+When the honest option and the impressive option differ, the pipeline takes
+the honest one.
+
+**Emergent, not queried.** Nothing searches your library for "beach" or "dog".
+The [special days catalogue](../cli/discover-days) is built by looking at what
+your days actually contain and asking whether anything happened — which is how
+it finds the day that mattered with 30 photos, not just the day with 300.
+
+## The craft you don't see
+
+Cuts land on musical beats. Speech is never cut mid-sentence — voice-activity
+detection moved mid-speech cuts from 34% of clips to 9%, measured on real
+libraries. HDR footage stays HDR end to end. A monthly memory opens with a
+month title, a yearly gets month dividers, a single day gets one intro card —
+because those are different shapes of story.
+
+## Where this is heading
+
+The current work — visible in the open issues — is event-level understanding:
+the model reads a whole moment as one contact sheet, names the event, and
+ranks photos by how well they show *that* rather than by generic priors like
+"has a face". The goal is stated in one line: curation based on moment →
+entirety. Follow along in
+[#707](https://github.com/sam-dumont/immich-video-memory-generator/issues/707).
+
+## The mechanics
+
+The arithmetic that serves these judgments — budgets, weights, and caps — is
+documented in [Clip Selection & Scoring](clip-selection-scoring), and the
+runtime cost of every stage in the
+[Pipeline Overview](pipeline-overview).

--- a/docs-site/docs/welcome/overview.mdx
+++ b/docs-site/docs/welcome/overview.mdx
@@ -19,7 +19,9 @@ You point it at your Immich instance, pick a time period (or a person, or a trip
 
 A polished memory video with:
 
-- **Cuts that earn their place**: clips scored on visual interest, motion, faces, and audio
+- **Cuts that earn their place**: a vision model describes what is happening in your material,
+  and selection, duplicate judgment, and a whole-cut review all work from those descriptions —
+  see [The Curator](create/pipeline/the-curator) for how it decides
 - **Animated satellite map** flying from home to your destination (for trip memories)
 - **AI-generated title** that actually describes the trip: "Sous les falaises de grès" instead of "TWO WEEKS IN GERMANY"
 - **AI music** that matches the mood of your clips (ACE-Step or MusicGen)

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -120,14 +120,14 @@ type ShowcaseItem = {
 
 const showcaseItems: ShowcaseItem[] = [
   {
-    title: '10 memory types',
-    description: 'Year in Review, Season, Person Spotlight, Multi-Person, Monthly Highlights, On This Day, Holiday, Then and Now, Trip, Album. Pick a preset and it handles the rest, or take the eleventh card, Custom, and set the date range yourself.',
+    title: '11 memory types',
+    description: 'Year in Review, Season, Person Spotlight, Multi-Person, Monthly Highlights, On This Day, Holiday, Then and Now, Trip, Album, and Surprise Me — a day your library says something happened on. Pick a preset and it handles the rest, or take the Custom card and set the date range yourself.',
     image: '/img/screenshots/step1-preset-cards.png',
     alt: 'Memory type preset selection cards',
   },
   {
-    title: 'AI-scored clip selection',
-    description: 'Scene detection, face recognition, motion analysis, and optional LLM scoring pick the moments worth keeping. Duplicates are filtered automatically.',
+    title: 'A curator, not a filter',
+    description: 'A vision model looks at your material and describes what is happening in it. Selection, duplicate judgment, and a final review of the whole cut all work from those descriptions — with real drop reasons, favourites treated as law, and strictly chronological order. The pipeline is the product.',
     image: '/img/screenshots/step2-refine-moments.png',
     alt: 'Clip review grid with scored video segments',
   },


### PR DESCRIPTION
Owner directive: the pipeline's intelligence is the core of the product and must be documented that way — "not just a sideshow but a real meaningful editor and curator."

## What was wrong

The landing page called the core **"optional LLM scoring"** — one feature bullet among four. `clip-selection-scoring.md` leads with quota arithmetic and weight tables. Nowhere did the docs tell the story that actually differentiates this from every other auto-memories feature: it looks, describes, judges, reviews the whole cut, and refuses to fake.

## What this adds

**New flagship page `create/pipeline/the-curator.md`** (sidebar position 0.5, right after the overview): the selection story as shipped —
- it looks before it picks (moments, one look per moment, favourites front their moment, cached forever)
- it judges what things show (content dedup, the whole-cut review with real drop reasons — "records an object rather than a moment" — loud fail-open, the coverage banner)
- the rules: **always chronological · favourites win their moment · grounded titles · refuse over fake · emergent, not queried**
- the invisible craft (speech boundaries 34%→9% measured, beat-aligned cuts, HDR end to end)
- one honest "where this is heading" paragraph pointing at #707 — shipped behavior only, no aspirations documented as features

**Surfacing:** the landing page's selection item is now "A curator, not a filter" (and the memory-type count is corrected to eleven, including Surprise Me); the README's third paragraph now says what the editor does and links the page; the welcome overview's first bullet leads with it; `clip-selection-scoring.md` opens by pointing at the judgment its arithmetic serves.

Every claim on the new page is shipped behavior on main as of today (#705, #693, #637, #673, #672, #702/#706). `make docs-build` green; docs contract suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f