### PR TITLE
fix(selection): one wide sheet per moment, and never one of foreign media

### DIFF
--- a/src/immich_memories/analysis/moment_grouping.py
+++ b/src/immich_memories/analysis/moment_grouping.py
@@ -1,4 +1,12 @@
-"""Group assets into moments by time AND place.
+"""Group assets into moments by time AND place, foreign media already gone.
+
+`moments_to_read` is the only way in. Grouping itself is private because a
+reader that reaches the raw function skips the source filter, and received
+media — forwarded messages, screenshots, memes — is often the most striking
+thing in an episode. A period read without the filter reported a wedding and a
+chihuahua-versus-muffin meme as its remarkable days. Anything genuinely needing
+unfiltered grouping imports the private name and owns that decision.
+
 
 A day is not a timeline. Measured on a real day: a racing circuit at 16:37,
 a house 120km away at 16:49, the circuit again at 18:05. Not one person moving
@@ -76,7 +84,7 @@ def _belongs_with(asset: Any, moment: list[Any], window_minutes: float, radius: 
     return True
 
 
-def moments_by_time_and_place(
+def _group_by_time_and_place(
     assets: list[Any],
     window_minutes: float = MOMENT_WINDOW_MINUTES,
     radius_metres: float = MOMENT_RADIUS_METRES,
@@ -102,3 +110,29 @@ def moments_by_time_and_place(
         else:
             moments.append([asset])
     return moments
+
+
+def moments_to_read(
+    assets: list[Any],
+    config: Any,
+    window_minutes: float = EPISODE_WINDOW_MINUTES,
+    radius_metres: float = MOMENT_RADIUS_METRES,
+) -> list[list[Any]]:
+    """Assets grouped for reading, with foreign media dropped before tiling.
+
+    Received media is often the most striking thing in an episode. A period
+    read from unfiltered sheets reported a wedding, a fresh tattoo and a grid
+    comparing chihuahuas to muffins as its remarkable days; they were forwarded
+    messages, screenshots and a meme. Nothing about them was photographed here.
+
+    source_filter already says where this belongs — gone "before it is sampled
+    into a prompt" — so it sits at the one door into grouping-for-reading, and
+    every reader downstream inherits it rather than remembering to ask.
+    """
+    from immich_memories.analysis.source_filter import from_the_camera_roll
+
+    return _group_by_time_and_place(
+        from_the_camera_roll(assets, config),
+        window_minutes=window_minutes,
+        radius_metres=radius_metres,
+    )

--- a/src/immich_memories/analysis/moment_reading.py
+++ b/src/immich_memories/analysis/moment_reading.py
@@ -14,6 +14,8 @@ real day, 215 photographs read in 14 calls and 22 seconds, against roughly
 from __future__ import annotations
 
 import json
+import math
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -23,17 +25,27 @@ if TYPE_CHECKING:
 
     from immich_memories.config_models_llm import LLMConfig
 
-# How many photographs go on one sheet. Sixteen tiles at 400px is a 1600x1600
-# image the model reads reliably; denser sheets lose the detail the reading
-# depends on.
-SHEET_TILES = 16
+# A moment goes on ONE sheet. Split across several, each sheet answers about
+# its own third of an event and the first answer wins by accident: measured on
+# a 37-photograph episode, sheet one said "cyclists and cars at a race track"
+# while later sheets named the circuit and the car.
+#
+# Past this many photographs a single sheet is postage stamps, so a very large
+# moment is split rather than shrunk to nothing.
+MAX_SHEET_TILES = 120
 
-# Tile size and sheet width. 400px across four columns is a 1600px sheet: big
-# enough that a car's model or a race number survives the downscale, small
-# enough that a full sheet stays a few hundred KB of base64.
-_TILE = 400
-_COLUMNS = 4
-_LABEL_BOX = (36, 24)
+# How wide a sheet may be before the encoder downscales it and tiles lose the
+# detail the reading depends on.
+MAX_SHEET_PX = 2100
+
+# Sheets are laid out WIDE, never tall. The same 37 photographs at 1920x2240
+# read worse than at 2080x1300 with SMALLER tiles — the tall sheet described
+# less and its shortlist collapsed to "keep all 37". A tall image is
+# downscaled harder before the model ever sees it, so shape matters more than
+# how big each tile is.
+_TARGET_ASPECT = 1.6
+_MAX_TILE = 400
+_MIN_TILE = 120
 _SHEET_BACKGROUND = (18, 18, 18)
 
 T = TypeVar("T")
@@ -48,7 +60,17 @@ class SheetReading:
     keep: tuple[int, ...]
 
 
-def sheets_of(items: list[T], per_sheet: int = SHEET_TILES) -> list[list[tuple[int, T]]]:
+def sheet_layout(count: int) -> tuple[int, int]:
+    """Columns and tile size for one wide sheet of `count` photographs."""
+    columns = max(1, round(math.sqrt(count * _TARGET_ASPECT)))
+    tile = min(_MAX_TILE, MAX_SHEET_PX // columns)
+    rows = -(-count // columns)
+    if rows * tile > MAX_SHEET_PX * 1.2:
+        tile = int(MAX_SHEET_PX * 1.2) // rows
+    return columns, max(_MIN_TILE, tile)
+
+
+def sheets_of(items: list[T], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, T]]]:
     """Cut a moment into sheets, numbering tiles across the whole moment.
 
     The model answers in tile numbers, so numbering has to run across the
@@ -135,21 +157,24 @@ def tile_sheet(frames: list[tuple[int, Image | None]]) -> Image | None:
 
     if not frames:
         return None
-    rows = (len(frames) + _COLUMNS - 1) // _COLUMNS
-    sheet = Image.new("RGB", (_COLUMNS * _TILE, rows * _TILE), _SHEET_BACKGROUND)
+    columns, tile = sheet_layout(len(frames))
+    rows = -(-len(frames) // columns)
+    sheet = Image.new("RGB", (columns * tile, rows * tile), _SHEET_BACKGROUND)
     draw = ImageDraw.Draw(sheet)
+    label = max(16, tile // 11)
     for position, (number, frame) in enumerate(frames):
-        left = (position % _COLUMNS) * _TILE
-        top = (position // _COLUMNS) * _TILE
+        left = (position % columns) * tile
+        top = (position // columns) * tile
         if frame is not None:
             thumbnail = frame.copy()
-            thumbnail.thumbnail((_TILE - 8, _TILE - 8))
-            sheet.paste(thumbnail, (left + 4, top + 4))
+            thumbnail.thumbnail((tile - 6, tile - 6))
+            sheet.paste(thumbnail, (left + 3, top + 3))
+        text = str(number)
         draw.rectangle(
-            [left + 4, top + 4, left + 4 + _LABEL_BOX[0], top + 4 + _LABEL_BOX[1]],
+            [left + 3, top + 3, left + 3 + label * (0.6 * len(text) + 0.8), top + 3 + label],
             fill=(0, 0, 0),
         )
-        draw.text((left + 10, top + 9), str(number), fill=(255, 255, 255))
+        draw.text((left + 7, top + 5), text, fill=(255, 255, 255))
     return sheet
 
 
@@ -218,7 +243,9 @@ SHEET_PROMPT = """These numbered photographs were taken close together in time.
    photographs show.
 
    Read what is there, including words: a number on a bib, branding on a
-   banner, the model of a car. WHO is in each photograph is given below, and
+   banner. Do NOT name the place — where this was is given below if it is
+   known, and if it is not, say nothing about where it was.
+   WHO is in each photograph is given below, and
    that list is the only source of names — never read a name off a wristband
    or document, and never invent one. Where no name is given, say "a baby",
    "a child", "two adults". Do not state a sex, an age or a relationship the
@@ -281,7 +308,7 @@ def _read_one_sheet(
     sheet.save(buffer, "JPEG", quality=_SHEET_QUALITY)
     answer = asyncio.run(
         query_llm(
-            SHEET_PROMPT + who_was_there(numbered),
+            prompt_for([asset for _n, asset in numbered]),
             llm_config,
             temperature=_SHEET_TEMPERATURE,
             max_tokens=SHEET_ANSWER_TOKENS,
@@ -330,3 +357,34 @@ def read_moment(
         subjects=tuple(subjects),
         keep=tuple(kept[:keep_cap] if keep_cap else kept),
     )
+
+
+def place_of(assets: list[Any]) -> str | None:
+    """Where these photographs were taken, according to their coordinates.
+
+    Never according to what the model reads off a sign. The same episode came
+    back named as two different racing circuits on two runs, 900km apart, and
+    only one was where the photographs were taken. Reading a name off signage
+    is worth having; trusting it is not, so the place is supplied and the
+    prompt forbids guessing one.
+
+    A city claimed by a single asset among several is a stray — a photograph
+    taken on the way, or a coordinate that drifted — so it takes agreement.
+    """
+    cities = Counter(
+        asset.exif_info.city
+        for asset in assets
+        if getattr(asset, "exif_info", None) and getattr(asset.exif_info, "city", None)
+    )
+    if not cities:
+        return None
+    city, seen = cities.most_common(1)[0]
+    return city if seen > 1 or len(cities) == 1 else None
+
+
+def prompt_for(assets: list[Any]) -> str:
+    """The sheet prompt, told where this was and who was in it."""
+    where = place_of(assets)
+    located = f"\n\nThese were taken in {where}." if where else ""
+    numbered = list(enumerate(assets, start=1))
+    return SHEET_PROMPT + located + who_was_there(numbered)

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -889,20 +889,14 @@ def _read_the_moments(
     if thumbnail_cache is thumbnail_fn is None:
         return None
 
-    from immich_memories.analysis.moment_grouping import (
-        EPISODE_WINDOW_MINUTES,
-        moments_by_time_and_place,
-    )
+    from immich_memories.analysis.moment_grouping import moments_to_read
     from immich_memories.analysis.moment_reading import read_moment
 
     by_id = {asset.id: (asset, score) for asset, score in metadata_scored}
     kept: list[tuple] = []
     # Sheets are asked about EPISODES, not ten-minute moments: a moment is
     # often one photograph, and a sheet of one photograph says nothing.
-    for episode in moments_by_time_and_place(
-        [asset for asset, _score in metadata_scored],
-        window_minutes=EPISODE_WINDOW_MINUTES,
-    ):
+    for episode in moments_to_read([asset for asset, _score in metadata_scored], app_config):
         frames = _frames_for_reading(
             [by_id[a.id] for a in episode if a.id in by_id], thumbnail_cache, thumbnail_fn
         )

--- a/tests/test_moment_grouping.py
+++ b/tests/test_moment_grouping.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
-from immich_memories.analysis.moment_grouping import moments_by_time_and_place
+# The private name on purpose: these test the grouping rules themselves, not
+# the filtered door every reader goes through. moments_to_read is tested below.
+from immich_memories.analysis.moment_grouping import (
+    _group_by_time_and_place as group_by_time_and_place,
+)
 
 MIDDAY = datetime(2024, 6, 4, 12, 0, tzinfo=UTC)
 CIRCUIT = (50.437, 5.971)
@@ -28,28 +32,93 @@ def _asset(name: str, minutes: int, where: tuple[float, float] | None = CIRCUIT)
 
 def test_close_in_time_and_place_is_one_moment() -> None:
     group = [_asset("a", 0), _asset("b", 2), _asset("c", 5)]
-    assert [[a.id for a in m] for m in moments_by_time_and_place(group)] == [["a", "b", "c"]]
+    assert [[a.id for a in m] for m in group_by_time_and_place(group)] == [["a", "b", "c"]]
 
 
 def test_a_gap_in_time_starts_a_new_moment() -> None:
     group = [_asset("a", 0), _asset("b", 90)]
-    assert [[a.id for a in m] for m in moments_by_time_and_place(group)] == [["a"], ["b"]]
+    assert [[a.id for a in m] for m in group_by_time_and_place(group)] == [["a"], ["b"]]
 
 
 def test_far_apart_at_the_same_time_is_two_moments_not_one() -> None:
     """The finding: someone else was somewhere else, at the same time."""
     group = [_asset("circuit", 0), _asset("home", 3, HOME), _asset("circuit2", 6)]
-    moments = moments_by_time_and_place(group)
+    moments = group_by_time_and_place(group)
     assert [[a.id for a in m] for m in moments] == [["circuit", "circuit2"], ["home"]]
 
 
 def test_an_asset_without_a_place_joins_the_moment_it_sits_in() -> None:
     """Most libraries have some assets with no GPS; they must not all cluster."""
     group = [_asset("a", 0), _asset("b", 2, None), _asset("c", 4)]
-    assert [[a.id for a in m] for m in moments_by_time_and_place(group)] == [["a", "b", "c"]]
+    assert [[a.id for a in m] for m in group_by_time_and_place(group)] == [["a", "b", "c"]]
 
 
 def test_travelling_is_one_thread_when_the_time_allows_it() -> None:
     """A device that drove there is not a second person: hours, not minutes."""
     group = [_asset("home", 0, HOME), _asset("circuit", 180)]
-    assert len(moments_by_time_and_place(group)) == 2
+    assert len(group_by_time_and_place(group)) == 2
+
+
+class TestForeignMediaNeverReachesASheet:
+    """Received media is often the most striking thing in an episode.
+
+    A period read from unfiltered sheets reported a wedding, a fresh tattoo and
+    a grid comparing chihuahuas to muffins as the month's remarkable days. The
+    library owner's verdict: forwarded messages, screenshots and a meme. The
+    sheet was not seeing more than the text — it was seeing things that were
+    never photographed here.
+
+    source_filter already says this: gone "before it is sampled into a prompt".
+    Reading bypassed it, so the filter now sits where assets enter grouping and
+    every reader inherits it.
+    """
+
+    def _config(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            analysis=SimpleNamespace(
+                exclude_filename_patterns=("IMG-*-WA*", "Screenshot*"),
+                exclude_stills_without_camera_exif=True,
+            )
+        )
+
+    def _asset(self, name: str, minutes: int, *, make: str | None = "Apple", fav: bool = False):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id=name,
+            original_file_name=name,
+            is_favorite=fav,
+            type="IMAGE",
+            duration=None,
+            exif_info=SimpleNamespace(make=make, city=None, latitude=None, longitude=None),
+            file_created_at=MIDDAY + timedelta(minutes=minutes),
+        )
+
+    def test_a_forwarded_file_never_reaches_a_moment(self) -> None:
+        from immich_memories.analysis.moment_grouping import moments_to_read
+
+        assets = [
+            self._asset("IMG_0001.HEIC", 0),
+            self._asset("IMG-20240604-WA0007.jpg", 1),
+            self._asset("Screenshot 2024-06-04.png", 2),
+        ]
+        moments = moments_to_read(assets, self._config())
+        assert [a.id for m in moments for a in m] == ["IMG_0001.HEIC"]
+
+    def test_a_still_no_camera_made_never_reaches_a_moment(self) -> None:
+        """1498 of 1541 make-less jpgs in one real library were messaging files."""
+        from immich_memories.analysis.moment_grouping import moments_to_read
+
+        assets = [self._asset("IMG_0002.HEIC", 0), self._asset("forward.jpg", 1, make=None)]
+        moments = moments_to_read(assets, self._config())
+        assert [a.id for m in moments for a in m] == ["IMG_0002.HEIC"]
+
+    def test_a_favourite_survives_whatever_it_looks_like(self) -> None:
+        """A star settles it here as everywhere: the owner said this one matters."""
+        from immich_memories.analysis.moment_grouping import moments_to_read
+
+        assets = [self._asset("IMG-20240604-WA0009.jpg", 0, make=None, fav=True)]
+        moments = moments_to_read(assets, self._config())
+        assert [a.id for m in moments for a in m] == ["IMG-20240604-WA0009.jpg"]

--- a/tests/test_moment_reading.py
+++ b/tests/test_moment_reading.py
@@ -175,12 +175,12 @@ class TestReadingAMoment:
         ) as asked:
             reading = read_moment(assets, self._frames(20), LLMConfig(model="m"), keep_cap=None)
 
-        # 20 photographs is two sheets, so two calls — not twenty.
-        assert asked.await_count == 2
+        # A moment is ONE sheet, so one call — not two, and not twenty. Split
+        # across sheets, each answers about its own share of an event and the
+        # first answer wins by accident.
+        assert asked.await_count == 1
         assert reading.about == "a walk"
-        # Tiles are 1-based, and each sheet answers only for its own numbers:
-        # both sheets said [2, 18], so sheet one contributes tile 2 and sheet
-        # two contributes tile 18 — neither reaches into the other.
+        # Tiles are 1-based: tile 2 is the second photograph.
         assert [a.id for a in reading.keep] == ["a1", "a17"]
 
     def test_a_moment_no_sheet_could_read_keeps_nothing(self) -> None:
@@ -201,3 +201,135 @@ class TestReadingAMoment:
 
         assert reading.about == ""
         assert reading.keep == ()
+
+
+class TestASheetIsLaidOutWide:
+    """One image for a whole moment, and wide rather than tall.
+
+    Measured on one 37-photograph episode: split into three sheets of sixteen,
+    the first sheet's answer won by accident and said "cyclists and cars at a
+    race track" while later sheets named the circuit. As ONE sheet at
+    1920x2240 it read no better and its shortlist collapsed — every one of the
+    37 came back as worth keeping. As one sheet at 2080x1300, using SMALLER
+    tiles, it named the circuit, the jerseys and the car, and kept 17.
+
+    Shape beats tile size: a tall image is downscaled harder before the model
+    ever sees it.
+    """
+
+    def test_a_moment_is_one_sheet_however_many_photographs(self) -> None:
+        from immich_memories.analysis.moment_reading import sheets_of
+
+        assert len(sheets_of(list(range(37)))) == 1
+
+    def test_a_sheet_is_wider_than_it_is_tall(self) -> None:
+        from immich_memories.analysis.moment_reading import sheet_layout
+
+        for count in (4, 16, 37, 80, 120):
+            columns, tile = sheet_layout(count)
+            rows = -(-count // columns)
+            assert columns * tile >= rows * tile, f"{count} tiles came out tall"
+
+    def test_a_sheet_stays_inside_what_the_model_can_read(self) -> None:
+        """Past this width the encoder downscales and tiles lose their detail."""
+        from immich_memories.analysis.moment_reading import MAX_SHEET_PX, sheet_layout
+
+        for count in (4, 37, 120):
+            columns, tile = sheet_layout(count)
+            rows = -(-count // columns)
+            assert columns * tile <= MAX_SHEET_PX * 1.05
+            assert rows * tile <= MAX_SHEET_PX * 1.25
+
+    def test_a_huge_moment_is_bounded_rather_than_shrunk_to_nothing(self) -> None:
+        """A thousand photographs at one sheet each would be postage stamps."""
+        from immich_memories.analysis.moment_reading import MAX_SHEET_TILES, sheets_of
+
+        sheets = sheets_of(list(range(1000)))
+        assert all(len(s) <= MAX_SHEET_TILES for s in sheets)
+        assert sum(len(s) for s in sheets) == 1000
+
+    def test_a_split_moment_keeps_each_sheet_to_its_own_numbers(self) -> None:
+        """Only a moment past the tile cap splits — and then numbers must not leak.
+
+        An earlier version shared the number-to-photograph map across sheets, so
+        a model answering with a number it had not been shown was handed a
+        different sheet's photograph.
+        """
+        from datetime import UTC, datetime, timedelta
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, patch
+
+        from PIL import Image
+
+        from immich_memories.analysis.moment_reading import MAX_SHEET_TILES, read_moment
+        from immich_memories.config_models_llm import LLMConfig
+
+        count = MAX_SHEET_TILES + 10
+        assets = [
+            SimpleNamespace(
+                id=f"a{i}",
+                people=[],
+                file_created_at=datetime(2020, 1, 1, tzinfo=UTC) + timedelta(minutes=i),
+            )
+            for i in range(count)
+        ]
+        frames = {f"a{i}": Image.new("RGB", (40, 30), (i % 255, 20, 20)) for i in range(count)}
+        answer = f'{{"about": "a walk", "subjects": [], "best": [2, {count - 1}]}}'
+
+        # WHY: the model is the external boundary; both sheets get one answer.
+        with patch(
+            "immich_memories.analysis.llm_query.query_llm", new=AsyncMock(return_value=answer)
+        ) as asked:
+            reading = read_moment(assets, frames, LLMConfig(model="m"), keep_cap=None)
+
+        assert asked.await_count == 2
+        # Sheet one owns tile 2; sheet two owns the high number. Neither is
+        # handed the other's photograph for a number it never showed.
+        assert [a.id for a in reading.keep] == ["a1", f"a{count - 2}"]
+
+
+class TestWhereItWas:
+    """The place comes from coordinates, never from what the model reads.
+
+    The same episode came back as two different named circuits on two runs,
+    900km apart, and only one of them was where the photographs were taken.
+    Reading a name off a sign is worth having; trusting it is not. So the
+    place is supplied from GPS and the model is told not to name one.
+    """
+
+    def _asset(self, city: str | None):
+        from types import SimpleNamespace
+
+        exif = SimpleNamespace(city=city) if city is not None else None
+        return SimpleNamespace(id="a", exif_info=exif)
+
+    def test_a_place_agreed_by_the_coordinates_is_supplied(self) -> None:
+        from immich_memories.analysis.moment_reading import place_of
+
+        assert place_of([self._asset("Somewhere"), self._asset("Somewhere")]) == "Somewhere"
+
+    def test_a_single_stray_coordinate_names_no_place(self) -> None:
+        """One asset's city among many is a stray, not where the moment was."""
+        from immich_memories.analysis.moment_reading import place_of
+
+        assets = [self._asset("Here"), self._asset("Here"), self._asset("Elsewhere")]
+        assert place_of(assets) == "Here"
+
+    def test_no_coordinates_names_no_place(self) -> None:
+        from immich_memories.analysis.moment_reading import place_of
+
+        assert place_of([self._asset(None), self._asset(None)]) is None
+
+    def test_the_prompt_tells_the_model_where_it_was_and_not_to_guess(self) -> None:
+        from immich_memories.analysis.moment_reading import SHEET_PROMPT, prompt_for
+
+        asked = prompt_for([self._asset("Somewhere"), self._asset("Somewhere")])
+        assert "Somewhere" in asked
+        assert SHEET_PROMPT in asked
+
+    def test_without_coordinates_the_prompt_still_refuses_a_guess(self) -> None:
+        """Unknown is not licence to invent: most libraries are part-tagged."""
+        from immich_memories.analysis.moment_reading import prompt_for
+
+        asked = prompt_for([self._asset(None)])
+        assert "do not name" in asked.lower() or "not name the place" in asked.lower()


### PR DESCRIPTION
Refs #707. Three changes to how a moment reaches the model, each from a
measurement rather than a preference.

## A moment is one sheet

Split across several, each sheet answers about its own share of an event and
the first answer wins by accident. On a 37-photograph episode:

| | reading |
|---|---|
| sheet 1 of 3 | "cyclists and cars at a race track" |
| sheets 2-3 | named the circuit and the car — and were discarded |

Past 120 photographs a single sheet is postage stamps, so a very large moment
still splits, and each sheet honours **only the tile numbers it showed**. An
earlier version shared that map across sheets, so a model answering with a
number it had never been shown was handed a different sheet's photograph.

## Sheets are laid out wide

The same 37 photographs, same model, same prompt:

| sheet | tiles | result |
|---|---|---|
| 1920x2240 (tall) | 320px | described less, shortlist collapsed to **37 of 37** |
| 2080x1300 (wide) | **260px** | named the circuit, jerseys and car, kept **17 of 37** |

The wide sheet used *smaller* tiles and read better: a tall image is
downscaled harder before the model sees it. Shape matters more than tile size,
which is not what I would have guessed.

## The place comes from coordinates

The same episode came back as two different named racing circuits on two runs,
900km apart. Only one was where the photographs were taken.

Reading a name off signage is worth having; trusting it is not. So the place is
supplied from GPS and the prompt is forbidden from naming one. A city claimed
by a single asset among several is a stray rather than where the moment was, so
it takes agreement — and with no GPS the model says nothing, rather than
treating unknown as licence to invent.

## Foreign media never reaches a sheet

Read unfiltered, a month reported a wedding, a fresh tattoo and a grid
comparing chihuahuas to muffins as its remarkable days. They were forwarded
messages, screenshots and a meme. **327 of that month's 1493 assets were not
shot here at all.**

Received media is often the *most* striking thing in an episode, precisely
because it was made to be noticed — so leaning on looking rather than on
metadata makes the source filter load-bearing rather than housekeeping.
`source_filter` already said where this belongs, gone "before it is sampled
into a prompt", and reading had bypassed it.

Grouping is therefore **private**, and `moments_to_read` is the only way in, so
the module's public surface is the guarantee rather than a convention. Anything
genuinely needing unfiltered grouping imports the private name and owns that.

A favourite survives the filter as it survives every other hard gate: a star is
the owner answering directly, where provenance is only a guess about whether
anybody wanted it.

## Note on local test failures

`tests/test_auto_runner.py` fails **on main** on any machine that has a real
special-days catalogue at the default home path — see #715. Verified with
`HOME=$(mktemp -d)`: 108 passed including those two. Nothing in this branch
touches that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL