### PR TITLE
fix(parity): close the day-one surface divergences

### DIFF
--- a/docs-site/docs/create/memory-types/trip-memories.mdx
+++ b/docs-site/docs/create/memory-types/trip-memories.mdx
@@ -77,4 +77,4 @@ The homebase coordinates are required. Without them, the algorithm can't determi
 - **Set your homebase accurately.** The algorithm filters everything within `min_distance_km` of your home. If your coordinates are wrong, local trips might show up or real trips might get filtered out.
 - **Lower `min_distance_km` for local trips.** Default is 50 km. If you want to capture weekend drives to a nearby city, try 20 km.
 - **Lower `min_duration_days` for day trips.** Set it to 1 to include single-day excursions.
-- The person filter works with trips too: `--person "Alice"` generates a trip video using only clips that contain Alice.
+- **`--person` narrows trip *detection*, not the finished video.** `--person "Alice"` looks for trips among the assets Alice appears in — useful when one person's photos are the ones carrying GPS. Each video is then built from everything shot in that window, so the rest of the group is still in it.

--- a/src/immich_memories/api/person_scope.py
+++ b/src/immich_memories/api/person_scope.py
@@ -1,0 +1,52 @@
+"""Which Immich query a memory's people imply, whichever surface asked.
+
+One rule, three endpoints. Naming several people asks for the moments holding
+all of them rather than the union of their solo reels; naming one narrows to
+them; naming nobody takes the window whole. The CLI resolved ``--person`` into
+a list and branched on its length, while the wizard read a single pick and a
+group pick out of two different state fields and branched on each separately --
+so a group of one came out unfiltered on one surface and filtered on the other.
+Both now ask through here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from immich_memories.timeperiod import DateRange
+
+
+class VideoSource(Protocol):
+    """The three video endpoints a windowed fetch can reach for."""
+
+    def get_videos_for_all_persons(self, person_ids: list[str], date_range: DateRange) -> list: ...
+
+    def get_videos_for_person_and_date_range(
+        self, person_id: str, date_range: DateRange
+    ) -> list: ...
+
+    def get_videos_for_date_range(self, date_range: DateRange) -> list: ...
+
+
+def videos_in_window(client: VideoSource, person_ids: list[str], date_range: DateRange) -> list:
+    """The videos one window holds, narrowed to the people the memory names."""
+    if len(person_ids) > 1:
+        return client.get_videos_for_all_persons(person_ids, date_range)
+    if len(person_ids) == 1:
+        return client.get_videos_for_person_and_date_range(person_ids[0], date_range)
+    return client.get_videos_for_date_range(date_range)
+
+
+def stills_person_args(person_ids: list[str]) -> tuple[str | None, list[str] | None]:
+    """The ``person_id``/``person_ids`` pair the photo and Live Photo reads take.
+
+    Both endpoints spell "one person" and "these people" as separate keyword
+    arguments, so the choice between them is the same choice videos make and is
+    made in the same place.
+    """
+    if len(person_ids) > 1:
+        return None, person_ids
+    if len(person_ids) == 1:
+        return person_ids[0], None
+    return None, None

--- a/src/immich_memories/cli/_asset_fetch.py
+++ b/src/immich_memories/cli/_asset_fetch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from immich_memories.api.person_scope import stills_person_args, videos_in_window
 from immich_memories.cli._helpers import print_info, print_success, print_warning
 from immich_memories.timeperiod import DateRange
 
@@ -95,14 +96,11 @@ def fetch_photos(
     Several people means the photos holding all of them, the same rule videos
     and Live Photos already follow.
     """
+    person_id, group_ids = stills_person_args(person_ids)
     photos: list = []
     seen: set[str] = set()
     for dr in date_ranges:
-        batch = client.get_photos_for_date_range(
-            dr,
-            person_id=person_ids[0] if len(person_ids) == 1 else None,
-            person_ids=person_ids if len(person_ids) > 1 else None,
-        )
+        batch = client.get_photos_for_date_range(dr, person_id=person_id, person_ids=group_ids)
         for photo in batch:
             if photo.id not in seen:
                 seen.add(photo.id)
