### PR TITLE
docs(deploy): drop unmeasured speedups and stale scheduling advice

### DIFF
--- a/docs-site/docs/deploy/common-setups/kubernetes-gpu.md
+++ b/docs-site/docs/deploy/common-setups/kubernetes-gpu.md
@@ -76,7 +76,10 @@ kubectl apply -k overlays/gpu
 ```
 
 `kubectl kustomize overlays/gpu` shows the rendered result. `base/kustomization.yaml` pins the
-image tag (no `v` prefix: `0.59.2`); bump it when you upgrade.
+image tag (no `v` prefix: release `vX.Y.Z` is tag `X.Y.Z`). The checked-in pin trails the current
+release — check it against the
+[releases page](https://github.com/sam-dumont/immich-video-memory-generator/releases) and bump it
+when you upgrade.
 
 ## Access the UI
 

--- a/docs-site/docs/deploy/common-setups/linux-nvidia.md
+++ b/docs-site/docs/deploy/common-setups/linux-nvidia.md
@@ -118,20 +118,18 @@ IMMICH_API_KEY=your-api-key-here
 
 ## Performance expectations
 
-On an RTX 3060 12 GB (Linux, Docker):
+No GPU run of this pipeline has been measured end to end, so there is no table here. The one
+measured run is CPU-only ([NAS-only](./nas-only.md#performance-expectations)): 10 minutes for a
+14-clip monthly, of which analysis was 7.4.
 
-| Clips | Resolution | Time |
-|-------|-----------|------|
-| 15 | 1080p | ~3 min |
-| 30 | 1080p | ~5 min |
-| 30 | 4K | ~9 min |
-| 50 | 1080p | ~8 min |
+That shape is what to plan around. Render was 2.7 of those ten minutes and the encode is only part
+of it — the titles are the rest, and a CUDA Taichi backend is what shortens those. The other 7.4
+minutes are analysis and selection: downloading each candidate clip from Immich, scoring it, and
+the LLM passes if you turned them on. Those are bounded by your Immich server and your LLM, not by
+the card. Analysis is cached, so a second run of the same period is much cheaper than the first.
 
-NVENC encoding is roughly 3x faster than CPU libx264 at equivalent quality, and that is the smaller
-half of the run. With the encode accelerated, what is left is analysis and selection: downloading
-each candidate clip from Immich, scoring it, and the LLM passes if you turned them on. The times
-above are first runs. A second run of the same period reuses the cached scores and finishes in
-roughly a third of the time.
+If you measure a run on your own box, [an issue](https://github.com/sam-dumont/immich-video-memory-generator/issues)
+with the numbers is welcome.
 
 ## Adding LLM analysis
 

--- a/docs-site/docs/deploy/common-setups/mac-local-llm.md
+++ b/docs-site/docs/deploy/common-setups/mac-local-llm.md
@@ -109,7 +109,7 @@ so check it covers whatever you load before you count on it.
 ## What works
 
 - **LLM content analysis**: the model reads video frames and scores clips on what is in them (birthday cakes, sunsets, kids playing). Adds a content score weighted at 35% in the overall clip ranking.
-- **VideoToolbox encoding**: hardware-accelerated H.264/H.265 encoding via Apple's VideoToolbox. 5-10x faster than CPU encoding.
+- **VideoToolbox encoding**: H.264/H.265 encoding on the chip's media engine instead of the CPU cores.
 - **Vision framework face detection**: uses macOS native Vision framework for face detection. More accurate than the CPU fallback, no additional model downloads needed.
 - **Taichi GPU title renderer**: particle effects and gradient backgrounds rendered on Apple GPU.
 - **AI music generation**: ACE-Step runs in-process on Apple Silicon via MLX, no server involved. A 60 s track takes ~17 s with `use_lm: false`, or ~45 s with thinking mode on. What it costs is memory, not time: see below.

--- a/docs-site/docs/deploy/common-setups/nas-only.md
+++ b/docs-site/docs/deploy/common-setups/nas-only.md
@@ -89,7 +89,7 @@ If Immich runs on the same Docker network, use the container name (`immich-serve
 - **Title screens**: PIL-based renderer (works everywhere, no GPU needed)
 - **Custom music**: upload your own MP3/WAV in Step 3
 - **All memory types**: year in review, monthly, person spotlight, trips (if GPS data exists)
