### PR TITLE
chore(deploy): pin the kustomize image to the current release

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -44,7 +44,10 @@ kubectl port-forward -n immich-memories svc/immich-memories 8080:80
 ```
 
 `base/kustomization.yaml` pins the image tag (`images: newTag`). Published tags carry no `v`
-prefix (`0.59.2`, `latest`); bump it when you upgrade.
+prefix — release `vX.Y.Z` is image tag `X.Y.Z` — plus `latest`. The checked-in pin trails the
+current release, so check it against the
+[releases page](https://github.com/sam-dumont/immich-video-memory-generator/releases) before you
+apply, and bump it when you upgrade.
 
 ## How the pod is wired
 

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -20,7 +20,9 @@ resources:
   #   cp ingress.yaml.example ingress.yaml
   # - ingress.yaml
 
-# Published image tags carry no `v` prefix (0.59.2, latest). Bump on upgrade.
+# Published image tags carry no `v` prefix: release `vX.Y.Z` ships as image tag `X.Y.Z`
+# (plus `latest`). Releases land faster than this pin does — check it against the releases
+# page before you apply, and bump it when you upgrade.
 images:
   - name: ghcr.io/sam-dumont/immich-video-memory-generator
-    newTag: "0.59.2"
+    newTag: "0.70.0"

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -96,7 +96,7 @@ module "immich_memories" {
 | `namespace` | Kubernetes namespace | `string` | `"immich-memories"` |
 | `create_namespace` | Create the namespace | `bool` | `true` |
 | `image_repository` | Container image | `string` | `"ghcr.io/sam-dumont/immich-video-memory-generator"` |
-| `image_tag` | Image tag (no `v` prefix: `0.59.2`, `latest`) | `string` | `"latest"` |
+| `image_tag` | Image tag (no `v` prefix: `vX.Y.Z` ships as `X.Y.Z`, plus `latest`) | `string` | `"latest"` |
 | `replicas` | Keep at 1 | `number` | `1` |
 | `resources` | Requests/limits object | `object` | `2Gi/1000m` – `8Gi/4000m` |
 | `tmp_size` | `/tmp` emptyDir (8Gi for 4K) | `string` | `"4Gi"` |

--- a/deploy/terraform/examples/production/terraform.tfvars.example
+++ b/deploy/terraform/examples/production/terraform.tfvars.example
@@ -6,8 +6,10 @@ kubeconfig_context = "production-cluster"
 namespace          = "immich-memories"
 environment        = "production"
 
-# Image (published tags carry no `v` prefix)
-image_tag = "0.59.2"
+# Image — production pins a release rather than tracking `latest`. Published tags carry no
+# `v` prefix: release `vX.Y.Z` is image tag `X.Y.Z`. Pick the one you want from
+# https://github.com/sam-dumont/immich-video-memory-generator/releases
+image_tag = "replace-with-a-release-tag"
 
 # Immich
 immich_url     = "https://photos.example.com"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "image_repository" {
 }
 
 variable "image_tag" {
-  description = "Container image tag. Published tags carry no `v` prefix: 0.59.2, latest"
+  description = "Container image tag. Published tags carry no `v` prefix: `vX.Y.Z` ships as `X.Y.Z`, plus `latest`"
   type        = string
   default     = "latest"
 }

--- a/tests/test_deploy_manifests_contract.py
+++ b/tests/test_deploy_manifests_contract.py
@@ -88,6 +88,22 @@ def test_kustomization_pins_a_published_image_tag() -> None:
     assert "commonLabels" not in kustomization
 
 
+def test_only_the_kustomization_pin_names_a_concrete_version() -> None:
+    """One `0.59.2` was copied into five prose sites and all six rotted together (#732).
+
+    The pin is the only number a reader should trust, so everything else states the rule
+    (`vX.Y.Z` ships as `X.Y.Z`) instead of quoting a release that goes stale within a day.
+    """
+    offenders = {}
+    for name, text in _deploy_texts().items():
+        if name.endswith("base/kustomization.yaml"):
+            text = re.sub(r"(?m)^\s*newTag:.*$", "", text)
+        if found := re.findall(r"\d+\.\d+\.\d+", text):
+            offenders[name] = found
+
+    assert not offenders, offenders
+
+
 def test_config_directory_is_a_writable_persistent_volume() -> None:
     """The app writes cache/, projects/, cache.db and .storage_secret at startup."""
     for label, pod in _pod_specs():


### PR DESCRIPTION
Closes #732.

## What shipped

The pin was ten releases stale at `0.59.2`; it now reads `0.70.0`. While bumping it I found the
same number copy-pasted into **five** more places that had all rotted with it:

| file | was |
|---|---|
| `deploy/kubernetes/base/kustomization.yaml` (the comment above the pin) | `0.59.2` |
| `deploy/kubernetes/README.md` | `0.59.2` |
| `deploy/terraform/README.md` | `0.59.2` |
| `deploy/terraform/variables.tf` | `0.59.2` |
| `deploy/terraform/examples/production/terraform.tfvars.example` | `image_tag = "0.59.2"` |

Only one of those six is a pin. The other five now state the rule — release `vX.Y.Z` ships as
image tag `X.Y.Z` — the way #721 already did for the docs site, and a contract test keeps it
that way. `test_only_the_kustomization_pin_names_a_concrete_version` fails if anything under
`deploy/` names a concrete `X.Y.Z` other than the pin itself. Its source of truth is in-repo
(the pin), so it needs no network and never has to be re-bumped.

## The automation: blocked, and not by anything I should route around

Read `release.yml` first, as asked. Two things it turned out not to be.

**It is not semantic-release.** `[tool.semantic_release]` in `pyproject.toml` and `make release`
both exist, but the workflow that actually cuts releases never invokes them — the `analyze` job
is hand-rolled bash that greps merge-commit subjects and conventional-commit prefixes since the
last tag. So shape (b) is out: extending a semantic-release `prepare`/`assets` hook would be
dead config on the path that matters.

**Shape (a) cannot commit back to `main`.** `main` carries an active repository ruleset
(id 13789507):

```json
"rules": [{"type": "deletion"}, {"type": "non_fast_forward"},
          {"type": "pull_request", "require_code_owner_review": true,
           "allowed_merge_methods": ["squash"]}],
