### PR TITLE
fix(discover-days): a dropped title falls back to something honest, not a description dump

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,6 +136,7 @@ src/immich_memories/
 │   ├── progress.py             # Progress tracking helpers
 │   ├── trip_detection.py       # GPS-based trip detection (clustering, geocoding)
 │   ├── special_day.py          # Which days had something happen: active hours, not photo volume
+│   ├── special_day_title.py    # What a day may be called: the grounding guard, the re-ask, the fallback
 │   ├── album_source.py         # Album mode: the album is the candidate pool, nothing is searched for
 │   ├── source_filter.py        # Drop doorbell / dashcam / screen-recorder uploads by filename
 │   ├── source_quality.py       # Drop messaging re-encodes: sub-1080p with no camera EXIF

--- a/docs-site/docs/create/cli/discover-days.md
+++ b/docs-site/docs/create/cli/discover-days.md
@@ -195,3 +195,16 @@ Titles are checked against what the day actually recorded before they are kept. 
 naming a place the day was never in is dropped rather than shown, and so is one claiming a
 distance or a race — "the 10K" — that nothing the model was shown mentions. A title card is
 the wrong place for a plausible invention, and a number reads exactly as true as a real one.
+
+A dropped title is asked for once more, with the claim it just made quoted back and the
+rule stated as what a title *may* say rather than as another prohibition. That is usually
+enough — the model can generally write a grounded title on the second try — and it costs
+one extra call on the handful of days a year where it happens. Never a third.
+
+If the second attempt is no better, the day falls back to the plainest true thing left:
+`A day in <place>` where its pictures recorded one, or what the model said the day was
+where that reads as a title ("Children's camp activities") rather than as a description of
+it. A day where neither is available is left out of the catalogue rather than written down
+with an empty title — because every reader of the file falls back to the description when
+the title is empty, which is how "Six images captured between 07:32 and 16:06, tracing a
+route from weathered apar" ended up on a card in place of a name.

--- a/src/immich_memories/analysis/special_day.py
+++ b/src/immich_memories/analysis/special_day.py
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
     from immich_memories.config_models_llm import LLMConfig
 
 from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
