### PR TITLE
test(auto): suggest tests stop reading this machine's real catalogue

### DIFF
--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -33,6 +33,20 @@ from immich_memories.config_loader import Config
 from immich_memories.tracking.models import RunMetadata
 
 
+@pytest.fixture(autouse=True)
+def _no_machine_catalogue(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point discovery at an absent catalogue instead of this machine's real one.
+
+    discover() reads the special-days catalogue from the user's home; on a
+    developer machine that file holds real discovered days, and these tests
+    would count candidates that CI never sees.
+    """
+    monkeypatch.setattr(
+        "immich_memories.automation.candidate_discovery.default_catalogue_path",
+        lambda: tmp_path / "no-catalogue.json",
+    )
+
+
 @pytest.fixture
 def config(tmp_path: Path) -> Config:
     """Create a Config with a temp database and Immich credentials."""


### PR DESCRIPTION
Main is red on any machine that has a real special-days catalogue at the default path — which every machine that has ever run `discover-days` now does. Two `TestSuggestReturnsCandidates` tests count candidates from the machine's own catalogue: real discovered days join the suggestion pool and break the variety-history and rejection-preservation assertions. CI never sees it because runners have no catalogue — the exact inverse of the known config-less-CI trap.

Repro: the two tests fail with real $HOME, pass with `HOME=$(mktemp -d)`.

Fix: an autouse fixture in `test_auto_runner.py` points `default_catalogue_path` at an absent file, so the suite is hermetic on every machine. CI behavior unchanged. Full suite: 69/69 locally with a populated real catalogue present; adjacent suites (auto_status, special_day_detector, cli_smoke) green.

Introduced by #709 (the detector reads the default catalogue in `discover()`), surfaced by the first real catalogue build tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f