### PR TITLE
fix(config): a credential alias must round-trip, not just persist

### DIFF
--- a/docs-site/docs/deploy/configuration/environment-variables.md
+++ b/docs-site/docs/deploy/configuration/environment-variables.md
@@ -105,6 +105,7 @@ A few common variables are also supported without the full prefix, for convenien
 | `ACE_STEP_ENABLED` | `ace_step.enabled` |
 | `ACE_STEP_MODE` | `ace_step.mode` (`api` or `lib`; other values ignored) |
 | `ACE_STEP_API_URL` | `ace_step.api_url` |
+| `ACE_STEP_API_KEY` | `ace_step.api_key` |
 | `IMMICH_MEMORIES_AUTH_USERNAME` + `IMMICH_MEMORIES_AUTH_PASSWORD` | `auth.username` / `auth.password`, and sets `auth.enabled=true`, `auth.provider=basic`. **Both** must be set; either alone is ignored. |
 
 :::caution Shorthand vars are skipped with an explicit config path

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -343,6 +343,8 @@ def _apply_env_overrides(config: Config) -> None:
         config.ace_step.mode = ace_step_mode  # type: ignore[assignment]
     if ace_step_url := os.environ.get("ACE_STEP_API_URL"):
         config.ace_step.api_url = ace_step_url
+    if ace_step_key := os.environ.get("ACE_STEP_API_KEY"):
+        config.ace_step.api_key = ace_step_key
 
     # Auth shortcut: set both USERNAME + PASSWORD to auto-enable basic auth
     if (auth_user := os.environ.get("IMMICH_MEMORIES_AUTH_USERNAME")) and (

--- a/src/immich_memories/config_models_soundtrack.py
+++ b/src/immich_memories/config_models_soundtrack.py
@@ -132,7 +132,7 @@ class ACEStepConfig(BaseModel):
         description="Maximum time per generation job (seconds)",
     )
 
-    @field_validator("api_url", mode="before")
+    @field_validator("api_url", "api_key", mode="before")
     @classmethod
     def expand_env(cls, v: str) -> str:
         """Expand environment variables in config values."""

--- a/tests/test_config_env_secrets.py
+++ b/tests/test_config_env_secrets.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from immich_memories.config_loader import Config
+import pytest
+
+from immich_memories.config_loader import _CREDENTIAL_ENV_ALIASES, Config, _apply_env_overrides
 
 FROM_ENV = "sk-do-not-write-me-to-disk"
 
@@ -66,6 +68,69 @@ def test_a_templated_secret_round_trips(tmp_path: Path, monkeypatch):
     Config.from_yaml(source).save_yaml(out)
 
     assert Config.from_yaml(out).immich.api_key == FROM_ENV
