### PR TITLE
fix(cache): a failed look is remembered by kind, not re-asked forever

### DIFF
--- a/src/immich_memories/cache/asset_score_cache.py
+++ b/src/immich_memories/cache/asset_score_cache.py
@@ -119,6 +119,41 @@ class AssetScoreCache:
             )
             conn.commit()
 
+    def failed_looks(self, asset_ids: list[str], *, model_version: str) -> dict[str, dict]:
+        """What failed for these assets under this exact version, and how often.
+
+        Answers `{asset_id: {"kind": ..., "attempts": ...}}` for the assets that
+        have one. Whether that many attempts is enough to stop asking is the
+        caller's policy, not the cache's.
+        """
+        if not asset_ids:
+            return {}
+        with self._get_connection() as conn:
+            placeholders = ",".join("?" * len(asset_ids))
+            rows = conn.execute(
+                "SELECT asset_id, kind, attempts FROM asset_look_failures"  # noqa: S608
+                f" WHERE asset_id IN ({placeholders}) AND model_version = ?",
+                [*asset_ids, model_version],
+            ).fetchall()
+            return {row["asset_id"]: dict(row) for row in rows}
+
+    def record_failed_look(self, asset_id: str, model_version: str, kind: str) -> None:
+        """Bank one failed look, counting how often it has failed this way."""
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO asset_look_failures (
+                    asset_id, model_version, kind, attempts, last_attempt_at
+                ) VALUES (?, ?, ?, 1, datetime('now'))
+                ON CONFLICT(asset_id, model_version) DO UPDATE SET
+                    kind = excluded.kind,
+                    attempts = attempts + 1,
+                    last_attempt_at = excluded.last_attempt_at
+                """,
+                (asset_id, model_version, kind),
+            )
+            conn.commit()
+
     def get_cache_stats(self) -> dict:
         """Statistics for the `cache stats` CLI command.
 

--- a/src/immich_memories/cache/migration_v23.py
+++ b/src/immich_memories/cache/migration_v23.py
@@ -1,0 +1,33 @@
+"""v23: a look that failed is remembered by kind, keyed like any look (#699).
+
+Only a successful look was ever written, so an asset that failed was
+indistinguishable from one never seen and was re-asked on every run, forever —
+observed as `24 hits, 20 misses` repeating byte-identically across a cold run
+and a warm re-run of identical input.
+
+Failures live beside the scores rather than in them: a verdict is not a score,
+and a read for "what did the model say about these photos" must not have to
+filter out the assets it said nothing about.
+
+The key is `(asset_id, model_version)`, the same key a look uses — what a
+prompt could not answer is a fact about that prompt, and a bump re-asks.
+`attempts` is what makes the ledger a policy rather than a tombstone: the
+caller decides how many tries a version is worth before it stops paying.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate_look_failure_ledger(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS asset_look_failures (
+            asset_id TEXT NOT NULL,
+            model_version TEXT NOT NULL DEFAULT '',
+            kind TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 1,
+            last_attempt_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (asset_id, model_version)
+        )
+    """)

--- a/src/immich_memories/cache/schema_migrator.py
+++ b/src/immich_memories/cache/schema_migrator.py
@@ -22,6 +22,7 @@ from immich_memories.cache.migration_v17 import migrate_segment_transcripts
 from immich_memories.cache.migration_v19 import migrate_target_duration_seconds
 from immich_memories.cache.migration_v21 import migrate_run_llm_metrics
 from immich_memories.cache.migration_v22 import migrate_asset_score_version_key
+from immich_memories.cache.migration_v23 import migrate_look_failure_ledger
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -98,6 +99,7 @@ class SchemaMigrator:
             20: self._migration_v20_safe_cut_gaps,
             21: migrate_run_llm_metrics,
             22: migrate_asset_score_version_key,
+            23: migrate_look_failure_ledger,
         }
 
         for version in range(from_version + 1, target_version + 1):

--- a/src/immich_memories/cache/versions.py
+++ b/src/immich_memories/cache/versions.py
@@ -1,5 +1,5 @@
 """Independent database schema and cached-analysis algorithm versions."""
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 ANALYSIS_VERSION = 15
 SCORING_VERSION = 3

--- a/src/immich_memories/photos/scoring.py
+++ b/src/immich_memories/photos/scoring.py
@@ -17,7 +17,7 @@ import math
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from immich_memories.api.immich import ImmichAPIError
 from immich_memories.api.models import Asset
@@ -64,20 +64,23 @@ def score_photo_with_llm(
     config: PhotoConfig,
     app_config: Config,
     provider_circuit=None,
-) -> PhotoLook | None:
+) -> PhotoLook | LookFailed | None:
     """Enhance a photo's score with what the VLM sees, and keep what it says.
 
     Sends the photo to the configured VLM (the same one video content analysis
     uses) and blends its interest and quality into the metadata score. The
     words come back too: a photograph that cannot describe itself is a
     photograph the holistic review cannot judge.
+
+    Returns a typed verdict when the look fails, and None only when no look was
+    attempted at all — content analysis is off, so there is nothing to remember.
     """
     if app_config is None or not app_config.content_analysis.enabled:
         return None
 
     look = _query_photo_llm(photo_path, app_config, provider_circuit=provider_circuit)
-    if look is None:
-        return None
+    if isinstance(look, LookFailed):
+        return look
 
     # Blend: replace the LLM placeholder weight with actual LLM score
     # metadata_score was computed with _W_LLM * 0.5 as placeholder
@@ -124,6 +127,31 @@ def _photo_score_value(value: object) -> float | None:
     return score
 
 
+FailureKind = Literal["truncated", "unparseable", "provider_down", "download_failed"]
+
+# There is no refusal class here on purpose: the local model is abliterated and
+# nothing refused in any measured run. A refusal, if one ever appeared, would
+# arrive as `unparseable` — prose where JSON was asked for.
+#
+# A dead server and a missing thumbnail say nothing about the photograph, so
+# banking them would freeze a network blip into a permanently unanswerable
+# asset. They are retried on the next run; within a run the provider circuit
+# already stops the pipeline from asking a server that is down.
+_TRANSIENT_FAILURES: frozenset[str] = frozenset({"provider_down", "download_failed"})
+
+# A prompt that truncates or comes back unparseable will do it again — the
+# picture and the question have not changed. Two tries rides out a flake
+# without paying for a third; a prompt edit resets the count by changing the key.
+_MAX_LOOK_ATTEMPTS = 2
+
+
+@dataclass(frozen=True)
+class LookFailed:
+    """Why a look produced no answer, in the vocabulary the cache banks."""
+
+    kind: FailureKind
+
+
 @dataclass(frozen=True)
 class PhotoLook:
     """One look at a photograph: the score, and what the model saw in it.
@@ -145,29 +173,33 @@ def _text_field(value: object) -> str | None:
     return cleaned[:400] or None
 
 
-def _parse_photo_look(text: str) -> PhotoLook | None:
+def _parse_photo_look(text: str) -> PhotoLook | LookFailed:
     """Extract the scores a photo must have, and whatever else it came with.
 
     interest and quality stay required — they are what selection ranks on, and
     a response without them is not an answer. Everything else is optional: a
     small model that returns the two numbers alone still scores exactly as it
     used to, it just tells the review nothing.
+
+    A failure says which kind it is, because the two are worth different
+    things to the cache. An answer that opened a JSON object and never closed
+    it ran out of tokens; anything else came back whole and unusable.
     """
     match = re.search(r"\{[^}]+\}", text)
     if not match:
         logger.debug("LLM photo analysis: no JSON in response: %s", text[:100])
-        return None
+        return LookFailed("truncated" if "{" in text else "unparseable")
 
     data = json.loads(match.group())
     if not isinstance(data, dict) or not {"interest", "quality"} <= data.keys():
         logger.debug("LLM photo analysis: response omitted required score fields")
-        return None
+        return LookFailed("unparseable")
 
     interest = _photo_score_value(data["interest"])
     quality = _photo_score_value(data["quality"])
     if interest is None or quality is None:
         logger.debug("LLM photo analysis: score fields were invalid")
-        return None
+        return LookFailed("unparseable")
 
     subjects = data.get("subjects")
     return PhotoLook(
@@ -186,7 +218,9 @@ def _parse_photo_look(text: str) -> PhotoLook | None:
     )
 
 
-def _query_photo_llm(photo_path: Path, config: object, provider_circuit=None) -> PhotoLook | None:
+def _query_photo_llm(
+    photo_path: Path, config: object, provider_circuit=None
+) -> PhotoLook | LookFailed:
     """Ask the configured model about a photo, through the one client.
 
     This used to be a second HTTP client with its own rules: it POSTed
@@ -199,7 +233,15 @@ def _query_photo_llm(photo_path: Path, config: object, provider_circuit=None) ->
     for a run when the provider is unwell.
     """
     if provider_circuit is not None and not provider_circuit.available:
-        return None
+        return LookFailed("provider_down")
+
+    # Read outside the try below: a picture that cannot be read never reached
+    # the model, so it is not a bad answer and must not be banked as one.
+    try:
+        image = photo_path.read_bytes()
+    except OSError as e:
+        logger.debug(f"Photo unreadable for analysis: {e}")
+        return LookFailed("download_failed")
 
     try:
         import httpx
@@ -216,7 +258,7 @@ def _query_photo_llm(photo_path: Path, config: object, provider_circuit=None) ->
                 temperature=0.1,
                 max_tokens=_PHOTO_ANSWER_TOKENS,
                 timeout_seconds=llm_config.timeout_seconds,
-                images=[photo_path.read_bytes()],
+                images=[image],
                 image_detail=ca_config.openai_image_detail,
             )
         )
@@ -224,15 +266,17 @@ def _query_photo_llm(photo_path: Path, config: object, provider_circuit=None) ->
 
     except httpx.HTTPStatusError as e:
         _note_provider_health(e.response, config, provider_circuit)
-        return None
+        return LookFailed("provider_down")
     except httpx.HTTPError as e:
         if provider_circuit is not None:
             provider_circuit.disable("content-analysis provider is unreachable")
         logger.debug(f"LLM photo analysis failed: {e}")
-        return None
+        return LookFailed("provider_down")
     except (RuntimeError, ValueError, OSError, KeyError, IndexError, TypeError) as e:
+        # Malformed JSON, a missing key, an answer that was never content —
+        # a reply arrived and could not be read.
         logger.debug(f"LLM photo analysis returned an invalid response: {e}")
-        return None
+        return LookFailed("unparseable")
 
 
 def _note_provider_health(response: object, config: object, provider_circuit) -> None:
@@ -343,6 +387,7 @@ def _enhance_with_llm(
     asset_ids = [a.id for a, _ in scored]
     model_version = _photo_look_version(app_config.llm.model)
     cached = _cached_scores(cache, asset_ids, model_version)
+    spent = _exhausted_looks(cache, asset_ids, model_version)
 
     cache_hits = 0
     enhanced: list[tuple[Asset, float]] = []
@@ -356,6 +401,11 @@ def _enhance_with_llm(
             cache_hits += 1
             continue
 
+        # This prompt has already failed on this photo as often as it is worth.
+        if asset.id in spent:
+            enhanced.append((asset, meta_score))
+            continue
+
         # Cache miss — download + LLM
         look = _llm_score_photo(
             asset,
@@ -367,31 +417,77 @@ def _enhance_with_llm(
             thumbnail_fn=thumbnail_fn,
             provider_circuit=provider_circuit,
         )
-        effective_score = look.score if look is not None else meta_score
-        enhanced.append((asset, effective_score))
-        if look is not None:
+        if isinstance(look, PhotoLook):
+            enhanced.append((asset, look.score))
             payloads[asset.id] = look.payload
+            _bank_look(cache, asset.id, meta_score, look, model_version)
+            continue
 
-        # Only successful semantic results belong to the configured model.
-        if cache and look is not None and model_version:
-            cache.save_asset_score(
-                asset_id=asset.id,
-                asset_type="photo",
-                metadata_score=meta_score,
-                combined_score=effective_score,
-                llm_interest=_as_float(look.payload.get("interestingness")),
-                llm_quality=_as_float(look.payload.get("quality")),
-                llm_emotion=_as_text(look.payload.get("emotion")),
-                llm_description=_as_text(look.payload.get("description")),
-                model_version=model_version,
-            )
+        enhanced.append((asset, meta_score))
+        if isinstance(look, LookFailed):
+            _bank_failure(cache, asset.id, look, model_version)
 
     # Reported on any pass that had photos, not just one that hit: an all-miss
     # pass staying silent is indistinguishable in a log from no photo work.
     if scored:
-        logger.info(f"Photo score cache: {cache_hits} hits, {len(scored) - cache_hits} misses")
+        given_up = f", {len(spent)} given up on" if spent else ""
+        logger.info(
+            f"Photo score cache: {cache_hits} hits, {len(scored) - cache_hits} misses{given_up}"
+        )
 
     return enhanced, payloads
+
+
+def _bank_look(cache, asset_id: str, meta_score: float, look: PhotoLook, version: str) -> None:
+    """Keep what the model said, under the version that said it."""
+    if not cache or not version:
+        return
+    cache.save_asset_score(
+        asset_id=asset_id,
+        asset_type="photo",
+        metadata_score=meta_score,
+        combined_score=look.score,
+        llm_interest=_as_float(look.payload.get("interestingness")),
+        llm_quality=_as_float(look.payload.get("quality")),
+        llm_emotion=_as_text(look.payload.get("emotion")),
+        llm_description=_as_text(look.payload.get("description")),
+        model_version=version,
+    )
+
+
+def _bank_failure(cache, asset_id: str, failure: LookFailed, version: str) -> None:
+    """Remember a failure by kind — unless the kind is one that may pass.
+
+    A transient failure banked is a network blip frozen into a permanently
+    unanswerable asset, so those are simply not written and are asked again on
+    the next run.
+    """
+    import sqlite3
+
+    if not cache or not version or failure.kind in _TRANSIENT_FAILURES:
+        return
+    try:
+        cache.record_failed_look(asset_id, version, failure.kind)
+    except (OSError, sqlite3.Error) as exc:
+        logger.debug("Photo score cache unwritable (%s): the failure is not remembered", exc)
+
+
+def _exhausted_looks(cache, asset_ids: list[str], version: str) -> set[str]:
+    """Assets this prompt has already failed on as often as it is worth."""
+    import sqlite3
+
+    if not cache or not version:
+        return set()
+    try:
+        failures = cache.failed_looks(asset_ids, model_version=version)
+    except (OSError, sqlite3.Error) as exc:
+        logger.debug("Photo failure ledger unreadable (%s): asking again", exc)
+        return set()
+    return {
+        asset_id
+        for asset_id, row in failures.items()
+        if row.get("attempts", 0) >= _MAX_LOOK_ATTEMPTS
+    }
 
 
 def _llm_score_photo(
@@ -403,16 +499,19 @@ def _llm_score_photo(
     app_config: Any,
     thumbnail_fn: Any = None,
     provider_circuit: Any = None,
-) -> PhotoLook | None:
+) -> PhotoLook | LookFailed | None:
     """Look at a photo with the VLM, using a lightweight thumbnail.
 
     Uses Immich thumbnail API (~100 KB) instead of downloading the full
     HEIC (5-15 MB). Falls back to full download if no thumbnail_fn.
+
+    Never reaching a picture is `download_failed`: transient by nature, and a
+    verdict about the network rather than about the photograph.
     """
     from immich_memories.photos.scoring import score_photo_with_llm
 
     if provider_circuit is not None and not provider_circuit.available:
-        return None
+        return LookFailed("provider_down")
 
     thumb_path = work_dir / f"{asset.id}_thumb.jpg"
 
@@ -435,7 +534,10 @@ def _llm_score_photo(
                 provider_circuit=provider_circuit,
             )
         except (OSError, RuntimeError, ValueError):
-            return None
+            # The look path classifies its own failures, so anything escaping it
+            # is unclassifiable — call it transient and ask again rather than
+            # write the asset off over a code path nobody understands yet.
+            return LookFailed("download_failed")
 
     # Fallback: download full file (old behavior)
     ext = Path(asset.original_file_name).suffix if asset.original_file_name else ".jpg"
@@ -444,7 +546,7 @@ def _llm_score_photo(
         try:
             download_fn(asset.id, raw_path)
         except (ImmichAPIError, OSError, RuntimeError, ValueError):
-            return None
+            return LookFailed("download_failed")
 
     try:
         from immich_memories.photos.animator import prepare_photo_source
@@ -458,7 +560,7 @@ def _llm_score_photo(
             provider_circuit=provider_circuit,
         )
     except (OSError, RuntimeError, ValueError):
-        return None
+        return LookFailed("download_failed")
 
 
 def _cached_scores(cache, asset_ids: list[str], model_version: str | None) -> dict:

--- a/tests/test_photo_pipeline.py
+++ b/tests/test_photo_pipeline.py
@@ -148,6 +148,8 @@ def test_a_score_cached_before_photos_could_describe_themselves_is_re_asked(tmp_
             stale if model_version == "qwen-3.6" else {}
         ),
         save_asset_score=lambda **_kw: None,
+        failed_looks=lambda _ids, **_kw: {},
+        record_failed_look=lambda *_a: None,
     )
     monkeypatch.setattr(scoring, "_get_score_cache", lambda _db: cache)
     monkeypatch.setattr(

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -11,6 +11,7 @@ import pytest
 from immich_memories.api.models import Person
 from immich_memories.config_models_render import PhotoConfig
 from immich_memories.photos.scoring import (
+    LookFailed,
     PhotoLook,
     _photo_look_version,
     score_photo,
@@ -100,7 +101,21 @@ class TestPhotoScoring:
     def test_parse_photo_look_rejects_missing_required_field(self) -> None:
         from immich_memories.photos.scoring import _parse_photo_look
 
-        assert _parse_photo_look('{"message": "analysis unavailable"}') is None
+        assert _parse_photo_look('{"message": "analysis unavailable"}') == LookFailed("unparseable")
+
+    def test_an_answer_that_never_closed_its_json_is_truncated_not_unparseable(self) -> None:
+        """The two permanent kinds are worth the same to the ledger, not to a human.
+
+        An answer cut off mid-object ran out of tokens; one that came back
+        whole and useless is a different problem with a different fix.
+        """
+        from immich_memories.photos.scoring import _parse_photo_look
+
+        cut_off = _parse_photo_look('{"description": "A child on a beach, holding a')
+        whole = _parse_photo_look("I looked at the photo and saw a child.")
+
+        assert cut_off == LookFailed("truncated")
+        assert whole == LookFailed("unparseable")
 
     def test_the_look_keeps_what_the_model_saw(self) -> None:
         """The model was asked only for two numbers and its answer averaged.
@@ -145,6 +160,23 @@ class TestPhotoScoring:
 
         assert _photo_score_value(value) is None
 
+    def test_a_picture_that_cannot_be_read_is_transient_not_a_bad_answer(
+        self, tmp_path: Path
+    ) -> None:
+        """The model never saw it, so it never said anything unparseable.
+
+        Classing a local read failure as a bad answer would bank it, and two
+        runs later the asset would be written off over a disk hiccup.
+        """
+        from immich_memories.config_loader import Config
+        from immich_memories.photos.scoring import _query_photo_llm
+
+        config = Config(llm={"model": "qwen-vl"}, content_analysis={"enabled": True})
+
+        assert _query_photo_llm(tmp_path / "never-written.jpg", config) == LookFailed(
+            "download_failed"
+        )
+
     def test_permanent_llm_failure_is_not_cached_or_retried(self, tmp_path: Path) -> None:
         """A provider failure stays distinguishable while opening the run circuit."""
         import httpx
@@ -176,8 +208,8 @@ class TestPhotoScoring:
                 photo_b, 0.42, PhotoConfig(), config, provider_circuit=circuit
             )
 
-        assert first is None
-        assert second is None
+        assert first == LookFailed("provider_down")
+        assert second == LookFailed("provider_down")
         assert request.call_count == 1
 
 
@@ -274,6 +306,89 @@ class TestCacheFirstScoring:
         assert result[0][1] == 0.77
         assert banked["photo-1"]["combined_score"] == 0.77
         assert stranded["photo-1"]["combined_score"] == 0.91