+from immich_memories.analysis.special_day_title import (
+    honest_title,
+    line_the_day_can_keep,
+    retitle_prompt,
+    title_the_day_can_keep,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,64 +56,6 @@ logger = logging.getLogger(__name__)
 # about. Both sit below every labelled positive and above every negative.
 MIN_ACTIVE_HOURS = 6
 MIN_PHOTOS = 20
-
-# Capitalised words a title may use without naming anything: sentence starts,
-# the calendar, and the few verbs an English title puts after "to" — "A Day to
-# Remember" was blanked for never having been to a place called Remember.
-# Anything else has to come from the day itself. The verb list will never be
-# complete, and does not need to be: what it misses is a blanked title, which
-# is visible, rather than an invented one, which is not.
-_EVERYDAY_CAPITALS = {
-    "a",
-    "an",
-    "the",
-    "and",
-    "with",
-    "at",
-    "in",
-    "on",
-    "of",
-    "to",
-    "from",
-    "for",
-    "remember",
-    "forget",
-    "celebrate",
-    "cherish",
-    "treasure",
-    "behold",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-    "sunday",
-    "january",
-    "february",
-    "march",
-    "april",
-    "may",
-    "june",
-    "july",
-    "august",
-    "september",
-    "october",
-    "november",
-    "december",
-    "morning",
-    "afternoon",
-    "evening",
-    "night",
-    "day",
-    "birthday",
-    "wedding",
-    "christmas",
-    "easter",
-    "new",
-    "year",
-    "eve",
-}
 
 _PROMPT = """One day from someone's photo library, sampled across the day, with the
 pictures that go with these lines.
@@ -255,228 +203,6 @@ def sample_across_day(assets: list, count: int = 8) -> list:
             if not bucket:
                 hours.remove(hour)
     return sorted(picked, key=lambda a: a.file_created_at)
-
-
-def _titled(text: str, people: set[str]) -> str:
-    return text if _is_a_real_title(text, people) else ""
-
-
-def _place_vocabulary(assets: list) -> set[str]:
-    """Every place name the day recorded, or empty if it recorded none."""
-    words: set[str] = set()
-    for asset in assets:
-        exif = getattr(asset, "exif_info", None)
-        for attr in ("city", "state", "country"):
-            value = getattr(exif, attr, None) if exif else None
-            if value:
-                words.update(re.findall(r"[\w\u00c0-\u024f]+", str(value)))
-    return {w.casefold() for w in words}
-
-
-def _grounding_vocabulary(assets: list) -> set[str]:
-    """Every proper noun the model was given: the places, and who was there."""
-    words = _place_vocabulary(assets).copy()
-    for asset in assets:
-        for person in getattr(asset, "people", None) or []:
-            if getattr(person, "name", ""):
-                words.update(w.casefold() for w in re.findall(r"[\w\u00c0-\u024f]+", person.name))
-    return words
-
-
-def _knows_where_it_was(assets: list) -> bool:
-    """Did anything tell us where this day happened?"""
-    for asset in assets:
-        exif = getattr(asset, "exif_info", None)
-        if not exif:
-            continue
-        if getattr(exif, "city", None) or getattr(exif, "country", None):
-            return True
-        if getattr(exif, "latitude", None) and getattr(exif, "longitude", None):
-            return True
-    return False
-
-
-def _is_a_real_title(text: str, people: set[str]) -> bool:
-    """Reject the two things the model falls back on when it is unsure.
-
-    Asked to prefer the plain true thing, it starts answering with the one
-    fact it is certain of: "Monday 13 August 2007", or simply a
-    person's name. Both are already on the card. Seven of twenty-three titles in a
-    library sweep came back like that.
-    """
-    if not text:
-        return False
-    stripped = re.sub(
-        r"[\d,]|\b(mon|tues|wednes|thurs|fri|satur|sun)day\b", "", text, flags=re.IGNORECASE
-    )
-    stripped = re.sub(
-        r"\b(january|february|march|april|may|june|july|august|september|october"
-        r"|november|december|at|in|on|the|of)\b",
-        "",
-        stripped,
-        flags=re.IGNORECASE,
-    )
-    if not stripped.strip():
-        return False
-    return text.casefold() not in people
-
-
-# How close a written place has to be to one the day recorded. EXIF is in the
-# local language and the model writes English: a local spelling and its English form are the
-# same place and must pass.
-#
-# A ratio cannot also separate two different towns, and measuring says so: two
-# neighbouring towns twelve kilometres apart score 0.750 while a city and its
-# other-language name score 0.706, and two more pairs — one the same city in
-# two languages, one two unrelated cities — both score 0.600. There is no
-# cutoff that gets all four right. What the check is actually for is the
-# invention, and an invented famous place bears no resemblance to anything the
-# day recorded at all, so it fails at any cutoff in this range. Set low enough
-# to keep real titles, then, and do not tighten it believing it can do more.
-_SAME_PLACE_RATIO = 0.70
-
-_PLACE_PREPOSITIONS = ("in", "at", "near", "around", "from", "to", "de", "outside")
-
-
-def _named_places(text: str) -> list[str]:
-    """Capitalised words used as somewhere, rather than as something.
-
-    "to" introduces a destination as readily as it introduces a verb, and in
-    a title both are capitalised: "A Day to Remember" was blanked for having
-    never been to a place called Remember. So a candidate made only of words
-    a title may use without naming anything is not a place claim — which is
-    what _EVERYDAY_CAPITALS has always been for — and "to" stays, because
-    dropping it left a located day with no guard on place claims at all.
-    """
-    pattern = (
-        r"\b(?:" + "|".join(_PLACE_PREPOSITIONS) + r")\s+"
-        r"((?:[A-Z\u00c0-\u00dd][\w\u00c0-\u024f'-]+(?:[ -](?:de|la|le|sur|of|the))?\s*){1,3})"
-    )
-    found = [m.strip() for m in re.findall(pattern, text)]
-    return [
-        place
-        for place in found
-        if not all(
-            word.casefold() in _EVERYDAY_CAPITALS
-            for word in re.findall(r"[\w\u00c0-\u024f]+", place)
-        )
-    ]
-
-
-def _place_is_real(place: str, vocabulary: set[str]) -> bool:
-    """Did the day actually happen anywhere by this name?"""
-    import difflib
-
-    for word in re.findall(r"[\w\u00c0-\u024f]+", place):
-        if len(word) < 4:
-            continue
-        if difflib.get_close_matches(
-            word.casefold(), list(vocabulary), n=1, cutoff=_SAME_PLACE_RATIO
-        ):
-            return True
-    return False
-
-
-# Distances and the races named after one. Both are claims a title makes as
-# flatly as it names a place, and both read as true whether or not the day
-# recorded anything of the kind.
-_QUANTITY = re.compile(
-    r"\b\d+\s?(?:k|km|mi|miles?)\b|\b(?:marathon|triathlon|ironman|ultra)\b",
-    re.IGNORECASE,
-)
-
-
-def _same_quantity(written: str) -> str:
-    """ "20 km" and "20km" are one claim, written twice."""
-    return re.sub(r"\s+", "", written).casefold()
-
-
-def _unsupported_quantity(text: str, evidence: str) -> str | None:
-    """A distance or a race the lines the model was given never mention.
-
-    Asked about a morning of running whose evidence says only that there were
-    runners in numbered bibs, the model answered with a specific distance. The
-    place guard had nothing to say about it — it only ever read places — and a
-    number is a claim of exactly the same kind.
-    """
-    supported = {_same_quantity(q) for q in _QUANTITY.findall(evidence)}
-    return next((q for q in _QUANTITY.findall(text) if _same_quantity(q) not in supported), None)
-
-
-def _only_if_grounded(
-    text: str, vocabulary: set[str], *, located: bool, places: set[str], evidence: str
-) -> str:
-    """Drop a line whose specifics the day cannot support.
-
-    Asked about a night out with no city and no GPS anywhere in it, the model
-    answered with three names and a town. The names were real
-    and a place was invented, in spite of the prompt forbidding it. A title card
-    is the wrong place for a plausible invention.
-
-    The capitalised-word check only applies when the day carries no location at
-    all. Given coordinates, naming the circuit they sit on is inference from
-    data, and an earlier version that policed every capitalised word threw away
-    "Audi R8 V10 Track Day at a place" — a correct reading of the pictures —
-    because no EXIF field happens to contain the word Audi.
-    """
-    # A number nothing on the day mentions. This one runs on every day,
-    # located or not: a distance is not inference from coordinates the way a
-    # circuit's name is, and the prompt asking for it costs nothing to ignore.
-    if unsupported := _unsupported_quantity(text, evidence):
-        logger.info("Dropping %r: nothing on this day mentions %r", text, unsupported)
-        return ""
-
-    if place := _place_it_was_never_in(text, places):
-        logger.info("Dropping %r: the day was never in %r", text, place)
-        return ""
-
-    if coined := _guessed_name(text, vocabulary):
-        logger.info("Dropping %r: %r looks like a guessed name", text, coined)
-        return ""
-
-    if not text or located:
-        return text
-
-    # On a day with no location at all, every capitalised word has to come
-    # from the day itself.
-    for word in re.findall(r"\b[A-Z\u00c0-\u00dd][\w\u00c0-\u024f'-]{2,}", text):
-        if word.casefold() not in vocabulary and word.casefold() not in _EVERYDAY_CAPITALS:
-            logger.info(
-                "Dropping title %r: the day has no location and nothing mentions %r", text, word
-            )
-            return ""
-    return text
-
-
-def _place_it_was_never_in(text: str, places: set[str]) -> str | None:
-    """A place the day never recorded.
-
-    Asked about a track day at a place — with three villages all in its EXIF —
-    the model answered "the famous circuit", Belgium's famous circuit rather
-    than the one the coordinates sit on. Recognising the kind of place and
-    naming the well-known instance of it is the failure that keeps recurring.
-
-    Only when the day recorded place names at all: with coordinates and no
-    city, naming the circuit they sit on is inference this cannot check, and
-    rejecting it would throw away the model's best work.
-    """
-    if not places:
-        return None
-    return next((p for p in _named_places(text) if not _place_is_real(p, places)), None)
-
-
-def _guessed_name(text: str, vocabulary: set[str]) -> str | None:
-    """A CamelCase name nothing on the day mentions.
-
-    Told twice in the prompt not to name an event it could not read, the model
-    answered "Attending KubeCon" and then, the same day, "Attending GitLab
-    All-Hands" — a hall full of lanyards, and an invented answer to which
-    conference it was. Both of those days knew exactly where they were, so this
-    runs before the located early-return or it never runs at all. An internal
-    capital is what separates it from Audi, R8 or a place name.
-    """
-    coined = re.findall(r"\b[A-Z][a-z]+[A-Z][\w]*", text)
-    return next((c for c in coined if c.casefold() not in vocabulary), None)
 
 
 # Two places count as one if they are closer than this.
@@ -699,6 +425,58 @@ def _look_at(
     return seen
 
 
+def _asked_again(
+    rejected: str,
+    assets: list,
+    lines: str,
+    llm_config: LLMConfig,
+    timeout_seconds: int,
+    images: list[bytes],
+    thinking: bool,
+) -> str:
+    """One more attempt at a title, once the guard has taken the first one away.
+
+    Once, never twice: a model that has now been told what the evidence shows
+    and answered with an invention anyway is not going to be talked round on a
+    third try, and every attempt is a live call on a scan that makes a handful
+    per year. Same call shape as the judgement it follows, so it inherits the
+    same routing, cache and thinking budget.
+    """
+    try:
+        raw = _ask(
+            retitle_prompt(lines, rejected=rejected, assets=assets),
+            llm_config,
+            timeout_seconds,
+            images,
+            thinking=thinking,
+        )
+    except Exception as exc:  # noqa: BLE001 - a second ask that fails is not a verdict
+        stop_if_this_is_our_bug(exc, "special-day retitle")
+        logger.debug("Special-day retitle failed: %s", type(exc).__name__)
+        return ""
+    # A null content is documented mlx-vlm behaviour, guarded here exactly as
+    # the judgement above guards it rather than coerced away.
+    if not raw:
+        logger.debug("Special-day retitle came back empty")
+        return ""
+    answer = _json_in(raw)
+    if answer is None:
+        return ""
+    return title_the_day_can_keep(str(answer.get("title", ""))[:60].strip(), assets, evidence=lines)
+
+
+def _json_in(raw: str) -> dict | None:
+    """The one JSON object in an answer, or nothing if there is none to read."""
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        return None
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 @dataclass(frozen=True)
 class SpecialDay:
     """What the model made of a day."""
@@ -759,38 +537,24 @@ def ask_if_special(
         logger.debug("Special-day question came back empty")
         return SpecialDay(special=False)
 
-    match = re.search(r"\{.*\}", raw, re.DOTALL)
-    if not match:
+    answer = _json_in(raw)
+    if answer is None:
         return SpecialDay(special=False)
-    try:
-        answer = json.loads(match.group(0))
-    except json.JSONDecodeError:
-        return SpecialDay(special=False)
-    grounded = _grounding_vocabulary(assets)
-    located = _knows_where_it_was(assets)
-    places = _place_vocabulary(assets)
-    named = {
-        p.name.casefold()
-        for a in assets
-        for p in (getattr(a, "people", None) or [])
-        if getattr(p, "name", "")
-    }
+    special = bool(answer.get("special"))
+    written = str(answer.get("title", ""))[:60].strip()
+    what = str(answer.get("what", ""))[:80].strip()
+    title = title_the_day_can_keep(written, assets, evidence=lines)
+    # Only for a day that is going to be kept. An ordinary day is discarded
+    # whatever it is called, and a second live call to name it better is spent
+    # on nothing.
+    if special and written and not title:
+        title = _asked_again(written, assets, lines, llm_config, timeout_seconds, images, reasons)
     return SpecialDay(
-        special=bool(answer.get("special")),
-        title=_only_if_grounded(
-            _titled(str(answer.get("title", ""))[:60].strip(), named),
-            grounded,
-            located=located,
-            places=places,
-            evidence=lines,
+        special=special,
+        title=title or honest_title(assets, what=what, evidence=lines),
+        subtitle=line_the_day_can_keep(
+            str(answer.get("subtitle", ""))[:90].strip(), assets, evidence=lines
         ),
-        subtitle=_only_if_grounded(
-            str(answer.get("subtitle", ""))[:90].strip(),
-            grounded,
-            located=located,
-            places=places,
-            evidence=lines,
-        ),
-        what=str(answer.get("what", ""))[:80].strip(),
+        what=what,
         window=_window_the_model_gave(answer, assets),
     )

--- a/src/immich_memories/analysis/special_day_title.py
+++ b/src/immich_memories/analysis/special_day_title.py
@@ -1,0 +1,411 @@
+"""What a day may be called, and what to call it when the model's answer cannot be.
+
+The model writes the title; this decides whether the day can support it. Asked
+about a night out with no city and no GPS anywhere in it, the model answered
+with three names and a town — the names real, the town invented — and a title
+card is the wrong place for a plausible invention.
+
+Dropping the invention is only half the job. A 2010 scan put days in the
+catalogue titled "Six images captured between 07:32 and 16:06, tracing a route
+from weathered apar": the day's own description, cut at eighty characters and
+wearing a title's hat, because the drop left nothing else to show. So a dropped
+title is asked for once more, and what is kept after that is the plainest true
+thing the day still knows — where it was, or what it was. There is no
+date-derived last resort here on purpose: the date is already on the card, and
+a day nothing can name is a day the catalogue is better off not keeping.
+"""
+
+from __future__ import annotations
+
+import collections
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Capitalised words a title may use without naming anything: sentence starts,
+# the calendar, and the few verbs an English title puts after "to" — "A Day to
+# Remember" was blanked for never having been to a place called Remember.
+# Anything else has to come from the day itself. The verb list will never be
+# complete, and does not need to be: what it misses is a blanked title, which
+# is visible, rather than an invented one, which is not.
+_EVERYDAY_CAPITALS = {
+    "a",
+    "an",
+    "the",
+    "and",
+    "with",
+    "at",
+    "in",
+    "on",
+    "of",
+    "to",
+    "from",
+    "for",
+    "remember",
+    "forget",
+    "celebrate",
+    "cherish",
+    "treasure",
+    "behold",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+    "january",
+    "february",
+    "march",
+    "april",
+    "may",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+    "morning",
+    "afternoon",
+    "evening",
+    "night",
+    "day",
+    "birthday",
+    "wedding",
+    "christmas",
+    "easter",
+    "new",
+    "year",
+    "eve",
+}
+
+
+def title_the_day_can_keep(written: str, assets: list, *, evidence: str) -> str:
+    """The model's title, or nothing if the day cannot support it."""
+    return _only_if_grounded(_a_title_at_all(written, _named_people(assets)), assets, evidence)
+
+
+def line_the_day_can_keep(written: str, assets: list, *, evidence: str) -> str:
+    """The line under the title, held to the same rule as the title."""
+    return _only_if_grounded(written, assets, evidence)
+
+
+def honest_title(assets: list, *, what: str, evidence: str) -> str:
+    """What to call a day whose own title was dropped, or nothing.
+
+    The place comes before `what` because it is the checked signal: it is read
+    off the day's own EXIF, while `what` is another line of the same answer the
+    guard just refused. And `what` is only a title when it reads as one — the
+    model writes that field as a caption as readily as a name, and the
+    description it wrote for a day in 2010 is what put a truncated sentence on
+    a title card in the first place.
+
+    Nothing at all is a valid answer. A day the library cannot name honestly is
+    refused rather than rendered under a generic date, here as everywhere else.
+    """
+    if not what:
+        return ""
+    if place := _where_it_was(assets):
+        return f"A day in {place}"
+    return (
+        title_the_day_can_keep(what, assets, evidence=evidence) if _reads_as_a_title(what) else ""
+    )
+
+
+def retitle_prompt(lines: str, *, rejected: str, assets: list) -> str:
+    """Ask again for a title, saying what the last one claimed and what a title may claim.
+
+    Told once, positively, rather than handed the growing list of things not to
+    say: the model usually can write a grounded title on a second try, and the
+    thing it got wrong is worth naming because it is the thing it is otherwise
+    about to write again.
+    """
+    unplaced = (
+        ""
+        if _knows_where_it_was(assets)
+        else "\nNothing on this day records where it was, so no place name can be right.\n"
+    )
+    return _RETITLE_PROMPT.format(lines=lines, rejected=rejected, unplaced=unplaced)
+
+
+_RETITLE_PROMPT = """The same day again, one line per picture, in the order they were taken.
+
+{lines}
+
+A title was written for it and put aside: "{rejected}" claims something the
+lines above do not show.
+
+Write another one. Every specific in it — a place, a distance, a count, a name —
+comes from those lines: write what they show, as concretely as they show it, and
+nothing more. Not the date and not a name on its own; both are already on the card.
+{unplaced}
+Answer with STRICT JSON only, no prose:
+{{"title": "<a few words>"}}"""
+
+
+# A title is a few words; the day's description is a sentence. The model writes
+# `what` as either, and the sentence is what reached the catalogue as a title:
+# "Six images captured between 07:32 and 16:06, tracing a route from weathered
+# apar" is the day described, truncated, and it is 12 words with a clock in it.
+_TITLE_WORDS = 6
+_A_CLOCK = re.compile(r"\d{1,2}:\d{2}")
+
+
+def _reads_as_a_title(text: str) -> bool:
+    words = text.split()
+    return bool(words) and len(words) <= _TITLE_WORDS and not _A_CLOCK.search(text)
+
+
+def _where_it_was(assets: list) -> str:
+    """The place the day's own pictures name most often, spelled as they spell it.
+
+    Coordinates are not a place name: a day with GPS and no city has nowhere
+    this can name, and inventing one from the numbers is the failure the guard
+    above exists for.
+    """
+    for attr in ("city", "state", "country"):
+        names = collections.Counter(
+            str(value)
+            for asset in assets
+            if (value := getattr(getattr(asset, "exif_info", None), attr, None))
+        )
+        if names:
+            return names.most_common(1)[0][0]
+    return ""
+
+
+def _named_people(assets: list) -> set[str]:
+    return {
+        person.name.casefold()
+        for asset in assets
+        for person in (getattr(asset, "people", None) or [])
+        if getattr(person, "name", "")
+    }
+
+
+def _a_title_at_all(text: str, people: set[str]) -> str:
+    return text if _is_a_real_title(text, people) else ""
+
+
+def _place_vocabulary(assets: list) -> set[str]:
+    """Every place name the day recorded, or empty if it recorded none."""
+    words: set[str] = set()
+    for asset in assets:
+        exif = getattr(asset, "exif_info", None)
+        for attr in ("city", "state", "country"):
+            value = getattr(exif, attr, None) if exif else None
+            if value:
+                words.update(re.findall(r"[\w\u00c0-\u024f]+", str(value)))
+    return {w.casefold() for w in words}
+
+
+def _grounding_vocabulary(assets: list) -> set[str]:
+    """Every proper noun the model was given: the places, and who was there."""
+    words = _place_vocabulary(assets).copy()
+    for asset in assets:
+        for person in getattr(asset, "people", None) or []:
+            if getattr(person, "name", ""):
+                words.update(w.casefold() for w in re.findall(r"[\w\u00c0-\u024f]+", person.name))
+    return words
+
+
+def _knows_where_it_was(assets: list) -> bool:
+    """Did anything tell us where this day happened?"""
+    for asset in assets:
+        exif = getattr(asset, "exif_info", None)
+        if not exif:
+            continue
+        if getattr(exif, "city", None) or getattr(exif, "country", None):
+            return True
+        if getattr(exif, "latitude", None) and getattr(exif, "longitude", None):
+            return True
+    return False
+
+
+def _is_a_real_title(text: str, people: set[str]) -> bool:
+    """Reject the two things the model falls back on when it is unsure.
+
+    Asked to prefer the plain true thing, it starts answering with the one
+    fact it is certain of: "Monday 13 August 2007", or simply a
+    person's name. Both are already on the card. Seven of twenty-three titles in a
+    library sweep came back like that.
+    """
+    if not text:
+        return False
+    stripped = re.sub(
+        r"[\d,]|\b(mon|tues|wednes|thurs|fri|satur|sun)day\b", "", text, flags=re.IGNORECASE
+    )
+    stripped = re.sub(
+        r"\b(january|february|march|april|may|june|july|august|september|october"
+        r"|november|december|at|in|on|the|of)\b",
+        "",
+        stripped,
+        flags=re.IGNORECASE,
+    )
+    if not stripped.strip():
+        return False
+    return text.casefold() not in people
+
+
+# How close a written place has to be to one the day recorded. EXIF is in the
+# local language and the model writes English: a local spelling and its English form are the
+# same place and must pass.
+#
+# A ratio cannot also separate two different towns, and measuring says so: two
+# neighbouring towns twelve kilometres apart score 0.750 while a city and its
+# other-language name score 0.706, and two more pairs — one the same city in
+# two languages, one two unrelated cities — both score 0.600. There is no
+# cutoff that gets all four right. What the check is actually for is the
+# invention, and an invented famous place bears no resemblance to anything the
+# day recorded at all, so it fails at any cutoff in this range. Set low enough
+# to keep real titles, then, and do not tighten it believing it can do more.
+_SAME_PLACE_RATIO = 0.70
+
+_PLACE_PREPOSITIONS = ("in", "at", "near", "around", "from", "to", "de", "outside")
+
+
+def _named_places(text: str) -> list[str]:
+    """Capitalised words used as somewhere, rather than as something.
+
+    "to" introduces a destination as readily as it introduces a verb, and in
+    a title both are capitalised: "A Day to Remember" was blanked for having
+    never been to a place called Remember. So a candidate made only of words
+    a title may use without naming anything is not a place claim — which is
+    what _EVERYDAY_CAPITALS has always been for — and "to" stays, because
+    dropping it left a located day with no guard on place claims at all.
+    """
+    pattern = (
+        r"\b(?:" + "|".join(_PLACE_PREPOSITIONS) + r")\s+"
+        r"((?:[A-Z\u00c0-\u00dd][\w\u00c0-\u024f'-]+(?:[ -](?:de|la|le|sur|of|the))?\s*){1,3})"
+    )
+    found = [m.strip() for m in re.findall(pattern, text)]
+    return [
+        place
+        for place in found
+        if not all(
+            word.casefold() in _EVERYDAY_CAPITALS
+            for word in re.findall(r"[\w\u00c0-\u024f]+", place)
+        )
+    ]
+
+
+def _place_is_real(place: str, vocabulary: set[str]) -> bool:
+    """Did the day actually happen anywhere by this name?"""
+    import difflib
+
+    for word in re.findall(r"[\w\u00c0-\u024f]+", place):
+        if len(word) < 4:
+            continue
+        if difflib.get_close_matches(
+            word.casefold(), list(vocabulary), n=1, cutoff=_SAME_PLACE_RATIO
+        ):
+            return True
+    return False
+
+
+# Distances and the races named after one. Both are claims a title makes as
+# flatly as it names a place, and both read as true whether or not the day
+# recorded anything of the kind.
+_QUANTITY = re.compile(
+    r"\b\d+\s?(?:k|km|mi|miles?)\b|\b(?:marathon|triathlon|ironman|ultra)\b",
+    re.IGNORECASE,
+)
+
+
+def _same_quantity(written: str) -> str:
+    """ "20 km" and "20km" are one claim, written twice."""
+    return re.sub(r"\s+", "", written).casefold()
+
+
+def _unsupported_quantity(text: str, evidence: str) -> str | None:
+    """A distance or a race the lines the model was given never mention.
+
+    Asked about a morning of running whose evidence says only that there were
+    runners in numbered bibs, the model answered with a specific distance. The
+    place guard had nothing to say about it — it only ever read places — and a
+    number is a claim of exactly the same kind.
+    """
+    supported = {_same_quantity(q) for q in _QUANTITY.findall(evidence)}
+    return next((q for q in _QUANTITY.findall(text) if _same_quantity(q) not in supported), None)
+
+
+def _only_if_grounded(text: str, assets: list, evidence: str) -> str:
+    """Drop a line whose specifics the day cannot support.
+
+    Asked about a night out with no city and no GPS anywhere in it, the model
+    answered with three names and a town. The names were real
+    and a place was invented, in spite of the prompt forbidding it. A title card
+    is the wrong place for a plausible invention.
+
+    The capitalised-word check only applies when the day carries no location at
+    all. Given coordinates, naming the circuit they sit on is inference from
+    data, and an earlier version that policed every capitalised word threw away
+    "Audi R8 V10 Track Day at a place" — a correct reading of the pictures —
+    because no EXIF field happens to contain the word Audi.
+    """
+    # A number nothing on the day mentions. This one runs on every day,
+    # located or not: a distance is not inference from coordinates the way a
+    # circuit's name is, and the prompt asking for it costs nothing to ignore.
+    if unsupported := _unsupported_quantity(text, evidence):
+        logger.info("Dropping %r: nothing on this day mentions %r", text, unsupported)
+        return ""
+
+    if place := _place_it_was_never_in(text, _place_vocabulary(assets)):
+        logger.info("Dropping %r: the day was never in %r", text, place)
+        return ""
+
+    vocabulary = _grounding_vocabulary(assets)
+    if coined := _guessed_name(text, vocabulary):
+        logger.info("Dropping %r: %r looks like a guessed name", text, coined)
+        return ""
+
+    if not text or _knows_where_it_was(assets):
+        return text
+
+    # On a day with no location at all, every capitalised word has to come
+    # from the day itself \u2014 except the first, which is capitalised because it
+    # opens the line. "Children's camp activities" claims nothing, and dropping
+    # it for that C is how a day ends up with no title to show at all.
+    for found in re.finditer(r"\b[A-Z\u00c0-\u00dd][\w\u00c0-\u024f'-]{2,}", text):
+        word = found.group()
+        if found.start() == 0:
+            continue
+        if word.casefold() not in vocabulary and word.casefold() not in _EVERYDAY_CAPITALS:
+            logger.info(
+                "Dropping title %r: the day has no location and nothing mentions %r", text, word
+            )
+            return ""
+    return text
+
+
+def _place_it_was_never_in(text: str, places: set[str]) -> str | None:
+    """A place the day never recorded.
+
+    Asked about a track day at a place — with three villages all in its EXIF —
+    the model answered "the famous circuit", Belgium's famous circuit rather
+    than the one the coordinates sit on. Recognising the kind of place and
+    naming the well-known instance of it is the failure that keeps recurring.
+
+    Only when the day recorded place names at all: with coordinates and no
+    city, naming the circuit they sit on is inference this cannot check, and
+    rejecting it would throw away the model's best work.
+    """
+    if not places:
+        return None
+    return next((p for p in _named_places(text) if not _place_is_real(p, places)), None)
+
+
+def _guessed_name(text: str, vocabulary: set[str]) -> str | None:
+    """A CamelCase name nothing on the day mentions.
+
+    Told twice in the prompt not to name an event it could not read, the model
+    answered "Attending KubeCon" and then, the same day, "Attending GitLab
+    All-Hands" — a hall full of lanyards, and an invented answer to which
+    conference it was. Both of those days knew exactly where they were, so this
+    runs before the located early-return or it never runs at all. An internal
+    capital is what separates it from Audi, R8 or a place name.
+    """
+    coined = re.findall(r"\b[A-Z][a-z]+[A-Z][\w]*", text)
+    return next((c for c in coined if c.casefold() not in vocabulary), None)

--- a/src/immich_memories/automation/special_day_scan.py
+++ b/src/immich_memories/automation/special_day_scan.py
@@ -199,7 +199,14 @@ def scan_year(
     for day, items in sorted(candidates.items(), key=lambda kv: -len(kv[1]))[:ask]:
         thumbnails = _thumbnails_for(items, thumbnail_for)
         verdict = ask_if_special(items, llm_config, thumbnails=thumbnails)
-        if not verdict.special or not (verdict.title or verdict.what):
+        # A title, not just something written about the day. Every reader of
+        # this file falls back to `what` when the title is empty, so an entry
+        # with no title is how the day's own description — "Six images captured
+        # between 07:32 and 16:06, tracing a route from weathered apar" — ended
+        # up on a card. The ask already offers the day's place or its `what`
+        # where either can carry a title; nothing left after that means nothing
+        # truthful to call the day.
+        if not verdict.special or not verdict.title:
             continue
         started, ended = run_extent(items) or (None, None)
         found.append(

--- a/tests/test_special_day.py
+++ b/tests/test_special_day.py
@@ -252,12 +252,14 @@ class TestATitleHasToBeATitle:
             return ask_if_special(day, llm_config=SimpleNamespace())
 
     def test_a_date_is_not_a_title(self) -> None:
-        assert self._answer(self._day([]), "Monday 13 August 2007").title == ""
+        """Asked again and answered with the date again, so the day is left
+        with the plainest thing its own pictures recorded."""
+        assert self._answer(self._day([]), "Monday 13 August 2007").title == "A day in Anytown"
 
     def test_a_persons_name_is_not_a_title(self) -> None:
         day = self._day(["Third Person"])
 
-        assert self._answer(day, "Third Person").title == ""
+        assert self._answer(day, "Third Person").title == "A day in Anytown"
 
     def test_saying_what_happened_is(self) -> None:
         day = self._day(["Third Person"])
@@ -268,7 +270,7 @@ class TestATitleHasToBeATitle:
         """A day with a useless title is still a day something happened on."""
         verdict = self._answer(self._day([]), "Monday 13 August 2007")
 
-        assert verdict.title == ""
+        assert verdict.title == "A day in Anytown"
         assert verdict.special is True
 
 

--- a/tests/test_special_day_fallback.py
+++ b/tests/test_special_day_fallback.py
@@ -1,0 +1,144 @@
+"""What a day is called once the grounding guard has taken the model's title away.
+
+The guard works: an ungrounded title is dropped. What replaced it was the
+day's own description with the end cut off — "Six images captured between
+07:32 and 16:06, tracing a route from weathered apar" — which is a caption
+wearing a title's hat. A live scan over 2010 put several of those in the
+catalogue.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from immich_memories.analysis.special_day import ask_if_special
+
+# The entry #714 was reported for, at the width the catalogue stored it.
+_A_DESCRIPTION = "Six images captured between 07:32 and 16:06, tracing a route from weathered apar"
+
+
+def _day(city: str | None = None) -> list[SimpleNamespace]:
+    """A day with nothing to place it, which is when the guard blanks a title."""
+    return [
+        SimpleNamespace(
+            file_created_at=datetime(2010, 8, 14, hour, tzinfo=UTC),
+            exif_info=SimpleNamespace(
+                city=city,
+                state=None,
+                country=city and "Belgium",
+                latitude=None,
+                longitude=None,
+            ),
+            people=[],
+        )
+        for hour in range(8, 16)
+    ]
+
+
+def _answers(*payloads: str):
+    """The model, answering each question in turn."""
+    # WHY: the LLM server is the external boundary; these are its answers.
+    return patch("immich_memories.analysis.special_day._ask", side_effect=list(payloads))
+
+
+def test_a_dropped_title_is_asked_for_once_more() -> None:
+    """The model usually can write a grounded title on a second try."""
+    with _answers(
+        '{"special": true, "title": "The Ambassador\'s glass", "what": "a walk"}',
+        '{"title": "A long afternoon out"}',
+    ):
+        verdict = ask_if_special(_day(), llm_config=SimpleNamespace())
+
+    assert verdict.title == "A long afternoon out"
+
+
+def test_the_day_is_asked_again_once_and_only_when_its_title_was_taken() -> None:
+    """A scan makes a handful of live calls a year; a retry is a real cost.
+
+    Once, never twice: a model told what the evidence shows that answers with
+    an invention anyway will not be talked round on a third try.
+    """
+    kept = '{"special": true, "title": "A long afternoon out", "what": "a walk"}'
+    invented = '{"special": true, "title": "The Ambassador\'s glass", "what": "a walk"}'
+
+    with _answers(kept) as asked:
+        ask_if_special(_day(), llm_config=SimpleNamespace())
+    assert asked.call_count == 1, "a title the day supports is not questioned"
+
+    with _answers(invented, invented) as asked:
+        ask_if_special(_day(), llm_config=SimpleNamespace())
+    assert asked.call_count == 2, "and a title it does not is asked for exactly once more"
+
+    ordinary = '{"special": false, "title": "The Ambassador\'s glass", "what": "a walk"}'
+    with _answers(ordinary) as asked:
+        ask_if_special(_day(), llm_config=SimpleNamespace())
+    assert asked.call_count == 1, "an ordinary day is discarded, so its title is not worth a call"
+
+
+def test_a_day_that_knows_where_it_was_is_named_after_the_place() -> None:
+    """Two inventions in a row, and the day still recorded one true thing."""
+    with _answers(
+        f'{{"special": true, "title": "A drive day at Circuit de Faraway", "what": "{_A_DESCRIPTION}"}}',
+        '{"title": "Racing at Faraway"}',
+    ):
+        verdict = ask_if_special(_day(city="Gantvile"), llm_config=SimpleNamespace())
+
+    assert verdict.title == "A day in Gantvile"
+
+
+def test_a_day_with_no_place_is_named_after_what_it_was() -> None:
+    """The 2010 days had no location at all — that is why the guard fired.
+
+    All that is left of such a day is what the model said it was, and that
+    field is a title whenever it reads as one.
+    """
+    with _answers(
+        '{"special": true, "title": "The Ambassador\'s glass", "what": "Children\'s camp activities"}',
+        '{"title": "An evening at Faraway"}',
+    ):
+        verdict = ask_if_special(_day(), llm_config=SimpleNamespace())
+
+    assert verdict.title == "Children's camp activities"
+
+
+def test_the_days_description_never_wears_a_titles_hat() -> None:
+    """The reported bug, from the answer that produced it.
+
+    `what` comes back as a caption as readily as a name. A sentence with the
+    clock in it and the end cut off is not a title, and no amount of having
+    nothing better to show makes it one.
+    """
+    with _answers(
+        f'{{"special": true, "title": "The Ambassador\'s glass", "what": "{_A_DESCRIPTION}"}}',
+        '{"title": "An evening at Faraway"}',
+    ):
+        verdict = ask_if_special(_day(), llm_config=SimpleNamespace())
+
+    assert _A_DESCRIPTION not in verdict.title
+    assert verdict.title == "", "and there is nothing honest left to call this day"
+
+
+def test_a_day_nothing_can_name_is_not_written_down() -> None:
+    """An entry with an empty title is read as its description everywhere.
+
+    `days-due` and the wizard both print the title or fall back to `what`, so
+    a catalogue entry the scan could not title is exactly how the description
+    reached a card. A day the library cannot name is refused instead.
+    """
+    from immich_memories.automation.special_day_scan import scan_year
+
+    # Enough of the day to clear the structural bar and reach the model at all.
+    day = _day() * 3
+
+    # WHY: ask_if_special is the LLM call; here it comes back unable to name the day.
+    with patch(
+        "immich_memories.automation.special_day_scan.ask_if_special",
+        return_value=SimpleNamespace(
+            special=True, title="", subtitle="", what=_A_DESCRIPTION, window=None
+        ),
+    ):
+        found = scan_year(day, llm_config=None, home=None)
+
+    assert found == [], "a day with no title it can keep is not a find"


### PR DESCRIPTION
Closes #714

The #672 grounding guard does its job — an ungrounded title is dropped — but what replaced it was the day's own description with the end cut off.

## The live evidence

A `discover-days` run over 2010 filed several days like this:

> "Six images captured between 07:32 and 16:06, tracing a route from weathered apar…"

That is the `what` field at its eighty-character cap, reaching the card through the `title or what` fallback that `days-due`, the wizard's Surprise me card and `create_preset` all have. Other entries from the same run carry an empty title, which is the same bug seen from the file side. Those days had no location at all, which is exactly when the guard's capitalised-word check fires.

## The ladder

1. **Ask once more.** The dropped title is quoted back and the rule is stated as what a title *may* say — "every specific comes from those lines" — instead of appended to a list of prohibitions. Where the day recorded nowhere, the prompt says so, because that is the one correction it actually needs. Same `_ask` path as the judgement it follows, so it inherits that routing, cache and thinking budget. Once, never twice, and only for a day that will be kept — an ordinary day is discarded whatever it is called.
2. **`A day in <place>`** where the day's own EXIF recorded one. It comes before `what` because it is the checked signal: read off the pictures rather than written by the model whose last two answers were just refused.
3. **The `what` string** where it reads as a title ("Children's camp activities") rather than as a sentence with a clock in it — and held to the same grounding guard.

No date-derived last resort: the date is already on the card, and `factory.py` already refuses a day it cannot name rather than render "Memories from 12 June 2016". A day with none of the above is now left out of the catalogue instead of written down with an empty title, since an empty title *is* how the description reached a card.

## Falling out of it

- A capital at the **start** of a line is grammar, not a claim. The unlocated-day check no longer drops "Children's camp activities" for its C — a false positive that also cost real titles like "Cycling through the woods".
- The guard moved to `analysis/special_day_title.py` along with the re-ask and the fallback it now owns. One cohesion boundary — "what a day may be called" — and `special_day.py` goes 796 → 556 lines instead of past the 800 soft limit.

## Tests

`tests/test_special_day_fallback.py`, one behaviour each: the re-ask is used when it works; the place form when both asks fail; the `what` form when there is no place; the description dump never appears as a title; a day nothing can name is not written down; and the call budget — 1 call for a title the day supports, 2 for one it does not, 1 for an ordinary day. Three tests in `test_special_day.py` that pinned `title == ""` now pin the honest replacement instead — the claim is still refused, the day just is not left blank.

`make ci` green (5835 passed).

## Entries already in a catalogue

This fixes what gets written, not what was written. The 2010 entries carrying the truncated description are still in `~/.immich-memories/special-days.json` with an empty `title`, and `days-due` and the Surprise me card will keep showing their `what` until those years are scanned again with `--rescan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