@@ -127,15 +125,7 @@ def fetch_videos_and_live_photos(
 
     all_assets = []
     for dr in date_ranges:
-        if len(person_ids) > 1:
-            # Naming several people asks for the moments that hold all of them,
-            # not the union of their solo reels. Live photos already intersect.
-            batch = client.get_videos_for_all_persons(person_ids, dr)
-        elif len(person_ids) == 1:
-            batch = client.get_videos_for_person_and_date_range(person_ids[0], dr)
-        else:
-            batch = client.get_videos_for_date_range(dr)
-        all_assets.extend(batch)
+        all_assets.extend(videos_in_window(client, person_ids, dr))
 
     # Deduplicate across date ranges
     seen: dict[str, object] = {}
@@ -154,14 +144,15 @@ def fetch_videos_and_live_photos(
         from immich_memories.analysis.live_photo_pipeline import fetch_live_photo_clips
 
         lp_task = progress.add_task("Fetching live photos...", total=None)
+        lp_person_id, lp_group_ids = stills_person_args(person_ids)
         all_lp_clips: list = []
         all_lp_video_ids: set[str] = set()
         for dr in date_ranges:
             lp_clips, lp_vid_ids = fetch_live_photo_clips(
                 client,
                 dr,
-                person_id=person_ids[0] if len(person_ids) == 1 else None,
-                person_ids=person_ids if len(person_ids) > 1 else None,
+                person_id=lp_person_id,
+                person_ids=lp_group_ids,
                 config=config,
             )
             all_lp_clips.extend(lp_clips)

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -190,8 +190,9 @@ def _resolve_memory_type_dates(
     """Resolve date ranges from memory type preset."""
     from immich_memories.memory_types.date_builders import build_month, build_season
 
-    if memory_type == "special_day":
-        return _special_day_scope(preset_params or {})
+    discovered = _discovered_scope(memory_type, preset_params or {})
+    if discovered is not None:
+        return discovered
 
     if memory_type == "season":
         if not season:
@@ -220,6 +221,35 @@ def _resolve_memory_type_dates(
         return build_month(month, year)
 
     return calendar_year(year)
+
+
+def _discovered_scope(memory_type: str, preset_params: dict) -> DateRange | None:
+    """The window a memory type discovers rather than reads off the date flags.
+
+    Two types find their own scope: the catalogue records a special day's, and
+    GPS detection finds a trip's. None means the date flags still decide.
+    """
+    if memory_type == "special_day":
+        return _special_day_scope(preset_params)
+    if memory_type == "trip":
+        return _trip_scope(preset_params)
+    return None
+
+
+def _trip_scope(preset_params: dict) -> DateRange | None:
+    """The detected trip's own span, or None while no trip has been picked yet.
+
+    ``--year`` scopes trip *detection*, not the memory: the window a trip memory
+    actually covers is the trip, and it only exists once detection has run and
+    one has been selected. Until then the year is the honest answer, which is
+    what the caller falls through to.
+    """
+    from immich_memories.memory_types.date_builders import build_trip
+
+    start, end = preset_params.get("trip_start"), preset_params.get("trip_end")
+    if start is None or end is None:
+        return None
+    return build_trip(start, end)
 
 
 def _special_day_scope(preset_params: dict) -> DateRange:

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -223,6 +223,17 @@ def _resolve_memory_type_dates(
     return calendar_year(year)
 
 
+def _holiday_ranges(holiday: str, year: int | None, years_back: int | None) -> list[DateRange]:
+    """One window per year around a holiday, as the registered preset builds them."""
+    from immich_memories.memory_types.factory import create_preset
+    from immich_memories.memory_types.registry import MemoryType
+
+    preset = create_preset(
+        MemoryType.HOLIDAY, holiday=holiday, year=year, years_back=years_back or 5
+    )
+    return preset.date_ranges
+
+
 def _discovered_scope(memory_type: str, preset_params: dict) -> DateRange | None:
     """The window a memory type discovers rather than reads off the date flags.
 
@@ -348,7 +359,6 @@ def _multi_year_ranges(
     cognitive complexity past the gate.
     """
     from immich_memories.memory_types.date_builders import (
-        build_holiday,
         build_on_this_day,
         build_then_and_now,
     )
@@ -359,15 +369,10 @@ def _multi_year_ranges(
     if memory_type == "holiday":
         if not holiday:
             raise click.UsageError("--holiday is required with --memory-type holiday")
-        # WHY today= only when the year was defaulted: asking for Christmas in
-        # August would otherwise spend one of the requested years on a window
-        # that has not happened. An explicit --year is a choice.
-        return build_holiday(
-            holiday,
-            year or date.today().year,
-            years_back=years_back or 5,
-            today=None if year else date.today(),
-        )
+        # Through the preset, not build_holiday: the rule that a defaulted year
+        # must skip a holiday that has not happened yet belongs to whoever
+        # defaults the year, and the wizard defaults it there too.
+        return _holiday_ranges(holiday, year, years_back)
 
     if memory_type == "then_and_now":
         # WHY the `or 10`: --years-back defaults to None here, and 0 is read as

--- a/src/immich_memories/cli/_trip_generation.py
+++ b/src/immich_memories/cli/_trip_generation.py
@@ -17,8 +17,8 @@ from immich_memories.analysis.trip_detection import DetectedTrip, haversine_km
 from immich_memories.cli._asset_fetch import fetch_videos_and_live_photos
 from immich_memories.cli._helpers import console, print_error, print_info, print_success
 from immich_memories.cli._pipeline_runner import run_pipeline_and_generate
+from immich_memories.memory_types.date_builders import build_trip
 from immich_memories.processing.encoding_plan import resolve_output_selection
-from immich_memories.timeperiod import DateRange
 
 if TYPE_CHECKING:
     from immich_memories.api.immich import SyncImmichClient
@@ -185,8 +185,6 @@ def handle_trip_generation(
     dry_run: bool = False,
 ) -> None:
     """Detect trips, select, and generate video for each."""
-    from datetime import datetime as dt_cls
-
     from immich_memories.cli._trip_display import (
         format_trips_table,
         run_trip_detection,
@@ -229,10 +227,10 @@ def handle_trip_generation(
     )
 
     for trip in selected:
-        trip_date_range = DateRange(
-            start=dt_cls.combine(trip.start_date, dt_cls.min.time()),
-            end=dt_cls.combine(trip.end_date, dt_cls.max.time()),
-        )
+        # The wizard's Trip card resolves the same span through build_trip via
+        # the preset; sharing the builder is what keeps the two surfaces from
+        # ending the last day a microsecond apart.
+        trip_date_range = build_trip(trip.start_date, trip.end_date)
         trip_days = (trip.end_date - trip.start_date).days + 1
         trip_duration = float(duration) if duration is not None else None
 

--- a/src/immich_memories/memory_types/factory.py
+++ b/src/immich_memories/memory_types/factory.py
@@ -362,6 +362,11 @@ def _holiday(
     **kwargs,  # noqa: ARG001
 ) -> MemoryPreset:
     """A holiday is the date a library reliably has every year, so it spans them."""
+    # WHY today= only when the year was defaulted: asking for Christmas in
+    # August would otherwise spend one of the requested years on a window that
+    # has not happened. A year the caller named is a choice and is left alone.
+    # Both surfaces default the year here, so both get the guard from here.
+    today = None if year else date.today()
     year = year or date.today().year
     label = holiday_label(holiday, year)
     person_filter = PersonFilter()
@@ -372,7 +377,7 @@ def _holiday(
         memory_type=MemoryType.HOLIDAY,
         name=f"{label} Through the Years",
         description=f"{label} across {years_back} years",
-        date_ranges=build_holiday(holiday, year, years_back, window_days),
+        date_ranges=build_holiday(holiday, year, years_back, window_days, today=today),
         person_filter=person_filter,
         scoring=ScoringProfile(face_weight=0.3, content_weight=0.3),
         title_template="{holiday}",

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -92,12 +92,7 @@ def render_preset_selector(on_custom_selected=None) -> None:
                 on_custom_selected(params_container)
 
     def select_preset(key: str) -> None:
-        state.memory_type = key
-        state.memory_preset_params = {}
-        if key != MemoryType.ALBUM:
-            # A left-over album would otherwise satisfy the step 1 scope check.
-            state.album_id = None
-            state.album_name = None
+        state.choose_memory_type(key)
         params_container.clear()
         _fill_params(key)
         _build_preset_grid(grid_container, state, select_preset)

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -14,6 +14,7 @@ from immich_memories.analysis.cache_projection import (
 from immich_memories.analysis.live_photo_pipeline import fetch_live_photo_clips
 from immich_memories.api.immich import SyncImmichClient
 from immich_memories.api.models import VideoClipInfo
+from immich_memories.api.person_scope import stills_person_args, videos_in_window
 from immich_memories.operations.phases import OperationalPhase, PhaseEvent
 from immich_memories.processing.clip_probing import probe_video_url
 from immich_memories.security import sanitize_error_message
@@ -98,19 +99,10 @@ def _fetch_assets(state) -> list:
         api_key=state.immich_api_key,
         api_version=state.immich_api_version,
     ) as client:
-        multi_ids = state.memory_preset_params.get("person_ids", [])
+        person_ids = state.person_ids
         assets: list = []
         for date_range in state.date_ranges:
-            if len(multi_ids) >= 2:
-                assets.extend(client.get_videos_for_all_persons(multi_ids, date_range))
-            elif state.selected_person:
-                assets.extend(
-                    client.get_videos_for_person_and_date_range(
-                        state.selected_person.id, date_range
-                    )
-                )
-            else:
-                assets.extend(client.get_videos_for_date_range(date_range))
+            assets.extend(videos_in_window(client, person_ids, date_range))
         return _dedup_by_id(assets)
 
 
@@ -148,8 +140,7 @@ def _build_clips(assets: list) -> tuple[list[VideoClipInfo], int]:
 
 def _fetch_photos(state) -> list:
     """Fetch photo assets (blocking), one query per window."""
-    person_id = state.selected_person.id if state.selected_person else None
-    multi_ids = state.memory_preset_params.get("person_ids", [])
+    person_id, group_ids = stills_person_args(state.person_ids)
     with SyncImmichClient(
         base_url=state.immich_url,
         api_key=state.immich_api_key,
@@ -159,9 +150,7 @@ def _fetch_photos(state) -> list:
         for date_range in state.date_ranges:
             photos.extend(
                 client.get_photos_for_date_range(
-                    date_range,
-                    person_id=person_id,
-                    person_ids=multi_ids if len(multi_ids) >= 2 else None,
+                    date_range, person_id=person_id, person_ids=group_ids
                 )
             )
         return _dedup_by_id(photos)
@@ -169,8 +158,7 @@ def _fetch_photos(state) -> list:
 
 def _fetch_live_photos(state) -> tuple[list[VideoClipInfo], set[str]]:
     """Fetch live photo clips (blocking), one query per window."""
-    lp_person_id = state.selected_person.id if state.selected_person else None
-    multi_ids = state.memory_preset_params.get("person_ids", [])
+    lp_person_id, lp_group_ids = stills_person_args(state.person_ids)
 
     with SyncImmichClient(
         base_url=state.immich_url,
@@ -184,7 +172,7 @@ def _fetch_live_photos(state) -> tuple[list[VideoClipInfo], set[str]]:
                 lp_client,
                 date_range,
                 person_id=lp_person_id,
-                person_ids=multi_ids if len(multi_ids) >= 2 else None,
+                person_ids=lp_group_ids,
                 config=state.config,
             )
             clips.extend(window_clips)

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -178,6 +178,21 @@ class AppState:
         )
 
     @property
+    def person_ids(self) -> list[str]:
+        """The people this memory is narrowed to, as the one list a fetch reads.
+
+        The wizard writes a single pick into ``selected_person`` and a group
+        pick into ``memory_preset_params['person_ids']`` -- two fields, because
+        two different cards collect them. Every read of "who is this memory
+        about" goes through here so the fetch sees the same list the CLI builds
+        from ``--person``: a group of one is a filter, not an absence of one.
+        """
+        group = self.memory_preset_params.get("person_ids") or []
+        if group:
+            return list(group)
+        return [self.selected_person.id] if self.selected_person else []
+
+    @property
     def scope_is_selected(self) -> bool:
         """Whether step 1 has enough to go find media with.
 

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -203,6 +203,22 @@ class AppState:
             return self.album_id is not None
         return self.date_range is not None
 
+    def choose_memory_type(self, memory_type: str) -> None:
+        """Switch to a memory type, dropping what the previous card collected.
+
+        The person is the one input that used to survive: only two cards show a
+        person widget, so an Alice left behind by a Person Spotlight went on
+        narrowing a Year in Review with nothing on screen saying so -- the
+        wizard's own version of a filter the surface cannot explain.
+        """
+        self.memory_type = memory_type
+        self.memory_preset_params = {}
+        self.selected_person = None
+        if memory_type != "album":
+            # A left-over album would otherwise satisfy the step 1 scope check.
+            self.album_id = None
+            self.album_name = None
+
     def reset_clips(self) -> None:
         """Reset clip-related state when changing configuration."""
         self.clips = []

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -423,16 +423,6 @@ class FetchScenario:
     divergence: str | None = None
 
 
-MULTI_PERSON_OF_ONE_DIVERGENCE = (
-    "A Multi-Person memory naming one person is unfiltered in the wizard and "
-    "filtered on the CLI. step2_loading._fetch_assets only reads "
-    "memory_preset_params['person_ids'] when it holds two or more, and the "
-    "Multi-Person card never sets state.selected_person, so the single id falls "
-    "through to the whole-window query. The CLI's fetch_videos_and_live_photos "
-    "branches on len(person_ids) == 1 and filters. Same request, one video of "
-    "Alice and one of everybody."
-)
-
 PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE = (
     "--person narrows any memory type on the CLI and no type but two in the "
     "wizard. fetch_videos_and_live_photos takes whatever person_ids generate.py "
@@ -448,7 +438,7 @@ FETCH_SCENARIOS = (
     FetchScenario(MemoryType.YEAR_IN_REVIEW, ()),
     FetchScenario(MemoryType.PERSON_SPOTLIGHT, (ALICE,)),
     FetchScenario(MemoryType.MULTI_PERSON, (ALICE, BOB)),
-    FetchScenario(MemoryType.MULTI_PERSON, (ALICE,), MULTI_PERSON_OF_ONE_DIVERGENCE),
+    FetchScenario(MemoryType.MULTI_PERSON, (ALICE,)),
     FetchScenario(
         MemoryType.YEAR_IN_REVIEW, (ALICE, BOB), PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE
     ),

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -70,8 +70,6 @@ class MemorySpec:
             "holiday": self.holiday,
             "years_back": self.years_back,
             "target_date": self.on_this_day_target,
-            "trip_start": self.trip_start,
-            "trip_end": self.trip_end,
             "location_name": self.location_name,
             **self.as_cli_preset_params(),
         }
@@ -80,17 +78,22 @@ class MemorySpec:
     def as_cli_preset_params(self) -> dict:
         """What ``generate`` forwards to the preset factory, beside the flags.
 
-        Only a special day has inputs the CLI cannot spell as date flags: the
-        window and the title come out of the catalogue that ``--day`` names, so
-        they travel as preset parameters on both surfaces alike.
+        Two memory types have inputs the CLI cannot spell as date flags, and
+        both are discovered rather than typed: a special day's window and title
+        come out of the catalogue that ``--day`` names, and a trip's dates come
+        out of GPS detection. ``--start``/``--end`` mean something else on a
+        trip -- they pick which detected trip to render -- so the trip's own
+        span travels as preset parameters on both surfaces alike.
         """
-        catalogued = {
+        discovered = {
             "day": self.day,
             "window": self.window,
             "title": self.title,
             "active_hours": self.active_hours,
+            "trip_start": self.trip_start,
+            "trip_end": self.trip_end,
         }
-        return {key: value for key, value in catalogued.items() if value is not None}
+        return {key: value for key, value in discovered.items() if value is not None}
 
 
 # The people a spec can name, as the wizard would have picked them.
@@ -170,21 +173,6 @@ DOCUMENTED_DURATION_SPLIT: dict[MemoryType, DocumentedDifference] = {
     ),
 }
 
-# Divergences nobody decided on. Strict xfail, so the day one is repaired the
-# entry has to be deleted -- a fix cannot land while the record still claims
-# the surfaces disagree.
-TRIP_WINDOW_DIVERGENCE = (
-    "The CLI resolves --memory-type trip to the whole calendar year: "
-    "_resolve_memory_type_dates falls through to calendar_year() because no flag "
-    "carries the trip's dates. The window it really fetches is built a third time, "
-    "inline at cli/_trip_generation.py, from the detected trip -- and that copy ends "
-    "the last day at 23:59:59.999999 where date_builders.build_trip ends it at "
-    "23:59:59. The wizard calls build_trip through the preset. One rule, three "
-    "implementations, which is #658's disease on a second memory type. Duration "
-    "follows the window, so the CLI plans 300s off a 366-day span where the wizard "
-    "shows the trip's own editorial length."
-)
-
 
 def _bounds(date_range: DateRange) -> tuple[datetime, datetime]:
     return (date_range.start, date_range.end)
@@ -247,18 +235,14 @@ def ui_duration(memory_type: MemoryType, spec: MemorySpec) -> float | None:
     return create_preset(memory_type, **spec.as_preset_params()).default_duration_seconds
 
 
-def _parametrized_types(divergent: dict[MemoryType, str]):
-    """Every type in SPECS, with the ones known to disagree marked xfail."""
-    return [
-        pytest.param(
-            memory_type,
-            marks=pytest.mark.xfail(reason=divergent[memory_type], strict=True)
-            if memory_type in divergent
-            else (),
-            id=str(memory_type),
-        )
-        for memory_type in SPECS
-    ]
+def _every_type_with_a_spec():
+    """Every type in SPECS, each as its own case.
+
+    No window or duration divergence is outstanding. A new one is recorded the
+    way the fetch scenarios record theirs -- a strict xfail carrying the reason
+    -- so that repairing it forces the record to be deleted.
+    """
+    return [pytest.param(memory_type, id=str(memory_type)) for memory_type in SPECS]
 
 
 class TestRegistryCoverage:
@@ -285,9 +269,7 @@ class TestRegistryCoverage:
 class TestDateWindowParity:
     """Same spec, same windows to search."""
 
-    @pytest.mark.parametrize(
-        "memory_type", _parametrized_types({MemoryType.TRIP: TRIP_WINDOW_DIVERGENCE})
-    )
+    @pytest.mark.parametrize("memory_type", _every_type_with_a_spec())
     def test_windows_match(self, memory_type: MemoryType) -> None:
         spec = SPECS[memory_type]
         assert cli_windows(memory_type, spec) == ui_windows(memory_type, spec)
@@ -296,9 +278,7 @@ class TestDateWindowParity:
 class TestTargetDurationParity:
     """Same spec, same default length -- or the split #630 wrote down."""
 
-    @pytest.mark.parametrize(
-        "memory_type", _parametrized_types({MemoryType.TRIP: TRIP_WINDOW_DIVERGENCE})
-    )
+    @pytest.mark.parametrize("memory_type", _every_type_with_a_spec())
     def test_duration_matches_or_matches_the_record(self, memory_type: MemoryType) -> None:
         spec = SPECS[memory_type]
         cli, ui = cli_duration(memory_type, spec), ui_duration(memory_type, spec)

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -274,6 +274,23 @@ class TestDateWindowParity:
         spec = SPECS[memory_type]
         assert cli_windows(memory_type, spec) == ui_windows(memory_type, spec)
 
+    def test_a_holiday_with_no_year_given_skips_the_one_that_has_not_happened(self) -> None:
+        """Both surfaces default the year, so both must apply the same guard.
+
+        Asking for Christmas in August with no year spends one of the requested
+        years on a window no photo can fall in. The CLI refused to; the preset
+        the wizard calls had no way to know the year had been defaulted rather
+        than chosen, so it did not. SPECS pins an explicit year for every type,
+        which is the case where the two agreed all along.
+
+        Vacuous between Christmas and New Year, when there is no unhappened
+        Christmas left to skip. build_holiday's own guard is pinned against a
+        fixed ``today`` in tests/test_holiday_memory.py.
+        """
+        spec = MemorySpec(holiday="christmas", years_back=5)
+
+        assert cli_windows(MemoryType.HOLIDAY, spec) == ui_windows(MemoryType.HOLIDAY, spec)
+
 
 class TestTargetDurationParity:
     """Same spec, same default length -- or the split #630 wrote down."""

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -12,10 +12,13 @@ exception.
 
 Differences the project decided on live in ``DOCUMENTED_DURATION_SPLIT`` and
 are asserted *exactly*, so an intentional split still fails the day either side
-moves. Differences nobody decided on are recorded as strict ``xfail`` with the
-description they need in a tracker. Repairing them is not this file's job --
-each changes what a memory contains and wants its own PR and contact sheets.
-The point is to make the next divergence loud, not to quietly fix this one.
+moves. Differences nobody decided on are recorded as strict ``xfail`` carrying
+the reason, so repairing one forces its record to be deleted in the same commit
+-- a fix cannot land while the file still claims the surfaces disagree.
+
+One xfail is left on purpose. It is not drift: the wizard has no way to express
+the request at all, and closing it means deciding which surface is right. An
+xfail that needs a decision says so in its first line.
 """
 
 from __future__ import annotations
@@ -172,6 +175,36 @@ DOCUMENTED_DURATION_SPLIT: dict[MemoryType, DocumentedDifference] = {
         cli=62.30, ui=60, recorded_at=_SPLIT_RECORD
     ),
 }
+
+
+# ── Differences this file deliberately does not assert ────────────────────────
+#
+# The three below came out of #680's first run as findings rather than failures:
+# nothing here compares them, so each is written down with the reason it is not
+# drift. A finding that turns out to be drift becomes an xfail above, not a
+# longer comment.
+#
+# "All Time" has no CLI counterpart. The wizard's year pickers offer it and
+# _apply_preset_to_state answers it directly, without create_preset, because no
+# preset covers "every year you own" -- there is no window to build from a year
+# that was never chosen. On the CLI the same memory is --start/--end, which is
+# the manual path, not a memory type. Nothing to reconcile: the surfaces differ
+# because one has an affordance the other spells out.
+#
+# Each memory type computes its length its own way -- the span curve, the trip
+# and special-day editorial curves, a flat preset constant. That is three
+# formulas but not a surface divergence: what this file owns is that both
+# surfaces get the *same* answer per type, which TestTargetDurationParity
+# asserts, and DOCUMENTED_DURATION_SPLIT pins where the project chose otherwise.
+# Whether one curve should serve every type is a selection question, not a
+# parity one.
+#
+# A trip is not narrowed to a person on either surface. handle_trip_generation
+# fetches the trip's window with no person ids, and the wizard's Trip card
+# renders no person widget, so both take the window whole. --person still
+# reaches trip *detection* on the CLI, which is what scopes the GPS scan. This
+# is consistent, but it is the same open question as
+# PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE below and moves with its answer.
 
 
 def _bounds(date_range: DateRange) -> tuple[datetime, datetime]:
@@ -394,8 +427,10 @@ def _wizard_state(
 
     step1_presets writes a single pick into ``state.selected_person`` and a
     multi-person pick into ``memory_preset_params["person_ids"]`` -- two
-    different fields, and only the Person Spotlight and Multi-Person cards
-    render a person widget at all.
+    different fields, because two different cards collect them, and only the
+    Person Spotlight and Multi-Person cards render a person widget at all. The
+    fields stay two; ``AppState.person_ids`` is what reads them as one, which is
+    the thing the fetch comparison below is really checking.
     """
     state = AppState()
     state.date_ranges = windows
@@ -441,14 +476,20 @@ class FetchScenario:
 
 
 PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE = (
-    "--person narrows any memory type on the CLI and no type but two in the "
-    "wizard. fetch_videos_and_live_photos takes whatever person_ids generate.py "
+    "NEEDS A PRODUCT DECISION -- do not repair this by guessing. --person "
+    "narrows any memory type on the CLI and no type but two in the wizard. "
+    "fetch_videos_and_live_photos takes whatever person_ids generate.py "
     "resolved, so `--memory-type year_in_review --person Alice --person Bob` "
     "fetches only what holds both; the wizard renders a person widget for Person "
-    "Spotlight and Multi-Person alone, and create_preset's PersonFilter -- which "
-    "does carry the names for every type -- is discarded by "
-    "_apply_preset_to_state. This is the stills-filter and union-vs-intersection "
-    "family: the filter exists on one surface only."
+    "Spotlight and Multi-Person alone, so no other card can name anybody. The "
+    "question is which surface is right: is a person filter on every memory type "
+    "a feature the wizard is missing, or is it a two-card feature the CLI "
+    "over-offers? Answering it also settles what several names mean on a type "
+    "that is not about people -- the CLI intersects them, while create_preset's "
+    "PersonFilter keeps person_names[:1] and drops the rest, so the two would "
+    "still disagree after the widget shipped. Until then the wizard cannot even "
+    "express the request, which is why this stays a strict xfail rather than "
+    "becoming a documented exception."
 )
 
 FETCH_SCENARIOS = (

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -617,3 +617,42 @@ class TestPersonScope:
 
     def test_a_memory_about_nobody_names_nobody(self) -> None:
         assert AppState().person_ids == []
+
+
+class TestChoosingAMemoryType:
+    """Switching cards drops what the previous card collected."""
+
+    def test_the_person_does_not_follow_you_to_the_next_card(self) -> None:
+        """Alice picked for a Person Spotlight must not narrow a Year in Review.
+
+        Only two cards show a person widget, so a person left behind by the
+        previous one filters the new memory with nothing on screen saying so.
+        """
+        from immich_memories.api.models import Person
+
+        state = AppState()
+        state.selected_person = Person(id="person-alice", name="Alice")
+        state.memory_preset_params = {"person_id": "person-alice", "year": 2024}
+
+        state.choose_memory_type("year_in_review")
+
+        assert state.person_ids == []
+        assert state.memory_preset_params == {}
+
+    def test_switching_away_from_an_album_drops_it(self) -> None:
+        """A left-over album would otherwise satisfy the step 1 scope check."""
+        state = AppState()
+        state.choose_memory_type("album")
+        state.album_id, state.album_name = "album-1", "Holiday snaps"
+
+        state.choose_memory_type("season")
+
+        assert state.album_id is None
+
+    def test_choosing_the_album_card_keeps_the_album_selectable(self) -> None:
+        state = AppState()
+        state.album_id, state.album_name = "album-1", "Holiday snaps"
+
+        state.choose_memory_type("album")
+
+        assert state.album_id == "album-1"

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -590,3 +590,30 @@ class TestFormatDurationEdgeCases:
 
         result = format_duration(61.9)
         assert result == "1:01"
+
+
+class TestPersonScope:
+    """Who a memory is about, as the one list every fetch reads."""
+
+    def test_a_group_of_one_is_still_a_filter(self) -> None:
+        """A Multi-Person memory naming one person used to fetch everybody.
+
+        That card writes its picks to memory_preset_params and never touches
+        selected_person, so a lone id read as "no people named" turned a memory
+        of Alice into a memory of the whole window.
+        """
+        state = AppState()
+        state.memory_preset_params = {"person_ids": ["person-alice"]}
+
+        assert state.person_ids == ["person-alice"]
+
+    def test_a_single_pick_reads_as_a_list_of_one(self) -> None:
+        from immich_memories.api.models import Person
+
+        state = AppState()
+        state.selected_person = Person(id="person-alice", name="Alice")
+
+        assert state.person_ids == ["person-alice"]
+
+    def test_a_memory_about_nobody_names_nobody(self) -> None:
+        assert AppState().person_ids == []


### PR DESCRIPTION
The cross-surface contract from #680 recorded six strict xfails and five non-assertable findings on its first run. Four of the six were drift and are repaired here, each in its own commit. Two are the same divergence seen twice (once per fetch variant) and stay xfail: the wizard cannot express the request at all, so closing it is a product decision, not a repair.

Every fix moves the rule into a function both surfaces already reach — the pattern #706 used for `build_special_day` — rather than copying it to each side.

## Divergences

| # | Divergence | Verdict | Where the one rule now lives |
|---|---|---|---|
| 1 | Trip window built three ways; CLI planned 300s off a 366-day span where the wizard showed 130s | **fixed** | `date_builders.build_trip`, reached by `_resolve_memory_type_dates` and by `handle_trip_generation` |
| 2 | Multi-Person memory of exactly one person: filtered on the CLI, unfiltered in the wizard | **fixed** | `api/person_scope.py` + `AppState.person_ids` |
| 3 | `--person` narrows any type on the CLI, only two cards in the wizard | **needs an owner decision** | — (strict xfail, reason states the question) |
| 4 | `selected_person` never cleared when switching cards | **fixed** | `AppState.choose_memory_type` |
| 5 | Holiday's not-yet-happened guard existed on one surface only | **fixed** | the `HOLIDAY` preset, which is what defaults the year |
| 6 | Trip fetch hardcodes `person_ids=[]` | **legitimate** (documented) | both surfaces fetch a trip unfiltered; moves with #3's answer |
| 7 | "All Time" bypasses `create_preset` | **legitimate** (documented) | wizard affordance; the CLI spells it `--start`/`--end` |
| 8 | Three unrelated duration formulas across types | **legitimate** (documented) | per-type editorial choice, not a surface split |

SPECIAL_DAY was already repaired by #695/#702/#706 — its xfails were gone before this branch, and those cases pass.

## Needs an owner decision

**Should the wizard offer a person filter on every memory type, matching `--person`, or is the person filter deliberately a two-card feature the CLI over-offers?**

Answering it also settles the follow-on: several names on a type that is not about people. `--person Alice --person Bob --memory-type year_in_review` fetches the intersection on the CLI, while `create_preset`'s `PersonFilter` keeps `person_names[:1]` and drops the rest — so the two surfaces would still disagree the day a person widget shipped on those cards. Until it is answered the wizard cannot make the request at all, which is why this stays a strict xfail rather than becoming a documented exception. It is recorded in `tests/test_surface_parity.py` under `PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE`, leading with `NEEDS A PRODUCT DECISION`.

Divergence 6 rides on the same answer: `--person` currently scopes trip *detection* (union, via `get_assets_for_any_person`) and never narrows the clips. `trip-memories.mdx` claimed the opposite — "generates a trip video using only clips that contain Alice" — so the page now describes what the code does. If the decision goes the other way, code and page change together.

## Notes for review

- Divergence 2 was live, not theoretical: the Multi-Person card's "People (select 2+)" label is not enforced, so picking one person rendered everybody's clips.
- Divergence 5's guard only bites when the year is defaulted, which SPECS never does — it gets its own assertion. It is vacuous between Christmas and New Year; `build_holiday`'s own guard stays pinned against a fixed `today` in `tests/test_holiday_memory.py`.
- The state half of switching cards moved out of the coverage-excluded page into `AppState`, so it is tested without a browser.
- `make ci` green: 5853 passed, 2 xfailed.

Part of #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