+
+    def _failing_runs(
+        self, tmp_path: Path, failure: LookFailed, runs: int
+    ) -> tuple[int, str, Path]:
+        """Score one photo `runs` times against a model that always fails."""
+        from immich_memories.cache.database import VideoAnalysisCache
+        from immich_memories.config_loader import Config
+        from immich_memories.photos.scoring import _enhance_with_llm
+
+        db_path = tmp_path / "scores.db"
+        VideoAnalysisCache(db_path)
+        app_config = Config(llm={"model": "qwen-3.6"}, content_analysis={"enabled": True})
+
+        # WHY: the model is the external boundary this test reaches.
+        with patch(
+            "immich_memories.photos.scoring._llm_score_photo",
+            return_value=failure,
+        ) as mock_look:
+            for _ in range(runs):
+                _enhance_with_llm(
+                    [(_photo("photo-1"), 0.5)],
+                    PhotoConfig(),
+                    tmp_path,
+                    lambda *_args: None,
+                    db_path=db_path,
+                    app_config=app_config,
+                )
+
+        return mock_look.call_count, _photo_look_version("qwen-3.6"), db_path
+
+    def test_a_truncated_look_is_re_asked_once_more_then_left_alone(self, tmp_path: Path) -> None:
+        calls, _version, _db = self._failing_runs(tmp_path, LookFailed("truncated"), runs=4)
+
+        assert calls == 2
+
+    def test_an_unparseable_look_is_remembered_by_its_kind(self, tmp_path: Path) -> None:
+        from immich_memories.cache.asset_score_cache import AssetScoreCache
+
+        _calls, version, db_path = self._failing_runs(tmp_path, LookFailed("unparseable"), runs=1)
+        cache = AssetScoreCache(db_path)
+
+        assert cache.failed_looks(["photo-1"], model_version=version)["photo-1"]["kind"] == (
+            "unparseable"
+        )
+        # A verdict is not a score: nothing must read back as the model's answer.
+        assert cache.get_asset_scores_batch(["photo-1"], model_version=version) == {}
+
+    @pytest.mark.parametrize("kind", ["provider_down", "download_failed"])
+    def test_a_transient_failure_is_never_banked_and_is_asked_again(
+        self, tmp_path: Path, kind: str
+    ) -> None:
+        from immich_memories.cache.asset_score_cache import AssetScoreCache
+
+        calls, version, db_path = self._failing_runs(tmp_path, LookFailed(kind), runs=4)
+
+        assert calls == 4
+        assert AssetScoreCache(db_path).failed_looks(["photo-1"], model_version=version) == {}
+
+    def test_a_version_bump_re_asks_a_look_that_had_been_given_up_on(self, tmp_path: Path) -> None:
+        from immich_memories.cache.database import VideoAnalysisCache
+        from immich_memories.config_loader import Config
+        from immich_memories.photos.scoring import _enhance_with_llm
+
+        _calls, _version, db_path = self._failing_runs(tmp_path, LookFailed("truncated"), runs=3)
+        bumped = Config(llm={"model": "qwen-4.0"}, content_analysis={"enabled": True})
+        VideoAnalysisCache(db_path)
+
+        # WHY: the model is the external boundary this test reaches.
+        with patch(
+            "immich_memories.photos.scoring._llm_score_photo",
+            return_value=PhotoLook(score=0.66, payload={"description": "a photograph"}),
+        ) as mock_look:
+            result, _payloads = _enhance_with_llm(
+                [(_photo("photo-1"), 0.5)],
+                PhotoConfig(),
+                tmp_path,
+                lambda *_args: None,
+                db_path=db_path,
+                app_config=bumped,
+            )
+
+        assert mock_look.call_count == 1
+        assert result[0][1] == 0.66
 
     def test_failed_semantic_score_falls_back_without_claiming_model(self, tmp_path: Path) -> None:
         from immich_memories.cache.asset_score_cache import AssetScoreCache
@@ -506,7 +621,7 @@ class TestCacheFirstScoring:
         result = _llm_score_photo(
             asset, meta_score, PhotoConfig(), tmp_path, download_explodes, None
         )
-        assert result is None
+        assert result == LookFailed("download_failed")
 
     def test_llm_prepare_failure_is_not_a_semantic_score(self, tmp_path: Path):
         """A decode failure remains distinguishable so callers avoid caching it."""
@@ -533,7 +648,7 @@ class TestCacheFirstScoring:
                 None,
             )
 
-        assert result is None
+        assert result == LookFailed("download_failed")
 
     def test_get_score_cache_returns_none_on_import_error(self):
         """_get_score_cache returns None when dependencies are unavailable."""

--- a/tests/test_processing_coverage.py
+++ b/tests/test_processing_coverage.py
@@ -766,7 +766,7 @@ class TestLlmScorePhoto:
 
     def test_llm_error_is_not_reported_as_a_semantic_score(self, tmp_path):
         from immich_memories.config_models_render import PhotoConfig
-        from immich_memories.photos.scoring import _llm_score_photo
+        from immich_memories.photos.scoring import LookFailed, _llm_score_photo
 
         asset = _make_asset(id="err-001")
         config = PhotoConfig()