-- **Scheduling**: `immich-memories auto install` cannot install a cron job inside the container. Run it from the NAS host's scheduler instead: `docker exec immich-memories immich-memories auto run --quiet --cooldown 24` (daily is plenty)
+- **Scheduling**: set `IMMICH_MEMORIES_AUTOMATION__ENABLED=true` and `IMMICH_MEMORIES_AUTOMATION__DAILY_AT=09:00` (plus `TZ`) in the compose `environment:` — the UI process runs the daily decision itself, so there is no cron to install. `immich-memories auto install` is for host installs and cannot write a cron job inside the container; if you would rather drive it from the NAS host's scheduler, use `docker exec immich-memories immich-memories auto run --quiet --cooldown 24` and leave the built-in timer off. See [Daily automation](../installation/docker.md#daily-automation)
 - **Photo support**: Ken Burns animations, face-aware pan, blur backgrounds
 
 ### What still curates without an LLM

--- a/docs-site/docs/deploy/configuration/config-file.md
+++ b/docs-site/docs/deploy/configuration/config-file.md
@@ -84,8 +84,8 @@ advanced:
 
 Tier 2 sections: `analysis`, `hardware`, `llm`, `musicgen`, `ace_step`, `content_analysis`,
 `audio_content`, `speech`, `transcription`, `server`, `auth`, `automation`, `notifications`.
-Everything else (`immich`, `defaults`, `output`, `audio`, `title_screens`, `cache`, `upload`,
-`trips`, `photos`, `scheduler`) stays at the top level.
+Everything else (`immich`, `defaults`, `output`, `audio`, `title_screens`, `title_llm`, `cache`,
+`upload`, `trips`, `photos`, `scheduler`) stays at the top level.
 
 Unknown keys inside a section are silently ignored — a typo does not fail the load, it just does
 nothing. Unknown top-level keys and invalid values (`codec: av1`, `llm.provider: gemini`) do fail

--- a/docs-site/docs/deploy/hardware/apple-silicon.md
+++ b/docs-site/docs/deploy/hardware/apple-silicon.md
@@ -9,8 +9,8 @@ Apple Silicon Macs (M1, M2, M3, M4, M5) are probably the best platform for this 
 
 ## What you get
 
-- **VideoToolbox encoding**: 5-10x faster than software libx264. Uses the dedicated media engine on the chip.
-- **Vision Framework face detection**: runs on the Neural Engine, ~10x faster than OpenCV CPU. More accurate too, especially with small or partially occluded faces.
+- **VideoToolbox encoding**: uses the dedicated media engine on the chip instead of the CPU cores.
+- **Vision Framework face detection**: runs on the Neural Engine. More accurate than the OpenCV CPU fallback, especially with small or partially occluded faces.
 - **Unified memory**: no CPU/GPU transfer overhead. Frames stay in the same memory pool whether the CPU, GPU, or Neural Engine is working on them.
 - **mlx-vlm for local LLMs**: run vision models locally with Metal acceleration for [LLM content analysis](../../create/pipeline/llm-content-analysis.md). No API costs, no data leaving your machine.
 

--- a/docs-site/docs/deploy/hardware/cpu-only.md
+++ b/docs-site/docs/deploy/hardware/cpu-only.md
@@ -5,14 +5,14 @@ title: CPU-Only Mode
 
 # CPU-Only Mode
 
-The pipeline is designed around GPU acceleration and ML-powered features for the best results, but **every feature has a CPU fallback**. You can generate memory videos on a headless server, a cheap VPS, or any machine without a GPU.
+**Every feature has a CPU fallback.** You can generate memory videos on a headless server, a cheap VPS, or any machine without a GPU. What you give up is animated titles and the hardware encoder, not any step of the pipeline.
 
 ## What changes without a GPU
 
 | Feature | With GPU | Without GPU | Impact |
 |---------|----------|-------------|--------|
 | Title screens | Animated GPU-rendered (Taichi: bokeh particles, gradient animation, SDF text) | Static PIL-rendered (gradient background, text overlay) | Simpler visuals, same text — and the dominant cost of a run (see below) |
