### PR TITLE
refactor(scoring): judge a photograph by the rules footage is judged by

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -2467,43 +2467,59 @@
       {
         "name": "_stream_render_to_mp4",
         "complexity": 16,
-        "line_start": 692,
-        "line_end": 791,
+        "line_start": 682,
+        "line_end": 781,
         "line_complexities": [
           {
-            "line": 713,
+            "line": 703,
             "complexity": 0
           },
           {
-            "line": 714,
+            "line": 704,
             "complexity": 1
+          },
+          {
+            "line": 706,
+            "complexity": 1
+          },
+          {
+            "line": 707,
+            "complexity": 0
+          },
+          {
+            "line": 708,
+            "complexity": 2
+          },
+          {
+            "line": 709,
+            "complexity": 0
           },
           {
             "line": 716,
             "complexity": 1
           },
           {
-            "line": 717,
+            "line": 720,
             "complexity": 0
           },
           {
-            "line": 718,
-            "complexity": 2
-          },
-          {
-            "line": 719,
+            "line": 721,
             "complexity": 0
           },
           {
-            "line": 726,
+            "line": 722,
             "complexity": 1
           },
           {
-            "line": 730,
+            "line": 723,
             "complexity": 0
           },
           {
-            "line": 731,
+            "line": 724,
+            "complexity": 2
+          },
+          {
+            "line": 725,
             "complexity": 0
           },
           {
@@ -2511,19 +2527,23 @@
             "complexity": 1
           },
           {
-            "line": 733,
+            "line": 736,
             "complexity": 0
           },
           {
-            "line": 734,
+            "line": 739,
+            "complexity": 0
+          },
+          {
+            "line": 740,
             "complexity": 2
           },
           {
-            "line": 735,
-            "complexity": 0
+            "line": 741,
+            "complexity": 3
           },
           {
-            "line": 742,
+            "line": 743,
             "complexity": 1
           },
           {
@@ -2531,37 +2551,17 @@
             "complexity": 0
           },
           {
-            "line": 749,
-            "complexity": 0
-          },
-          {
-            "line": 750,
-            "complexity": 2
-          },
-          {
-            "line": 751,
-            "complexity": 3
-          },
-          {
-            "line": 753,
+            "line": 780,
             "complexity": 1
           },
           {
-            "line": 756,
-            "complexity": 0
-          },
-          {
-            "line": 790,
-            "complexity": 1
-          },
-          {
-            "line": 791,
+            "line": 781,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 95
+    "complexity": 94
   },
   {
     "path": "src/immich_memories/processing/clip_encoder.py",

--- a/docs-site/docs/create/pipeline/clip-selection-scoring.md
+++ b/docs-site/docs/create/pipeline/clip-selection-scoring.md
@@ -62,14 +62,19 @@ Photos use a mix of metadata and optional LLM visual analysis:
 | Factor | Weight | How |
 |--------|--------|-----|
 | Base | 0.15 | Every photo starts here |
-| Favorite | 0.25 | Favorited in Immich |
 | Has faces | 0.15 | People detected by Immich |
 | Face count | 0.10 | More faces = family moments (capped at 3+) |
 | Camera original | 0.05 | Real camera EXIF (not screenshot) |
 | LLM visual | 0.30 | VLM rates interest + quality |
 
-Photo scores are multiplied by `(1 - score_penalty)`. The default penalty is 0.2, so a photo
-scores 80% of an equally good video and videos win ties.
+A favourite is not in the table. It orders photos rather than scoring them: a
+starred photo sorts above an unstarred one whatever either measures. Scored as
+well, it was worth 0.25 — exactly what faces plus face count are worth — so
+three detected strangers tied with the owner saying this one mattered.
+
+Photos are scored on the same scale as footage. Stills used to be scaled to 80%
+so a video won every tie, which meant the asset's type decided the ranking
+before anything asked which asset was better.
 
 ### Live Photo Scoring
 
@@ -326,5 +331,4 @@ Set in config: `analysis.clip_style: balanced` (or pass no value to use individu
 photos:
   enabled: true           # Include photos (default: true)
   max_ratio: 0.50         # Max 50% of clips can be photos
-  score_penalty: 0.2      # Photos score 80% of equivalent videos
 ```

--- a/docs-site/docs/create/pipeline/photo-support.md
+++ b/docs-site/docs/create/pipeline/photo-support.md
@@ -68,7 +68,6 @@ photos:
   burst_hash_threshold: 8    # Hash bits two frames may differ by and still be one burst
   moment_gap_seconds: 120 # Window for "same moment as a video" (seconds)
   moment_hash_threshold: 10  # Bits a photo may differ from that video and still match
-  score_penalty: 0.2      # Photos score 80% of equivalent videos
 ```
 
 Older configs may still contain `collage_duration`, `animation_mode`, `enable_collage`, `series_gap_seconds` or `zoom_factor`; those keys were removed in 0.41 and are ignored (the zoom amount is randomized per photo, and collages no longer exist).

--- a/docs-site/docs/reference/config-reference.md
+++ b/docs-site/docs/reference/config-reference.md
@@ -206,7 +206,6 @@ photos:
   duration: 4.0                  # Seconds per photo clip (1-10)
   moment_gap_seconds: 120        # Window for "same moment as a video" (0-3600)
   moment_hash_threshold: 10      # Hash bits allowed between photo and that video (0-64)
-  score_penalty: 0.2             # Photos score 80% of equivalent videos (0-1)
   burst_window_seconds: 300      # Near-identical photos this close apart are one burst (0-3600)
   burst_hash_threshold: 8        # Hash bits two photos may differ by and still be one burst (0-64)
 ```

--- a/src/immich_memories/analysis/asset_merit.py
+++ b/src/immich_memories/analysis/asset_merit.py
@@ -1,0 +1,26 @@
+"""How much an asset is worth showing, on one scale for photographs and video.
+
+#677 moved video to a content-first score: what a clip shows, adjusted by how
+well it was shot. Photographs kept the additive weighted sum it replaced, which
+is why a face there is worth 0.15 + 0.10 — exactly what a favourite is worth —
+and three strangers rank a photograph as high as the owner starring it does.
+
+This module holds what both must agree on. Signal availability differs: a
+photograph has no motion track and a video has no EXIF maker. The priors do not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def ranking_key(asset: Any, merit: float) -> tuple[int, float]:
+    """Order assets for selection: the owner's mark first, then merit.
+
+    A favourite is a sort key rather than a term in the score, so no
+    accumulation of technical signal can buy what the owner marking an asset
+    means. Video already orders this way (clip_scaler, clip_backfill); adding
+    a favourite to the number instead — as photo scoring did — is what let
+    three detected faces tie with a star.
+    """
+    return (1 if getattr(asset, "is_favorite", False) else 0, merit)

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -316,21 +316,6 @@ class SelectionQuality:
         result = self.refiner.phase_refine(analyzed, self.tracker)
         return result, analyzed, True
 
-    def _floor_for(self, member: ClipWithSegment) -> float:
-        """The gate this clip answers to, on the scale its score was built on.
-
-        photos.score_penalty says outright that a photo scores a fixed share
-        of a video, so a floor calibrated on footage is that much too high for
-        a still. A no-people, non-favorite photo tops out at 0.15 base + 0.05
-        camera + half the LLM weight — 0.28 after the penalty, against a floor
-        of 0.30. Landscapes, pets and scenery could not clear it at all, and
-        were dropped as a class along with any day only they represented.
-        """
-        floor = self.config.judge_floor_score
-        if not is_a_still(member.clip.asset):
-            return floor
-        return floor * (1.0 - self._app_config.photos.score_penalty)
-
     def spare_last_voices(
         self,
         offenders: set[str],
@@ -394,7 +379,8 @@ class SelectionQuality:
         # dropped for being a weak last note is fine anywhere else, and
         # keeping it for lack of an alternative would defeat the rule.
         offenders = self.spare_last_voices(
-            {s.clip.asset.id for s in judgeable if s.score < self._floor_for(s)}, selected
+            {s.clip.asset.id for s in judgeable if s.score < self.config.judge_floor_score},
+            selected,
         )
         scores = [s.score for s in selected]
         mean_score = sum(scores) / len(scores)

--- a/src/immich_memories/config_models_render.py
+++ b/src/immich_memories/config_models_render.py
@@ -222,9 +222,3 @@ class PhotoConfig(BaseModel):
             "still count as the same scene (0 = only identical framing)"
         ),
     )
-    score_penalty: float = Field(
-        default=0.2,
-        ge=0.0,
-        le=1.0,
-        description="Score reduction for photos vs videos (0.2 = photos score 80% of videos)",
-    )

--- a/src/immich_memories/photos/burst_dedup.py
+++ b/src/immich_memories/photos/burst_dedup.py
@@ -15,6 +15,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 
+from immich_memories.analysis.asset_merit import ranking_key
 from immich_memories.analysis.duplicate_hashing import hamming_distance
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ class PhotoCandidate:
     taken_at: datetime
     thumbnail_hash: str | None
     score: float = 0.0
+    is_favorite: bool = False
 
 
 def drop_burst_duplicates(
@@ -45,6 +47,9 @@ def drop_burst_duplicates(
 
     A photo with no thumbnail hash is always kept. Redundancy is measured, never
     assumed -- a missing thumbnail says nothing about the picture.
+
+    Best means the owner's mark first, then score. A burst that contains the
+    starred frame keeps that frame, whatever the sharper ones measure.
     """
     if not photos:
         return []
@@ -57,7 +62,7 @@ def drop_burst_duplicates(
             continue
         burst = _burst_starting_at(by_time, index, window_seconds, hash_threshold, superseded)
         if len(burst) > 1:
-            best = max(burst, key=lambda p: p.score)
+            best = max(burst, key=lambda p: ranking_key(p, p.score))
             superseded.update(p.key for p in burst if p.key != best.key)
 
     if superseded:

--- a/src/immich_memories/photos/photo_pipeline.py
+++ b/src/immich_memories/photos/photo_pipeline.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import operator
 import random
 import subprocess
 from collections.abc import Iterator
@@ -21,6 +20,7 @@ from typing import Any
 import cv2
 import numpy as np
 
+from immich_memories.analysis.asset_merit import ranking_key
 from immich_memories.analysis.source_filter import from_the_camera_roll
 from immich_memories.analysis.unified_budget import (
     BudgetCandidate,
@@ -83,12 +83,6 @@ def score_photos(
     if not assets:
         return []
 
-    # Photos score below videos so a recap prefers moving footage. With no
-    # video in the month there is nothing to defer to, and the penalty only
-    # compresses the range the selection has to work with.
-    if video_clip_count == 0:
-        config = config.model_copy(update={"score_penalty": 0.0})
-
     # Phase 1: Fast metadata scoring (no I/O). Keep this complete pool so the
     # final optimizer can use unshortlisted photos when preferred media is sparse.
     metadata_scored = [(a, score_photo(a, config)) for a in assets]
@@ -101,7 +95,7 @@ def score_photos(
     # The metadata score alone ties hundreds of photos onto a handful of
     # values; what the pixels say breaks those ties (#489).
     metadata_scored = _apply_frame_quality(
-        metadata_scored, config, thumbnail_cache, thumbnail_fn=thumbnail_fn
+        metadata_scored, thumbnail_cache, thumbnail_fn=thumbnail_fn
     )
 
     # One look per moment, not a few per shippable slot. Sizing the shortlist
@@ -399,7 +393,6 @@ def _frames_for_quality(
 
 def _apply_frame_quality(
     scored: list[tuple[Asset, float]],
-    config: PhotoConfig,
     thumbnail_cache: Any,
     thumbnail_fn: Any = None,
     budget: int = _QUALITY_FETCH_BUDGET,
@@ -434,13 +427,9 @@ def _apply_frame_quality(
 
     # An unmeasurable thumbnail sits mid-pool rather than last: we know nothing
     # about it, which is not the same as knowing it is bad.
-    # The metadata score arrives already carrying the photo penalty, so the
-    # quality share takes it too — otherwise a third of every photo's score
-    # would quietly escape the rule that keeps photos behind videos.
-    penalty = 1.0 - config.score_penalty
     rescored = []
     for i, (asset, score) in enumerate(scored):
-        share = quality.get(i, 0.5) * penalty
+        share = quality.get(i, 0.5)
         rescored.append((asset, score * (1.0 - _QUALITY_SHARE) + share * _QUALITY_SHARE))
     logger.info(
         "Frame quality: %d of %d photos measured, %.0f%% of the score",
@@ -480,6 +469,7 @@ def _drop_burst_duplicates(
                 taken_at=asset.file_created_at,
                 thumbnail_hash=digest,
                 score=score,
+                is_favorite=asset.is_favorite,
             )
         )
 
@@ -537,7 +527,7 @@ def one_photo_per_moment(scored: list[tuple], window_minutes: float) -> list[tup
     better.
     """
     return [
-        max(g, key=lambda item: (bool(item[0].is_favorite), item[1]))
+        max(g, key=lambda item: ranking_key(item[0], item[1]))
         for g in moments_of(scored, window_minutes)
     ]
 
@@ -591,7 +581,7 @@ def _select_distributed(
             break
         bucket = by_date[bucket_start : bucket_start + bucket_size]
         # Pick the highest-scored photo in this bucket
-        best = max(bucket, key=operator.itemgetter(1))
+        best = max(bucket, key=lambda item: ranking_key(item[0], item[1]))
         if best[0].id not in seen:
             selected.append(best)
             seen.add(best[0].id)

--- a/src/immich_memories/photos/scoring.py
+++ b/src/immich_memories/photos/scoring.py
@@ -4,8 +4,11 @@ Two scoring modes:
 1. Fast (metadata only): favorites, faces, camera — no I/O, instant
 2. LLM (visual analysis): sends the photo to VLM for interest/quality rating
 
-Photos score lower than videos by default (via score_penalty) to ensure
-videos always win in a tie.
+A photograph is scored on the same scale as footage. It used to be scaled to
+80% so a video won every tie, which was the asset's TYPE deciding the ranking
+before anything asked which asset was better -- and it forced two further
+mechanisms to exist purely to undo it: a discounted judge floor for stills, and
+a matching discount inside the frame-quality re-weighting.
 """
 
 from __future__ import annotations
@@ -26,8 +29,11 @@ from immich_memories.config_models_render import PhotoConfig
 
 logger = logging.getLogger(__name__)
 
-# Weight distribution for metadata scoring
-_W_FAVORITE = 0.25
+# Weight distribution for metadata scoring.
+# A favourite is deliberately absent: it orders photographs rather than scoring
+# them (analysis.asset_merit.ranking_key), which is how video has always
+# treated it. Added here as well it was worth 0.25 -- exactly what 0.15 + 0.10
+# of detected faces was worth -- so three strangers tied with the owner's mark.
 _W_FACES = 0.15
 _W_FACE_COUNT = 0.10  # More faces = more interesting
 _W_CAMERA = 0.05
@@ -38,9 +44,6 @@ _W_BASE = 0.15
 def score_photo(asset: Asset, config: PhotoConfig) -> float:
     """Score a photo for selection priority. Returns 0.0-1.0."""
     raw = _W_BASE
-
-    if asset.is_favorite:
-        raw += _W_FAVORITE
 
     if asset.people:
         raw += _W_FACES
@@ -54,8 +57,7 @@ def score_photo(asset: Asset, config: PhotoConfig) -> float:
     # Without LLM, redistribute that weight to base
     raw += _W_LLM * 0.5  # Assume average LLM score when not available
 
-    raw = min(1.0, max(0.0, raw))
-    return raw * (1.0 - config.score_penalty)
+    return min(1.0, max(0.0, raw))
 
 
 def score_photo_with_llm(
@@ -79,13 +81,10 @@ def score_photo_with_llm(
     if look is None:
         return None
 
-    # Blend: replace the LLM placeholder weight with actual LLM score
-    # metadata_score was computed with _W_LLM * 0.5 as placeholder
-    penalty = 1.0 - config.score_penalty
-    # Remove placeholder, add actual LLM score
-    adjusted = (metadata_score / penalty) - _W_LLM * 0.5 + _W_LLM * look.score
-    blended = min(1.0, max(0.0, adjusted)) * penalty
-    return PhotoLook(score=blended, payload=look.payload)
+    # metadata_score was computed with _W_LLM * 0.5 standing in for the answer
+    # that has now arrived: swap the placeholder for the real one.
+    adjusted = metadata_score - _W_LLM * 0.5 + _W_LLM * look.score
+    return PhotoLook(score=min(1.0, max(0.0, adjusted)), payload=look.payload)
 
 
 # The same fields the video path asks the same model for. A photo used to be

--- a/tests/test_frame_quality.py
+++ b/tests/test_frame_quality.py
@@ -77,7 +77,6 @@ def test_frame_quality_breaks_a_metadata_tie_group() -> None:
     Without this, "best N photos" means "first N of the largest tie group",
     in whatever order the API happened to return them.
     """
-    from immich_memories.config_models_render import PhotoConfig
     from immich_memories.photos.photo_pipeline import _apply_frame_quality
 
     class _Thumbnails:
@@ -102,7 +101,7 @@ def test_frame_quality_breaks_a_metadata_tie_group() -> None:
         }
     )
 
-    rescored = _apply_frame_quality(scored, PhotoConfig(), thumbs)
+    rescored = _apply_frame_quality(scored, thumbs)
 
     scores = [s for _a, s in rescored]
     assert len(set(scores)) == len(scores), "a tie group must come out ordered"

--- a/tests/test_frame_quality_runs.py
+++ b/tests/test_frame_quality_runs.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import io
 
-from immich_memories.config_models_render import PhotoConfig
 from immich_memories.photos.photo_pipeline import _apply_frame_quality
 from tests.conftest import make_asset
 
@@ -49,7 +48,6 @@ def test_the_pixels_break_the_tie_when_nothing_cached_them(tmp_path) -> None:
 
     rescored = _apply_frame_quality(
         pool,
-        PhotoConfig(),
         _EmptyCache(),
         thumbnail_fn=lambda asset_id, **_kw: frames[asset_id],
     )
@@ -73,7 +71,6 @@ def test_a_cached_frame_is_not_fetched_again(tmp_path) -> None:
 
     rescored = _apply_frame_quality(
         pool,
-        PhotoConfig(),
         _WarmCache(),
         thumbnail_fn=lambda asset_id, **_kw: fetched.append(asset_id) or sharp,
     )
@@ -92,7 +89,7 @@ def test_without_a_way_to_fetch_it_still_uses_what_is_cached(tmp_path) -> None:
         def get(self, asset_id: str, _size: str) -> bytes | None:
             return sharp if asset_id.endswith("0") else (blurry if asset_id.endswith("1") else None)
 
-    rescored = _apply_frame_quality(pool, PhotoConfig(), _PartialCache())
+    rescored = _apply_frame_quality(pool, _PartialCache())
 
     assert len({round(score, 6) for _asset, score in rescored}) > 1
 

--- a/tests/test_judge_gate.py
+++ b/tests/test_judge_gate.py
@@ -1,11 +1,12 @@
-"""The mechanical judge sees scores, and a photo's score is on another scale.
+"""The mechanical judge sees scores, and silence is not a verdict.
 
-photos.score_penalty documents the difference outright — "photos score 80% of
-videos" — and the judge applied a video-calibrated floor to both. A no-people,
-non-favorite photo cannot clear it: 0.15 base + 0.05 camera + half the LLM
-weight is 0.28 after the penalty, against a floor of 0.30. Landscapes, pets
-and scenery were dropped as a class, and the days only they represented went
-with them.
+A photograph nobody has looked at scores 0.15 base + 0.05 camera + half the
+LLM weight standing in for the answer that has not arrived — 0.35, clearing
+the 0.30 floor on its own. A photograph the model actively called dull scores
+0.29 and does not. The gate must separate those two, and it once could not:
+photos.score_penalty scaled every still to 80%, putting the quiet landscape at
+0.28, so landscapes, pets and scenery were dropped as a class and the days
+only they represented went with them.
 """
 
 from __future__ import annotations
@@ -42,11 +43,11 @@ def _member(asset_id: str, score: float, *, photo: bool, hour: int = 12) -> Clip
 
 
 def test_a_landscape_nobody_has_looked_at_yet_is_not_an_offender(tmp_path: Path) -> None:
-    """0.280 is what a no-people photo scores before the VLM has an opinion.
+    """0.35 is what a no-people photo scores before the VLM has an opinion.
 
     Silence is not a verdict, and this one was being read as one.
     """
-    quiet_landscape = _member("landscape", 0.280, photo=True)
+    quiet_landscape = _member("landscape", 0.35, photo=True)
     others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
 
     offenders = _pipeline(tmp_path).quality.judge_offenders([quiet_landscape, *others])
@@ -55,8 +56,11 @@ def test_a_landscape_nobody_has_looked_at_yet_is_not_an_offender(tmp_path: Path)
 
 
 def test_a_photo_the_model_called_dull_is_still_an_offender(tmp_path: Path) -> None:
-    """0.232 is a photo the VLM actively scored 0.3. That is a verdict."""
-    dull = _member("dull", 0.232, photo=True)
+    """0.29 is a photo the VLM actively scored 0.3. That is a verdict.
+
+    0.35 metadata, less the 0.15 placeholder, plus 0.30 x 0.3 of real answer.
+    """
+    dull = _member("dull", 0.29, photo=True)
     others = [_member(f"v-{i}", 0.6, photo=False, hour=13 + i) for i in range(3)]
 
     offenders = _pipeline(tmp_path).quality.judge_offenders([dull, *others])

--- a/tests/test_one_scorer.py
+++ b/tests/test_one_scorer.py
@@ -1,0 +1,109 @@
+"""One scoring method everywhere — photographs judged by the rules video uses.
+
+#677 made a video's score content-first: what it shows, adjusted by how well it
+was shot. Photographs never made the trip, so they still run the additive
+weighted sum #677 replaced — which is why a face is worth what the owner
+starring the photograph is worth.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.asset_merit import ranking_key
+from immich_memories.api.models import Person
+from immich_memories.config_models_render import PhotoConfig
+from immich_memories.photos.scoring import score_photo
+from tests.conftest import make_asset
+
+
+def _photo(asset_id: str, *, is_favorite: bool = False, faces: int = 0):
+    asset = make_asset(asset_id, is_favorite=is_favorite, exif_make="Apple", duration=None)
+    asset.people = [Person(id=f"{asset_id}-{n}", name=f"Person {n}") for n in range(faces)]
+    return asset
+
+
+class TestFacesAreNotWorthAFavourite:
+    """The owner's mark must outrank a crowd of strangers."""
+
+    def test_the_owners_mark_outranks_a_crowd(self):
+        """A starred photograph beats an unstarred one full of faces.
+
+        Measured before the change: both score exactly 0.480000. Faces carry
+        0.15 + 0.10 and a favourite carries 0.25, so three strangers buy
+        precisely what the owner starring it buys, and the winner is whichever
+        order the API happened to return.
+        """
+        config = PhotoConfig()
+        starred = _photo("starred", is_favorite=True)
+        crowd = _photo("crowd", faces=3)
+
+        best = max([crowd, starred], key=lambda a: ranking_key(a, score_photo(a, config)))
+
+        assert best is starred
+
+    def test_the_star_is_not_also_a_number(self):
+        """Merit measures the photograph; the star orders it.
+
+        Kept in both places a favourite counts twice, and the number it adds is
+        the one three strangers matched. Video has never scored a favourite —
+        it sorts on one — so this is the photograph adopting the video method.
+        """
+        config = PhotoConfig()
+
+        starred = score_photo(_photo("starred", is_favorite=True), config)
+        plain = score_photo(_photo("plain"), config)
+
+        assert starred == plain
+
+
+class TestTheStarSurvivesEveryNarrowing:
+    """Wherever photographs are narrowed on score, the star must still win."""
+
+    def test_a_favourite_survives_its_burst(self):
+        """A held shutter that includes the starred frame keeps the star.
+
+        Burst de-duplication keeps one frame per burst, chosen on score. Once
+        the star stops being a number in that score, choosing on the number
+        alone drops the one frame the owner said mattered.
+        """
+        from immich_memories.photos.burst_dedup import PhotoCandidate, drop_burst_duplicates
+
+        moment = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+        burst = [
+            PhotoCandidate(key="sharp", taken_at=moment, thumbnail_hash="f" * 16, score=0.9),
+            PhotoCandidate(
+                key="starred",
+                taken_at=moment + timedelta(seconds=1),
+                thumbnail_hash="f" * 16,
+                score=0.4,
+                is_favorite=True,
+            ),
+        ]
+
+        kept = drop_burst_duplicates(burst, window_seconds=5.0, hash_threshold=10)
+
+        assert kept == ["starred"]
+
+
+class TestOnePoolOneScale:
+    """A photograph is not marked down for being a photograph."""
+
+    def test_a_plain_photograph_clears_the_judges_floor_unaided(self):
+        """One scale, one gate, no compensating discount.
+
+        score_penalty scaled every still to 80% so footage won ties while the
+        two ranked in separate budgets. A no-people, non-favourite photograph
+        then scored 0.28 against a judge floor of 0.30 and could not clear it,
+        so landscapes, pets and scenery were dropped as a class -- and the
+        floor itself had to be discounted for stills to undo it. A second
+        mechanism whose only job is to cancel a first.
+
+        Undiscounted the same photograph scores 0.35 and clears 0.30 on its
+        own, which is what lets the discounted floor go.
+        """
+        from immich_memories.analysis.smart_pipeline import PipelineConfig
+
+        config = PhotoConfig()
+
+        assert score_photo(_photo("landscape"), config) > PipelineConfig().judge_floor_score

--- a/tests/test_photo_config.py
+++ b/tests/test_photo_config.py
@@ -18,14 +18,13 @@ class TestPhotoConfig:
         assert cfg.enabled is True
         assert cfg.max_ratio == 0.50
         assert cfg.duration == 4.0
-        assert cfg.score_penalty == 0.2
 
     def test_boundary_values_accepted(self):
         """Boundary values at min/max are accepted."""
-        cfg = PhotoConfig(max_ratio=0.0, duration=1.0, score_penalty=0.0)
+        cfg = PhotoConfig(max_ratio=0.0, duration=1.0)
         assert cfg.max_ratio == 0.0
 
-        cfg = PhotoConfig(max_ratio=1.0, duration=10.0, score_penalty=1.0)
+        cfg = PhotoConfig(max_ratio=1.0, duration=10.0)
         assert cfg.max_ratio == 1.0
 
     @pytest.mark.parametrize(
@@ -35,8 +34,6 @@ class TestPhotoConfig:
             pytest.param("max_ratio", 1.1, "less than", id="ratio-over-1"),
             pytest.param("duration", 0.5, "greater than", id="duration-too-short"),
             pytest.param("duration", 20.0, "less than", id="duration-too-long"),
-            pytest.param("score_penalty", -0.1, "greater than", id="penalty-negative"),
-            pytest.param("score_penalty", 1.5, "less than", id="penalty-over-1"),
         ],
     )
     def test_validation_rejects_out_of_range(self, field, value, match):
@@ -61,12 +58,11 @@ class TestPhotoConfigInConfig:
         from immich_memories.config_loader import Config
 
         config_path = tmp_path / "config.yaml"
-        original = Config(photos=PhotoConfig(enabled=True, duration=5.0, score_penalty=0.3))
+        original = Config(photos=PhotoConfig(enabled=True, duration=5.0))
         original.save_yaml(config_path)
         loaded = Config.from_yaml(config_path)
         assert loaded.photos.enabled is True
         assert loaded.photos.duration == 5.0
-        assert loaded.photos.score_penalty == 0.3
 
     def test_photos_in_yaml_tier1(self, tmp_path):
         """Photos config loads from tier 1 (top-level YAML)."""

--- a/tests/test_photo_pipeline.py
+++ b/tests/test_photo_pipeline.py
@@ -116,7 +116,7 @@ def test_the_description_survives_scoring_and_the_score_stays_a_number(tmp_path,
 
     enhanced, payloads = photo_pipeline._enhance_with_llm(
         [(asset, 0.3)],
-        config=SimpleNamespace(score_penalty=0.0),
+        config=SimpleNamespace(),
         work_dir=tmp_path,
         download_fn=None,
         app_config=SimpleNamespace(
@@ -158,7 +158,7 @@ def test_a_score_cached_before_photos_could_describe_themselves_is_re_asked(tmp_
 
     enhanced, payloads = photo_pipeline._enhance_with_llm(
         [(asset, 0.3)],
-        config=SimpleNamespace(score_penalty=0.0),
+        config=SimpleNamespace(),
         work_dir=tmp_path,
         download_fn=None,
         db_path=tmp_path / "scores.db",

--- a/tests/test_photo_scoring.py
+++ b/tests/test_photo_scoring.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from immich_memories.analysis.asset_merit import ranking_key
 from immich_memories.api.models import Person
 from immich_memories.config_models_render import PhotoConfig
 from immich_memories.photos.scoring import (
@@ -47,12 +48,21 @@ class TestPhotoScoring:
         score = score_photo(_photo(), config)
         assert 0.0 <= score <= 1.0
 
-    def test_favorite_boost(self):
-        """Favorites score higher than non-favorites."""
+    def test_favorite_outranks_without_scoring_higher(self):
+        """A favourite outranks, but is not scored -- it orders.
+
+        Scored as well it was worth 0.25, exactly what detected faces were
+        worth, so three strangers tied with the owner's mark. It now sits in
+        the sort key that video has always used (asset_merit.ranking_key).
+        """
         config = PhotoConfig()
-        normal = score_photo(_photo("p1", is_favorite=False), config)
-        fav = score_photo(_photo("p2", is_favorite=True), config)
-        assert fav > normal
+        normal = _photo("p1", is_favorite=False)
+        fav = _photo("p2", is_favorite=True)
+
+        assert score_photo(fav, config) == score_photo(normal, config)
+        assert ranking_key(fav, score_photo(fav, config)) > ranking_key(
+            normal, score_photo(normal, config)
+        )
 
     def test_faces_boost(self):
         """Photos with faces score higher."""
@@ -68,27 +78,6 @@ class TestPhotoScoring:
         camera = score_photo(_photo("p1", exif_make="Apple"), config)
         screenshot = score_photo(_photo("p2", exif_make=None), config)
         assert camera > screenshot
-
-    def test_penalty_applied(self):
-        """Score is reduced by score_penalty factor."""
-        config_no_penalty = PhotoConfig(score_penalty=0.0)
-        config_with_penalty = PhotoConfig(score_penalty=0.3)
-        score_full = score_photo(_photo(), config_no_penalty)
-        score_penalized = score_photo(_photo(), config_with_penalty)
-        assert score_penalized < score_full
-
-    def test_zero_penalty_means_full_score(self):
-        """With score_penalty=0, score equals raw score."""
-        config = PhotoConfig(score_penalty=0.0)
-        score = score_photo(_photo(), config)
-        # Should be the raw score, not reduced
-        assert score > 0.0
-
-    def test_max_penalty_gives_zero(self):
-        """With score_penalty=1.0, all photos score 0."""
-        config = PhotoConfig(score_penalty=1.0)
-        score = score_photo(_photo(), config)
-        assert score == 0.0
 
     def test_parse_photo_look_averages_complete_numeric_fields(self) -> None:
         from immich_memories.photos.scoring import _parse_photo_look

--- a/tests/test_unified_budget.py
+++ b/tests/test_unified_budget.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+from immich_memories.analysis.asset_merit import ranking_key
 from immich_memories.analysis.unified_budget import (
     BudgetCandidate,
     _fill_with_photos,
@@ -605,9 +606,10 @@ class TestScorePhotos:
         assert len(result) == 2
         # Each entry is (Asset, float)
         assert all(isinstance(score, float) for _, score in result)
-        # Favorite should score higher than non-favorite
-        scores_by_id = {a.id: s for a, s in result}
-        assert scores_by_id["photo1"] > scores_by_id["photo2"]
+        # A favourite orders above a non-favourite rather than scoring above
+        # it: the star is a sort key, not a term (asset_merit.ranking_key).
+        by_id = {a.id: (a, s) for a, s in result}
+        assert ranking_key(*by_id["photo1"]) > ranking_key(*by_id["photo2"])
 
     def test_vlm_shortlist_does_not_delete_metadata_scored_photo_fallbacks(self, tmp_path):
         """Only semantic scoring is capped; every eligible photo remains selectable."""


### PR DESCRIPTION
Closes #708.

First of four slices toward one pool, one ranking, rendering last. This one
unifies the ranking, because merging pools first would hand the merged pool two
disagreeing formulas.

## What the split actually was

#677 already built the unified scorer — for video only. `blend_content_and_technical`
makes content primary and technical a bounded multiplier, measured over 5,505 real
segments. Photographs never made the trip and still ran the additive weighted sum it
replaced. So the "two implementations with different priors" are one migrated and one
stranded, and two priors sat in the wrong category:

- **Faces.** On video, `face_weight` is a term *inside* `technical` — how well the shot
  was taken. On photos it was a content-level addend worth 0.15 + 0.10.
- **The star.** Video has never scored a favourite; `clip_scaler` and `clip_backfill`
  sort on one. Photos added 0.25.

Both being 0.25 is not a coincidence to re-tune — it is why three detected strangers
tied *exactly* with the owner starring a photograph. Measured, both at `0.480000`, with
the winner decided by whatever order the API returned.

## What changed

The star leaves the number and joins the order, via `analysis/asset_merit.ranking_key`.
That makes it unbuyable: no accumulation of technical signal reaches it, because it is
not on the same axis. Applied at **every** narrowing a photograph passes through —
`one_photo_per_moment` already did this, but burst de-duplication and the distributed
shortlist ranked on score alone and would drop the starred frame.

`photos.score_penalty` goes too. It scaled every still to 80% so footage won ties while
the two ranked in separate budgets — the asset's type deciding the ranking before
anything asked which asset was better. It had grown **two** mechanisms whose only job
was to undo it: a judge floor discounted for stills (`selection_quality._floor_for`), and
a matching discount carried through the frame-quality re-weighting. Both delete.

## Measured on a real August (632 photographs, 142 moments)

| | before | after |
|---|---|---|
| moments holding a star where score alone drops it | 25 of 31 | 0 |
| photographs clearing the judge floor | 495 | 495 |
| distinct rank groups | 11 | 12 |
| mean still score vs unchanged footage | — | x1.195 |

**What did not improve:** zero moment representatives changed across 96 multi-photograph
moments. `one_photo_per_moment` already ordered star-first, so the visible pick is
unchanged; the win is at the two narrowings that lacked that key.

**What to watch:** stills now rank ~1.2x higher against footage, since videos were never
scaled. The judge floor is provably unaffected — the floor for stills was scaled by the
same 0.8, so the ratio is identical (0.28/0.24 = 0.35/0.30), which is why 495 is 495.
The photo-vs-video balance is now held only by `max_ratio`/`enforce_photo_cap`, which is
what the next slice (#735) takes on.

## Notes

- `make ci` green.
- Found in passing, fixed in slice 3: `motion_rendering.py:62` reads
  `live_photo_min_clip_seconds` via `getattr(..., 3.5)` but that field does not exist in
  the config schema, so the measured 3.5s threshold is an unconfigurable default nothing
  would flag if it drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL