### PR TITLE
feat(selection): the favourite wins its moment, as a rule rather than a weight

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,35 +6,31 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 261,
-        "line_end": 304,
+        "line_start": 262,
+        "line_end": 305,
         "line_complexities": [
           {
-            "line": 271,
-            "complexity": 0
-          },
-          {
             "line": 272,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 273,
-            "complexity": 0
+            "complexity": 1
           },
           {
-            "line": 276,
+            "line": 274,
             "complexity": 0
           },
           {
             "line": 277,
-            "complexity": 1
-          },
-          {
-            "line": 278,
             "complexity": 0
           },
           {
-            "line": 281,
+            "line": 278,
+            "complexity": 1
+          },
+          {
+            "line": 279,
             "complexity": 0
           },
           {
@@ -42,7 +38,7 @@
             "complexity": 0
           },
           {
-            "line": 284,
+            "line": 283,
             "complexity": 0
           },
           {
@@ -51,50 +47,54 @@
           },
           {
             "line": 286,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 287,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 288,
-            "complexity": 2
-          },
-          {
-            "line": 290,
             "complexity": 0
           },
           {
-            "line": 292,
+            "line": 289,
+            "complexity": 2
+          },
+          {
+            "line": 291,
             "complexity": 0
           },
           {
             "line": 293,
-            "complexity": 1
-          },
-          {
-            "line": 294,
-            "complexity": 2
-          },
-          {
-            "line": 295,
             "complexity": 0
           },
           {
+            "line": 294,
+            "complexity": 1
+          },
+          {
+            "line": 295,
+            "complexity": 2
+          },
+          {
             "line": 296,
+            "complexity": 0
+          },
+          {
+            "line": 297,
             "complexity": 3
           },
           {
-            "line": 298,
+            "line": 299,
             "complexity": 4
           },
           {
-            "line": 299,
+            "line": 300,
             "complexity": 5
           },
           {
-            "line": 304,
+            "line": 305,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/clip_distribution.py
+++ b/src/immich_memories/analysis/clip_distribution.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
 
+from immich_memories.analysis.asset_merit import ranking_key
+
 logger = logging.getLogger(__name__)
 
 
@@ -229,8 +231,14 @@ def _partition_photos_per_day(
 ) -> tuple[list[ClipWithSegment], list[ClipWithSegment]]:
     """Partition same-day photos into preferred and duration-fallback pools.
 
-    Videos are always preferred. Within each day, the highest-scored photos
-    enter initial selection and the remainder stay available for backfill.
+    Videos are always preferred. Within each day, the best photos enter initial
+    selection and the remainder stay available for backfill.
+
+    Best means the owner's mark first, then score (asset_merit.ranking_key).
+    Ranking on score alone made this the stage where favourites went: measured
+    on one real month, 52 in the pool and 13 left after it. It never asks
+    whether a photograph was starred, and it is the widest cut in the funnel,
+    so a star could be evicted by any neighbour that merely scored better.
     """
     from immich_memories.api.models import AssetType
 
@@ -250,7 +258,11 @@ def _partition_photos_per_day(
     kept_photos: list[ClipWithSegment] = []
     overflow_photos: list[ClipWithSegment] = []
     for day_key in sorted(by_day):
-        day_photos = sorted(by_day[day_key], key=lambda c: c.score, reverse=True)
+        day_photos = sorted(
+            by_day[day_key],
+            key=lambda c: ranking_key(c.clip.asset, c.score),
+            reverse=True,
+        )
         cap = day_caps[day_key]
         kept_photos.extend(day_photos[:cap])
         overflow_photos.extend(day_photos[cap:])

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -41,6 +41,7 @@ from immich_memories.analysis.clip_distribution import (
     photos_per_day_for,
     span_days_of,
 )
+from immich_memories.analysis.favourite_law import let_the_favourite_win
 
 logger = logging.getLogger(__name__)
 
@@ -748,6 +749,13 @@ class ClipRefiner:
             temporal_window=moment_window,
         )
         trace.record("duration backfill", before_backfill, selected)
+
+        # Last, and once: every stage above can drop a favourite while a
+        # neighbour from the same moment survives, each for its own good
+        # reason. The rule they all answer to is applied to what they produced.
+        before_law = selected
+        selected = let_the_favourite_win(selected, all_analyzed)
+        trace.record("the favourite wins its moment", before_law, selected)
 
         selected.sort(key=lambda c: c.clip.asset.file_created_at or datetime.min)
 

--- a/src/immich_memories/analysis/favourite_law.py
+++ b/src/immich_memories/analysis/favourite_law.py
@@ -1,0 +1,130 @@
+"""Within a moment, the favourite wins. Always.
+
+A rule that lives in a prompt is a rule the next prompt edit deletes. This one
+is stated as code and can be measured against any finished selection: name the
+moments that shipped something else while the photograph the owner starred was
+dropped.
+
+The rule is NOT that every favourite ships. A memory has a runtime, and whole
+moments go unshown. It is that no favourite is passed over in favour of
+something standing beside it — same time, same place, same moment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from immich_memories.analysis.moment_grouping import (
+    MOMENT_RADIUS_METRES,
+    MOMENT_WINDOW_MINUTES,
+)
+
+
+@dataclass(frozen=True)
+class LostFavourite:
+    """A moment that shipped something else while its favourite was dropped."""
+
+    favourites: tuple[str, ...]
+    shipped: tuple[str, ...]
+
+
+def moments_that_lost_their_favourite(
+    pool: list[Any],
+    shipped_ids: set[str],
+    *,
+    window_minutes: float = MOMENT_WINDOW_MINUTES,
+    radius_metres: float = MOMENT_RADIUS_METRES,
+) -> list[LostFavourite]:
+    """Every moment that shipped a non-favourite while its favourite was dropped.
+
+    An empty list is the law holding. Anything else is a moment where the owner
+    said which photograph mattered and the memory shipped its neighbour.
+
+    Grouping is imported private on purpose. moments_to_read drops foreign
+    media before tiling, which is right for reading and wrong here: this
+    measures the pool selection actually chose from, whatever is in it, and a
+    filter applied here would hide violations rather than prevent them.
+    """
+    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+
+    lost: list[LostFavourite] = []
+    for moment in _group_by_time_and_place(pool, window_minutes, radius_metres):
+        favourites = [a for a in moment if getattr(a, "is_favorite", False)]
+        if not favourites:
+            continue
+        shipped = [a for a in moment if a.id in shipped_ids]
+        # A moment nobody shipped is a moment the runtime could not hold, not a
+        # favourite passed over.
+        if not shipped:
+            continue
+        if any(a.id in shipped_ids for a in favourites):
+            continue
+        lost.append(
+            LostFavourite(
+                favourites=tuple(a.id for a in favourites),
+                shipped=tuple(a.id for a in shipped),
+            )
+        )
+    return lost
+
+
+def let_the_favourite_win(
+    selected: list[Any],
+    pool: list[Any],
+    *,
+    window_minutes: float = MOMENT_WINDOW_MINUTES,
+    radius_metres: float = MOMENT_RADIUS_METRES,
+) -> list[Any]:
+    """Give a moment's seat to the photograph the owner starred.
+
+    Substitute, never add. The cut has already been fitted to a runtime, and
+    adding the favourite on top would grow it past that; the neighbour standing
+    in for the moment gives up nothing but its place. Which favourite takes it
+    is asset_merit.ranking_key, the same order everything else uses, so a
+    moment holding several stars shows its best.
+
+    The stage every other stage answers to. Selection narrows a pool through
+    caps, distribution, fitting and dedup, each defensible on its own, and a
+    favourite can be dropped by any of them while a neighbour survives the
+    lot. Rather than teach six stages the rule, the rule is applied once to
+    what they produced.
+    """
+    from immich_memories.analysis.asset_merit import ranking_key
+    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+
+    shipped_ids = {_id_of(item) for item in selected}
+    by_id = {_id_of(item): item for item in pool}
+    swaps: dict[str, str] = {}
+
+    for moment in _group_by_time_and_place(
+        [_asset_of(item) for item in pool], window_minutes, radius_metres
+    ):
+        favourites = [a for a in moment if getattr(a, "is_favorite", False)]
+        if not favourites:
+            continue
+        here = [a.id for a in moment if a.id in shipped_ids and a.id not in swaps]
+        if not here or any(a.id in shipped_ids for a in favourites):
+            continue
+
+        winner = max(favourites, key=lambda a: ranking_key(a, _score_of(by_id.get(a.id))))
+        loser = min(here, key=lambda asset_id: _score_of(by_id.get(asset_id)))
+        if winner.id in by_id:
+            swaps[loser] = winner.id
+
+    if not swaps:
+        return selected
+    return [by_id[swaps[_id_of(item)]] if _id_of(item) in swaps else item for item in selected]
+
+
+def _asset_of(item: Any) -> Any:
+    clip = getattr(item, "clip", item)
+    return getattr(clip, "asset", clip)
+
+
+def _id_of(item: Any) -> str:
+    return str(getattr(_asset_of(item), "id", ""))
+
+
+def _score_of(item: Any) -> float:
+    return float(getattr(item, "score", 0.0) or 0.0)

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -44,6 +44,9 @@ class Trace:
     """Everything a run decided, in order."""
 
     stages: list[Stage] = field(default_factory=list)
+    # Moments that shipped something else while their favourite was dropped.
+    # None means nothing checked; an empty list means the law held.
+    lost_favourites: list | None = None
     # Not a stage: it describes the pool every stage worked on, not a step
     # the pool passed through. Re-set by each re-selection, so the value that
     # survives is the one the verify passes left behind (#489).
@@ -71,6 +74,22 @@ class Trace:
             )
         )
 
+    def _favourite_law_lines(self) -> list[str]:
+        """Whether any moment shipped a neighbour of the photograph it starred."""
+        if self.lost_favourites is None:
+            return []
+        if not self.lost_favourites:
+            return ["favourites law: held — no moment shipped over its favourite", ""]
+        lines = [
+            f"favourites law: BROKEN in {len(self.lost_favourites)} moment(s) — "
+            "a favourite was dropped and a neighbour shipped",
+        ]
+        for lost in self.lost_favourites[:5]:
+            lines.append(
+                f"    dropped {', '.join(lost.favourites)} · shipped {', '.join(lost.shipped)}"
+            )
+        return [*lines, ""]
+
     def report(self) -> str:
         """The funnel, as text — widest column is where the pool went."""
         if not self.stages:
@@ -78,6 +97,7 @@ class Trace:
         width = max(len(s.name) for s in self.stages)
         lines = [
             *self._coverage_lines(),
+            *self._favourite_law_lines(),
             f"{'stage'.ljust(width)}  {'kept':>5} {'lost':>5}  {'favorites':>12}",
             "",
         ]
@@ -160,6 +180,29 @@ def record_coverage(coverage: AnalysisCoverage) -> None:
     trace = _active.get()
     if trace is not None:
         trace.coverage = coverage
+
+
+def record_favourite_law(pool: Iterable, selected: Iterable) -> None:
+    """Check the one rule selection is not allowed to break, when tracing is on.
+
+    Measured against the finished cut rather than asserted mid-funnel: a
+    favourite may legitimately be dropped by one stage and restored by
+    backfill, and only the end of the run knows what actually shipped.
+    """
+    trace = _active.get()
+    if trace is None:
+        return
+    from immich_memories.analysis.favourite_law import moments_that_lost_their_favourite
+
+    trace.lost_favourites = moments_that_lost_their_favourite(
+        [_asset_of(item) for item in pool],
+        {_asset_id(item) for item in selected},
+    )
+
+
+def _asset_of(item: object) -> object:
+    clip = getattr(item, "clip", None)
+    return getattr(clip, "asset", None) if clip is not None else item
 
 
 class tracing:  # noqa: N801 - reads as a context manager at the call site

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -433,6 +433,10 @@ class SmartPipeline:
         *,
         verify: bool,
     ) -> PipelineResult:
+        # What selection was given, before any stage narrowed it. The one rule
+        # it may not break is measured against this, not against whatever
+        # survived to the end.
+        pool = analyzed.copy()
         try:
             result = self.refiner.phase_refine(analyzed, self.tracker)
             if verify:
@@ -457,6 +461,7 @@ class SmartPipeline:
                     # once more and simply drop what fails: a cut four seconds
                     # short beats a cut that ends on a shelf.
                     result, analyzed = self.quality.final_review_drop(analyzed, result)
+            trace.record_favourite_law(pool, result.selected_clips)
             self.tracker.finish()
             return result
         except (

--- a/tests/test_favourite_law.py
+++ b/tests/test_favourite_law.py
@@ -1,0 +1,147 @@
+"""Within a moment, the favourite wins. Always.
+
+A rule that lives in a prompt is a rule the next prompt edit deletes. This one
+is measurable: given the pool selection chose from and what it shipped, either
+no moment shipped something else while its favourite was dropped, or the ones
+that did can be named.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.favourite_law import moments_that_lost_their_favourite
+from tests.conftest import make_asset
+
+NOON = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+
+
+def _asset(asset_id: str, *, minutes: float = 0.0, favourite: bool = False):
+    return make_asset(
+        asset_id,
+        file_created_at=NOON + timedelta(minutes=minutes),
+        is_favorite=favourite,
+        duration=None,
+    )
+
+
+class TestTheFavouriteWinsItsMoment:
+    def test_a_moment_that_shipped_someone_else_is_named(self):
+        """The favourite was dropped and a neighbour from the same moment shipped.
+
+        This is the violation the law exists to forbid: not that every
+        favourite ships, but that none is passed over in favour of something
+        standing beside it.
+        """
+        starred = _asset("starred", favourite=True)
+        neighbour = _asset("neighbour", minutes=1)
+
+        lost = moments_that_lost_their_favourite([starred, neighbour], {"neighbour"})
+
+        assert len(lost) == 1
+        assert lost[0].favourites == ("starred",)
+        assert lost[0].shipped == ("neighbour",)
+
+    def test_a_moment_represented_by_its_favourite_is_not_a_violation(self):
+        starred = _asset("starred", favourite=True)
+        neighbour = _asset("neighbour", minutes=1)
+
+        assert moments_that_lost_their_favourite([starred, neighbour], {"starred"}) == []
+
+    def test_a_moment_nobody_shipped_is_not_a_violation(self):
+        """A memory has a runtime; whole moments go unshown.
+
+        The law is not that every favourite ships. It is that none is passed
+        over in favour of something standing beside it.
+        """
+        starred = _asset("starred", favourite=True)
+        neighbour = _asset("neighbour", minutes=1)
+        elsewhere = _asset("elsewhere", minutes=600)
+
+        assert (
+            moments_that_lost_their_favourite([starred, neighbour, elsewhere], {"elsewhere"}) == []
+        )
+
+    def test_a_moment_in_another_place_is_another_moment(self):
+        """Two devices at the same time in different places are parallel threads.
+
+        A favourite shot 120km away is not passed over by a photograph taken at
+        the same minute somewhere else.
+        """
+        starred = _asset("starred", favourite=True)
+        starred.exif_info.latitude, starred.exif_info.longitude = 50.85, 4.35
+        far = _asset("far", minutes=1)
+        far.exif_info.latitude, far.exif_info.longitude = 51.92, 4.48
+
+        assert moments_that_lost_their_favourite([starred, far], {"far"}) == []
+
+
+def _item(asset):
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+    from immich_memories.api.models import VideoClipInfo
+
+    return ClipWithSegment(
+        clip=VideoClipInfo(asset=asset, duration_seconds=4.0),
+        start_time=0.0,
+        end_time=4.0,
+        score=0.9 if not asset.is_favorite else 0.1,
+    )
+
+
+class TestTheLawIsEnforcedNotJustMeasured:
+    """Selection repairs the violation rather than reporting it."""
+
+    def test_the_favourite_takes_the_place_of_its_neighbour(self):
+        """Substitute, never add: the moment keeps one seat, and the star has it.
+
+        Adding the favourite instead would grow the cut past the runtime it
+        was fitted to. The neighbour gave up nothing but its place.
+        """
+        from immich_memories.analysis.favourite_law import let_the_favourite_win
+
+        starred = _item(_asset("starred", favourite=True))
+        neighbour = _item(_asset("neighbour", minutes=1))
+        far = _item(_asset("far", minutes=600))
+
+        repaired = let_the_favourite_win([neighbour, far], [starred, neighbour, far])
+
+        assert {i.clip.asset.id for i in repaired} == {"starred", "far"}
+
+    def test_a_moment_already_showing_its_favourite_is_left_alone(self):
+        from immich_memories.analysis.favourite_law import let_the_favourite_win
+
+        starred = _item(_asset("starred", favourite=True))
+        neighbour = _item(_asset("neighbour", minutes=1))
+
+        repaired = let_the_favourite_win([starred], [starred, neighbour])
+
+        assert [i.clip.asset.id for i in repaired] == ["starred"]
+
+
+class TestTheDayCapEvictsInTheRightOrder:
+    """Where the bulk of the loss happens, and it was favourite-blind."""
+
+    def test_a_days_cap_keeps_the_favourite_over_a_higher_scored_neighbour(self):
+        """The per-day cap ranked on score alone and dropped stars wholesale.
+
+        Measured on one real August: 52 favourites in the pool, 13 left after
+        this one stage. It keeps the best N photographs of each day, and "best"
+        did not know what the owner had starred.
+        """
+        from immich_memories.analysis.clip_distribution import _partition_photos_per_day
+        from immich_memories.api.models import AssetType
+
+        starred = _item(_asset("starred", favourite=True))
+        starred.score = 0.1
+        rivals = []
+        for index in range(6):
+            rival = _item(_asset(f"rival-{index}", minutes=index * 30))
+            rival.score = 0.9
+            rivals.append(rival)
+        for item in [starred, *rivals]:
+            item.clip.asset.type = AssetType.IMAGE
+
+        kept, overflow = _partition_photos_per_day([starred, *rivals])
+
+        assert "starred" in {c.clip.asset.id for c in kept}
+        assert "starred" not in {c.clip.asset.id for c in overflow}


### PR DESCRIPTION
Closes #707 (the favourites-law half). Last of four slices toward one pool, one
ranking, rendering last.

> "For every moment, the favourite should win. No discussion."

It was a metadata **weight** — a tiebreak any better-scoring neighbour could
outvote — and the funnel has six stages that can each drop a star for its own
good reason.

## The law as code

`analysis/favourite_law.py` states it and measures it: given the pool selection
chose from and what shipped, name the moments that shipped a neighbour while the
photograph the owner starred was dropped.

The rule is **not** that every favourite ships — a memory has a runtime, whole
moments go unshown — but that none is passed over in favour of something
standing beside it, same time and same place. Moments come from
`_group_by_time_and_place`, so a star shot 120km away at the same minute is
another moment, not a violation.

## Measured on every traced run

The trace now opens with whether the law held, checked at the **true end** of
selection (after the review loop, not after refinement) against the pool it
started from. Counting favourites-in against favourites-out cannot distinguish a
violation from legitimate favourite-less fill — it takes the per-moment join, so
the join is what runs.

```
pool coverage: 449 of 449 candidates (100%) were visually analyzed

favourites law: held — no moment shipped over its favourite
```

## Fixed where it actually broke

The **per-day photo cap** is the widest cut in the funnel and ranked on score
alone. Measured on one real August: **52 favourites in the pool, 13 left after
that one stage.** It now evicts in `ranking_key` order — the owner's mark first,
then score, the same order slice 1 gave everything else.

| 2026-08 | before | after |
|---|---|---|
| favourites through the per-day cap | 52 → **13** | 52 → **18** |
| favourites shipped | 9 | 9 |
| law violations | 0 | 0 |

Then `let_the_favourite_win` enforces it once, at the end, by **substitution**:
the cut has already been fitted to a runtime, so the neighbour standing in for
the moment gives up nothing but its place. Applied to what the stages produced
rather than taught to six stages separately.

## What I deliberately did NOT build

Making selection draw from **moment representatives only**. It's the mechanism on
record, but the tree disagrees with it:

- `same-moment dedup` already keeps `_clips_per_moment(target_clips, moments)`
  rather than one, and its comment records why — *"thinning to one left a long
  memory too short to fill, and backfill then restored the same clips by
  relaxing constraints."*
- `clip_scaler.py:129` already picks a moment's survivor favourite-first.

So the unit change buys the law nothing it doesn't now have, at the cost of a
regression that has already been measured once. Whether favourite-carrying
moments should beat favourite-less ones **globally** is a stronger rule nobody
has asked for — happy to build it if you want it.

## Honest limit on the acceptance probe

Measured 2026-08-01..04 and 2026-08-01..26: **zero violations, before and after.**
The specific case on record — a month with 11 favourites, 203 moments and 12
picks, where one moment held two favourites, shipped neither, and a non-favourite
from it took the slot — matches **no 2026 month** (I scanned all eight: fewest
favourites is June at 24). It was another year or a person-filtered label, and I
could not reproduce it in the windows I could afford to run. It is a unit test
instead, which outlives any one library.

`make ci` green (5839 passed), rebased onto main after #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL