### PR TITLE
feat(memories): a person filter on every memory type, and three dead fields buried

### DIFF
--- a/docs-site/docs/create/memory-types/monthly-person-season.mdx
+++ b/docs-site/docs/create/memory-types/monthly-person-season.mdx
@@ -24,7 +24,7 @@ Default duration: 60 seconds. The title screen shows the month and year (e.g., "
 
 ## Person Spotlight
 
-A year focused on one person. Filters clips to only those containing the named person (requires face recognition enabled in Immich). Scoring weights faces higher than usual (60% face weight vs the default 40%).
+A year focused on one person. Filters clips to only those containing the named person (requires face recognition enabled in Immich). Every memory type is scored the same way — see [Clip Selection & Scoring](../pipeline/clip-selection-scoring.md); what makes this one a spotlight is the filter, not a different set of weights.
 
 ```bash
 immich-memories generate --memory-type person_spotlight --person "Alice" --year 2025
@@ -60,9 +60,17 @@ Default duration: same range-scaled curve as Person Spotlight, so 10 minutes for
 
 **Best for:** couples, families, friend groups. The co-occurrence filter means you'll get clips where they're actually together, not separate appearances.
 
+The same rule applies wherever you name several people. Repeating `--person` on
+any memory type, or picking more than one in the wizard's **Only with** box,
+keeps what holds all of them:
+
+```bash
+immich-memories generate --memory-type season --season summer --year 2025 --person "Alice" --person "Bob"
+```
+
 ## Season
 
-Highlights from a specific season (spring, summer, fall, winter). Scoring emphasizes motion slightly more (35% motion weight) to favor outdoor activities.
+Highlights from a specific season (spring, summer, fall, winter).
 
 ```bash
 immich-memories generate --memory-type season --season summer --year 2025

--- a/docs-site/docs/create/memory-types/year-in-review.mdx
+++ b/docs-site/docs/create/memory-types/year-in-review.mdx
@@ -33,6 +33,9 @@ immich-memories generate --memory-type year_in_review --year 2025 --include-phot
 ## Web UI
 
 Select the **Year in Review** card in Step 1, pick the year from the dropdown.
+The card's optional **Only with** box narrows the year to one or more people —
+the same thing `--person` does above, and naming several keeps only what holds
+all of them.
 
 <ThemedScreenshot name="type-year-review" alt="Year in Review preset" />
 
@@ -47,4 +50,4 @@ Select the **Year in Review** card in Step 1, pick the year from the dropdown.
 - Works best with **50+ videos** spread across the year. If you only have clips from a summer trip, a [Season](./monthly-person-season.mdx) or [Trip](./trip-memories.mdx) memory will be a better fit.
 - Auto analysis is the default and uses LLM scoring for manageable libraries. Use `--analysis-depth thorough` when you explicitly want every eligible clip analyzed, regardless of library size.
 - The default 10-minute duration works well for most libraries. For smaller collections (under 100 videos), try `--duration 300` for a tighter 5-minute edit.
-- Combining `--person` with Year in Review creates a "Your Year With Alice" style video: only clips containing that person, but still with monthly structure.
+- Combining `--person` with Year in Review creates a "Your Year With Alice" style video: only clips containing that person, but still with monthly structure. Naming two people narrows it to the clips holding both.

--- a/docs-site/docs/create/web-ui/step1-configuration.mdx
+++ b/docs-site/docs/create/web-ui/step1-configuration.mdx
@@ -27,14 +27,14 @@ Each preset sets the date range and a default target duration, then shows the pa
 
 | Card | Parameters shown | Default target |
 |------|------------------|----------------|
-| Year in Review | Year | 10 min |
-| Season | Year, Season (spring/summer/autumn/winter), Hemisphere (north/south) | 2 min 15 s |
+| Year in Review | Year, Only with | 10 min |
+| Season | Year, Season (spring/summer/autumn/winter), Hemisphere (north/south), Only with | 2 min 15 s |
 | Person Spotlight | Year (or "All Time"), Person, checkbox "Birthday to birthday" | 2 min |
 | Multi-Person | Year, People (select 2+) | 5 min |
-| Monthly Highlights | Year, Month | 1 min |
-| On This Day | none (uses today's date across previous years) | 45 s |
-| Holiday | Holiday, Most recent year, Years to span (2–10) | 1 min |
-| Then and Now | Now (year), Years back (1–20) | 45 s |
+| Monthly Highlights | Year, Month, Only with | 1 min |
+| On This Day | Only with (otherwise uses today's date across previous years) | 45 s |
+| Holiday | Holiday, Most recent year, Years to span (2–10), Only with | 1 min |
+| Then and Now | Now (year), Years back (1–20), Only with | 45 s |
 | Trip | Year, then "Select a trip" from the trips detected in your GPS data | auto: 30 s + 10 s per active day, bounded 60–300 s |
 | Album | "Select an album" from your Immich albums | auto: 4 s per item in the album, bounded 30 s–10 min |
 | Surprise me | "Pick a day" from the days [`discover-days`](../cli/discover-days.md) found | auto: 30 s + 6 s per active hour, bounded 60–180 s |
@@ -90,9 +90,31 @@ command builds one, and Step 1 stays incomplete. It will not offer a random day.
 
 <ThemedScreenshot name="step1-person-dropdown" alt="Person Selection" />
 
-The **Person** dropdown is populated from Immich's face recognition data. It appears inside the Person Spotlight card (one person) and the Multi-Person card (pick 2 or more; the tool keeps clips where all of them appear).
+Every person dropdown is populated from Immich's face recognition data, so only
+named faces are offered.
 
-The Custom card has its own **Person** filter under "Person Filter", defaulting to **All people**, next to a **Target Duration (minutes)** field.
+Two cards are *about* people and collect them as part of the memory: **Person
+Spotlight** takes one person, and **Multi-Person** takes 2 or more.
+
+Every other card that covers a period — Year in Review, Season, Monthly
+Highlights, On This Day, Holiday, Then and Now — carries an optional **Only
+with** picker instead. Leave it empty and the memory covers everyone. Name one
+person and it becomes that person's version of the memory. Name several and only
+moments with **all** of them are used, which is exactly what repeating
+`--person` does on the CLI:
+
+```bash
+immich-memories generate --memory-type year_in_review --year 2025 --person "Alice" --person "Bob"
+```
+
+Three cards carry no person filter, each for its own reason:
+
+- **Album** is its own pool — the album decides what is in the memory, so
+  `--from-album` rejects `--person` too.
+- **Trip** takes its window whole on both surfaces. On the CLI `--person`
+  narrows trip *detection* — whose GPS trail is scanned — and the trip that
+  comes back is built from everything shot in that window.
+- **Surprise me** is the occasion rather than its guest list.
 
 ## Custom date range
 

--- a/docs-site/docs/create/web-ui/step1-configuration.mdx
+++ b/docs-site/docs/create/web-ui/step1-configuration.mdx
@@ -116,6 +116,10 @@ Three cards carry no person filter, each for its own reason:
   comes back is built from everything shot in that window.
 - **Surprise me** is the occasion rather than its guest list.
 
+The **Custom** card keeps its own single-person **Person** filter under "Person
+Filter", defaulting to **All people**, next to a **Target Duration (minutes)**
+field — it belongs to the custom date range rather than to a preset.
+
 ## Custom date range
 
 Choosing **Custom** opens a "Custom Date Range" section with three tabs:

--- a/src/immich_memories/analysis/scoring.py
+++ b/src/immich_memories/analysis/scoring.py
@@ -26,7 +26,6 @@ from immich_memories.analysis.scenes import Scene, get_video_info
 if TYPE_CHECKING:
     from immich_memories.analysis.content_analyzer import ContentAnalyzer
     from immich_memories.config_models_analysis import AnalysisConfig, ContentAnalysisConfig
-    from immich_memories.memory_types.presets import ScoringProfile
 
 logger = logging.getLogger(__name__)
 
@@ -486,12 +485,6 @@ class SceneScorer:
     def content_min_confidence(self) -> float:
         """Minimum confidence required to accept a semantic score."""
         return self._content_analysis_config.min_confidence
-
-    @classmethod
-    def from_profile(cls, profile: ScoringProfile, **kwargs) -> SceneScorer:
-        """Create a SceneScorer from a ScoringProfile dataclass."""
-        weights = profile.to_dict()
-        return cls(**weights, **kwargs)  # type: ignore[arg-type]
 
     def _get_capture(self, video_path: Path) -> cv2.VideoCapture:
         """Get or create video capture, reusing if same file."""

--- a/src/immich_memories/memory_types/__init__.py
+++ b/src/immich_memories/memory_types/__init__.py
@@ -2,7 +2,7 @@
 
 Public API:
 - MemoryType: Enum of all supported memory types
-- MemoryPreset, ScoringProfile, PersonFilter: Configuration dataclasses
+- MemoryPreset, PersonFilter: Configuration dataclasses
 - create_preset, list_memory_types: Factory functions
 - build_season, build_month, build_on_this_day: Date range builders
 """
@@ -16,7 +16,7 @@ from immich_memories.memory_types.factory import create_preset, list_memory_type
 from immich_memories.memory_types.presets import (
     MemoryPreset,
     PersonFilter,
-    ScoringProfile,
+    person_filter_for,
 )
 from immich_memories.memory_types.registry import MemoryType
 
@@ -24,10 +24,10 @@ __all__ = [
     "MemoryPreset",
     "MemoryType",
     "PersonFilter",
-    "ScoringProfile",
     "build_month",
     "build_on_this_day",
     "build_season",
     "create_preset",
     "list_memory_types",
+    "person_filter_for",
 ]

--- a/src/immich_memories/memory_types/factory.py
+++ b/src/immich_memories/memory_types/factory.py
@@ -23,7 +23,7 @@ from immich_memories.memory_types.date_builders import (
 from immich_memories.memory_types.presets import (
     MemoryPreset,
     PersonFilter,
-    ScoringProfile,
+    person_filter_for,
 )
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import birthday_year, calendar_year
@@ -95,17 +95,12 @@ def _year_in_review(
     person_names: list[str] | None = None,
     **kwargs,  # noqa: ARG001
 ) -> MemoryPreset:
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
     return MemoryPreset(
         memory_type=MemoryType.YEAR_IN_REVIEW,
         name=f"{year} Memories",
         description=f"A look back at your best moments of {year}",
         date_ranges=[calendar_year(year)],
-        person_filter=person_filter,
-        scoring=ScoringProfile(),
-        title_template="{year}",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=600,  # ~50s per month × 12
     )
 
@@ -126,17 +121,12 @@ def _season(
         raise ValueError("season is required for SEASON memory type")
     date_range = build_season(season, year, hemisphere)
     season_cap = season.capitalize()
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
     return MemoryPreset(
         memory_type=MemoryType.SEASON,
         name=f"{season_cap} {year}",
         description=f"{season_cap} highlights of {year}",
         date_ranges=[date_range],
-        person_filter=person_filter,
-        scoring=ScoringProfile(motion_weight=0.35),
-        title_template="{season} {year}",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=135,  # ~45s per month × 3
     )
 
@@ -162,10 +152,9 @@ def _person_spotlight(
         name=f"Your Year with {name}",
         description=f"Best moments with {name} in {year}",
         date_ranges=[date_range],
-        person_filter=PersonFilter(mode="single", person_names=[name]),
-        scoring=ScoringProfile(face_weight=0.6, motion_weight=0.15),
-        title_template="{year}",
-        subtitle_template="Your Year with {person}",
+        # A spotlight is one person by definition, so extra names name a
+        # different memory -- Multi-Person -- rather than narrowing this one.
+        person_filter=person_filter_for([name]),
         default_duration_seconds=120,
     )
 
@@ -195,9 +184,6 @@ def _multi_person(
             person_names=list(person_names),
             require_co_occurrence=require_co_occurrence,
         ),
-        scoring=ScoringProfile(face_weight=0.5, motion_weight=0.2),
-        title_template="{year}",
-        subtitle_template="{persons}",
         default_duration_seconds=300,
     )
 
@@ -219,17 +205,12 @@ def _monthly_highlights(
 
     month_name = cal.month_name[month]
     date_range = build_month(month, year)
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
     return MemoryPreset(
         memory_type=MemoryType.MONTHLY_HIGHLIGHTS,
         name=f"{month_name} {year}",
         description=f"Highlights from {month_name} {year}",
         date_ranges=[date_range],
-        person_filter=person_filter,
-        scoring=ScoringProfile(),
-        title_template="{month} {year}",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=60,
     )
 
@@ -251,18 +232,12 @@ def _on_this_day(
     import calendar
 
     month_name = calendar.month_name[target_date.month]
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
     return MemoryPreset(
         memory_type=MemoryType.ON_THIS_DAY,
         name=f"{month_name} {target_date.day} Through the Years",
         description=f"Memories from {month_name} {target_date.day} across previous years",
         date_ranges=date_ranges,
-        person_filter=person_filter,
-        scoring=ScoringProfile(),
-        title_template="{month} {day}",
-        subtitle_template="Through the Years",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=45,  # ~30-45s — it's a single date across years
     )
 
@@ -292,26 +267,13 @@ def _trip(
     from immich_memories.planning.auto_duration import trip_editorial_duration_seconds
 
     duration = trip_editorial_duration_seconds(trip_days)
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
 
     return MemoryPreset(
         memory_type=MemoryType.TRIP,
         name=location,
         description=f"Trip to {location}",
         date_ranges=[date_range],
-        person_filter=person_filter,
-        scoring=ScoringProfile(
-            motion_weight=0.3,
-            content_weight=0.3,
-            face_weight=0.2,
-            stability_weight=0.1,
-            audio_weight=0.0,
-            duration_weight=0.1,
-        ),
-        title_template="{location}",
-        subtitle_template="{start_date} - {end_date}",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=duration,
     )
 
@@ -369,19 +331,13 @@ def _holiday(
     today = None if year else date.today()
     year = year or date.today().year
     label = holiday_label(holiday, year)
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
 
     return MemoryPreset(
         memory_type=MemoryType.HOLIDAY,
         name=f"{label} Through the Years",
         description=f"{label} across {years_back} years",
         date_ranges=build_holiday(holiday, year, years_back, window_days, today=today),
-        person_filter=person_filter,
-        scoring=ScoringProfile(face_weight=0.3, content_weight=0.3),
-        title_template="{holiday}",
-        subtitle_template="Through the Years",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=60,
     )
 
@@ -404,19 +360,13 @@ def _then_and_now(
     """
     year = year or date.today().year
     then_year = year - years_back
-    person_filter = PersonFilter()
-    if person_names:
-        person_filter = PersonFilter(mode="single", person_names=person_names[:1])
 
     return MemoryPreset(
         memory_type=MemoryType.THEN_AND_NOW,
         name=f"{then_year} and {year}",
         description=f"{then_year} beside {year}",
         date_ranges=build_then_and_now(year, years_back),
-        person_filter=person_filter,
-        scoring=ScoringProfile(face_weight=0.4, content_weight=0.3),
-        title_template="{then_year} & {now_year}",
-        subtitle_template="Then and Now",
+        person_filter=person_filter_for(person_names),
         default_duration_seconds=45,
     )
 
@@ -462,8 +412,5 @@ def _special_day(
         # Not person-filtered on purpose: the memory is the occasion, and real
         # names would reach durable run history through it.
         person_filter=PersonFilter(),
-        scoring=ScoringProfile(),
-        title_template="{title}",
-        subtitle_template="{subtitle}" if subtitle else None,
         default_duration_seconds=special_day_editorial_duration_seconds(hours),
     )

--- a/src/immich_memories/memory_types/presets.py
+++ b/src/immich_memories/memory_types/presets.py
@@ -1,34 +1,12 @@
-"""Memory presets — dataclasses for scoring, filtering, and preset config."""
+"""Memory presets — what a memory type asks for before anything is fetched."""
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import DateRange
-
-
-@dataclass
-class ScoringProfile:
-    """Weights for video clip scoring across different dimensions."""
-
-    face_weight: float = 0.4
-    motion_weight: float = 0.25
-    stability_weight: float = 0.2
-    audio_weight: float = 0.15
-    content_weight: float = 0.0
-    duration_weight: float = 0.15
-
-    def to_dict(self) -> dict[str, float]:
-        """Return scoring weights as a plain dictionary."""
-        return {
-            "face_weight": self.face_weight,
-            "motion_weight": self.motion_weight,
-            "stability_weight": self.stability_weight,
-            "audio_weight": self.audio_weight,
-            "content_weight": self.content_weight,
-            "duration_weight": self.duration_weight,
-        }
 
 
 @dataclass
@@ -40,6 +18,22 @@ class PersonFilter:
     require_co_occurrence: bool = False
 
 
+def person_filter_for(person_names: Sequence[str] | None) -> PersonFilter:
+    """The people a memory is narrowed to, whatever memory type it is.
+
+    Several names intersect: the memory is what holds all of them, which is
+    what ``--person Alice --person Bob`` has always fetched and what a
+    multi-person memory has always meant. Keeping only the first name was how
+    the wizard and the CLI came to disagree on the same request (#683).
+    """
+    names = list(person_names or [])
+    if not names:
+        return PersonFilter()
+    if len(names) == 1:
+        return PersonFilter(mode="single", person_names=names)
+    return PersonFilter(mode="all_of", person_names=names, require_co_occurrence=True)
+
+
 @dataclass
 class MemoryPreset:
     """Full preset configuration for a memory type."""
@@ -49,7 +43,4 @@ class MemoryPreset:
     description: str
     date_ranges: list[DateRange]
     person_filter: PersonFilter
-    scoring: ScoringProfile
-    title_template: str
-    subtitle_template: str | None = None
     default_duration_seconds: float | None = None

--- a/src/immich_memories/ui/pages/step1_people.py
+++ b/src/immich_memories/ui/pages/step1_people.py
@@ -1,0 +1,166 @@
+"""Who a memory is about — the wizard's person picking, in one place.
+
+Every card that can be narrowed to people gets the same widget and the same
+meaning: several people is an intersection, the memory being what holds all of
+them. That is what ``--person Alice --person Bob`` has always fetched, and
+until #666 the wizard could only phrase it on two cards.
+
+The renderers take the state and the "apply" callback rather than reaching for
+either: the card that owns a memory type is what knows when its parameters are
+complete, and injecting the state is what lets these be exercised without a
+NiceGUI session behind them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from nicegui import ui
+
+from immich_memories.memory_types.registry import MemoryType
+
+if TYPE_CHECKING:
+    from immich_memories.api.models import Person
+    from immich_memories.ui.state import AppState
+
+ApplyPreset = Callable[[MemoryType], None]
+
+# The cards that render the shared picker. The two person memory types are
+# absent because they collect their people as part of *being* those memories
+# and have their own widgets below. So are the three that take no person
+# filter at all: an Album is its own pool, a Trip's window is taken whole on
+# both surfaces (--person scopes trip detection there, not the fetch), and a
+# Special Day is the occasion rather than its guest list.
+PERSON_FILTERABLE = frozenset(
+    {
+        MemoryType.YEAR_IN_REVIEW,
+        MemoryType.SEASON,
+        MemoryType.MONTHLY_HIGHLIGHTS,
+        MemoryType.ON_THIS_DAY,
+        MemoryType.HOLIDAY,
+        MemoryType.THEN_AND_NOW,
+    }
+)
+
+
+def _named_people(state: AppState) -> dict[str, Person]:
+    """Immich's roster by name. Unnamed faces cannot be asked for by name."""
+    return {person.name: person for person in state.people if person.name}
+
+
+def render_person_picker(state: AppState, memory_type: MemoryType, apply: ApplyPreset) -> None:
+    """An optional person filter, on any memory type that can carry one."""
+    by_name = _named_people(state)
+    if not by_name:
+        return
+
+    saved = state.memory_preset_params.get("person_names") or []
+
+    def on_people(e) -> None:
+        chosen = [name for name in (e.value or []) if name in by_name]
+        state.memory_preset_params["person_names"] = chosen
+        apply(memory_type)
+
+    ui.select(
+        options=list(by_name),
+        label="Only with (optional)",
+        value=[name for name in saved if name in by_name],
+        on_change=on_people,
+        multiple=True,
+    ).props("use-chips").classes("w-64 mt-2").tooltip(
+        "Narrow this memory to these people. Pick several and only moments "
+        "with all of them are used — the same as --person twice on the CLI."
+    )
+
+
+def render_person_spotlight_params(state: AppState, apply: ApplyPreset) -> None:
+    """Year (with All Time) + single person picker + birthday toggle."""
+    by_name = _named_people(state)
+
+    with ui.row().classes("gap-4 items-end flex-wrap"):
+        year_options = state.years or list(range(2024, 2019, -1))
+        year_list = ["All Time"] + [str(y) for y in year_options]
+        default_year = year_options[0] if year_options else 2024
+        saved_year = state.memory_preset_params.get("year", default_year)
+        current_label = "All Time" if saved_year == 0 else str(saved_year)
+
+        def on_year(e) -> None:
+            state.memory_preset_params["year"] = 0 if e.value == "All Time" else int(e.value)
+            apply(MemoryType.PERSON_SPOTLIGHT)
+
+        ui.select(options=year_list, label="Year", value=current_label, on_change=on_year).classes(
+            "w-36"
+        )
+
+        saved_person_id = state.memory_preset_params.get("person_id")
+        current_name = next((name for name, p in by_name.items() if p.id == saved_person_id), None)
+
+        def on_person(e) -> None:
+            selected = by_name.get(e.value)
+            if selected:
+                state.memory_preset_params["person_id"] = selected.id
+                state.memory_preset_params["person_names"] = [e.value]
+                # Auto-enable birthday mode if person has a birth_date
+                if selected.birth_date:
+                    state.memory_preset_params["use_birthday"] = True
+                    state.memory_preset_params["birthday"] = selected.birth_date
+            apply(MemoryType.PERSON_SPOTLIGHT)
+
+        ui.select(
+            options=list(by_name),
+            label="Person",
+            value=current_name,
+            on_change=on_person,
+        ).classes("w-48")
+
+    def on_birthday_toggle(e) -> None:
+        state.memory_preset_params["use_birthday"] = e.value
+        apply(MemoryType.PERSON_SPOTLIGHT)
+
+    ui.checkbox(
+        "Birthday to birthday",
+        value=state.memory_preset_params.get("use_birthday", False),
+        on_change=on_birthday_toggle,
+    ).classes("mt-2").tooltip("Year runs from birthday to birthday instead of January to December")
+
+    state.memory_preset_params.setdefault("year", saved_year)
+    apply(MemoryType.PERSON_SPOTLIGHT)
+
+
+def render_multi_person_params(state: AppState, apply: ApplyPreset) -> None:
+    """Year (with All Time) + multi-person chips (2+ people)."""
+    by_name = _named_people(state)
+
+    with ui.row().classes("gap-4 items-end flex-wrap"):
+        year_options = state.years or list(range(2024, 2019, -1))
+        year_list = ["All Time"] + [str(y) for y in year_options]
+        saved_year = state.memory_preset_params.get("year", 0)
+        current_label = "All Time" if saved_year == 0 else str(saved_year)
+
+        def on_year(e) -> None:
+            state.memory_preset_params["year"] = 0 if e.value == "All Time" else int(e.value)
+            apply(MemoryType.MULTI_PERSON)
+
+        ui.select(options=year_list, label="Year", value=current_label, on_change=on_year).classes(
+            "w-36"
+        )
+
+        saved_names = state.memory_preset_params.get("person_names") or []
+
+        def on_people(e) -> None:
+            state.memory_preset_params["person_names"] = [
+                name for name in (e.value or []) if name in by_name
+            ]
+            apply(MemoryType.MULTI_PERSON)
+
+        ui.select(
+            options=list(by_name),
+            label="People (select 2+)",
+            value=[name for name in saved_names if name in by_name],
+            on_change=on_people,
+            multiple=True,
+        ).props("use-chips").classes("w-64")
+
+    state.memory_preset_params.setdefault("year", saved_year)
+    apply(MemoryType.MULTI_PERSON)

--- a/src/immich_memories/ui/pages/step1_presets.py
+++ b/src/immich_memories/ui/pages/step1_presets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import calendar as cal
 import logging
+from collections.abc import Callable
 from datetime import date
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,13 @@ from immich_memories.memory_types.factory import create_preset
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.ui.components import im_card
 from immich_memories.ui.nicegui_compat import io_bound_result
-from immich_memories.ui.state import get_app_state
+from immich_memories.ui.pages.step1_people import (
+    PERSON_FILTERABLE,
+    render_multi_person_params,
+    render_person_picker,
+    render_person_spotlight_params,
+)
+from immich_memories.ui.state import AppState, get_app_state
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -117,41 +124,26 @@ def _render_params(key: str) -> None:
     except ValueError:
         return
 
+    state = get_app_state()
     with im_card() as card:
         card.classes("p-4 mt-3")
-
-        if memory_type == MemoryType.YEAR_IN_REVIEW:
-            _render_year_picker()
-        elif memory_type == MemoryType.SEASON:
-            _render_season_params()
-        elif memory_type == MemoryType.PERSON_SPOTLIGHT:
-            _render_person_spotlight_params()
-        elif memory_type == MemoryType.MULTI_PERSON:
-            _render_multi_person_params()
-        elif memory_type == MemoryType.MONTHLY_HIGHLIGHTS:
-            _render_monthly_params()
-        elif memory_type == MemoryType.ON_THIS_DAY:
-            ui.label("Automatically uses today's date across previous years").style(
-                "color: var(--im-text-secondary)"
-            ).classes("text-sm italic")
-            _apply_preset_to_state(memory_type)
-        elif memory_type == MemoryType.HOLIDAY:
-            _render_holiday_params()
-        elif memory_type == MemoryType.THEN_AND_NOW:
-            _render_then_and_now_params()
-        elif memory_type == MemoryType.TRIP:
-            _render_trip_params()
-        elif memory_type == MemoryType.ALBUM:
-            _render_album_picker()
-        elif memory_type == MemoryType.SPECIAL_DAY:
-            _render_special_day_params()
+        _CARD_RENDERERS[memory_type](state)
+        if memory_type in PERSON_FILTERABLE:
+            render_person_picker(state, memory_type, _apply_preset_to_state)
 
 
-def _render_holiday_params() -> None:
+def _render_on_this_day_params(state: AppState) -> None:  # noqa: ARG001
+    """The only card with nothing to ask: today's date is the whole parameter."""
+    ui.label("Automatically uses today's date across previous years").style(
+        "color: var(--im-text-secondary)"
+    ).classes("text-sm italic")
+    _apply_preset_to_state(MemoryType.ON_THIS_DAY)
+
+
+def _render_holiday_params(state: AppState) -> None:
     """Holiday + year + how many years back to span."""
     from immich_memories.memory_types.factory import holiday_choices
 
-    state = get_app_state()
     choices = holiday_choices()
 
     with ui.row().classes("gap-4 items-end flex-wrap"):
@@ -201,9 +193,8 @@ def _render_holiday_params() -> None:
     _apply_preset_to_state(MemoryType.HOLIDAY)
 
 
-def _render_then_and_now_params() -> None:
+def _render_then_and_now_params(state: AppState) -> None:
     """The recent year, and how far back the other one sits."""
-    state = get_app_state()
 
     with ui.row().classes("gap-4 items-end flex-wrap"):
         year_options = state.years or list(range(2024, 2019, -1))
@@ -250,9 +241,8 @@ def _year_options_with_all() -> list:
     return [("all", "All Time")] + [(y, str(y)) for y in years]
 
 
-def _render_year_picker() -> None:
+def _render_year_picker(state: AppState) -> None:
     """Year picker shared by multiple presets."""
-    state = get_app_state()
     year_options = state.years or list(range(2024, 2019, -1))
     current = state.memory_preset_params.get("year", year_options[0] if year_options else 2024)
 
@@ -267,9 +257,8 @@ def _render_year_picker() -> None:
     _apply_preset_to_state(MemoryType(state.memory_type))  # type: ignore[arg-type]
 
 
-def _render_season_params() -> None:
+def _render_season_params(state: AppState) -> None:
     """Year + Season + Hemisphere pickers."""
-    state = get_app_state()
 
     with ui.row().classes("gap-4 items-end flex-wrap"):
         year_options = state.years or list(range(2024, 2019, -1))
@@ -311,113 +300,8 @@ def _render_season_params() -> None:
     _apply_preset_to_state(MemoryType.SEASON)
 
 
-def _render_person_spotlight_params() -> None:
-    """Year (with All Time) + single person picker + birthday toggle."""
-    state = get_app_state()
-    named_people = [p for p in state.people if p.name]
-    name_to_person = {p.name: p for p in named_people}
-
-    with ui.row().classes("gap-4 items-end flex-wrap"):
-        year_options = state.years or list(range(2024, 2019, -1))
-        year_list = ["All Time"] + [str(y) for y in year_options]
-        default_year = year_options[0] if year_options else 2024
-        saved_year = state.memory_preset_params.get("year", default_year)
-        current_label = "All Time" if saved_year == 0 else str(saved_year)
-
-        def on_year(e):
-            val = 0 if e.value == "All Time" else int(e.value)
-            state.memory_preset_params["year"] = val
-            _apply_preset_to_state(MemoryType.PERSON_SPOTLIGHT)
-
-        ui.select(options=year_list, label="Year", value=current_label, on_change=on_year).classes(
-            "w-36"
-        )
-
-        person_names = [p.name for p in named_people]
-        saved_person_id = state.memory_preset_params.get("person_id")
-        current_name = next((p.name for p in named_people if p.id == saved_person_id), None)
-
-        def on_person(e):
-            selected = name_to_person.get(e.value)
-            if selected:
-                state.memory_preset_params["person_id"] = selected.id
-                state.memory_preset_params["person_names"] = [selected.name]
-                state.selected_person = selected
-                # Auto-enable birthday mode if person has a birth_date
-                if hasattr(selected, "birth_date") and selected.birth_date:
-                    state.memory_preset_params["use_birthday"] = True
-                    state.memory_preset_params["birthday"] = selected.birth_date
-            _apply_preset_to_state(MemoryType.PERSON_SPOTLIGHT)
-
-        ui.select(
-            options=person_names,
-            label="Person",
-            value=current_name,
-            on_change=on_person,
-        ).classes("w-48")
-
-    # Birthday-to-birthday toggle
-    def on_birthday_toggle(e):
-        state.memory_preset_params["use_birthday"] = e.value
-        _apply_preset_to_state(MemoryType.PERSON_SPOTLIGHT)
-
-    ui.checkbox(
-        "Birthday to birthday",
-        value=state.memory_preset_params.get("use_birthday", False),
-        on_change=on_birthday_toggle,
-    ).classes("mt-2").tooltip("Year runs from birthday to birthday instead of January to December")
-
-    state.memory_preset_params.setdefault("year", saved_year)
-    _apply_preset_to_state(MemoryType.PERSON_SPOTLIGHT)
-
-
-def _render_multi_person_params() -> None:
-    """Year (with All Time) + multi-person chips (2+ people)."""
-    state = get_app_state()
-    named_people = [p for p in state.people if p.name]
-    name_to_person = {p.name: p for p in named_people}
-
-    with ui.row().classes("gap-4 items-end flex-wrap"):
-        year_options = state.years or list(range(2024, 2019, -1))
-        year_list = ["All Time"] + [str(y) for y in year_options]
-        saved_year = state.memory_preset_params.get("year", 0)
-        current_label = "All Time" if saved_year == 0 else str(saved_year)
-
-        def on_year(e):
-            val = 0 if e.value == "All Time" else int(e.value)
-            state.memory_preset_params["year"] = val
-            _apply_preset_to_state(MemoryType.MULTI_PERSON)
-
-        ui.select(options=year_list, label="Year", value=current_label, on_change=on_year).classes(
-            "w-36"
-        )
-
-        person_names = [p.name for p in named_people]
-        saved_ids = state.memory_preset_params.get("person_ids", [])
-        current_names = [p.name for p in named_people if p.id in saved_ids]
-
-        def on_people(e):
-            selected_names = list(e.value) if e.value else []
-            selected = [name_to_person[n] for n in selected_names if n in name_to_person]
-            state.memory_preset_params["person_ids"] = [p.id for p in selected]
-            state.memory_preset_params["person_names"] = [p.name for p in selected]
-            _apply_preset_to_state(MemoryType.MULTI_PERSON)
-
-        ui.select(
-            options=person_names,
-            label="People (select 2+)",
-            value=current_names,
-            on_change=on_people,
-            multiple=True,
-        ).props("use-chips").classes("w-64")
-
-    state.memory_preset_params.setdefault("year", saved_year)
-    _apply_preset_to_state(MemoryType.MULTI_PERSON)
-
-
-def _render_monthly_params() -> None:
+def _render_monthly_params(state: AppState) -> None:
     """Year + month picker."""
-    state = get_app_state()
 
     with ui.row().classes("gap-4 items-end flex-wrap"):
         year_options = state.years or list(range(2024, 2019, -1))
@@ -448,9 +332,8 @@ def _render_monthly_params() -> None:
     _apply_preset_to_state(MemoryType.MONTHLY_HIGHLIGHTS)
 
 
-def _render_album_picker() -> None:
+def _render_album_picker(state: AppState) -> None:
     """Album dropdown. The album is the whole pool, so no date range is chosen."""
-    state = get_app_state()
     album_container = ui.column().classes("w-full mt-2")
 
     def _select(album_id: str | None, albums: dict[str, str]) -> None:
@@ -524,11 +407,9 @@ def _render_album_picker() -> None:
     ui.timer(0.1, _load_albums, once=True)
 
 
-def _render_trip_params() -> None:
+def _render_trip_params(state: AppState) -> None:
     """Year picker + dynamic trip detection dropdown."""
     from immich_memories.analysis.trip_detection import DetectedTrip
-
-    state = get_app_state()
 
     year_options = state.years or list(range(2024, 2019, -1))
     current_year = state.memory_preset_params.get("year", year_options[0] if year_options else 2024)
@@ -733,9 +614,8 @@ def _choose_special_day(entry: DiscoveredDay) -> None:
     state.title_suggestion_subtitle = entry.subtitle or None
 
 
-def _render_special_day_params() -> None:
+def _render_special_day_params(state: AppState) -> None:
     """The days the catalogue found, read on mount."""
-    state = get_app_state()
     container = ui.column().classes("w-full mt-2")
 
     def _offer_the_catalogue() -> None:
@@ -770,29 +650,49 @@ def _render_special_day_params() -> None:
 
 
 def _apply_preset_to_state(memory_type: MemoryType) -> None:
-    """Create a preset and write its date_range + duration into app state."""
+    """Build the preset the card describes and let the state adopt it."""
     from immich_memories.timeperiod import custom_range
 
     state = get_app_state()
     params = state.memory_preset_params
 
-    # "All Time" → wide date range covering all years
+    # "All Time" → wide date range covering all years. No preset covers "every
+    # year you own", so this is the one path with no filter to adopt and the
+    # picker's names are resolved directly.
     if params.get("year") == 0:
         state.date_ranges = [custom_range(date(2000, 1, 1), date.today())]
         state.target_duration = 10
+        state.narrow_to_people(params.get("person_names") or [])
         return
 
     try:
-        preset = create_preset(memory_type, **params)
-        state.date_ranges = preset.date_ranges.copy()
-        if preset.default_duration_seconds:
-            state.target_duration = preset.default_duration_seconds / 60
-            state.duration_mode = "auto"
-        elif preset.date_ranges:
-            # Auto-compute duration from date range: ~1 min/month, ~8 min/year
-            days = preset.date_ranges[0].days
-            state.target_duration = max(1, min(10, round(days / 45)))
+        state.apply_preset(create_preset(memory_type, **params))
     except (ValueError, TypeError) as exc:
-        # Preset not fully configured yet (e.g. no person selected) — clear stale ranges
+        # Preset not fully configured yet (e.g. no person selected) — clear stale
+        # ranges. The picker's names are still the truth about who was named, so
+        # emptying it has to reach the fetch even when no window can be built.
         state.date_ranges = []
+        state.narrow_to_people(params.get("person_names") or [])
         logger.debug("Preset not ready yet: %s", exc)
+
+
+# Which widgets a card puts inside its panel. Every memory type appears, so a
+# type added to the registry and not here fails loudly on click rather than
+# rendering an empty card.
+_CARD_RENDERERS: dict[MemoryType, Callable[[AppState], None]] = {
+    MemoryType.YEAR_IN_REVIEW: _render_year_picker,
+    MemoryType.SEASON: _render_season_params,
+    MemoryType.PERSON_SPOTLIGHT: lambda state: render_person_spotlight_params(
+        state, _apply_preset_to_state
+    ),
+    MemoryType.MULTI_PERSON: lambda state: render_multi_person_params(
+        state, _apply_preset_to_state
+    ),
+    MemoryType.MONTHLY_HIGHLIGHTS: _render_monthly_params,
+    MemoryType.ON_THIS_DAY: _render_on_this_day_params,
+    MemoryType.HOLIDAY: _render_holiday_params,
+    MemoryType.THEN_AND_NOW: _render_then_and_now_params,
+    MemoryType.TRIP: _render_trip_params,
+    MemoryType.ALBUM: _render_album_picker,
+    MemoryType.SPECIAL_DAY: _render_special_day_params,
+}

--- a/src/immich_memories/ui/state.py
+++ b/src/immich_memories/ui/state.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from immich_memories.api.models import Person, VideoClipInfo
     from immich_memories.cache.thumbnail_cache import ThumbnailCache
     from immich_memories.config_loader import Config
+    from immich_memories.memory_types.presets import MemoryPreset
     from immich_memories.processing.timeline_budget import TimelinePlan
 
 
@@ -181,16 +182,49 @@ class AppState:
     def person_ids(self) -> list[str]:
         """The people this memory is narrowed to, as the one list a fetch reads.
 
-        The wizard writes a single pick into ``selected_person`` and a group
-        pick into ``memory_preset_params['person_ids']`` -- two fields, because
-        two different cards collect them. Every read of "who is this memory
-        about" goes through here so the fetch sees the same list the CLI builds
-        from ``--person``: a group of one is a filter, not an absence of one.
+        ``apply_preset`` resolves a preset's person filter into
+        ``memory_preset_params['person_ids']``; ``selected_person`` is the
+        older single pick and still answers for the paths that set it directly.
+        Every read of "who is this memory about" goes through here so the fetch
+        sees the same list the CLI builds from ``--person``: a group of one is
+        a filter, not an absence of one.
         """
         group = self.memory_preset_params.get("person_ids") or []
         if group:
             return list(group)
         return [self.selected_person.id] if self.selected_person else []
+
+    def apply_preset(self, preset: MemoryPreset) -> None:
+        """Adopt everything a preset decided: its windows, its length, its people.
+
+        The person filter travels on the preset rather than being re-derived per
+        card, so a Year in Review narrowed to two people asks Immich exactly
+        what ``--person Alice --person Bob`` asks it -- one rule, both surfaces
+        (#666, #683). Names resolve against ``people``, the roster Immich
+        returned, because a filter is written in names and fetched by id.
+        """
+        self.date_ranges = preset.date_ranges.copy()
+        if preset.default_duration_seconds:
+            self.target_duration = preset.default_duration_seconds / 60
+            self.duration_mode = "auto"
+        elif preset.date_ranges:
+            # ~1 min per month, ~8 min per year, for a preset with no opinion.
+            self.target_duration = max(1, min(10, round(preset.date_ranges[0].days / 45)))
+        self.narrow_to_people(preset.person_filter.person_names)
+
+    def narrow_to_people(self, person_names: list[str]) -> None:
+        """Resolve a filter's names to the ids a fetch queries with.
+
+        Public because "All Time" has no preset to carry a filter -- no window
+        can be built from a year that was never chosen -- and it still has to
+        answer the same picker.
+        """
+        by_name = {person.name: person for person in self.people if person.name}
+        wanted = [by_name[name] for name in person_names if name in by_name]
+        self.memory_preset_params["person_ids"] = [person.id for person in wanted]
+        # Kept for the title and the filename, which want a name and only make
+        # sense when the memory is about exactly one person.
+        self.selected_person = wanted[0] if len(wanted) == 1 else None
 
     @property
     def scope_is_selected(self) -> bool:

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -1612,22 +1612,6 @@ class TestSceneScorerInit:
         assert scorer._use_vision is False
         assert scorer._face_cascade is not None
 
-    def test_from_profile_factory(self):
-        """from_profile creates a SceneScorer from a ScoringProfile."""
-        from immich_memories.analysis.scoring import SceneScorer
-        from immich_memories.memory_types.presets import ScoringProfile
-
-        profile = ScoringProfile(face_weight=0.5, motion_weight=0.3)
-        # WHY: check_vision_available does OS detection — mock for unit test
-        with patch("immich_memories.analysis.scoring.check_vision_available", return_value=False):
-            scorer = SceneScorer.from_profile(
-                profile,
-                content_analysis_config=MagicMock(),
-                analysis_config=AnalysisConfig(),
-            )
-        assert scorer.face_weight > 0
-        assert scorer.motion_weight > 0
-
 
 class TestSceneScorerCapture:
     """Cover lines 621-623, 630: _get_capture reuse and release_capture."""

--- a/tests/test_memory_types/test_factory.py
+++ b/tests/test_memory_types/test_factory.py
@@ -13,7 +13,7 @@ from immich_memories.memory_types.registry import MemoryType
 
 
 class TestCreatePresetYearInReview:
-    """Year in Review preset uses calendar year with default weights."""
+    """Year in Review preset uses the calendar year."""
 
     def test_creates_preset(self) -> None:
         preset = create_preset(MemoryType.YEAR_IN_REVIEW, year=2024)
@@ -26,27 +26,50 @@ class TestCreatePresetYearInReview:
         assert preset.date_ranges[0].start == datetime(2024, 1, 1, 0, 0, 0)
         assert preset.date_ranges[0].end == datetime(2024, 12, 31, 23, 59, 59)
 
-    def test_default_scoring_weights(self) -> None:
-        preset = create_preset(MemoryType.YEAR_IN_REVIEW, year=2024)
-        assert preset.scoring.face_weight == 0.4
-        assert preset.scoring.motion_weight == 0.25
-
     def test_title_template(self) -> None:
         preset = create_preset(MemoryType.YEAR_IN_REVIEW, year=2024)
         assert "2024" in preset.name
 
 
+class TestPersonFilterOnEveryType:
+    """#683: a memory type that is not about people still narrows to them.
+
+    Every factory that takes ``person_names`` kept only the first, so
+    ``--person Alice --person Bob`` fetched what held both while the wizard's
+    preset asked for Alice alone. One rule now, and it is the CLI's.
+    """
+
+    @pytest.mark.parametrize(
+        ("memory_type", "params"),
+        [
+            (MemoryType.YEAR_IN_REVIEW, {"year": 2024}),
+            (MemoryType.SEASON, {"year": 2024, "season": "summer"}),
+            (MemoryType.MONTHLY_HIGHLIGHTS, {"year": 2024, "month": 3}),
+            (MemoryType.ON_THIS_DAY, {"target_date": date(2024, 6, 15)}),
+            (MemoryType.HOLIDAY, {"year": 2024, "holiday": "christmas"}),
+            (MemoryType.THEN_AND_NOW, {"year": 2024}),
+        ],
+        ids=str,
+    )
+    def test_every_name_survives_and_intersects(self, memory_type, params) -> None:
+        preset = create_preset(memory_type, person_names=["Alice", "Bob"], **params)
+
+        assert preset.person_filter.person_names == ["Alice", "Bob"]
+        assert preset.person_filter.require_co_occurrence
+
+    def test_naming_nobody_leaves_the_memory_wide(self) -> None:
+        preset = create_preset(MemoryType.YEAR_IN_REVIEW, year=2024)
+
+        assert not preset.person_filter.person_names
+
+
 class TestCreatePresetSeason:
-    """Season preset uses season date range with boosted motion weight."""
+    """Season preset uses the season's own date range."""
 
     def test_summer_date_range(self) -> None:
         preset = create_preset(MemoryType.SEASON, year=2024, season="summer")
         expected = build_season("summer", 2024)
         assert preset.date_ranges[0] == expected
-
-    def test_boosted_motion_weight(self) -> None:
-        preset = create_preset(MemoryType.SEASON, year=2024, season="summer")
-        assert preset.scoring.motion_weight == 0.35
 
     def test_winter_uses_hemisphere(self) -> None:
         preset = create_preset(MemoryType.SEASON, year=2024, season="winter", hemisphere="south")
@@ -59,11 +82,7 @@ class TestCreatePresetSeason:
 
 
 class TestCreatePresetPersonSpotlight:
-    """Person spotlight preset boosts face weight."""
-
-    def test_boosted_face_weight(self) -> None:
-        preset = create_preset(MemoryType.PERSON_SPOTLIGHT, year=2024, person_names=["Alice"])
-        assert preset.scoring.face_weight == 0.6
+    """Person spotlight is a year narrowed to one person."""
 
     def test_single_person_filter(self) -> None:
         preset = create_preset(MemoryType.PERSON_SPOTLIGHT, year=2024, person_names=["Alice"])
@@ -107,10 +126,6 @@ class TestCreatePresetPersonSpotlight:
 
 class TestCreatePresetMultiPerson:
     """Multi-person preset requires co-occurrence by default."""
-
-    def test_boosted_face_weight(self) -> None:
-        preset = create_preset(MemoryType.MULTI_PERSON, year=2024, person_names=["Alice", "Bob"])
-        assert preset.scoring.face_weight == 0.5
 
     def test_co_occurrence_default(self) -> None:
         preset = create_preset(MemoryType.MULTI_PERSON, year=2024, person_names=["Alice", "Bob"])
@@ -225,19 +240,6 @@ class TestCreatePresetTrip:
             location_name="Barcelona, Spain",
         )
         assert "Barcelona" in preset.name
-        assert preset.title_template == "{location}"
-
-    def test_scoring_boosts_motion_and_content(self) -> None:
-        preset = create_preset(
-            MemoryType.TRIP,
-            year=2024,
-            trip_start=date(2024, 6, 12),
-            trip_end=date(2024, 6, 18),
-            location_name="Barcelona, Spain",
-        )
-        assert preset.scoring.motion_weight == 0.3
-        assert preset.scoring.content_weight == 0.3
-        assert preset.scoring.face_weight == 0.2
 
     def test_twelve_day_trip_starts_with_a_realistic_auto_duration(self) -> None:
         """Regression: the old 35-seconds/day placeholder produced seven minutes."""

--- a/tests/test_memory_types/test_registry_presets.py
+++ b/tests/test_memory_types/test_registry_presets.py
@@ -2,11 +2,9 @@
 
 from datetime import datetime
 
-from immich_memories.memory_types.presets import (
-    MemoryPreset,
-    PersonFilter,
-    ScoringProfile,
-)
+import pytest
+
+from immich_memories.memory_types.presets import MemoryPreset, PersonFilter, person_filter_for
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import DateRange
 
@@ -57,43 +55,6 @@ class TestMemoryTypeEnum:
         assert MemoryType.TRIP == "trip"
 
 
-class TestScoringProfile:
-    """Tests for ScoringProfile dataclass."""
-
-    def test_defaults(self) -> None:
-        profile = ScoringProfile()
-        assert profile.face_weight == 0.4
-        assert profile.motion_weight == 0.25
-        assert profile.stability_weight == 0.2
-        assert profile.audio_weight == 0.15
-        assert profile.content_weight == 0.0
-        assert profile.duration_weight == 0.15
-
-    def test_to_dict(self) -> None:
-        profile = ScoringProfile()
-        result = profile.to_dict()
-        assert result == {
-            "face_weight": 0.4,
-            "motion_weight": 0.25,
-            "stability_weight": 0.2,
-            "audio_weight": 0.15,
-            "content_weight": 0.0,
-            "duration_weight": 0.15,
-        }
-
-    def test_custom_weights(self) -> None:
-        profile = ScoringProfile(face_weight=0.8, content_weight=0.5)
-        assert profile.face_weight == 0.8
-        assert profile.content_weight == 0.5
-        # Other defaults remain
-        assert profile.motion_weight == 0.25
-
-    def test_custom_weights_in_to_dict(self) -> None:
-        profile = ScoringProfile(face_weight=0.9)
-        result = profile.to_dict()
-        assert result["face_weight"] == 0.9
-
-
 class TestPersonFilter:
     """Tests for PersonFilter dataclass."""
 
@@ -121,44 +82,45 @@ class TestPersonFilter:
         assert not pf2.person_names
 
 
-class TestMemoryPreset:
-    """Tests for MemoryPreset dataclass."""
+class TestPersonFilterFor:
+    """One rule for what a list of names means, on every memory type."""
 
-    def test_creation_with_all_fields(self) -> None:
-        date_range = DateRange(
-            start=datetime(2025, 1, 1),
-            end=datetime(2025, 12, 31),
-        )
-        preset = MemoryPreset(
-            memory_type=MemoryType.YEAR_IN_REVIEW,
-            name="Year in Review 2025",
-            description="A look back at your best moments of 2025",
-            date_ranges=[date_range],
-            person_filter=PersonFilter(),
-            scoring=ScoringProfile(),
-            title_template="Your {year} in Review",
-            subtitle_template="Best moments of {year}",
-            default_duration_seconds=300,
-        )
-        assert preset.memory_type == MemoryType.YEAR_IN_REVIEW
-        assert preset.name == "Year in Review 2025"
-        assert len(preset.date_ranges) == 1
-        assert preset.subtitle_template == "Best moments of {year}"
-        assert preset.default_duration_seconds == 300
+    def test_several_names_intersect(self) -> None:
+        """Both on the picture — the CLI's semantics, now the preset's too."""
+        pf = person_filter_for(["Alice", "Bob"])
 
-    def test_optional_fields_default_to_none(self) -> None:
-        date_range = DateRange(
-            start=datetime(2025, 6, 1),
-            end=datetime(2025, 8, 31),
-        )
-        preset = MemoryPreset(
-            memory_type=MemoryType.SEASON,
-            name="Summer 2025",
-            description="Summer highlights",
-            date_ranges=[date_range],
-            person_filter=PersonFilter(),
-            scoring=ScoringProfile(),
-            title_template="Summer {year}",
-        )
-        assert preset.subtitle_template is None
-        assert preset.default_duration_seconds is None
+        assert pf.person_names == ["Alice", "Bob"]
+        assert pf.require_co_occurrence
+
+    def test_no_names_narrows_nothing(self) -> None:
+        assert not person_filter_for(None).person_names
+        assert not person_filter_for([]).person_names
+
+
+class TestBuriedFields:
+    """#666: three fields no code ever read, and the pins that keep them dead.
+
+    They were never functional, so they were removed outright rather than
+    deprecated. Building a preset that still names one has to fail loudly —
+    a silently ignored keyword is how they survived this long.
+    """
+
+    @pytest.mark.parametrize("dead", ["scoring", "title_template", "subtitle_template"])
+    def test_naming_a_buried_field_is_an_error(self, dead: str) -> None:
+        with pytest.raises(TypeError, match=dead):
+            MemoryPreset(
+                memory_type=MemoryType.YEAR_IN_REVIEW,
+                name="2025 Memories",
+                description="A look back",
+                date_ranges=[DateRange(start=datetime(2025, 1, 1), end=datetime(2025, 12, 31))],
+                person_filter=PersonFilter(),
+                **{dead: "whatever it used to hold"},
+            )
+
+    def test_the_scoring_profile_is_gone_from_the_package(self) -> None:
+        """Its only converter, SceneScorer.from_profile, went with it."""
+        import immich_memories.memory_types as memory_types
+        from immich_memories.analysis.scoring import SceneScorer
+
+        assert not hasattr(memory_types, "ScoringProfile")
+        assert not hasattr(SceneScorer, "from_profile")

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -16,9 +16,9 @@ moves. Differences nobody decided on are recorded as strict ``xfail`` carrying
 the reason, so repairing one forces its record to be deleted in the same commit
 -- a fix cannot land while the file still claims the surfaces disagree.
 
-One xfail is left on purpose. It is not drift: the wizard has no way to express
-the request at all, and closing it means deciding which surface is right. An
-xfail that needs a decision says so in its first line.
+No xfail is outstanding. A new divergence is recorded as one -- ``FetchScenario``
+carries the reason and ``_fetch_params`` marks it strict -- and an xfail that
+needs a product decision rather than a repair says so in its first line.
 """
 
 from __future__ import annotations
@@ -200,11 +200,15 @@ DOCUMENTED_DURATION_SPLIT: dict[MemoryType, DocumentedDifference] = {
 # parity one.
 #
 # A trip is not narrowed to a person on either surface. handle_trip_generation
-# fetches the trip's window with no person ids, and the wizard's Trip card
-# renders no person widget, so both take the window whole. --person still
-# reaches trip *detection* on the CLI, which is what scopes the GPS scan. This
-# is consistent, but it is the same open question as
-# PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE below and moves with its answer.
+# fetches the trip's window with no person ids, and the wizard's Trip card is
+# the one card #666 left without a person picker, so both take the window
+# whole. That is deliberate rather than left over: on the CLI --person scopes
+# trip *detection* -- which people's GPS trail is scanned -- and the trip that
+# comes back is then rendered entire. A picker on the wizard's Trip card would
+# narrow its fetch and nothing else's, which is how a divergence gets made
+# while another is being closed. Widening it means changing what a trip
+# selects on both surfaces at once, which is a selection change with its own
+# contact sheets, not this file's business.
 
 
 def _bounds(date_range: DateRange) -> tuple[datetime, datetime]:
@@ -423,22 +427,21 @@ def cli_fetch_calls(
 def _wizard_state(
     memory_type: MemoryType, windows: list[DateRange], people: tuple[Person, ...]
 ) -> AppState:
-    """The state the wizard's two person widgets leave behind.
+    """The state the wizard leaves behind once a card has been filled in.
 
-    step1_presets writes a single pick into ``state.selected_person`` and a
-    multi-person pick into ``memory_preset_params["person_ids"]`` -- two
-    different fields, because two different cards collect them, and only the
-    Person Spotlight and Multi-Person cards render a person widget at all. The
-    fields stay two; ``AppState.person_ids`` is what reads them as one, which is
-    the thing the fetch comparison below is really checking.
+    Every card ends at ``AppState.apply_preset``, which is where the preset's
+    windows, length and person filter become state -- so this builds the state
+    the same way ``step1_presets._apply_preset_to_state`` does rather than
+    imitating the widgets. ``people`` is the roster Immich returned, which is
+    what a filter's names resolve against.
     """
+    spec = replace(SPECS[memory_type], people=people)
     state = AppState()
-    state.date_ranges = windows
-    if memory_type is MemoryType.PERSON_SPOTLIGHT and people:
-        state.selected_person = people[0]
-        state.memory_preset_params = {"person_id": people[0].id}
-    elif memory_type is MemoryType.MULTI_PERSON:
-        state.memory_preset_params = {"person_ids": [person.id for person in people]}
+    state.people = list(people)
+    state.apply_preset(create_preset(memory_type, **spec.as_preset_params()))
+    assert _windows(state.date_ranges) == _windows(windows), (
+        "apply_preset disagreed with the windows the fetch was handed"
+    )
     return state
 
 
@@ -475,31 +478,17 @@ class FetchScenario:
     divergence: str | None = None
 
 
-PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE = (
-    "NEEDS A PRODUCT DECISION -- do not repair this by guessing. --person "
-    "narrows any memory type on the CLI and no type but two in the wizard. "
-    "fetch_videos_and_live_photos takes whatever person_ids generate.py "
-    "resolved, so `--memory-type year_in_review --person Alice --person Bob` "
-    "fetches only what holds both; the wizard renders a person widget for Person "
-    "Spotlight and Multi-Person alone, so no other card can name anybody. The "
-    "question is which surface is right: is a person filter on every memory type "
-    "a feature the wizard is missing, or is it a two-card feature the CLI "
-    "over-offers? Answering it also settles what several names mean on a type "
-    "that is not about people -- the CLI intersects them, while create_preset's "
-    "PersonFilter keeps person_names[:1] and drops the rest, so the two would "
-    "still disagree after the widget shipped. Until then the wizard cannot even "
-    "express the request, which is why this stays a strict xfail rather than "
-    "becoming a documented exception."
-)
-
+# A person filter is not a two-card feature. #666 ruled that the wizard offers
+# one wherever the CLI's --person reaches, and that several names mean the same
+# thing on both surfaces: an intersection, the way a multi-person memory has
+# always meant "both on the picture". So a Year in Review narrowed to Alice and
+# Bob is a request both surfaces can now phrase, and both answer identically.
 FETCH_SCENARIOS = (
     FetchScenario(MemoryType.YEAR_IN_REVIEW, ()),
     FetchScenario(MemoryType.PERSON_SPOTLIGHT, (ALICE,)),
     FetchScenario(MemoryType.MULTI_PERSON, (ALICE, BOB)),
     FetchScenario(MemoryType.MULTI_PERSON, (ALICE,)),
-    FetchScenario(
-        MemoryType.YEAR_IN_REVIEW, (ALICE, BOB), PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE
-    ),
+    FetchScenario(MemoryType.YEAR_IN_REVIEW, (ALICE, BOB)),
 )
 
 

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -8,6 +8,8 @@ import pytest
 
 from immich_memories.api.compatibility import ApiVersionPolicy
 from immich_memories.config_loader import Config
+from immich_memories.memory_types.factory import create_preset
+from immich_memories.memory_types.registry import MemoryType
 from immich_memories.tracking import DeliveryStatus
 from immich_memories.ui.state import (
     AppState,
@@ -619,14 +621,93 @@ class TestPersonScope:
         assert AppState().person_ids == []
 
 
+class TestAdoptingAPreset:
+    """A preset is the one thing the wizard reads a memory's scope from.
+
+    ``apply_preset`` is where a card's answer becomes state, so the person
+    filter it carries has to reach the fetch the same way its windows do --
+    that is what makes the wizard and ``--person`` agree (#666, #683).
+    """
+
+    def _state_with(self, *people):
+        from immich_memories.api.models import Person
+
+        state = AppState()
+        state.people = [Person(id=f"person-{n.lower()}", name=n) for n in people]
+        return state
+
+    def test_a_year_in_review_narrows_to_everyone_the_filter_names(self) -> None:
+        """The wizard could not phrase this at all before #666."""
+        state = self._state_with("Alice", "Bob")
+
+        state.apply_preset(
+            create_preset(MemoryType.YEAR_IN_REVIEW, year=2024, person_names=["Alice", "Bob"])
+        )
+
+        assert state.person_ids == ["person-alice", "person-bob"]
+
+    def test_naming_nobody_leaves_the_memory_wide(self) -> None:
+        state = self._state_with("Alice", "Bob")
+
+        state.apply_preset(create_preset(MemoryType.YEAR_IN_REVIEW, year=2024))
+
+        assert state.person_ids == []
+
+    def test_a_name_immich_does_not_know_narrows_nothing(self) -> None:
+        """A filter is written in names and fetched by ids, and only ids exist.
+
+        The roster is what Immich returned; a name absent from it has no id to
+        query with, so it cannot silently become "everybody".
+        """
+        state = self._state_with("Alice")
+
+        state.apply_preset(
+            create_preset(MemoryType.YEAR_IN_REVIEW, year=2024, person_names=["Alice", "Mallory"])
+        )
+
+        assert state.person_ids == ["person-alice"]
+
+    def test_one_person_is_named_for_the_title(self) -> None:
+        state = self._state_with("Alice", "Bob")
+
+        state.apply_preset(
+            create_preset(MemoryType.PERSON_SPOTLIGHT, year=2024, person_names=["Alice"])
+        )
+
+        assert state.selected_person is not None
+        assert state.selected_person.name == "Alice"
+
+    def test_a_group_has_no_single_name_to_put_on_the_title(self) -> None:
+        state = self._state_with("Alice", "Bob")
+        state.apply_preset(
+            create_preset(MemoryType.PERSON_SPOTLIGHT, year=2024, person_names=["Alice"])
+        )
+
+        state.apply_preset(
+            create_preset(MemoryType.MULTI_PERSON, year=2024, person_names=["Alice", "Bob"])
+        )
+
+        assert state.selected_person is None
+
+    def test_the_preset_also_brings_its_windows_and_its_length(self) -> None:
+        state = self._state_with("Alice")
+        preset = create_preset(MemoryType.MONTHLY_HIGHLIGHTS, year=2024, month=3)
+
+        state.apply_preset(preset)
+
+        assert state.date_ranges == preset.date_ranges
+        assert state.target_duration == 1.0
+
+
 class TestChoosingAMemoryType:
     """Switching cards drops what the previous card collected."""
 
     def test_the_person_does_not_follow_you_to_the_next_card(self) -> None:
         """Alice picked for a Person Spotlight must not narrow a Year in Review.
 
-        Only two cards show a person widget, so a person left behind by the
-        previous one filters the new memory with nothing on screen saying so.
+        Every card shows a person widget now, so a person left behind by the
+        previous one would filter the new memory with a picker on screen
+        claiming nobody is named.
         """
         from immich_memories.api.models import Person
 


### PR DESCRIPTION
Closes #666, closes #683

The owner's ruling on #666 was *delete three, wire one*. This does both, and the
intersect bug #683 flagged is fixed as part of the wiring.

## What died

Removed outright rather than deprecated. All three were inert since the day they
were written, so there is no behaviour to keep working and nothing to migrate —
the repo's deprecate-document-remove rule has no deprecation window to spend on a
field that never did anything.

| Removed | Why it was dead |
|---|---|
| `MemoryPreset.scoring` + the whole `ScoringProfile` dataclass | Every scorer the pipeline builds takes config (`SceneScorer(content_analysis_config=…, analysis_config=…)`). A Person Spotlight was scored identically to a Year in Review. |
| `SceneScorer.from_profile` | `ScoringProfile`'s only converter. One caller, and it was its own test. |
| `MemoryPreset.title_template` / `subtitle_template` | Nothing read either. Titles come from `pipeline_title.py` and the CLI's title path. |

Nine construction sites in `memory_types/factory.py` lost their dead arguments.
Vulture is clean; the docs that described the decorative weights as real
("60% face weight", "35% motion weight") are corrected rather than deleted.

## The wiring shape

`MemoryPreset.person_filter` — the fourth dead field #666 found — becomes the
real vehicle. One rule, resolved the same way by both surfaces:

```
person_names  ──►  person_filter_for()  ──►  MemoryPreset.person_filter
                                                      │
                        ┌─────────────────────────────┴──────────────────┐
                   CLI: --person names → ids                 UI: AppState.apply_preset
                        → fetch_videos_and_live_photos            → narrow_to_people
                                                                  → state.person_ids
                                                                  → the same fetch
```

- **`person_filter_for(names)`** (`memory_types/presets.py`) is the single place
  that decides what a list of names means. It replaces the same three lines
  copy-pasted into eight factories.
- **`AppState.apply_preset(preset)`** adopts a preset's windows, its length and
  its people in one move, resolving the filter's names against the roster Immich
  returned. State-level, so it is tested without a browser.
- **`ui/pages/step1_people.py`** holds the wizard's person picking: the shared
  **Only with** picker plus the two person-memory cards, which used to live in
  `step1_presets.py`. The renderers take the state and the apply callback rather
  than reaching for either, which is what lets them be exercised headless.
- `_render_params`' eleven-arm dispatch chain became a `_CARD_RENDERERS` table —
  adding the picker pushed it past the cognitive-complexity gate, and the table
  is the fix rather than a carve-out.

**Three cards carry no picker**, each for a reason already written down in the
codebase, and each consistent across both surfaces:

- **Album** — the album is the pool; `--from-album` rejects `--person` too.
- **Trip** — the trip's window is taken whole on *both* surfaces today.
  `--person` narrows trip *detection* on the CLI (whose GPS trail is scanned),
  and `handle_trip_generation` then fetches the window with `person_ids=[]`.
  A picker on the wizard's Trip card would narrow its fetch and nothing else's,
  i.e. manufacture a divergence while closing another. Widening it means
  changing what a trip *selects* on both surfaces at once — a selection change
  that wants its own contact sheets. The parity file's note on this is updated
  from "open question, moves with #683's answer" to why it stays put.
- **Surprise me** — the memory is the occasion, not its guest list, and real
  names would reach durable run history through it (existing `_special_day`
  comment).

## The intersect fix

`create_preset` kept `person_names[:1]` on every type but Multi-Person. So:

```bash
immich-memories generate --memory-type year_in_review --year 2024 --person Alice --person Bob
```

fetched only what held **both** — the CLI passes every resolved id to
`fetch_videos_and_live_photos` — while the same request through the preset
narrowed to Alice and silently dropped Bob. Both now go through
`person_filter_for`, which keeps every name and marks the intersection. That
matches the CLI's existing semantics and the multi-person rule ("both on the
picture"), so nothing about `--person` changes; the preset path stops
disagreeing with it.

## Parity

`PERSON_FILTER_ON_NON_PERSON_TYPE_DIVERGENCE` is gone, both variants
(`videos` and `videos+photos`) pass strict. **`tests/test_surface_parity.py`
ends this PR with zero xfails** — 34 passed, 0 xfailed.

`_wizard_state` no longer imitates the two person widgets by hand; it builds
state through `AppState.apply_preset`, the path the wizard actually takes, and
asserts the windows it produces match the ones the fetch is handed. The module
docstring's "one xfail is left on purpose" paragraph is replaced by how a *new*
divergence gets recorded — the mechanism stays, it just has no occupants.

## Tests

TDD: the xfail was flipped to a hard failure first (`assert cli == ui` failing on
`('person-alice','person-bob')` vs `()`), then wired until green.

- Regression pins for the buried fields: constructing a `MemoryPreset` that names
  `scoring`, `title_template` or `subtitle_template` raises `TypeError` — the
  honest pin, since the factories' `**kwargs` catch-alls would swallow a dead
  keyword silently. Plus `ScoringProfile` and `from_profile` are gone from the
  package.
- `TestPersonFilterOnEveryType` — six memory types, two names, both survive.
- `TestAdoptingAPreset` — `apply_preset` at the state level: two people reach the
  fetch, a name Immich does not know narrows nothing rather than becoming
  everybody, one person is named for the title and a group is not.

No new mocks in any of them.

`make ci` passes: 5902 passed, 9 skipped. `make docs-build` passes.

## Docs

- `create/web-ui/step1-configuration.mdx` — the per-card parameter table gains
  **Only with**, and "Person selection" is rewritten from "two cards have a
  person widget" to the three-way split above, with the CLI equivalent shown.
- `create/memory-types/monthly-person-season.mdx` — drops the two claims about
  per-type scoring weights (they described the field this PR buries) and adds the
  several-names rule.
- `create/memory-types/year-in-review.mdx` — the wizard's Only with box, and what
  two names mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
