### PR TITLE
docs(reference): accuracy sweep — claims the tree contradicts

### DIFF
--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -16,7 +16,7 @@ Now the four main orchestrators compose smaller service objects via constructor 
 | Orchestrator | Services | What it does |
 |---|---|---|
 | **VideoAssembler** | FFmpegProber, FilterBuilder, ClipEncoder, AssemblyEngine, AudioMixerService, TitleInserter | Assembles clips into final video |
-| **SmartPipeline** | ClipAnalyzer, PreviewBuilder, ClipRefiner, ClipScaler | Analyzes and selects the best clips |
+| **SmartPipeline** | ClipAnalyzer, PreviewBuilder, ClipRefiner, ClipScaler, SelectionQuality | Analyzes and selects the best clips |
 | **ImmichClient** | SearchService, AllAssetsService, AssetService, PersonService, AlbumService | Talks to the Immich API |
 | **TitleScreenGenerator** | RenderingService, EndingService, TripService | Creates title/ending screens |
 
@@ -26,9 +26,10 @@ Each service is a standalone class you can test in isolation. The orchestrator w
 
 CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no point waiting 3 minutes for tests to tell you the same thing.
 
-**Tier 0: Cache setup** (shared by all jobs)
+**Tier 0: Cache setup** (every job that installs the project waits on it; the docs build doesn't)
 
-**Tier 1: Cheap quality gates** (~10s each, all parallel):
+**Tier 1: Cheap quality gates** — one job, run as steps in order. Each carries `if: !cancelled()`,
+so the first failure doesn't hide the ones behind it and you get the whole list from one run:
 - Commit message linting (Conventional Commits)
 - Ruff lint + format check
 - mypy type checking
@@ -50,15 +51,19 @@ CI runs in tiers, cheap to expensive. If lint fails in 10 seconds, there's no po
 - Gitleaks secret detection
 - Hadolint Dockerfile linting
 
-**Tier 3: Tests** (runs after Tier 1 passes):
-- Full test suite (Linux + macOS matrix)
-- Tests with optional extras (Taichi GPU, etc.)
+**Tier 3: Tests** (runs after both Tier 1 and Tier 2 pass):
+- Full test suite (Ubuntu on 3.11/3.12/3.13; macOS on 3.13 for a pull request, all three on main)
+- `make test-extras`: only the tests marked `extras`, which are what the torch family
+  (audio-ml/demucs) unlocks
 
 **Tier 4: Build + Docker** (runs after tests pass):
 - Package build verification
 - Docker image build
-- Docs site build
-- Hermetic launch check on pull requests (`make launch-check`: build + docs + Playwright e2e)
+
+Two jobs sit outside the tiers. The docs site build depends on nothing and starts immediately. The
+hermetic launch check runs on pull requests off the cache setup alone, in parallel with the tests:
+CI calls `make launch-check-ci`, which is the Playwright e2e run against a fake Immich. The local
+`make launch-check` is the bigger one that also does `check`, `build`, and the docs build.
 
 A PR passes 20 gates: 15 static checks in the quality job and 5 security scans in the security job. Locally, `make ci` runs 16 of them plus the unit tests: lint, format-check, typecheck, file-length, complexity, cognitive-complexity, dead-code, security-lint, semgrep, refurb, dep-check, arch-check, duplication, critique, docs-cli-check, docs-config-check, test. CI adds the four that need a remote or a diff (commitlint, pip-audit, gitleaks, hadolint), then the build/docker/docs jobs and the launch check. Every PR must pass all of them.
 
@@ -75,7 +80,7 @@ A PR passes 20 gates: 15 static checks in the quality job and 5 security scans i
 | Security | Bandit + Semgrep | Common vulnerability patterns |
 | Secrets | Gitleaks | Accidentally committed API keys |
 | Dependencies | pip-audit + deptry | Known CVEs; unused, missing or transitive imports |
-| Architecture | import-linter | Layer violations (e.g., UI importing from processing internals) |
+| Architecture | import-linter | Two forbidden-import contracts: `analysis`/`processing`/`titles` must not import `ui`, and those three plus `audio` must not import `cli`. The dependency runs one way — UI and CLI import core, never the reverse |
 | Commits | commitizen | Non-conventional commit messages |
 | Tests | pytest | 5,600+ tests: 5,000+ unit in CI, 600+ integration/E2E locally and on the GPU runner |
 
@@ -87,7 +92,7 @@ A PR passes 20 gates: 15 static checks in the quality job and 5 security scans i
 2. Keep it under 800 lines (soft limit; 1000 is the hard CI failure). If it needs more, split into a service + helpers file
 3. Inject it into the orchestrator's `__init__` in `video_assembler.py`
 4. Add tests in `tests/test_my_service.py`
-5. Run `make check` before committing
+5. Run `make ci` before committing — `make check` is the fast subset and skips the drift, security and duplication gates
 
 ### Adding a new API endpoint
 
@@ -98,10 +103,11 @@ A PR passes 20 gates: 15 static checks in the quality job and 5 security scans i
 
 ### Adding a new memory type
 
-1. Add the type to `MemoryType` enum in `memory_types/registry.py`
-2. Create a factory function in `memory_types/factory.py`
-3. Register it in the factory registry
-4. Add date builder logic if needed in `memory_types/date_builders.py`
+1. Add the value to the `MemoryType` enum in `memory_types/registry.py`
+2. Write a factory function in `memory_types/factory.py` and decorate it with `@register_preset` — the decorator *is* the registration, there is no second list to edit there
+3. Add date builder logic if the type needs its own, in `memory_types/date_builders.py`
+4. Add the string to the `--memory-type` choice list in `cli/generate_options.py`. That list is hand-written, not derived from the enum, so a type you skip here exists everywhere except the CLI
+5. Add a page under `docs-site/docs/create/memory-types/`
 
 ### Adding a new CLI command
 
@@ -117,8 +123,9 @@ A PR passes 20 gates: 15 static checks in the quality job and 5 security scans i
 
 ## File Naming Conventions
 
-- `_prefixed.py`: private helpers, same package only
+- `_prefixed.py`: private helpers, meant for their own package. Nothing enforces that — import-linter only guards the core/UI and core/CLI directions — and a couple of cross-package imports have leaked in
 - `*_service.py`: composed service classes
 - `*_models.py`: data models (Pydantic or dataclass)
 - `*_helpers.py`: standalone helper functions
-- `*.py` (no prefix): public modules, re-export shims, or standalone classes
+- `*.py` (no prefix): public modules and standalone classes. Re-export shims belong in
+  `__init__.py` and nowhere else

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -21,8 +21,10 @@ advanced:
 ```
 
 When reading, both placements work; if a section appears in both places the top-level one wins.
-Everything else (`immich`, `defaults`, `output`, `audio`, `title_screens`, `cache`, `upload`,
-`trips`, `photos`, `scheduler`) is Tier 1 and stays at the top level.
+Everything else stays at the top level: `immich`, `defaults`, `output`, `audio`, `title_screens`,
+`cache`, `upload`, `trips`, `photos`, `preset`, and the two the loader calls internal rather than
+Tier 1, `scheduler` and `title_llm`. The rule is mechanical — anything outside the Tier 2 set is
+left where it is.
 Unknown keys *inside* a section are silently ignored; unknown top-level keys and invalid values
 fail validation at startup.
 :::
@@ -154,12 +156,13 @@ defaults:
 Target duration and orientation are chosen per run — the UI slider / `--duration` (seconds) and
 `--orientation` — with the memory type preset supplying the default duration; there is no config
 default for either. The target duration describes the finished video, not just the selected source
-clips. The planner budgets opening/title/ending cards and subtracts the expected overlap from fades
-before it sets the content budget. Month dividers use an all-or-none policy, and trip location cards
-are counted only after the final media selection. If filtering leaves usable time on the table, the
-optimizer backfills eligible leftovers and can relax the preferred photo ratio; hard eligibility and
-deduplication rules remain enforced. Frame and transition boundaries can leave the encoded result
-less than one transition away from the requested duration.
+clips. The planner budgets opening/title/ending cards, then adds back the time the fades overlap
+away — so the content budget ends up larger than the timeline left over, not smaller. Month
+dividers use an all-or-none policy, and trip location cards are counted only after the final media
+selection. If filtering leaves usable time on the table, the optimizer backfills eligible leftovers
+and can relax the preferred photo ratio; hard eligibility and deduplication rules remain enforced.
+Treat the target as a target: frame and transition boundaries mean the encoded file lands near the
+requested duration, not exactly on it.
 
 ## Output
 
@@ -212,7 +215,8 @@ The animation per photo (Ken Burns, face pan, blurred background) is picked auto
 photo's content; it is not configurable.
 
 Burst de-duplication keeps only the best-scored frame of a run of near-identical photos, so the
-fifteen shots of the same jump do not become fifteen clips. `burst_window_seconds: 0` turns it off.
+fifteen shots of the same jump do not become fifteen clips. `burst_window_seconds: 0` all but turns
+it off: photos sharing an identical timestamp still group.
 It is separate from `moment_gap_seconds`, which is about a photo and a *video* of the same moment.
 
 ## Hardware acceleration
@@ -235,12 +239,13 @@ Image quality still comes from the CRF translation described above.
 
 ## Audio and music
 
-Background music is generated when `ace_step.enabled` or `musicgen.enabled` is on. With both on,
-ACE-Step generates and the MusicGen server is used only for stem separation (ducking); with neither,
-stems come from a local Demucs install if present. Per run you can still override that:
-`--music PATH` uses your own file, `--no-music` skips music, and the UI offers None / Upload file /
-AI Generated in Step 3. Music volume is a per-run setting too (`--music-volume` or the UI slider);
-ducking under speech and the 2 s / 3 s fades are fixed.
+Background music needs `ace_step.enabled` or `musicgen.enabled`. With neither, the pipeline refuses
+to build rather than running silent. With both on, ACE-Step generates, and MusicGen is both the
+fallback generator and the stem separator used for ducking. With MusicGen off, stems come from a
+local Demucs install if there is one. Per run you can still override that: `--music PATH` uses your
+own file, `--no-music` skips music, and Step 3 in the UI offers None / Upload file / AI Generated,
+plus Bundled when the `music` extra is installed. Music volume is a per-run setting too
+(`--music-volume` or the UI slider); ducking under speech and the 2 s / 3 s fades are fixed.
 
 ```yaml
 musicgen:
@@ -309,12 +314,12 @@ to configure. Explicit `base_url`/`thinking_params` always win over a preset.
 
 `thinking: true` runs the model in reasoning mode for the judgement calls
 only — the holistic selection review, title generation, and the special-day
-question in `discover-days`. Each such call
-costs roughly 5-10× the latency and 10-20× the completion tokens of a fast
-call, which matters on a paid API. Bulk work (per-clip content analysis,
-photo scoring) always runs in fast mode: reasoning over multiple images is
-unreliable on current models, and the volume would make it unaffordable
-anyway.
+question in `discover-days`. Measured on the live endpoint, a thinking call
+ran 30-134 s where the same model answered in 4-7 s without it, and it needs
+a 4000-token ceiling to finish reasoning — which matters on a paid API. Bulk
+work (per-clip content analysis, photo scoring) always runs in fast mode:
+reasoning over multiple images is unreliable on current models, and the volume
+would make it unaffordable anyway.
 
 `thinking_params` is merged verbatim into a thinking request, so the switch
 matches your server's dialect: the default is Qwen's
@@ -347,8 +352,8 @@ A provider's dialect can also be declared up front instead of negotiated:
 
 ```yaml
 llm:
-  max_tokens_param: max_completion_tokens  # token-limit field name
-  drop_params: [temperature]               # fields this server rejects
+  max_tokens_param: max_completion_tokens  # example; the default is max_tokens
+  drop_params: [temperature]               # example; the default is []
   extra_params: {}                         # fields merged into every call
 ```
 
@@ -359,14 +364,14 @@ options block rather than replacing it — content analysis already asks for a
 4096-token window that way, since Ollama's 2048 default does not hold the
 prompt plus several frames.
 
-A separate `title_llm` section can point the web UI's title step at a different model than the one
-used for content analysis:
+A separate `title_llm` section can point title generation at a different model than the one used for
+content analysis. It applies to the CLI and the web UI alike:
 
 ```yaml
 title_llm:
   provider: "openai-compatible"
-  base_url: "http://localhost:11434/v1"
-  model: "llama3.2"
+  base_url: "http://localhost:8080/v1"
+  model: "llama3.2"              # example; the default is empty, which means "use llm"
   api_key: ""
   timeout_seconds: 300
 ```
@@ -374,7 +379,7 @@ title_llm:
 The switch is all-or-nothing on `title_llm.model`: when it is set the whole `title_llm` block is
 used, and any field you leave out takes the *built-in* default (`provider: openai-compatible`,
 `base_url: http://localhost:8080/v1`, empty `api_key`) — it is not inherited from `llm`. When
-`title_llm.model` is empty, `llm` is used. CLI title generation always uses `llm`.
+`title_llm.model` is empty, `llm` is used. Both entry points resolve it the same way.
 
 ## Content analysis (LLM-based scoring)
 
@@ -385,7 +390,7 @@ content_analysis:
   analyze_frames: 2              # Frames per segment (1-4)
   min_confidence: 0.5
   frame_max_height: 480
-  openai_image_detail: "low"     # low (85 tokens) or high (1889 tokens)
+  openai_image_detail: "low"     # low (85 tokens), high (1889 tokens), or auto
 
 audio_content:
   enabled: false
@@ -452,8 +457,9 @@ One entry forces that language and skips detection entirely. Several restrict de
 languages, so the model chooses between the two or three your library actually contains instead of
 guessing among 99.
 
-Transcripts are stored on the top five candidate segments of each video and **do not affect any
-score**. Nothing reads them yet.
+Transcripts are stored on the top five candidate segments of each video, and the vision model reads
+them — see [What the transcript is used for](#what-the-transcript-is-used-for) below. They move
+LLM-derived scores.
 
 Unlike the FireRedVAD weights, which ship inside the package, whisper models are downloaded from
 HuggingFace on first use — about 1.5 GB for the `medium` default. In Docker, mount the model
@@ -477,12 +483,10 @@ is unchanged, only the audio handed to the model widens.
 
 ### What the gate can and cannot catch
 
-Measured over 80 clips and 282 candidate segments from a real family library:
+Measured over 80 clips from a real family library:
 
 | | |
 |---|---|
-| Clips with no voice activity at all | 9% |
-| Candidate segments declined before reaching whisper | 71% |
 | Whisper calls saved by reusing overlapping candidates | 46% |
 | Cost per segment, `medium` | ~0.6 s |
 
@@ -511,8 +515,9 @@ same description as the frames alone.
 Because the model reads the speech, spoken names can end up in the stored description. Enabling
 transcription therefore changes what the analysis cache records about the people in your videos.
 
-Turning transcription on changes LLM-derived scores, so it bumps the scoring version and cached
-scores are recomputed.
+Because transcripts change what the model is given, wiring them in bumped the scoring version once,
+which invalidated every cached LLM score at that release. Toggling the setting afterwards does not
+bump anything: `SCORING_VERSION` is a fixed constant, not a function of your config.
 
 ## Title screens
 
@@ -586,13 +591,15 @@ server:
                                  # Immich library behind it
 ```
 
-These can also be set via CLI flags: `immich-memories ui --host 127.0.0.1 --port 9090`.
+`host` and `port` also have CLI flags: `immich-memories ui --host 127.0.0.1 --port 9090`. The rest
+of the section is config-only.
 
 `trigger_token` turns on the HTTP trigger — one POST that runs whatever `auto run` would have
 decided, so an Immich workflow (or a cron, or a phone shortcut) can start a memory. See
 [Trigger from Immich or anything else](../create/recipes/trigger-endpoint.md). Keep it out of
 `config.yaml` with `IMMICH_MEMORIES_SERVER__TRIGGER_TOKEN` or a `${VAR}` reference; either way it
-is redacted from logs, `/health`, and the config viewer like every other secret.
+is redacted from `/health` and the config viewer. There is no global log filter, so treat anything
+you print yourself as your own problem.
 
 `host` is the one value "save" leaves out of `config.yaml` when you never set it. Writing the
 `0.0.0.0` default would make the next load treat it as your decision and quietly retire the

--- a/docs-site/docs/reference/faq.md
+++ b/docs-site/docs/reference/faq.md
@@ -14,7 +14,7 @@ Anything FFmpeg can decode, which is basically everything: MP4, MOV, AVI, MKV, W
 
 **Can I use it without face recognition?**
 
-Yes. Skip the `--person` flag and it'll pull all videos from the selected time period. Face recognition just narrows the selection to videos containing a specific person.
+Yes. Skip the `--person` flag and it'll pull everything eligible from the selected time period. Face recognition just narrows the pool to assets containing a specific person.
 
 **How long does analysis take?**
 
@@ -23,7 +23,7 @@ Depends mostly on whether analysis runs on Apple Silicon / a GPU or on a CPU-onl
 - Apple Silicon or GPU: ~1 minute per 10 clips
 - CPU-only (4-core NAS class): ~1-2 minutes per clip
 
-Analysis already downscales to 480p by default, so there is no extra "fast mode" to switch on. Results are cached, so a library only pays this once; re-runs over the same period are quick. The [README resource table](https://github.com/sam-dumont/immich-video-memory-generator#resource-requirements) has RAM and encoding numbers, and the [NAS-only guide](../deploy/common-setups/nas-only.md) has a Celeron-class table.
+Analysis already downscales to 480p by default, so the resolution knob is not the one to reach for. What is left is `--analysis-depth fast`, which restricts the LLM pass to favorites, and `preset: fast`, the whole CPU-only profile. Results are cached, so a library only pays this once; re-runs over the same period are quick. The [README resource table](https://github.com/sam-dumont/immich-video-memory-generator#resource-requirements) has RAM and encoding numbers, and the [NAS-only guide](../deploy/common-setups/nas-only.md) has a Celeron-class table.
 
 **Can I run it headless?**
 
@@ -39,17 +39,19 @@ Yes. Use `--person "Alice" --person "Bob"` with `--memory-type multi_person`. By
 
 **How much disk space does it need?**
 
-The tool downloads videos temporarily for analysis. A rough estimate: 2x the total size of your source videos (original downloads + processed clips). The temporary files are cleaned up after generation. The final output video is typically 50-200MB for a 5-10 minute 1080p video.
+Downloads are a bounded cache, not per-run scratch, so the ceiling is set by config rather than by your library size. The defaults under `cache:` are 10 GB of downloaded video (evicted after 7 days), 2 GB of clip previews, 500 MB of thumbnails, and `cache.db` keeping 30 days of analysis results.
+
+The output is small next to that. One measured run: 62 seconds of 1080p H.264 came out at 87 MB, or 30 MB under `preset: fast`. The [NAS-only guide](../deploy/common-setups/nas-only.md) has the rest of that measurement.
 
 **Can it use iPhone Live Photos?**
 
-Yes. Live Photos are included by default (`analysis.include_live_photos: true`). Live Photos are ~3 second video clips captured with every iPhone photo. When you took photos in rapid succession, the tool detects overlapping clips and merges them into longer continuous moments: transitions happen at each shutter press. A burst of 5 Live Photos becomes one ~8 second clip.
+Yes. Live Photos are included by default (`analysis.include_live_photos: true`). Live Photos are ~3 second video clips captured with every iPhone photo. When you took photos in rapid succession, the tool detects the overlap and merges them into one continuous moment, cutting at the midpoint between consecutive shutter presses. Two real examples from the [Live Photos page](../create/pipeline/live-photos.md): three Live Photos merged to 4.5 seconds, six merged to 8.4 seconds.
 
 Tested on iPhones. Samsung and Google Pixel motion photos should work (Immich normalizes them to the same field), but I only use iOS so it hasn't been tested firsthand. PRs from Android users welcome.
 
 **How big should my PRs be?**
 
-Under 200-300 lines of diff. Smaller PRs get reviewed faster and catch bugs earlier. If your change is bigger, split it into focused chunks. See [CONTRIBUTING.md](https://github.com/sam-dumont/immich-video-memory-generator/blob/main/CONTRIBUTING.md) for the full guidelines.
+About 300 lines of diff, excluding generated and lock files, one concern per PR. Smaller PRs get reviewed faster and catch bugs earlier. If your change is bigger, split it into focused chunks. See [CONTRIBUTING.md](https://github.com/sam-dumont/immich-video-memory-generator/blob/main/CONTRIBUTING.md) for the full guidelines.
 
 **Does it work on Apple Silicon?**
 

--- a/docs-site/docs/reference/troubleshooting.md
+++ b/docs-site/docs/reference/troubleshooting.md
@@ -4,25 +4,28 @@ title: Troubleshooting
 
 # Troubleshooting
 
-## Connection Refused
+## Cannot Connect to Immich
 
-```
-ConnectionError: Cannot connect to Immich at https://photos.example.com
-```
-
-- Double-check your URL. Include the protocol (`https://`). Don't include a trailing slash.
-- Verify your API key is correct: **Immich > Account Settings > API Keys**. A `403 Forbidden` means the key exists but lacks permissions — recreate it with **All** permissions (or the read + upload + album scopes described in the quick start).
-- Immich must be **v2 or newer**; Immich 1.x is rejected at connect time (`Unsupported Immich major version 1`).
-- Make sure Immich is actually reachable from wherever you're running this tool. If you're in Docker, `localhost` means the container, not your host machine: use the host's IP or Docker network hostname.
-
-Run the read-only compatibility check before changing anything:
+Run the read-only compatibility check first. It checks authentication and reports the resolved
+Immich API contract. It does not search, generate, create an album, or upload a video:
 
 ```bash
 immich-memories config test
 ```
 
-It checks authentication and reports the resolved Immich API contract. It does not search,
-generate, create an album, or upload a video.
+It prints one line and exits 1 on failure:
+
+```
+Error: Connection failed: <what the server or the socket returned>
+```
+
+`URL not configured` and `API key not configured` instead mean the setting never reached the
+process at all.
+
+- Double-check your URL. Include the protocol (`https://`). Don't include a trailing slash.
+- Verify your API key is correct: **Immich > Account Settings > API Keys**. A `403 Forbidden` means the key exists but lacks permissions — recreate it with **All** permissions (or the read + upload + album scopes described in the quick start).
+- Immich must be **v2 or newer**; Immich 1.x is rejected at connect time (`Unsupported Immich major version 1`).
+- Make sure Immich is actually reachable from wherever you're running this tool. If you're in Docker, `localhost` means the container, not your host machine: use the host's IP or Docker network hostname.
 
 ## Immich v2/v3 Version Mismatch
 
@@ -49,34 +52,38 @@ relevant Immich server logs. API keys are redacted.
 
 ## No Videos Found
 
-- Check the person name matches exactly what Immich has. Face recognition names are case-sensitive.
-- If photo support is enabled (`photos.enabled: true` or `--include-photos`), videos and photos compete in a unified selection pool. A time period with only photos is valid and will produce a memory.
-- If photo support is **not** enabled, the selected time range must contain at least one video.
+- Check the person name matches what Immich has. The lookup is case-insensitive, but nothing else about it is fuzzy: no partial or first-name match, no accent folding.
+- Photos are included by default (`photos.enabled: true`, or `--include-photos` / `--no-photos` per run), and videos and photos compete in one selection pool. A time period with only photos is valid and will produce a memory.
+- If you turned photos off, the selected time range must contain at least one video.
 - If you're filtering by `--person`, make sure that person has tagged assets in the time range.
 
 ## Slow Analysis
 
 First-run analysis takes roughly 1-2 minutes per clip on a CPU-only box, about 1 minute per 10 clips on Apple Silicon or a GPU. Downscaling to 480p is already on by default (`analysis.enable_downscaling`, `analysis.analysis_resolution`), so the levers left are:
 
-- **Analyze fewer clips**: `--analysis-depth fast` (or the "Analysis Depth" selector in Step 1) scores favorites first instead of every eligible clip. `auto` (the default) already does this for large pools.
+- **Analyze fewer clips**: `--analysis-depth fast` (or the "Analysis Depth" selector in Step 1) runs the LLM pass on favorites only; every other clip falls back to metadata scoring. `auto` (the default) analyses every eligible clip while 60 or fewer of them still need work under the active model, and shortlists by density past that. It does not drop to favorites-only unless you also set `preset: fast`.
 - **Narrow the period**: a month or a person filter is analyzed in minutes; a whole year of a busy library is an overnight job on a NAS.
 - **Let the cache work**: results are stored per asset in `~/.immich-memories/cache.db`, so the second run over the same clips skips analysis. Do not clear the cache between runs.
-- **Turn off the LLM pass**: with `content_analysis.enabled: true`, every candidate waits on the model server; a slow Ollama box dominates the run.
+- **Turn off the LLM pass**: it is off by default, but with `content_analysis.enabled: true` every candidate waits on the model server and a slow Ollama box dominates the run.
 
 ## Out of Memory (OOM)
 
 ```
-RuntimeError: CUDA out of memory
+CUDA out of memory
 ```
 
-- Reduce `analysis.analysis_resolution` to `360` or `240`.
-- If using ACE-Step, switch to `lm_model_size: "0.6B"`.
+- Reduce `analysis.analysis_resolution` to `360` or `240` (the floor is 240).
+- If you turned the ACE-Step language model on (`ace_step.use_lm`, off by default), set
+  `ace_step.lm_model_size: "0.6B"` or switch it back off.
 - If using LLM content analysis, set `content_analysis.frame_max_height: 240`.
 
 ## FFmpeg Not Found
 
+FFmpeg is called by name off `PATH` and nothing pre-checks it, so a missing binary surfaces as
+Python's own error the first time a clip is encoded:
+
 ```
-FileNotFoundError: ffmpeg not found
+FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'
 ```
 
 Install it:
@@ -87,9 +94,13 @@ Install it:
 
 ## GPU Not Detected
 
+The run log says:
+
 ```
-No hardware acceleration available, falling back to CPU
+No hardware acceleration detected, using software encoding
 ```
+
+and `immich-memories preflight` reports `Hardware: No GPU acceleration`.
 
 - Check your GPU drivers are installed and up to date.
 - Run `immich-memories hardware` to see what the tool detects.
@@ -98,7 +109,12 @@ No hardware acceleration available, falling back to CPU
 
 ## Music Generation Fails
 
-- Check the music API server is running and reachable.
-- For ACE-Step: hit `http://your-server:8000/health` in a browser. Expect `{"data": {"status": "ok"}}`.
-- For MusicGen: same thing, check the health endpoint.
-- If generation times out, increase `timeout_seconds` in your config. Some tracks take a while on slower GPUs.
+- Check the music API server is running and reachable. Both backends default to
+  `http://localhost:8000`.
+- For ACE-Step: hit `http://your-server:8000/health` in a browser. The backend treats the server as
+  up only when the body is `{"data": {"status": "ok"}}` — anything else is logged as unhealthy.
+- For MusicGen: the same `/health` route, but it only has to return HTTP 200. The body is read for
+  device and status, not gated on.
+- If generation times out, raise `timeout_seconds` in the backend's config section
+  (`ace_step.timeout_seconds` defaults to 3600, `musicgen.timeout_seconds` to 10800; both cap at
+  18000). Some tracks take a while on slower GPUs.

--- a/docs-site/docs/reference/troubleshooting.md
+++ b/docs-site/docs/reference/troubleshooting.md
@@ -61,7 +61,7 @@ relevant Immich server logs. API keys are redacted.
 
 First-run analysis takes roughly 1-2 minutes per clip on a CPU-only box, about 1 minute per 10 clips on Apple Silicon or a GPU. Downscaling to 480p is already on by default (`analysis.enable_downscaling`, `analysis.analysis_resolution`), so the levers left are:
 
-- **Analyze fewer clips**: `--analysis-depth fast` (or the "Analysis Depth" selector in Step 1) runs the LLM pass on favorites only; every other clip falls back to metadata scoring. `auto` (the default) analyses every eligible clip while 60 or fewer of them still need work under the active model, and shortlists by density past that. It does not drop to favorites-only unless you also set `preset: fast`.
+- **Analyze fewer clips**: `--analysis-depth fast` (or the "Analysis Depth" selector in Step 1) does two things — it shortlists candidates by density instead of taking every eligible clip, and it runs the LLM pass on favorites only, leaving the rest to metadata scoring. `auto` (the default) takes every eligible clip while 60 or fewer of them still need work under the active model, and shortlists past that. It never drops to favorites-only unless you also set `preset: fast`.
 - **Narrow the period**: a month or a person filter is analyzed in minutes; a whole year of a busy library is an overnight job on a NAS.
 - **Let the cache work**: results are stored per asset in `~/.immich-memories/cache.db`, so the second run over the same clips skips analysis. Do not clear the cache between runs.
 - **Turn off the LLM pass**: it is off by default, but with `content_analysis.enabled: true` every candidate waits on the model server and a slow Ollama box dominates the run.


### PR DESCRIPTION
Closes #636

Accuracy sweep of `docs-site/docs/reference/`. Every claim on the five pages was checked against the tree — not against plausibility, and not against what an older doc said. The two generated pages were left to their generators: `make docs-cli-check` and `make docs-config-check` both pass, and `config-reference.md`'s YAML blocks turned out to be exact (every default, every `ge=`/`le=`). The drift was all in prose.

## troubleshooting.md

Three of the five fenced code blocks quoted errors that no code emits. Grepping `src/` for them returns nothing.

| Before | After |
|---|---|
| `ConnectionError: Cannot connect to Immich at https://photos.example.com` | `Error: Connection failed: …`, what `config test` actually prints before exiting 1 |
| `FileNotFoundError: ffmpeg not found` | `FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'` — FFmpeg is called by bare name off `PATH` with no pre-check |
| `No hardware acceleration available, falling back to CPU` | `No hardware acceleration detected, using software encoding`, plus what `preflight` reports |
| `RuntimeError: CUDA out of memory` | `CUDA out of memory` — the prefix was invented |
| "Face recognition names are case-sensitive" | Case-**in**sensitive. `person_service.get_person_by_name` lowercases both sides |
| "If photo support is enabled (`photos.enabled: true` or `--include-photos`)" | Photos are on by default; the off switch is `--no-photos` |
| "`auto` (the default) already does this for large pools" (favorites-first) | `auto` takes every eligible clip while ≤60 need work, then shortlists by density. It never drops to favorites-only unless `preset: fast` |
| "`--analysis-depth fast` scores favorites first" | It shortlists **and** restricts the LLM pass to favorites |
| "Turn off the LLM pass: with `content_analysis.enabled: true`…" | Said it is off by default, so nobody hunts for a switch already off |
| "If using ACE-Step, switch to `lm_model_size: \"0.6B\"`" | `ace_step.use_lm` is off by default, so the knob does nothing until you turn it on |
| "increase `timeout_seconds` in your config" | Named both keys and their defaults (3600 / 10800, cap 18000) |
| "For MusicGen: same thing" | ACE-Step gates on `{"data": {"status": "ok"}}`; MusicGen only needs HTTP 200 |

## architecture.md

| Before | After |
|---|---|
| Tier 1 gates "~10s each, all parallel" | One job, sequential steps, each `if: !cancelled()` so one failure doesn't hide the rest |
| "Full test suite (Linux + macOS matrix)" | Ubuntu 3.11–3.13; macOS 3.13 on a PR, all three on main |
| "Tests with optional extras (Taichi GPU, etc.)" | The `extras` marker is the torch family (audio-ml/demucs) |
| "Tier 4 … Docs site build / launch check (runs after tests pass)" | Neither waits on tests. The docs job has no `needs:` at all; launch-check needs only `setup` |
| "`make launch-check`: build + docs + Playwright e2e" | CI runs `make launch-check-ci`, which is e2e only. `make launch-check` is the local superset |
| "Tier 0: Cache setup (shared by all jobs)" | The docs build doesn't use it |
| SmartPipeline composes 4 services | 5 — `SelectionQuality` was missing |
| import-linter "e.g., UI importing from processing internals" | Backwards. Both contracts forbid **core → UI/CLI**; UI importing core is the allowed direction |
| "Run `make check` before committing" | `make ci` — `check` skips the drift, security and duplication gates |
| Add-a-memory-type: 4 steps | 5. The `--memory-type` choice list in `cli/generate_options.py` is hand-written, not derived from the enum, so a type skipped there exists everywhere except the CLI |
| "`*.py`: public modules, re-export shims, or standalone classes" | CLAUDE.md bans shims outside `__init__.py` |
| "`_prefixed.py`: private helpers, same package only" | Nothing enforces it, and two cross-package imports have leaked in |

## faq.md

| Before | After |
|---|---|
| "2x the total size of your source videos … temporary files are cleaned up" | Downloads are a bounded cache: 10 GB / 7 days video, 2 GB previews, 500 MB thumbnails, 30 days in `cache.db` |
| "typically 50-200MB for a 5-10 minute 1080p video" | Off by ~5×. Measured: 62 s of 1080p H.264 at 87 MB, 30 MB under `preset: fast` |
| "A burst of 5 Live Photos becomes one ~8 second clip" | The two real merges on the Live Photos page: 3 → 4.5 s, 6 → 8.4 s |
| "transitions happen at each shutter press" | Cuts land at the **midpoint between** consecutive presses |
| "Under 200-300 lines of diff" | ~300, per CONTRIBUTING |
| "no extra 'fast mode' to switch on" | There are two: `--analysis-depth fast` and `preset: fast` |

## config-reference.md

The YAML is exact; the prose was not.

| Before | After |
|---|---|
| "CLI title generation always uses `llm`" | False. `cli/_llm_title.py:59` resolves `title_llm` exactly like the UI |
| "A separate `title_llm` section can point **the web UI's** title step…" | Applies to the CLI too |
| "Transcripts … **do not affect any score**. Nothing reads them yet." | False, and contradicted 50 lines later. The vision model is given the transcript; that is why `e218298` bumped `SCORING_VERSION` 2→3 |
| "Turning transcription on … bumps the scoring version" | One-off at that release. `SCORING_VERSION` is a module constant, not a function of your config |
| "With both on, MusicGen is used only for stem separation; with neither, stems come from Demucs" | With both on MusicGen is also the fallback generator (#499); with neither, `create_pipeline` raises. Demucs keys on MusicGen being off |
| "the UI offers None / Upload file / AI Generated" | Fourth option, Bundled, with the `music` extra |
| "subtracts the expected overlap from fades" from the content budget | Backwards. `timeline_budget` **adds** the transition budget to it |
| "These can also be set via CLI flags" (whole `server:` block) | `ui` has `--host`/`--port` only; the other four keys have none |
| trigger_token "redacted from logs, /health, and the config viewer" | `/health` and the viewer, yes. There is no global log redaction filter |
| Tier 1 list | Omitted `preset` and `title_llm`, and called `scheduler` Tier 1 where the loader calls it internal |
| `openai_image_detail: low or high` | `auto` is accepted too |
| "`burst_window_seconds: 0` turns it off" | All but — identical timestamps still group |
| Two YAML blocks showing example values | Labelled as examples; the page promises defaults |

**Deleted rather than softened**, per the doctrine:

- "roughly 5-10× the latency and 10-20× the completion tokens" for thinking mode. The only in-tree measurement (`llm_query.py:37-41`) says 30–134 s vs 4–7 s. Replaced with that; the token multiple had no basis anywhere and is gone.
- The `9%` / `71%` / "282 candidate segments" rows of the transcription gate table. Nothing substantiates them. The `46%` and `~0.6 s` rows are corroborated by `efef45c` and the config model, and stay.

## Not changed, deliberately

- **Test counts.** `architecture.md` and `faq.md` say "5,600+ tests (5,000+ unit, 600+ integration/E2E)". Measured today: 6,489 collected, 5,844 in the default unit run, 645 integration/E2E. The floors still hold, README and CONTRIBUTING carry the identical phrasing, and #639 deliberately made README the single breakdown two days ago. Churning three pages out of sync with it would undo that.
- **The two generated pages' generators.** `make docs-cli-check` and `make docs-config-check` are green; the CLI help strings I spot-checked (`--photo-duration` 4.0, `--port` 8080, `--host` 0.0.0.0, `--scale-mode` blur, `--transition` smart, `--quality` high, `--refinement-passes` 10) all match the schema.

## Candidate follow-ups

Two things worth their own issue rather than a docs PR:

1. **No global log redaction.** `logging_config.py` installs only `RunIdFilter`; `sanitize_error_message` is call-site-only and its patterns (`api-key`, `Bearer`, `api_key`) would not catch a bare `trigger_token`. The doc now says what is true instead of what we'd like to be true.
2. **`--memory-type` choices are hand-maintained** in `cli/generate_options.py` and can silently fall behind `MemoryType`. Deriving them from the enum would remove a whole class of "it works everywhere except the CLI".

## Gates

`make docs-build`, `make docs-cli-check`, `make docs-config-check`, `make ci` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