@@ -787,7 +787,7 @@ class TestLlmScorePhoto:
                 thumbnail_fn=MagicMock(return_value=b"\xff"),
             )
 
-        assert result is None
+        assert result == LookFailed("download_failed")
 
     def test_falls_back_to_full_download(self, tmp_path):
         from immich_memories.config_models_render import PhotoConfig
@@ -823,7 +823,7 @@ class TestLlmScorePhoto:
 
     def test_download_failure_is_not_reported_as_a_semantic_score(self, tmp_path):
         from immich_memories.config_models_render import PhotoConfig
-        from immich_memories.photos.scoring import _llm_score_photo
+        from immich_memories.photos.scoring import LookFailed, _llm_score_photo
 
         asset = _make_asset(id="dl-fail-001")
         config = PhotoConfig()
@@ -834,7 +834,7 @@ class TestLlmScorePhoto:
         result = _llm_score_photo(
             asset, 0.3, config, tmp_path, fail_download, None, thumbnail_fn=None
         )
-        assert result is None
+        assert result == LookFailed("download_failed")
 
 
 class TestRenderSinglePhoto:


### PR DESCRIPTION
Closes #699

> Builds on #738 (#698's composite cache key), which has now merged — this
> branch is rebased onto `main` and its diff is this change alone. A failure is
> version-scoped, so it needed that key first.

## The problem

`photos/scoring.py` only wrote a cache row when the look succeeded. A look that
failed wrote nothing, so the asset was indistinguishable from one never seen and
was re-asked on the next run, and every run after that. Observed as
`24 hits, 20 misses` repeating byte-identically across a cold run and a warm
re-run of identical input — each miss a model call, and it never converges.

## The verdict, by kind

A failure is now typed and keyed like any look, on `(asset_id, model_version)`:

| kind | banked? | re-asked within a version | re-asked on a version bump |
|---|---|---|---|
| `truncated` | yes | up to 2 attempts, then never | yes |
| `unparseable` | yes | up to 2 attempts, then never | yes |
| `provider_down` | **no** | every run | n/a |
| `download_failed` | **no** | every run | n/a |

That split is the whole point. Caching a transient error freezes a network blip
into a permanently unanswerable asset; not caching a permanent one loops it
forever. `attempts` lives in the ledger and the threshold lives in the caller,
so the cache stores facts and the scoring path owns the policy.

There is **no refusal class**: the local model is abliterated and nothing
refused in any measured run. A refusal, if one ever appeared, would arrive as
`unparseable` — prose where JSON was asked for.

`provider_down` keeps its existing backoff: the provider circuit already stops
the pipeline asking a server that is down for the rest of the run.

## Where each kind comes from

- `provider_down` — circuit open, an HTTP status error (which also opens the
  circuit via `classify_openai_response`), or the server unreachable
- `download_failed` — no thumbnail and the full download or decode failed, or
  the picture on disk could not be read. The model never saw it, so it is not a
  bad answer and must not be banked as one — the image read was moved out of the
  broad `except` that used to call this `unparseable`, which would have written
  an asset off after two disk hiccups
- `truncated` — the reply opened a JSON object and never closed it; the answer
  ran out of tokens
- `unparseable` — anything else that came back whole and unusable: no JSON at
  all, missing `interest`/`quality`, out-of-range scores, malformed JSON

`_query_photo_llm`, `score_photo_with_llm` and `_llm_score_photo` now return
`PhotoLook | LookFailed`; `None` survives only where **no look was attempted**
(content analysis off). The existing tests that asserted `is None` on a failure
now assert the kind, which is a stronger claim than the one they were making.

## Schema

v23 adds `asset_look_failures (asset_id, model_version, kind, attempts,
last_attempt_at)`, PK `(asset_id, model_version)`. Additive — a new table, no
existing row touched.

Failures live beside the scores rather than in them: a verdict is not a score,
and "what did the model say about these photos" must not have to filter out the
assets it said nothing about.

## Tests (TDD, one per class)

- `truncated` — four runs, two model calls, then silence
- `unparseable` — banked by its kind, and no score row claims the model
- `provider_down` / `download_failed` — four runs, four calls, ledger empty
- a version bump re-asks a look that had been given up on
- the classifier actually separates `truncated` from `unparseable` on raw text
- a picture that cannot be read is `download_failed`, not a bad answer

`make ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