+
+
+def test_an_ace_step_key_from_the_env_survives_save_and_reload(tmp_path: Path, monkeypatch):
+    """The ACE-Step alias was write-only: persisted as a template nothing expanded.
+
+    Saving wrote `${ACE_STEP_API_KEY}` because the alias is a feeder for the
+    field, but `ACEStepConfig` expanded `${VAR}` on `api_url` alone. The file
+    then held a placeholder that read back as the literal string, so a working
+    config lost its ACE-Step key the first time anyone pressed Save.
+    """
+    monkeypatch.setenv("ACE_STEP_API_KEY", FROM_ENV)
+    config = Config()
+    config.ace_step.api_key = FROM_ENV
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+    assert "${ACE_STEP_API_KEY}" in out.read_text(), "the save path stopped writing the template"
+
+    assert Config.from_yaml(out).ace_step.api_key == FROM_ENV
+
+
+def test_the_ace_step_key_is_read_from_its_own_env_var(monkeypatch):
+    """An alias the save path writes is one the load path has to answer to.
+
+    `MUSICGEN_API_KEY` reaches its field with nothing in config.yaml; the
+    ACE-Step block already read `ACE_STEP_ENABLED`, `_MODE` and `_API_URL` and
+    skipped only the key, so the one variable that is a secret was the one
+    variable the loader ignored.
+    """
+    monkeypatch.setenv("ACE_STEP_API_KEY", FROM_ENV)
+    config = Config()
+
+    _apply_env_overrides(config)
+
+    assert config.ace_step.api_key == FROM_ENV
+
+
+@pytest.mark.parametrize(
+    ("path", "alias"),
+    [(path, alias) for path, aliases in _CREDENTIAL_ENV_ALIASES.items() for alias in aliases],
+)
+def test_every_credential_alias_reads_back_from_the_file_it_was_persisted_into(
+    path: str, alias: str, tmp_path: Path, monkeypatch
+):
+    """Being a feeder for the save path obliges a variable to survive the load path.
+
+    Membership in `_CREDENTIAL_ENV_ALIASES` is what makes `save_yaml` write
+    `${ALIAS}` in place of the secret, so every member owes the reverse: the file
+    it just produced has to resolve on its own. Asserted through `from_yaml`
+    alone, because `_apply_env_overrides` would answer the same variable a second
+    time and hide a field whose `${VAR}` expansion was never wired up -- which is
+    exactly how the ACE-Step key stayed broken.
+    """
+    section, field = path.split(".")
+    monkeypatch.setenv(alias, FROM_ENV)
+    config = Config()
+    setattr(getattr(config, section), field, FROM_ENV)
+
+    out = tmp_path / "saved.yaml"
+    config.save_yaml(out)
+    assert FROM_ENV not in out.read_text(), f"{alias} is not feeding the save path any more"
+
+    assert getattr(getattr(Config.from_yaml(out), section), field) == FROM_ENV
 
 
 def test_other_credential_fields_are_covered_too(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Closes #731

`ACE_STEP_API_KEY` fed the save path but nothing on the load path answered it: membership in `_CREDENTIAL_ENV_ALIASES` is what makes `save_yaml` write `${ACE_STEP_API_KEY}` in place of the secret, so a working config lost its ACE-Step key the first time anyone pressed Save.

## The decision: symmetric alias, both directions

The other four aliases round-trip, so this one is made to match them rather than dropped from the save path. Verified against the tree instead of assumed — a script that saved and reloaded every alias in the registry:

```
immich.api_key    IMMICH_API_KEY                   reloaded=OK
llm.api_key       OPENAI_API_KEY                   reloaded=OK
musicgen.api_key  MUSICGEN_API_KEY                 reloaded=OK
ace_step.api_key  ACE_STEP_API_KEY                 reloaded='${ACE_STEP_API_KEY}'   <-- literal
auth.password     IMMICH_MEMORIES_AUTH_PASSWORD    reloaded=OK
```

Dropping the alias instead would have been the wrong half: it would put the resolved secret back on disk, and `ace_step.api_key` is the only credential in the registry whose siblings (`ACE_STEP_ENABLED`, `_MODE`, `_API_URL`) are already read.

## Two gaps, one behavior

That same probe showed the break is **upstream of `_apply_env_overrides`**, which the issue named as the sole cause:

- `ACEStepConfig` expanded `${VAR}` on `api_url` alone, so the persisted placeholder read back as the literal string. Its `MusicGenConfig` twin covers `api_key` and `base_url` both. **This is the root cause** — and the one that matters under `--config PATH`, where the shorthand table is skipped entirely.
- `_apply_env_overrides`'s ACE-Step block read `ACE_STEP_ENABLED`, `_MODE` and `_API_URL`, skipping only the variable that is a secret.

Fixing only the second would have turned the round-trip test green while leaving any `${VAR}` in `ace_step.api_key` broken. Two lines of source.

## Tests

Three, each RED-verified before its fix:

- `test_an_ace_step_key_from_the_env_survives_save_and_reload` — the issue's scenario, failed with `assert '${ACE_STEP_API_KEY}' == 'sk-...'`.
- `test_the_ace_step_key_is_read_from_its_own_env_var` — the bare-variable direction, failed with `assert '' == 'sk-...'`.
- `test_every_credential_alias_reads_back_from_the_file_it_was_persisted_into` — parametrized over `_CREDENTIAL_ENV_ALIASES`, pinning the class. Reverting the validator fix fails exactly `[ace_step.api_key-ACE_STEP_API_KEY]` and leaves the other four green.

That last one asserts through `from_yaml` alone on purpose: `_apply_env_overrides` would answer the same variable a second time and mask a field whose `${VAR}` expansion was never wired up — which is how this one stayed broken.

Docs: the issue said not to document the variable until it round-trips. It does now, so it joins the shorthand-overrides table. `make docs-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f