"bypass_actors": [],
"current_user_can_bypass": "never",
"enforcement": "active"
```

`bypass_actors` is empty — nobody bypasses, the Actions bot included. A `git push origin main`
from the release job is rejected with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Classic protection stacks on top (7 required contexts, `strict: true`), and the Contents API is
refused for the same reason — rulesets apply to the API, not only to git. The release job's
existing `git push origin "v$NEXT_VERSION"` works because it targets `refs/tags/*`, which this
branch-targeted ruleset does not cover. That is why the workflow has never pushed a commit to
`main`, and why there is not one bot commit in the last 400 on `main`.

The obvious fallback — have the release job open a PR instead of pushing — is blocked
independently. `ci.yml` triggers on `pull_request`, and a PR opened with `GITHUB_TOKEN` does not
fire `pull_request` events, so those 7 required contexts would never report and the PR would sit
unmergeable forever. `release.yml:411` already documents this repo hitting the same rule from
the other side ("GITHUB_TOKEN events don't trigger other workflows").

Renovate is not a way out either. `renovate.json` exists, but the app has never opened a single
PR here, `enabledManagers` has no custom/regex manager, and the schedule is weekly with
`minimumReleaseAge: 7 days` — against a several-releases-per-day cadence the pin would be
structurally stale even if it ran.

That leaves two real unblocks, both of which are yours to make rather than mine:

1. add `github-actions[bot]` (or a dedicated GitHub App) to the ruleset's `bypass_actors`, after
   which shape (a) is ~15 lines in `release.yml`; or
2. give the release job a GitHub App token that holds the bypass.

Both punch a hole in a protection that currently has *zero* bypass actors, on a repo that signs
build provenance and runs Scorecard. Not an agent's call to make unilaterally.

## Loop prevention, for whenever that unblock happens

Verified by replaying the `analyze` job's own filters against the subject, not assumed:

- branch heuristic — `chore/…` matches none of `breaking/|major/`, `feat/|feature/|minor/`,
  `fix/|bugfix/|patch/|hotfix/`
- commit heuristic — `chore(deploy):` matches none of `^feat…!:|BREAKING CHANGE`, `^feat…:`,
  `^(fix|perf)…:`
- → `RELEASE_TYPE=none` → `should_release=false`

Belt and braces: `GITHUB_TOKEN` pushes do not trigger workflows at all, so `push: branches:
[main]` would not re-enter even if the subject did match; and under
`allowed_merge_methods: ["squash"]` there are no merge commits, so the branch heuristic never
fires. Independently, python-semantic-release would also read it as version-neutral — `chore` is
in `allowed_tags` but in neither `minor_tags` (`feat`) nor `patch_tags` (`fix`, `perf`).

## Checks

`make ci` green locally. Nothing under `.github/workflows/` is touched, so this PR carries no
CODEOWNERS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
