### PR TITLE
fix(security): redact known secret values from every log record

### DIFF
--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -598,8 +598,9 @@ of the section is config-only.
 decided, so an Immich workflow (or a cron, or a phone shortcut) can start a memory. See
 [Trigger from Immich or anything else](../create/recipes/trigger-endpoint.md). Keep it out of
 `config.yaml` with `IMMICH_MEMORIES_SERVER__TRIGGER_TOKEN` or a `${VAR}` reference; either way it
-is redacted from `/health` and the config viewer. There is no global log filter, so treat anything
-you print yourself as your own problem.
+is redacted from `/health`, the config viewer, and the logs. Log redaction is armed at config
+load, so the handful of lines printed before the config exists — startup, a config file that
+fails to parse — cannot be covered by it.
 
 `host` is the one value "save" leaves out of `config.yaml` when you never set it. Writing the
 `0.0.0.0` default would make the next load treat it as your decision and quietly retire the

--- a/src/immich_memories/config_loader.py
+++ b/src/immich_memories/config_loader.py
@@ -42,8 +42,13 @@ from immich_memories.config_models_render import (
 from immich_memories.config_models_server import WILDCARD_HOST, ServerConfig
 from immich_memories.config_models_soundtrack import ACEStepConfig, AudioConfig, MusicGenConfig
 from immich_memories.config_presets import PresetName, apply_preset
+from immich_memories.logging_config import install_secret_redaction
 from immich_memories.scheduling.models import SchedulerConfig
-from immich_memories.security import CREDENTIAL_FIELD_NAMES, write_secret_file
+from immich_memories.security import (
+    CREDENTIAL_FIELD_NAMES,
+    configured_secret_values,
+    write_secret_file,
+)
 
 # Tier 2 sections — grouped under `advanced:` in YAML, flat on Config at runtime.
 _TIER2_SECTIONS = frozenset(
@@ -268,6 +273,7 @@ class Config(BaseSettings):
         try:
             config = cls()
             config._credential_templates = _credential_templates(_yaml_source_data)
+            _arm_log_redaction(config)
             return config
         finally:
             _yaml_source_data = {}
@@ -319,6 +325,16 @@ class Config(BaseSettings):
 _config: Config | None = None
 
 
+def _arm_log_redaction(config: Config) -> None:
+    """Teach the log filter this config's secrets so they never reach a log line.
+
+    Called from every path that produces a live Config, because config load is
+    the first moment the values exist. Lines logged before it -- startup, a
+    config file that fails to parse -- cannot be redacted by construction.
+    """
+    install_secret_redaction(configured_secret_values(config))
+
+
 def _apply_env_overrides(config: Config) -> None:
     """Apply environment variable overrides to a Config instance."""
     if url := os.environ.get("IMMICH_URL"):
@@ -368,6 +384,8 @@ def get_config(reload: bool = False) -> Config:
     if _config is None or reload:
         _config = Config.from_yaml(Config.get_default_path())
         _apply_env_overrides(_config)
+        # Env vars can introduce credentials the YAML never held.
+        _arm_log_redaction(_config)
 
     return _config
 
@@ -376,6 +394,7 @@ def set_config(config: Config) -> None:
     """Set the global configuration instance."""
     global _config
     _config = config
+    _arm_log_redaction(config)
 
 
 def init_config_dir() -> Path:

--- a/src/immich_memories/logging_config.py
+++ b/src/immich_memories/logging_config.py
@@ -11,6 +11,12 @@ The format can be selected via:
 run_id injection:
 - Call set_current_run_id() at pipeline start to tag all subsequent log lines.
 - Enables: jq 'select(.run_id=="...")' for JSON logs.
+
+Secret redaction:
+- Call install_secret_redaction() at config load with the configured credentials;
+  SecretRedactionFilter then strips those values from every record.
+- Config load is the earliest the values are known, so the lines printed before
+  it -- startup, a config file that fails to parse -- are unredacted.
 """
 
 from __future__ import annotations
@@ -21,6 +27,7 @@ import logging
 import os
 import sys
 import traceback
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Protocol
 
@@ -49,6 +56,72 @@ class RunIdFilter(logging.Filter):
         return True
 
 
+REDACTED = "[redacted]"
+
+# A secret shorter than this is not worth hiding: substring-replacing "abc"
+# would shred every innocent line that happens to contain it, and the damage
+# would outlast the leak it prevented.
+MIN_REDACTABLE_SECRET_LENGTH = 8
+
+# Secret VALUES to strip from log records. Populated at config load, because
+# that is the first moment the values are known.
+_secret_values: tuple[str, ...] = ()
+
+
+def install_secret_redaction(values: Iterable[str]) -> None:
+    """Register secret values to strip from every subsequent log record.
+
+    Accumulates rather than replaces, so reloading a config never un-redacts a
+    secret that earlier code may already have captured. Values shorter than
+    MIN_REDACTABLE_SECRET_LENGTH and empty values are ignored.
+
+    Log lines emitted before this is called -- startup, config parse errors --
+    are unredacted by construction: nothing knows the secrets yet.
+    """
+    global _secret_values
+    keep = {v for v in values if isinstance(v, str) and len(v) >= MIN_REDACTABLE_SECRET_LENGTH}
+    # WHY: longest first -- when one secret contains another (an api key inside
+    # a notification URL), replacing the short one first would leave the rest of
+    # the long one in the clear.
+    _secret_values = tuple(sorted(keep | set(_secret_values), key=len, reverse=True))
+
+
+def _redact(text: str) -> str:
+    for secret in _secret_values:
+        text = text.replace(secret, REDACTED)
+    return text
+
+
+class SecretRedactionFilter(logging.Filter):
+    """Strip registered secret values out of a record's message and traceback."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not _secret_values:
+            return True
+
+        # WHY: collapse msg % args into one string before redacting. A secret
+        # can arrive as a non-str arg (an exception object, a URL wrapper) whose
+        # value only surfaces once %-formatting has run, so redacting msg and
+        # args separately would miss it. Only a record that actually carried a
+        # secret is rewritten; getMessage() skips %-formatting when args is
+        # None, so the substituted text is safe to re-emit verbatim.
+        message = record.getMessage()
+        redacted = _redact(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = None
+
+        if record.exc_text:
+            record.exc_text = _redact(record.exc_text)
+        elif record.exc_info and record.exc_info[1] is not None:
+            # WHY: formatters render the traceback from exc_info, out of a
+            # filter's reach. Pre-rendering it into exc_text -- the cache
+            # logging.Formatter prefers -- is the only place redaction can land.
+            record.exc_text = _redact("".join(traceback.format_exception(*record.exc_info)))
+
+        return True
+
+
 class JsonFormatter(logging.Formatter):
     """Format log records as single-line JSON."""
 
@@ -66,7 +139,11 @@ class JsonFormatter(logging.Formatter):
             log_entry["run_id"] = run_id
 
         if record.exc_info and record.exc_info[1] is not None:
-            log_entry["exception"] = traceback.format_exception(*record.exc_info)
+            # WHY: exc_text carries SecretRedactionFilter's already-cleaned
+            # traceback. Re-rendering from exc_info here would undo it and put
+            # the secrets straight back into the JSON.
+            text = record.exc_text or "".join(traceback.format_exception(*record.exc_info))
+            log_entry["exception"] = text.splitlines(keepends=True)
 
         return json.dumps(log_entry, default=str)
 
@@ -121,6 +198,7 @@ def install_live_handler(display: _LogSink) -> list[logging.Handler]:
 
     handler = LiveDisplayLogHandler(display)
     handler.addFilter(RunIdFilter())
+    handler.addFilter(SecretRedactionFilter())
     root.addHandler(handler)
 
     # WHY: Disable lastResort handler — Python's logging module has a
@@ -181,6 +259,7 @@ def configure_logging(
 
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.addFilter(RunIdFilter())
+    stream_handler.addFilter(SecretRedactionFilter())
 
     if fmt == "json":
         stream_handler.setFormatter(JsonFormatter())
@@ -195,6 +274,7 @@ def configure_logging(
     if log_file:
         file_handler = logging.FileHandler(log_file)
         file_handler.addFilter(RunIdFilter())
+        file_handler.addFilter(SecretRedactionFilter())
         if fmt == "json":
             file_handler.setFormatter(JsonFormatter())
         else:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,8 +4,29 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 
-from immich_memories.logging_config import JsonFormatter, configure_logging
+import pytest
+
+from immich_memories import logging_config
+from immich_memories.logging_config import (
+    JsonFormatter,
+    SecretRedactionFilter,
+    configure_logging,
+    install_secret_redaction,
+)
+
+
+def _record(msg: object, args: object = (), exc_info: object = None) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg=msg,
+        args=args,
+        exc_info=exc_info,  # type: ignore[arg-type]
+    )
 
 
 class TestConfigureLogging:
@@ -129,3 +150,94 @@ class TestJsonFormatter:
         )
         output = formatter.format(record)
         assert "\n" not in output
+
+
+class TestSecretRedaction:
+    """Known secret values never reach a formatted log line.
+
+    Pre-config behaviour is deliberately not asserted here: redaction is armed
+    by `install_secret_redaction` at config load, so anything logged before the
+    config exists (startup, a config-file parse error) is unredacted by
+    construction. There is no earlier moment at which the values are known.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_registered_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Registration accumulates process-wide, so each test starts from empty.
+        monkeypatch.setattr(logging_config, "_secret_values", ())
+
+    def test_trigger_token_in_a_message_is_redacted(self) -> None:
+        install_secret_redaction(["trigger-token-from-config"])
+        record = _record("POST /api/trigger rejected token=trigger-token-from-config")
+
+        SecretRedactionFilter().filter(record)
+
+        assert "trigger-token-from-config" not in record.getMessage()
+        assert "[redacted]" in record.getMessage()
+
+    def test_api_key_in_an_exception_is_redacted(self) -> None:
+        install_secret_redaction(["immich-api-key-0123456789"])
+        try:
+            raise RuntimeError("upstream rejected immich-api-key-0123456789")
+        except RuntimeError:
+            record = _record("asset fetch failed", exc_info=sys.exc_info())
+
+        SecretRedactionFilter().filter(record)
+        rendered = logging.Formatter("%(message)s").format(record)
+
+        assert "immich-api-key-0123456789" not in rendered
+        assert "[redacted]" in rendered
+
+    def test_api_key_in_an_exception_is_redacted_in_json_output(self) -> None:
+        install_secret_redaction(["immich-api-key-0123456789"])
+        try:
+            raise RuntimeError("upstream rejected immich-api-key-0123456789")
+        except RuntimeError:
+            record = _record("asset fetch failed", exc_info=sys.exc_info())
+
+        SecretRedactionFilter().filter(record)
+        rendered = JsonFormatter().format(record)
+
+        assert "immich-api-key-0123456789" not in rendered
+        assert any("RuntimeError" in line for line in json.loads(rendered)["exception"])
+
+    def test_a_record_carrying_no_secret_is_unchanged(self) -> None:
+        install_secret_redaction(["immich-api-key-0123456789"])
+        record = _record("selected %d clips from %s", args=(42, "Summer 2024"))
+        formatter = logging.Formatter("%(message)s")
+        before = formatter.format(record)
+
+        SecretRedactionFilter().filter(record)
+
+        assert formatter.format(record) == before == "selected 42 clips from Summer 2024"
+
+    def test_secrets_below_the_length_floor_are_never_applied(self) -> None:
+        # 0, 3 and 7 characters -- all under MIN_REDACTABLE_SECRET_LENGTH.
+        install_secret_redaction(["", "abc", "short12"])
+        record = _record("abc short12 appear in an album title")
+
+        SecretRedactionFilter().filter(record)
+
+        assert record.getMessage() == "abc short12 appear in an album title"
+
+    def test_handlers_configured_by_configure_logging_redact(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        install_secret_redaction(["trigger-token-from-config"])
+        configure_logging(fmt="text", level="INFO")
+
+        logging.getLogger("test.redaction").warning("token=trigger-token-from-config")
+
+        printed = capsys.readouterr().out
+        assert "trigger-token-from-config" not in printed
+        assert "[redacted]" in printed
+
+    def test_loading_a_config_arms_redaction_for_its_trigger_token(self) -> None:
+        from immich_memories.config import Config, set_config
+
+        set_config(Config(server={"trigger_token": "workflow-token-secret-value"}))
+        record = _record("rejected token=workflow-token-secret-value")
+
+        SecretRedactionFilter().filter(record)
+
+        assert "workflow-token-secret-value" not in record.getMessage()


### PR DESCRIPTION
Closes #729

`logging_config` installed only `RunIdFilter`, so a bare trigger token that reached a log line — a rejected-request message, a URL in an error, anything inside a traceback — was printed verbatim. `sanitize_error_message` is call-site-only and pattern-based; its `api-key` / `Bearer` / `api_key` patterns never matched a naked token. It stays exactly where it is, as the second line for messages built before logging.

## What changed

`SecretRedactionFilter` now rides alongside `RunIdFilter` on every handler `configure_logging` and `install_live_handler` build (stream, file, and the LiveDisplay handler). It redacts by **value**, not by pattern, because the values are known the moment the config loads.

Coverage comes from the existing `configured_secret_values()` walk of the config tree, so the filter picks up every field the schema already marks secret:

| Field | Source |
|---|---|
| `immich.api_key` | `CREDENTIAL_FIELD_NAMES` |
| `server.trigger_token` | `CREDENTIAL_FIELD_NAMES` |
| `llm.api_key`, `title_llm.api_key` | `CREDENTIAL_FIELD_NAMES` |
| `musicgen.api_key`, `ace_step.api_key` | `CREDENTIAL_FIELD_NAMES` |
| `auth.password`, `auth.client_secret` | `CREDENTIAL_FIELD_NAMES` |
| `notifications.urls` | credential-bearing URLs |

Per-account identity keys join automatically when #717 lands — nothing here enumerates fields itself.

## Details worth knowing

- **Registration is at config load**, via `install_secret_redaction()` called from `Config.from_yaml`, `get_config` (after env overrides, which can introduce credentials the YAML never held), and `set_config` (the UI saving a new key). Log lines emitted *before* a config exists — startup, a config file that fails to parse — are unredacted by construction; there is no earlier moment the values are known. Documented in the module docstring, the test class, and the config reference.
- **Registration accumulates**, so reloading a config never un-redacts a secret earlier code may already have captured.
- **8-character floor.** Substring-replacing a short value would shred every innocent line containing it — the damage would outlast the leak it prevented. Empty values are skipped too.
- **Longest secret first**, so an api key embedded in a notification URL cannot leave the tail of the URL in the clear.
- **`msg` and `args` are collapsed before redacting.** A secret can arrive as a non-`str` arg whose value only surfaces once `%`-formatting has run, so redacting the two separately would miss it. Only a record that actually carried a secret is rewritten.
- **Tracebacks go through `exc_text`.** Formatters render the traceback from `exc_info`, out of a filter's reach; pre-rendering into `exc_text` — the cache `logging.Formatter` prefers — is the only place redaction can land. `JsonFormatter` was re-rendering from `exc_info` and had to be taught to prefer `exc_text`, otherwise JSON logs put the secrets straight back.

## Tests

Six behaviour tests in `tests/test_logging_config.py`: trigger token in a message, api key in an exception under both the text and JSON formatters, a clean record coming out byte-identical, secrets under the length floor never applied, and the two wiring paths (handlers built by `configure_logging` actually redact; loading a config arms the filter). Pre-config behaviour is documented in the test class docstring rather than asserted. No mocks.

`make ci` green; `make docs-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
