### PR TITLE
test(cli): the --memory-type choices can no longer fall behind the enum

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -21,6 +21,7 @@ from immich_memories.automation.system_scheduler import (
 )
 from immich_memories.cli import main
 from immich_memories.config_loader import Config
+from immich_memories.memory_types.registry import MemoryType
 
 
 def _invoke(args: list[str], config: Config | None = None) -> Result:
@@ -221,6 +222,21 @@ class TestCLIMemoryTypeFlags:
         """--person flag accepts multiple values."""
         result = _invoke(["generate", "--help"])
         assert "--person" in result.output
+
+    def test_choices_are_every_memory_type_but_album(self):
+        """The flag's choice list is hand-written; MemoryType is what it must track.
+
+        `album` is the one member left out on purpose: an album is a set of
+        assets rather than a window to resolve, so it is selected by naming it
+        with `--from-album`, and `--memory-type album` would have nothing to
+        compute. Any other member missing here ships unreachable from the CLI.
+        """
+        memory_type_option = next(
+            param for param in main.commands["generate"].params if param.name == "memory_type"
+        )
+        assert set(memory_type_option.type.choices) == {m.value for m in MemoryType} - {"album"}, (
+            "--memory-type's choices in cli/generate_options.py have fallen behind MemoryType"
+        )
 
 
 class TestCLIMemoryTypeResolve:


### PR DESCRIPTION
Closes #730

`--memory-type`'s `click.Choice` list in `cli/generate_options.py` is hand-maintained. Today that is 11 members in `MemoryType` against 10 choices on the flag — `album` is left out on purpose — but nothing held the difference to exactly that. Add a memory type to the registry, forget the choice, and it ships unreachable from the CLI with a user as the first person to notice.

One test, in `TestCLIMemoryTypeFlags` where the rest of the flag's surface is checked:

```python
assert set(memory_type_option.type.choices) == {m.value for m in MemoryType} - {"album"}
```

It reads the choices off the built Click command rather than a hand-copied list, so it pins the real flag rather than a second copy of it. The `album` exclusion carries the reason in the docstring: an album is a set of assets, not a window to resolve — it is selected by naming it with `--from-album`, and `--memory-type album` would have nothing to compute.

Verified RED-capable rather than assumed: adding a `PET = "pet"` member to the registry fails the test with `Extra items in the right set: 'pet'` and a message naming the file to edit. Reverted.

`tests/test_surface_parity.py`'s contract machinery is untouched — it covers UI/CLI agreement, this covers enum/CLI agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f