-| Video encoding | NVENC / VideoToolbox / VAAPI / QSV | libx264 / libx265 (software) | 3-10x slower encoding, the smaller half |
+| Video encoding | NVENC / VideoToolbox / VAAPI / QSV | libx264 / libx265 (software) | Slower encoding — the smaller half of a run |
 | Face detection (macOS) | Apple Vision (Neural Engine) | OpenCV Haar cascades (CPU) | Slightly less accurate |
 | SDF text rendering | Taichi GPU kernels + FreeType atlas | PIL text drawing | No SDF glow/shadow effects |
 | Video scaling | GPU-accelerated (scale_cuda, scale_vaapi) | FFmpeg swscale (CPU) | Slower for resolution changes |
@@ -56,12 +56,13 @@ image) the `gpu` extra skips Taichi altogether — titles are always PIL-rendere
 
 ## Performance expectations
 
-On a modern CPU (4+ cores), expect roughly:
+The one end-to-end measurement is in the [NAS-only guide](../common-setups/nas-only.md#performance-expectations):
+a 14-clip monthly, 62 s of 1080p out, cold cache, 4 cores and no GPU took 10 min with
+`preset: fast` and 15.7 min on the default profile. Analysis was 7.4 of those 10 minutes.
 
-- **Encoding**: 0.2-0.5x realtime for 1080p H.264 (a 3-minute video takes 6-15 minutes)
-- **Analysis**: Similar speed (most analysis is CPU-bound regardless of GPU)
-- **Title rendering**: the dominant cost — see below
-- **Transitions**: Negligible difference for typical clip counts
+Two things follow. Analysis is CPU-bound whether or not you have a GPU, and it is cached — a
+second run over the same period is much cheaper. Title rendering is the part a GPU would
+actually take off your hands.
 
 ### Title rendering is the bottleneck, not encoding
 

--- a/docs-site/docs/deploy/hardware/intel-qsv.md
+++ b/docs-site/docs/deploy/hardware/intel-qsv.md
@@ -54,4 +54,4 @@ services:
 
 ## Good for headless servers
 
-QSV is common in home server setups: Intel NUCs, older desktops repurposed as media servers. The encoding speed bump is nice (3-5x over software), and since it uses the integrated GPU, it doesn't require a discrete graphics card.
+QSV is common in home server setups: Intel NUCs, older desktops repurposed as media servers. It takes the encode off the CPU cores without needing a discrete graphics card. The encode is the smaller half of a run, though — see [CPU-Only Mode](./cpu-only.md#title-rendering-is-the-bottleneck-not-encoding). The larger win on such a box is usually the titles: install the `gpu` extra and Taichi will try the Vulkan backend on the integrated GPU.

--- a/docs-site/docs/deploy/hardware/nvidia.md
+++ b/docs-site/docs/deploy/hardware/nvidia.md
@@ -5,7 +5,7 @@ title: NVIDIA
 
 # NVIDIA
 
-NVIDIA GPUs with NVENC provide hardware-accelerated video encoding that's 5-10x faster than software encoding. If you have a GTX 1050 or newer, you've got NVENC. The encode is not the phase that dominates a run, though — see [Encoding quality](#encoding-quality) for what the card actually buys you.
+NVIDIA GPUs with NVENC move video encoding off the CPU and onto dedicated silicon. If you have a GTX 1050 or newer, you've got NVENC. The encode is not the phase that dominates a run, though — see [Encoding quality](#encoding-quality) for what the card actually buys you.
 
 ## What you get
 

--- a/docs-site/docs/deploy/hardware/overview.md
+++ b/docs-site/docs/deploy/hardware/overview.md
@@ -5,11 +5,11 @@ title: Hardware Acceleration Overview
 
 # Hardware Acceleration Overview
 
-The pipeline is designed around GPU acceleration for the best quality and speed: animated title screens, fast encoding, and (on Apple Silicon) GPU-accelerated face detection. However, **every feature has a CPU fallback**, so it works on any machine. See [CPU-Only Mode](./cpu-only.md) for details on running without a GPU.
+A GPU buys three things here: animated title screens, faster encoding, and (on Apple Silicon) face detection on the Neural Engine. **Every feature has a CPU fallback**, so it works on any machine. See [CPU-Only Mode](./cpu-only.md) for details on running without a GPU.
 
-Encoding video in software (libx264) works everywhere but it's slow. If you have a GPU or dedicated media engine, hardware acceleration can speed up encoding by 5-10x. The pipeline auto-detects your hardware and picks the best available backend; NVENC, Quick Sync and VAAPI are only selected after a one-frame test encode succeeds, so an FFmpeg build that merely lists them (Debian's does, including inside the Docker image) doesn't send a GPU-less box down the hardware path.
+Encoding video in software (libx264) works everywhere but it's slow. A hardware encoder is faster; how much faster depends on your card, codec and preset, and this project has not measured it. The pipeline auto-detects your hardware and picks the best available backend; NVENC, Quick Sync and VAAPI are only selected after a one-frame test encode succeeds, so an FFmpeg build that merely lists them (Debian's does, including inside the Docker image) doesn't send a GPU-less box down the hardware path.
 
-That 5-10x applies to a phase that is not where a run spends its time. Analysis and title rendering are — measured at `--cpus=2`, title rendering was ~263 s of a ~339 s assembly ([CPU-Only Mode](./cpu-only.md#title-rendering-is-the-bottleneck-not-encoding)), and in a measured end-to-end run analysis was 7.4 of 10.1 minutes ([NAS-Only](../common-setups/nas-only.md#performance-expectations)). Hardware acceleration shortens the last phase; a GPU earns its keep first on titles.
+The encode is not where a run spends its time, though. Analysis and title rendering are — measured at `--cpus=2`, title rendering was ~263 s of a ~339 s assembly ([CPU-Only Mode](./cpu-only.md#title-rendering-is-the-bottleneck-not-encoding)), and in a measured end-to-end run analysis was 7.4 of 10.1 minutes ([NAS-Only](../common-setups/nas-only.md#performance-expectations)). Hardware acceleration shortens the last phase; a GPU earns its keep first on titles.
 
 ## Supported backends
 

--- a/docs-site/docs/deploy/installation/kubernetes.md
+++ b/docs-site/docs/deploy/installation/kubernetes.md
@@ -9,11 +9,12 @@ Kustomize manifests live in `deploy/kubernetes/`. The base boots on any cluster 
 GPU scheduling is an overlay.
 
 :::note Less travelled than Docker Compose
-Docker Compose is the primary self-hosting path. These manifests are rendered with
-`kubectl kustomize` in the test suite (base and GPU overlay) and their contracts are pinned —
-Secret applied, writable state volume, `/health/live` + `/health/ready` probes, no GPU
-requirement in the base — but they are not applied to a live cluster on every release. Read the
-rendered output before you apply it, and open an issue if something does not boot.
+Docker Compose is the primary self-hosting path. What the test suite pins on every run is the
+manifests' contract: Secret applied, writable state volume, `/health/live` + `/health/ready`
+probes, no GPU requirement in the base. A separate test renders base and GPU overlay with
+`kubectl kustomize`, but it skips wherever `kubectl` is not installed — which includes CI — and
+nothing is applied to a live cluster. Read the rendered output before you apply it, and open an
+issue if something does not boot.
 :::
 
 ```
@@ -48,9 +49,11 @@ kubectl apply -k base
 kubectl apply -k overlays/gpu
 ```
 
-`kubectl kustomize base` shows what will be applied. `base/kustomization.yaml` pins the image
-tag (`images: newTag`); published tags carry no `v` prefix (`0.59.2`, `latest`) — bump it when you
-upgrade.
+`kubectl kustomize base` shows what will be applied. `base/kustomization.yaml` pins the image tag
+(`images: newTag`). Published tags carry no `v` prefix — release `vX.Y.Z` is image tag `X.Y.Z` —
+plus `latest`. The checked-in pin trails the current release, so check it against the
+[releases page](https://github.com/sam-dumont/immich-video-memory-generator/releases) before you
+apply, and bump it when you upgrade.
 
 ## Access the UI
 
@@ -72,7 +75,8 @@ Once auth is on (basic-auth keys in the Secret, or [OIDC](../configuration/authe
 ## How the pod is wired
 
 The image runs as user `immich`, UID/GID 1000, `HOME=/home/immich` — the manifests set
-`runAsUser`/`fsGroup` 1000, drop all capabilities and use the `RuntimeDefault` seccomp profile.
+`runAsUser`/`fsGroup` 1000, drop all capabilities, use the `RuntimeDefault` seccomp profile and
+mount the root filesystem read-only. The three mounts below are the only writable paths.
 
 | Mount | Backed by | Holds |
 |-------|-----------|-------|

--- a/docs-site/docs/deploy/installation/terraform.md
+++ b/docs-site/docs/deploy/installation/terraform.md
@@ -9,11 +9,11 @@ Deploy Immich Memories to Kubernetes using Terraform. The module lives in `deplo
 uses the `hashicorp/kubernetes` provider. CPU only by default; NVIDIA GPU scheduling is a variable.
 
 :::note Less travelled than Docker Compose
-Docker Compose is the primary self-hosting path. The module and both examples pass
-`terraform validate` and their contracts are pinned in the test suite (writable state volume,
-`/health/live` + `/health/ready` probes, `gpu_enabled = false` by default), but they are not
-applied to a live cluster on every release. Read the plan before you apply it, and open an issue
-if something does not boot.
+Docker Compose is the primary self-hosting path. What the test suite pins is the module's
+contract: writable state volume, `/health/live` + `/health/ready` probes, `gpu_enabled = false` by
+default, and that the examples only set variables the module declares. Nothing runs
+`terraform validate`, and nothing applies the module to a live cluster. Read the plan before you
+apply it, and open an issue if something does not boot.
 :::
 
 :::caution Before enabling Ingress
@@ -28,7 +28,8 @@ single-user, single-replica; do not scale the deployment beyond one pod.
 Namespace (optional), Secret, two `ReadWriteOnce` PVCs, Deployment, Service, Ingress (optional).
 
 The image runs as user `immich`, UID/GID 1000, `HOME=/home/immich` (`run_as_user` / `fs_group`
-1000, all capabilities dropped, `RuntimeDefault` seccomp):
+1000, all capabilities dropped, `RuntimeDefault` seccomp, `read_only_root_filesystem = true`).
+These three mounts are the only writable paths:
 
 | Mount | Backed by | Holds |
 |-------|-----------|-------|
@@ -113,11 +114,11 @@ module "immich_memories" {
 | `namespace` | Kubernetes namespace | `string` | `"immich-memories"` |
 | `create_namespace` | Create the namespace | `bool` | `true` |
 | `image_repository` | Container image | `string` | `"ghcr.io/sam-dumont/immich-video-memory-generator"` |
-| `image_tag` | Image tag (no `v` prefix: `0.59.2`, `latest`) | `string` | `"latest"` |
+| `image_tag` | Image tag — no `v` prefix, so release `vX.Y.Z` is tag `X.Y.Z` | `string` | `"latest"` |
 | `replicas` | Replica count — keep at 1, the UI is single-replica | `number` | `1` |
 | `resources` | Requests/limits object (`requests.memory/cpu`, `limits.memory/cpu`) | `object` | `2Gi/1000m` – `8Gi/4000m` |
 | `tmp_size` | `/tmp` emptyDir for FFmpeg intermediates (8Gi for 4K) | `string` | `"4Gi"` |
-| `env` | Extra `IMMICH_MEMORIES_<SECTION>__<KEY>` env vars | `map(string)` | `{}` |
+| `env` | Extra env vars, typically `IMMICH_MEMORIES_<SECTION>__<KEY>` (plain names like `TZ` work too) | `map(string)` | `{}` |
 | `secret_env` | Extra env vars stored in the Secret (auth password, storage secret) | `map(string)` | `{}` |
 | `labels` | Extra labels on every resource | `map(string)` | `{}` |
 

--- a/docs-site/docs/deploy/installation/uv-pip.md
+++ b/docs-site/docs/deploy/installation/uv-pip.md
@@ -9,7 +9,7 @@ Requires **Python 3.11 or newer** and FFmpeg on your `PATH`.
 
 ## uv (Recommended)
 
-[uv](https://docs.astral.sh/uv/) is 10-100x faster than pip.
+[uv](https://docs.astral.sh/uv/) resolves and installs faster than pip, and `uvx` runs the CLI without installing anything.
 
 ### One-Liner (No Install Required)
 


### PR DESCRIPTION
Accuracy sweep of the 20 pages under `docs-site/docs/deploy/`. Every command checked against the Click tree, every config key against the pydantic schema, every compose/k8s/terraform claim against the actual files, every perf number against the calibrated README table.

Closes #620

## Corrections

**Unmeasured speedups, deleted (not softened)**

Nothing in this repo measures encoder throughput, so these numbers had no source:

| Page | Was |
|---|---|
| `hardware/overview.md` | "speed up encoding by 5-10x" |
| `hardware/apple-silicon.md` | "5-10x faster than software libx264", "~10x faster than OpenCV CPU" |
| `hardware/nvidia.md` | "5-10x faster than software encoding" |
| `hardware/intel-qsv.md` | "3-5x over software" |
| `hardware/cpu-only.md` | "3-10x slower encoding" |
| `common-setups/mac-local-llm.md` | "5-10x faster than CPU encoding" |
| `common-setups/linux-nvidia.md` | "roughly 3x faster than CPU libx264" |
| `installation/uv-pip.md` | "uv is 10-100x faster than pip" |

Each now says what the hardware *does* (moves the encode off the CPU cores) and defers to the measured split that already exists on those pages: 263 s of a 339 s assembly in titles, analysis 7.4 of 10.1 minutes.

**Unverifiable perf tables**

- `common-setups/linux-nvidia.md` — deleted the RTX 3060 table (4 rows of timings with no date, no clip source, no way to reproduce). Replaced with the one run that *was* measured (CPU-only, NAS-only guide) and the shape it implies for a GPU box, plus an invitation to report real numbers. The Mac table on `mac-local-llm.md` was kept: it already states what it was measured on and flags itself as a floor.
- `hardware/cpu-only.md` — replaced the estimated "0.2-0.5x realtime" bullets with the measured NAS run (10 min / 15.7 min, analysis 7.4 of 10).

**Stale advice**

- `common-setups/nas-only.md` — still routed NAS users to the host scheduler via `docker exec`. The in-container daily timer (`IMMICH_MEMORIES_AUTOMATION__ENABLED` / `__DAILY_AT`) shipped and `docker.md` documents it; it now leads, with the host-scheduler route kept as the alternative.

**Overstated testing**

- `installation/kubernetes.md` — claimed the manifests "are rendered with `kubectl kustomize` in the test suite". That test is `skipif(shutil.which("kubectl") is None)` and no workflow installs kubectl, so it never runs in CI. Now distinguishes the contract tests (always run) from the render test (skips in CI).
- `installation/terraform.md` — claimed "the module and both examples pass `terraform validate`". Nothing runs `terraform validate`: no Makefile target, no workflow step, no pre-commit hook. Deleted; the note now lists what `tests/test_deploy_manifests_contract.py` actually pins.

**Gaps and drift**

- `installation/kubernetes.md`, `installation/terraform.md` — both set `readOnlyRootFilesystem` / `read_only_root_filesystem = true` in the manifests but neither page said so, which made the mount tables read as suggestions rather than as the only writable paths.
- `configuration/config-file.md` — the top-level section list omitted `title_llm` (it is not in `_TIER2_SECTIONS`).
- `installation/kubernetes.md`, `common-setups/kubernetes-gpu.md`, `installation/terraform.md` — the image-tag pin was quoted as a literal version that goes stale on every release. Now stated as the rule (release `vX.Y.Z` is tag `X.Y.Z`) with a pointer to the releases page.
- `hardware/overview.md`, `hardware/cpu-only.md` — dropped "designed around GPU acceleration for the best quality and speed"; replaced with what a GPU concretely buys.

## Verified as already correct

Checked and left alone: the `uv sync --extra` list matches `pyproject.toml` exactly (no `face`, `music` present); no `qwen2.5-vl` or "smart clip" left under `deploy/`; the `IMMICH_MEMORIES_OUTPUT__DIRECTORY` "disappears with the container" warnings are gone and `docker.md` correctly credits the Dockerfile `ENV`; every env var in `environment-variables.md` including the single-underscore auth/storage/log ones resolves in `config_loader.py` / `logging_config.py` / `ui/app.py`; the shorthand table matches `_apply_env_overrides` row for row; `authentication.mdx`'s field table matches the auth schema defaults exactly and already documents the `/api/trigger` token path; all 32 Terraform variables and 9 outputs match `variables.tf` / `outputs.tf` with no default drift; cache defaults (10 GB / 7 days), the 35% content weight, `auto run` flags and the `cache` subcommands all check out.

## Gates

`make docs-build`, `make docs-config-check`, `make ci` — all pass. `tests/test_docs_contract.py` pins the `config-file.md` span that was edited; the pinned sentences were not touched and all 57 contract tests pass, so no pin change was needed.
