### PR TITLE
fix(cache): a version bump re-asks, it does not strand the corpus

### DIFF
--- a/docs-site/docs/deploy/maintenance/health-logs-cache.md
+++ b/docs-site/docs/deploy/maintenance/health-logs-cache.md
@@ -142,6 +142,14 @@ From the CLI:
 immich-memories cache stats
 ```
 
+`cache stats` reports **scored assets** and **banked looks** separately. They
+differ because a look is stored against the model and prompt version that
+produced it: when either changes, the new answer is banked *beside* the old one
+rather than replacing it, so an asset can hold several. That is deliberate —
+the previous behaviour made every stored answer unreadable on a prompt edit, and
+re-analysed the whole library from scratch. The cost is a few MB; the benefit is
+that a rollback is free and the corpus keeps growing instead of resetting.
+
 The CLI has no `clear` command. To clear caches:
 
 - **UI**: the Cache page (sidebar > Cache) shows current usage and has per-cache

--- a/src/immich_memories/cache/asset_score_cache.py
+++ b/src/immich_memories/cache/asset_score_cache.py
@@ -36,10 +36,17 @@ class AssetScoreCache:
             conn.close()
 
     def get_asset_score(self, asset_id: str) -> dict | None:
-        """Look up cached score for an asset. Returns None if not cached."""
+        """The most recent look banked for an asset, whichever version wrote it.
+
+        An asset now holds a row per model+prompt version, so this answers with
+        the newest of them. Callers that need the answer a *particular* version
+        gave must ask for it by version through ``get_asset_scores_batch``.
+        """
         with self._get_connection() as conn:
             row = conn.execute(
-                "SELECT * FROM asset_scores WHERE asset_id = ?", (asset_id,)
+                "SELECT * FROM asset_scores WHERE asset_id = ?"
+                " ORDER BY analyzed_at DESC, rowid DESC LIMIT 1",
+                (asset_id,),
             ).fetchone()
             if row:
                 return dict(row)
@@ -51,7 +58,11 @@ class AssetScoreCache:
         *,
         model_version: str | None = None,
     ) -> dict[str, dict]:
-        """Look up cached scores, optionally restricted to an exact model."""
+        """Look up cached scores, optionally restricted to an exact model.
+
+        Without a version this answers with each asset's newest look, since an
+        asset may now hold one per model+prompt version.
+        """
         if not asset_ids:
             return {}
         with self._get_connection() as conn:
@@ -61,6 +72,8 @@ class AssetScoreCache:
             if model_version is not None:
                 query += " AND model_version = ?"
                 params.append(model_version)
+            # Oldest first, so the newest row is the one left standing per asset.
+            query += " ORDER BY analyzed_at, rowid"
             rows = conn.execute(query, params).fetchall()
             return {row["asset_id"]: dict(row) for row in rows}
 
@@ -76,7 +89,13 @@ class AssetScoreCache:
         llm_description: str | None = None,
         model_version: str | None = None,
     ) -> None:
-        """Save or update a cached asset score."""
+        """Bank a look under its version, replacing only that version's answer.
+
+        A save under a new version leaves what earlier versions said in place —
+        a prompt edit re-asks the model, it does not throw the corpus away.
+        Rows saved without a version share the one empty-string version, which
+        is what the pre-versioning rows migrate onto.
+        """
         with self._get_connection() as conn:
             conn.execute(
                 """
@@ -95,15 +114,21 @@ class AssetScoreCache:
                     llm_quality,
                     llm_emotion,
                     llm_description,
-                    model_version,
+                    model_version or "",
                 ),
             )
             conn.commit()
 
     def get_cache_stats(self) -> dict:
-        """Get cache statistics for the `cache stats` CLI command."""
+        """Statistics for the `cache stats` CLI command.
+
+        `total` counts banked looks and `assets` counts the assets they are
+        about — the two differ once a prompt version bump leaves an asset
+        holding an answer from each version, which is the point of doing so.
+        """
         with self._get_connection() as conn:
             total = conn.execute("SELECT COUNT(*) FROM asset_scores").fetchone()[0]
+            assets = conn.execute("SELECT COUNT(DISTINCT asset_id) FROM asset_scores").fetchone()[0]
             by_type = conn.execute(
                 "SELECT asset_type, COUNT(*) as cnt FROM asset_scores GROUP BY asset_type"
             ).fetchall()
@@ -114,6 +139,7 @@ class AssetScoreCache:
             ).fetchone()[0]
         return {
             "total": total,
+            "assets": assets,
             "by_type": {row["asset_type"]: row["cnt"] for row in by_type},
             "with_llm": with_llm,
             "oldest": oldest,

--- a/src/immich_memories/cache/migration_v22.py
+++ b/src/immich_memories/cache/migration_v22.py
@@ -1,0 +1,93 @@
+"""v22: an asset banks one look per version, not one look total (#698).
+
+`asset_scores` keyed on `asset_id` alone holds exactly one row per asset while
+reads filter on the version in force, so editing the prompt made every banked
+row unreadable and the next run overwrote it in place. Measured on one real
+cache: 8375 rows, 3545 of them reachable — the rest stranded under keys nobody
+asks for any more.
+
+The key becomes `(asset_id, model_version)`. SQLite cannot alter a primary key
+in place, so the table is rebuilt and every existing row copied across.
+
+Rows written before versions existed carry NULL, and a rowid table does not
+enforce NOT NULL on primary key columns — two NULL-version rows for one asset
+would both insert and `INSERT OR REPLACE` would stop replacing either. They
+land under `''` instead, which is a version like any other: addressable, and
+unique per asset.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+# The v7 shape, which nothing since has added to. Copying the intersection with
+# what the database actually has keeps a cache built by an older or hand-rolled
+# path from failing the whole ladder.
+_COLUMNS = (
+    "asset_id",
+    "asset_type",
+    "llm_interest",
+    "llm_quality",
+    "llm_emotion",
+    "llm_description",
+    "llm_category",
+    "safe_cut_gaps",
+    "metadata_score",
+    "combined_score",
+    "analyzed_at",
+    "model_version",
+)
+
+_REBUILT_TABLE = """
+    CREATE TABLE asset_scores_v22 (
+        asset_id TEXT NOT NULL,
+        asset_type TEXT NOT NULL,
+        llm_interest REAL,
+        llm_quality REAL,
+        llm_emotion TEXT,
+        llm_description TEXT,
+        llm_category TEXT,
+        safe_cut_gaps TEXT,
+        metadata_score REAL NOT NULL,
+        combined_score REAL NOT NULL,
+        analyzed_at TEXT NOT NULL DEFAULT (datetime('now')),
+        model_version TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (asset_id, model_version)
+    )
+"""
+
+
+def migrate_asset_score_version_key(conn: sqlite3.Connection) -> None:
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'asset_scores'"
+    ).fetchone()
+    if table_exists is None:
+        return
+
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(asset_scores)")}
+    carried = [column for column in _COLUMNS if column in existing]
+    if "asset_id" not in carried:
+        return
+
+    conn.execute("DROP TABLE IF EXISTS asset_scores_v22")
+    conn.execute(_REBUILT_TABLE)
+    _copy_rows(conn, carried)
+    conn.execute("DROP TABLE asset_scores")
+    conn.execute("ALTER TABLE asset_scores_v22 RENAME TO asset_scores")
+    conn.execute("CREATE INDEX idx_asset_scores_type ON asset_scores(asset_type)")
+    conn.execute("CREATE INDEX idx_asset_scores_combined ON asset_scores(combined_score DESC)")
+
+
+def _copy_rows(conn: sqlite3.Connection, carried: list[str]) -> None:
+    """Move every banked row across, NULL versions folded onto ``''``."""
+    selected = ", ".join(
+        "COALESCE(model_version, '')" if column == "model_version" else column for column in carried
+    )
+    order = " ORDER BY analyzed_at" if "analyzed_at" in carried else ""
+    # WHY OR REPLACE: the old primary key rules out duplicate asset ids, so this
+    # cannot fire on a cache this ladder built. On one it did not, losing the
+    # older of two rows beats raising and leaving a real multi-GB bank unopenable.
+    conn.execute(
+        f"INSERT OR REPLACE INTO asset_scores_v22 ({', '.join(carried)}) "  # noqa: S608
+        f"SELECT {selected} FROM asset_scores{order}"
+    )

--- a/src/immich_memories/cache/schema_migrator.py
+++ b/src/immich_memories/cache/schema_migrator.py
@@ -21,6 +21,7 @@ from immich_memories.cache.migration_v16 import migrate_video_analysis_model_ver
 from immich_memories.cache.migration_v17 import migrate_segment_transcripts
 from immich_memories.cache.migration_v19 import migrate_target_duration_seconds
 from immich_memories.cache.migration_v21 import migrate_run_llm_metrics
+from immich_memories.cache.migration_v22 import migrate_asset_score_version_key
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -96,6 +97,7 @@ class SchemaMigrator:
             19: migrate_target_duration_seconds,
             20: self._migration_v20_safe_cut_gaps,
             21: migrate_run_llm_metrics,
+            22: migrate_asset_score_version_key,
         }
 
         for version in range(from_version + 1, target_version + 1):

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 ANALYSIS_VERSION = 15
 SCORING_VERSION = 3

--- a/src/immich_memories/cli/cache_cmd.py
+++ b/src/immich_memories/cli/cache_cmd.py
@@ -33,7 +33,8 @@ def register_cache_commands(cli_group: click.Group) -> None:
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="green")
 
-        table.add_row("Total scored assets", str(s["total"]))
+        table.add_row("Scored assets", str(s["assets"]))
+        table.add_row("Banked looks (all versions)", str(s["total"]))
         for asset_type, count in s.get("by_type", {}).items():
             table.add_row(f"  {asset_type}", str(count))
         table.add_row("With LLM analysis", str(s["with_llm"]))

--- a/tests/test_asset_score_cache.py
+++ b/tests/test_asset_score_cache.py
@@ -2,34 +2,24 @@
 
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 import pytest
 
 from immich_memories.cache.asset_score_cache import AssetScoreCache
+from immich_memories.cache.database import VideoAnalysisCache
 
 
 @pytest.fixture
 def cache(tmp_path: Path) -> AssetScoreCache:
-    """Create a cache with the asset_scores table pre-created."""
+    """A cache on the migrated schema, rather than a hand-copy of it.
+
+    The hand-written CREATE TABLE this replaced had drifted from the real one
+    and pinned the primary key that #698 is about, so it could not have shown
+    the bug.
+    """
     db_path = tmp_path / "test.db"
-    conn = sqlite3.connect(str(db_path))
-    conn.executescript("""
-        CREATE TABLE IF NOT EXISTS asset_scores (
-            asset_id TEXT PRIMARY KEY,
-            asset_type TEXT NOT NULL,
-            llm_interest REAL,
-            llm_quality REAL,
-            llm_emotion TEXT,
-            llm_description TEXT,
-            metadata_score REAL NOT NULL,
-            combined_score REAL NOT NULL,
-            analyzed_at TEXT NOT NULL DEFAULT (datetime('now')),
-            model_version TEXT
-        );
-    """)
-    conn.close()
+    VideoAnalysisCache(db_path)
     return AssetScoreCache(db_path)
 
 
@@ -74,6 +64,18 @@ class TestAssetScoreCache:
         assert set(result) == {"current"}
         assert result["current"]["combined_score"] == 0.8
 
+    def test_a_banked_look_is_still_served_after_a_later_version_exists(
+        self, cache: AssetScoreCache
+    ) -> None:
+        cache.save_asset_score("photo-1", "IMAGE", 0.5, 0.81, model_version="qwen#look1")
+        cache.save_asset_score("photo-1", "IMAGE", 0.5, 0.42, model_version="qwen#look2")
+
+        under_old = cache.get_asset_scores_batch(["photo-1"], model_version="qwen#look1")
+        under_new = cache.get_asset_scores_batch(["photo-1"], model_version="qwen#look2")
+
+        assert under_old["photo-1"]["combined_score"] == 0.81
+        assert under_new["photo-1"]["combined_score"] == 0.42
+
     def test_batch_empty_ids(self, cache: AssetScoreCache):
         assert cache.get_asset_scores_batch([]) == {}
 
@@ -89,6 +91,19 @@ class TestAssetScoreCache:
         assert stats["with_llm"] == 1
         assert stats["oldest"] is not None
         assert stats["newest"] is not None
+
+    def test_stats_separate_the_assets_from_the_looks_banked_about_them(
+        self, cache: AssetScoreCache
+    ) -> None:
+        """One asset under two versions is one asset and two looks."""
+        cache.save_asset_score("photo-1", "IMAGE", 0.5, 0.81, model_version="qwen#look1")
+        cache.save_asset_score("photo-1", "IMAGE", 0.5, 0.42, model_version="qwen#look2")
+        cache.save_asset_score("photo-2", "IMAGE", 0.5, 0.33, model_version="qwen#look2")
+
+        stats = cache.get_cache_stats()
+
+        assert stats["assets"] == 2
+        assert stats["total"] == 3
 
     def test_upsert_overwrites(self, cache: AssetScoreCache):
         cache.save_asset_score("abc", "VIDEO", 0.5, 0.6)

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -76,6 +76,7 @@ class TestCacheStats:
     def test_renders_table_with_stats(self):
         stats = {
             "total": 42,
+            "assets": 37,
             "by_type": {"VIDEO": 30, "IMAGE": 12},
             "with_llm": 15,
             "oldest": "2025-01-01 10:00:00",
@@ -94,6 +95,7 @@ class TestCacheStats:
     def test_renders_empty_cache(self):
         stats = {
             "total": 0,
+            "assets": 0,
             "by_type": {},
             "with_llm": 0,
             "oldest": None,

--- a/tests/test_model_cache_migration.py
+++ b/tests/test_model_cache_migration.py
@@ -6,6 +6,7 @@ import sqlite3
 from pathlib import Path
 
 from immich_memories.cache import database as cache_database
+from immich_memories.cache.asset_score_cache import AssetScoreCache
 from immich_memories.cache.database import VideoAnalysisCache
 
 
@@ -37,3 +38,38 @@ def test_v16_marks_existing_video_analysis_as_unversioned(tmp_path: Path, monkey
     assert version == 16
     assert analysis is not None
     assert analysis.model_version is None
+
+
+def test_v22_carries_every_banked_row_onto_the_version_key(tmp_path: Path, monkeypatch) -> None:
+    """Rows written under the old single-asset key stay readable, versions and all."""
+    db_path = tmp_path / "v21.db"
+    monkeypatch.setattr(cache_database, "SCHEMA_VERSION", 21)
+    VideoAnalysisCache(db_path)
+    banked = [
+        ("current", 0.81, "qwen#look2"),
+        ("stale", 0.62, "qwen#look1"),
+        ("unversioned", 0.43, None),
+    ]
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            "INSERT INTO asset_scores (asset_id, asset_type, metadata_score,"
+            " combined_score, model_version) VALUES (?, 'photo', 0.5, ?, ?)",
+            banked,
+        )
+        conn.commit()
+
+    monkeypatch.setattr(cache_database, "SCHEMA_VERSION", 22)
+    VideoAnalysisCache(db_path)
+
+    cache = AssetScoreCache(db_path)
+    # A row that predates versions is addressable under the empty version, not lost.
+    served = {
+        asset_id: cache.get_asset_scores_batch([asset_id], model_version=version or "")
+        for asset_id, _score, version in banked
+    }
+
+    assert [served[asset_id][asset_id]["combined_score"] for asset_id, _s, _v in banked] == [
+        0.81,
+        0.62,
+        0.43,
+    ]

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -233,7 +233,9 @@ class TestCacheFirstScoring:
         assert result[0][1] == 0.88
         mock_llm.assert_not_called()
 
-    def test_different_model_refreshes_and_replaces_cached_score(self, tmp_path: Path) -> None:
+    def test_a_version_bump_re_looks_once_and_leaves_the_old_answer_banked(
+        self, tmp_path: Path
+    ) -> None:
         from immich_memories.cache.asset_score_cache import AssetScoreCache
         from immich_memories.cache.database import VideoAnalysisCache
         from immich_memories.config_loader import Config
@@ -242,7 +244,8 @@ class TestCacheFirstScoring:
         db_path = tmp_path / "scores.db"
         VideoAnalysisCache(db_path)
         score_cache = AssetScoreCache(db_path)
-        score_cache.save_asset_score("photo-1", "photo", 0.5, 0.91, model_version="qwen-3.5")
+        old_version = _photo_look_version("qwen-3.5")
+        score_cache.save_asset_score("photo-1", "photo", 0.5, 0.91, model_version=old_version)
         app_config = Config(
             llm={"model": "qwen-3.6"},
             content_analysis={"enabled": True},
@@ -252,21 +255,25 @@ class TestCacheFirstScoring:
         with patch(
             "immich_memories.photos.scoring._llm_score_photo",
             return_value=PhotoLook(score=0.77, payload={"description": "a photograph"}),
-        ):
-            result, _payloads = _enhance_with_llm(
-                [(_photo("photo-1"), 0.5)],
-                PhotoConfig(),
-                tmp_path,
-                lambda *_args: None,
-                db_path=db_path,
-                app_config=app_config,
-            )
+        ) as mock_look:
+            for _ in range(2):
+                result, _payloads = _enhance_with_llm(
+                    [(_photo("photo-1"), 0.5)],
+                    PhotoConfig(),
+                    tmp_path,
+                    lambda *_args: None,
+                    db_path=db_path,
+                    app_config=app_config,
+                )
 
-        refreshed = score_cache.get_asset_score("photo-1")
+        new_version = _photo_look_version("qwen-3.6")
+        banked = score_cache.get_asset_scores_batch(["photo-1"], model_version=new_version)
+        stranded = score_cache.get_asset_scores_batch(["photo-1"], model_version=old_version)
+
+        assert mock_look.call_count == 1
         assert result[0][1] == 0.77
-        assert refreshed is not None
-        assert refreshed["combined_score"] == 0.77
-        assert refreshed["model_version"] == _photo_look_version("qwen-3.6")
+        assert banked["photo-1"]["combined_score"] == 0.77
+        assert stranded["photo-1"]["combined_score"] == 0.91
 
     def test_failed_semantic_score_falls_back_without_claiming_model(self, tmp_path: Path) -> None:
         from immich_memories.cache.asset_score_cache import AssetScoreCache


### PR DESCRIPTION
Closes #698

## The problem

`asset_scores` had `asset_id` as its sole primary key, so an asset could hold
exactly one model+prompt version at a time — while reads filter on the version
in force. A prompt edit therefore made every banked row unreadable *and* the
next run overwrote it in place. The corpus never accumulated across versions;
each bump reset effective coverage toward zero.

## The key

`PRIMARY KEY (asset_id, model_version)`.

- a look banked under version A is still served under version A once B exists
- a bump re-asks the model once per asset and banks the answer under B
- a rollback costs nothing, and two prompt versions can be A/B'd on the same assets

## The migration (v22 — additive, never a wipe)

SQLite cannot alter a primary key in place, so v22 rebuilds `asset_scores` and
copies **every** existing row across, indexes included. Nothing is deleted.

One wrinkle worth knowing: rows written before versions existed carry
`model_version = NULL`, and a rowid table does not enforce NOT NULL on primary
key columns — two NULL-version rows for one asset would both insert and
`INSERT OR REPLACE` would stop replacing either. The column becomes
`NOT NULL DEFAULT ''` and those rows land under `''`, which is a version like
any other: addressable, unique per asset, and readable by
`get_asset_scores_batch(ids, model_version="")`.

`INSERT OR REPLACE` on the copy is deliberate: the old primary key rules out
duplicate asset ids, so it cannot fire on a cache this ladder built. On one it
did not, losing the older of two rows beats raising and leaving a real
multi-GB cache unopenable.

## Verified against the shape the issue measured

Rebuilt the reported distribution (3545 `#look2` + 3862 bare-model + 899 NULL +
69 `#look1` = 8375 rows) on a v21 database and ran the ladder:

```
rows before=8375 after=8375
NULL model_version after=0  ''=899
reachable under their own version = 8375
composite PK present: True
indexes: ['idx_asset_scores_combined', 'idx_asset_scores_type']
```

3545 of 8375 reachable before, 8375 of 8375 after, nothing deleted.

## Reads

An asset may now hold several rows, so the two version-less reads answer with
the newest: `get_asset_score(id)` orders by `analyzed_at DESC, rowid DESC`, and
`get_asset_scores_batch` without a version lets the newest row win per asset.
Asking for a specific version is unchanged.

## `cache stats`

`COUNT(*)` on `asset_scores` stops meaning "assets" the moment one asset holds
two versions, so `cache stats` would have reported 8375 assets for a library of
about 3900. It now reports **Scored assets** (`COUNT(DISTINCT asset_id)`) and
**Banked looks (all versions)** separately, and the maintenance doc explains why
the second number grows.

## Tests (TDD)

- a look banked under version A is still served under A after B exists
- a version bump re-looks exactly once per asset, banks under B, and leaves A's
  answer readable (two runs, one model call)
- pre-migration rows — current, stale and NULL-version — all load after v22
- stats separate the assets from the looks banked about them

The `AssetScoreCache` fixture also stops hand-writing a `CREATE TABLE` that had
drifted from the real schema and pinned the very primary key this fixes; it now
runs the migrator, so it could actually show the bug.

`make ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
