### PR TITLE
fix(memories): a birthday memory runs birthday to birthday, not July to July

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -776,398 +776,394 @@
     "functions": [
       {
         "name": "register_generate_commands",
-        "complexity": 158,
-        "line_start": 50,
-        "line_end": 602,
+        "complexity": 149,
+        "line_start": 51,
+        "line_end": 628,
         "line_complexities": [
-          {
-            "line": 138,
-            "complexity": 0
-          },
           {
             "line": 139,
             "complexity": 0
           },
           {
-            "line": 146,
-            "complexity": 2
+            "line": 140,
+            "complexity": 0
           },
           {
             "line": 147,
-            "complexity": 0
+            "complexity": 2
           },
           {
             "line": 148,
             "complexity": 0
           },
           {
-            "line": 150,
+            "line": 149,
+            "complexity": 0
+          },
+          {
+            "line": 151,
             "complexity": 2
           },
           {
-            "line": 152,
-            "complexity": 3
-          },
-          {
-            "line": 156,
+            "line": 153,
             "complexity": 3
           },
           {
             "line": 157,
-            "complexity": 0
+            "complexity": 3
           },
           {
-            "line": 159,
+            "line": 158,
             "complexity": 0
           },
           {
             "line": 160,
-            "complexity": 2
-          },
-          {
-            "line": 161,
-            "complexity": 1
-          },
-          {
-            "line": 166,
-            "complexity": 3
-          },
-          {
-            "line": 167,
             "complexity": 0
           },
           {
-            "line": 171,
+            "line": 161,
+            "complexity": 2
+          },
+          {
+            "line": 162,
+            "complexity": 1
+          },
+          {
+            "line": 167,
+            "complexity": 3
+          },
+          {
+            "line": 168,
             "complexity": 0
           },
           {
             "line": 172,
-            "complexity": 1
+            "complexity": 0
           },
           {
             "line": 173,
+            "complexity": 1
+          },
+          {
+            "line": 174,
             "complexity": 0
           },
           {
-            "line": 175,
+            "line": 176,
             "complexity": 2
           },
           {
-            "line": 191,
+            "line": 192,
             "complexity": 0
           },
           {
-            "line": 202,
+            "line": 203,
             "complexity": 3
           },
           {
-            "line": 206,
+            "line": 207,
             "complexity": 3
           },
           {
-            "line": 210,
+            "line": 211,
             "complexity": 4
           },
           {
-            "line": 214,
+            "line": 215,
             "complexity": 3
           },
           {
-            "line": 218,
+            "line": 221,
             "complexity": 3
           },
           {
-            "line": 227,
+            "line": 238,
             "complexity": 0
           },
           {
-            "line": 228,
+            "line": 239,
             "complexity": 0
           },
           {
-            "line": 232,
+            "line": 243,
             "complexity": 0
           },
           {
-            "line": 250,
+            "line": 261,
             "complexity": 2
           },
           {
-            "line": 251,
+            "line": 262,
             "complexity": 0
           },
           {
-            "line": 252,
+            "line": 263,
             "complexity": 1
           },
           {
-            "line": 254,
+            "line": 265,
             "complexity": 0
           },
           {
-            "line": 255,
+            "line": 266,
             "complexity": 1
           },
           {
-            "line": 256,
+            "line": 267,
             "complexity": 0
           },
           {
-            "line": 264,
+            "line": 275,
             "complexity": 2
           },
           {
-            "line": 269,
+            "line": 280,
             "complexity": 0
           },
           {
-            "line": 272,
+            "line": 283,
             "complexity": 0
           },
           {
-            "line": 278,
+            "line": 289,
             "complexity": 1
           },
           {
-            "line": 281,
+            "line": 292,
             "complexity": 3
           },
           {
-            "line": 282,
+            "line": 293,
             "complexity": 3
-          },
-          {
-            "line": 284,
-            "complexity": 0
-          },
-          {
-            "line": 291,
-            "complexity": 0
           },
           {
             "line": 295,
+            "complexity": 0
+          },
+          {
+            "line": 302,
+            "complexity": 0
+          },
+          {
+            "line": 306,
             "complexity": 3
           },
           {
-            "line": 296,
+            "line": 307,
             "complexity": 0
           },
           {
-            "line": 297,
+            "line": 313,
             "complexity": 3
           },
           {
-            "line": 298,
+            "line": 314,
             "complexity": 0
           },
           {
-            "line": 300,
+            "line": 316,
             "complexity": 0
-          },
-          {
-            "line": 324,
-            "complexity": 1
-          },
-          {
-            "line": 325,
-            "complexity": 2
-          },
-          {
-            "line": 329,
-            "complexity": 1
           },
           {
             "line": 340,
-            "complexity": 3
+            "complexity": 1
           },
           {
             "line": 341,
+            "complexity": 2
+          },
+          {
+            "line": 345,
+            "complexity": 1
+          },
+          {
+            "line": 356,
+            "complexity": 3
+          },
+          {
+            "line": 357,
             "complexity": 0
           },
           {
-            "line": 342,
+            "line": 358,
             "complexity": 0
           },
           {
-            "line": 344,
+            "line": 360,
             "complexity": 0
           },
           {
-            "line": 346,
+            "line": 362,
             "complexity": 0
           },
           {
-            "line": 348,
+            "line": 364,
             "complexity": 0
           },
           {
-            "line": 355,
+            "line": 371,
             "complexity": 5
           },
           {
-            "line": 397,
+            "line": 413,
             "complexity": 6
-          },
-          {
-            "line": 441,
-            "complexity": 0
-          },
-          {
-            "line": 442,
-            "complexity": 5
-          },
-          {
-            "line": 443,
-            "complexity": 6
-          },
-          {
-            "line": 444,
-            "complexity": 0
-          },
-          {
-            "line": 445,
-            "complexity": 0
-          },
-          {
-            "line": 446,
-            "complexity": 7
-          },
-          {
-            "line": 454,
-            "complexity": 6
-          },
-          {
-            "line": 455,
-            "complexity": 0
-          },
-          {
-            "line": 456,
-            "complexity": 7
           },
           {
             "line": 457,
             "complexity": 0
           },
           {
+            "line": 458,
+            "complexity": 5
+          },
+          {
             "line": 459,
-            "complexity": 1
+            "complexity": 6
           },
           {
-            "line": 464,
-            "complexity": 7
-          },
-          {
-            "line": 465,
+            "line": 460,
             "complexity": 0
           },
           {
-            "line": 478,
+            "line": 461,
+            "complexity": 0
+          },
+          {
+            "line": 462,
             "complexity": 7
           },
           {
-            "line": 479,
+            "line": 472,
+            "complexity": 6
+          },
+          {
+            "line": 473,
             "complexity": 0
+          },
+          {
+            "line": 475,
+            "complexity": 7
           },
           {
             "line": 480,
-            "complexity": 0
-          },
-          {
-            "line": 483,
             "complexity": 1
           },
           {
-            "line": 484,
-            "complexity": 0
-          },
-          {
-            "line": 485,
+            "line": 483,
             "complexity": 0
           },
           {
             "line": 489,
-            "complexity": 7
-          },
-          {
-            "line": 490,
             "complexity": 0
           },
           {
-            "line": 498,
+            "line": 502,
+            "complexity": 6
+          },
+          {
+            "line": 503,
             "complexity": 0
           },
           {
-            "line": 506,
+            "line": 504,
             "complexity": 0
           },
           {
             "line": 507,
-            "complexity": 5
+            "complexity": 1
           },
           {
             "line": 508,
             "complexity": 0
           },
           {
-            "line": 513,
-            "complexity": 6
-          },
-          {
-            "line": 518,
+            "line": 509,
             "complexity": 0
           },
           {
-            "line": 520,
+            "line": 511,
             "complexity": 6
           },
           {
-            "line": 525,
+            "line": 512,
             "complexity": 0
           },
           {
-            "line": 527,
-            "complexity": 5
+            "line": 523,
+            "complexity": 0
           },
           {
-            "line": 531,
+            "line": 532,
+            "complexity": 0
+          },
+          {
+            "line": 533,
             "complexity": 5
           },
           {
             "line": 534,
-            "complexity": 1
-          },
-          {
-            "line": 536,
             "complexity": 0
           },
           {
-            "line": 538,
+            "line": 539,
+            "complexity": 6
+          },
+          {
+            "line": 544,
             "complexity": 0
           },
           {
-            "line": 585,
-            "complexity": 1
+            "line": 546,
+            "complexity": 6
           },
           {
-            "line": 588,
-            "complexity": 1
-          },
-          {
-            "line": 591,
-            "complexity": 1
-          },
-          {
-            "line": 592,
+            "line": 551,
             "complexity": 0
           },
           {
-            "line": 593,
+            "line": 553,
+            "complexity": 5
+          },
+          {
+            "line": 557,
+            "complexity": 5
+          },
+          {
+            "line": 560,
+            "complexity": 1
+          },
+          {
+            "line": 562,
+            "complexity": 0
+          },
+          {
+            "line": 564,
+            "complexity": 0
+          },
+          {
+            "line": 611,
+            "complexity": 1
+          },
+          {
+            "line": 614,
+            "complexity": 1
+          },
+          {
+            "line": 617,
+            "complexity": 1
+          },
+          {
+            "line": 618,
+            "complexity": 0
+          },
+          {
+            "line": 619,
             "complexity": 1
           }
         ]
       }
     ],
-    "complexity": 158
+    "complexity": 149
   },
   {
     "path": "src/immich_memories/cli/music_cmd.py",

--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -32,7 +32,7 @@ immich-memories generate [OPTIONS]
 | `--holiday` | — | text | — | Holiday name or `MM-DD` (with `--memory-type holiday`) |
 | `--from-album` | — | string | — | Generate from an Immich album (name or ID) instead of a date range. See [Album Memories](../memory-types/album-memories). Cannot be combined with any time-period or person flag |
 | `--person` | `-p` | string | — | Person name from Immich face recognition (repeatable: `--person "Alice" --person "Bob"`) |
-| `--birthday` | `-b` | flag/string | — | Use birthday-based year. Bare flag auto-detects from Immich; or pass `MM-DD` to override |
+| `--birthday` | `-b` | flag/string | — | Anchor the memory on a birthday. Bare flag reads Immich's birth date; pass `MM-DD` to override |
 | `--season` | — | choice | — | `spring`, `summer`, `fall`, `autumn`, `winter` (use with `--memory-type season`) |
 | `--month` | — | int | — | Month 1-12 (with `--year`, generates that month; selects trip by month) |
 | `--hemisphere` | — | choice | `north` | `north` or `south` (for season date calculation) |
@@ -178,13 +178,15 @@ immich-memories generate --year 2024
 
 ### Birthday year
 
-Auto-detects the birthday from Immich when `--birthday` is used as a flag:
+Reads the birth date off the Immich person when `--birthday` is used as a bare flag:
 
 ```bash
-immich-memories generate --year 2024 --birthday --person "Emma" --duration 900
+immich-memories generate --year 2025 --birthday --person "Emma" --duration 900
 ```
 
-Or specify manually: `--birthday 07-21`. Slashes work too and read day-first, like every other date flag — `--birthday 07/02` is 7 February. `MM-DD` is the form that cannot be misread.
+`--year` names the birthday being celebrated. The memory is the year **ending** on it — 22 July 2024 to 21 July 2025 for a 21 July birthday — plus the five previous birthdays as ±1 day windows. `--years-back` changes how many.
+
+If the person has no birth date in Immich the run stops and says where to add one. Override for a single run with `--birthday 07-21`; slashes work too and read day-first, like every other date flag — `--birthday 07/02` is 7 February. `MM-DD` is the form that cannot be misread.
 
 ### Person spotlight for a single month
 
@@ -320,7 +322,7 @@ immich-memories generate --year 2024 --include-photos --photo-duration 5.0
 | Method | Flags | What you get |
 |--------|-------|-------------|
 | Calendar year | `--year 2024` | Jan 1 2024 to Dec 31 2024 |
-| Birthday year | `--year 2024 --birthday --person "Emma"` | Birthday to birthday (auto-detected from Immich) |
+| Birthday year | `--year 2025 --birthday --person "Emma"` | The year ending on the 2025 birthday, plus earlier birthdays (date read from Immich) |
 | Single month | `--year 2024 --month 7` | Jul 1 to Jul 31 2024 |
 | Custom range | `--start 2024-06-01 --end 2024-08-31` | Exact start and end dates |
 | Period from start | `--start 2024-01-01 --period 6m` | 6 months from the start date |

--- a/docs-site/docs/create/memory-types/monthly-person-season.mdx
+++ b/docs-site/docs/create/memory-types/monthly-person-season.mdx
@@ -36,13 +36,15 @@ Narrow to a single month with `--month`:
 immich-memories generate --memory-type person_spotlight --person "Alice" --year 2025 --month 7
 ```
 
-Use birthday-based year (auto-detects from Immich):
+Anchor it on the person's birthday instead, reading the birth date from Immich:
 
 ```bash
 immich-memories generate --memory-type person_spotlight --person "Alice" --year 2025 --birthday
 ```
 
-Default duration: the CLI scales it with the date range — about 60 seconds for a single month, 10 minutes for a full year. (The web UI's Person Spotlight card defaults to 2 minutes regardless of range; see [the note below](#ui-and-cli-defaults-disagree).) You can also override the date range entirely with `--start/--end`.
+That is a different memory: the year **ending** on the 2025 birthday, plus each of the five previous birthdays as a ±1 day cutaway. It asks for 10 minutes on both surfaces. See [Birthday Compilations](../recipes/birthday-compilations.md).
+
+Default duration for the calendar-year version: the CLI scales it with the date range — about 60 seconds for a single month, 10 minutes for a full year. (The web UI's Person Spotlight card defaults to 2 minutes regardless of range; see [the note below](#ui-and-cli-defaults-disagree).) You can also override the date range entirely with `--start/--end`.
 
 **Best for:** parent-child compilations, partner videos, or any relationship where you want to see just that person's moments. Needs Immich face recognition to be set up and the person tagged.
 

--- a/docs-site/docs/create/recipes/birthday-compilations.md
+++ b/docs-site/docs/create/recipes/birthday-compilations.md
@@ -5,45 +5,65 @@ title: Birthday Compilations
 
 # Birthday Compilations
 
-A birthday compilation spans from one birthday to the next: for example, Jul 21, 2024 through Jul 20, 2025. It captures a full year of someone's life, which makes for a great video to play at their birthday party.
+A birthday compilation is the year of someone's life that **ends** on the birthday you are celebrating, plus that birthday in earlier years. For a 21 July birthday and `--year 2025` it runs 22 July 2024 through 21 July 2025 — the party itself is in the video, and last year's party belongs to last year's video.
+
+## Set the birth date in Immich
+
+Immich is where the date lives. Open **People**, pick the person, edit, and fill in the birth date. Every birthday memory then anchors on it — the CLI, the wizard and the nightly automation alike — and you never type it again.
+
+Without one, a birthday memory refuses rather than guessing a date and quietly rendering the wrong twelve months.
+
+## What the video covers
+
+| Window | Span | Why |
+|---|---|---|
+| The rolling year | day after the previous birthday → the birthday | The year being celebrated |
+| Each earlier birthday | ±1 day around it | The "look how small you were" cutaways |
+
+Five earlier birthdays by default, the same reach On This Day and Holiday use. `--years-back` changes it, up to thirty.
+
+Most of those single days hold nothing, and that is expected — the run prints one summary line for them (`history: 2 of 5 earlier windows hold material`) instead of a warning per year. An empty **rolling year** does still get a warning: that one means something is wrong.
 
 ## CLI
 
-If Emma's birthday is set in Immich, just use the `--birthday` flag — it auto-detects:
+With the birth date in Immich, `--birthday` takes no value:
 
 ```bash
 immich-memories generate \
   --person "Emma" \
-  --year 2024 \
+  --year 2025 \
   --birthday \
   --duration 600
 ```
 
-Or specify the date manually:
+To override it for one run — the stored date is missing or wrong — give the date:
 
 ```bash
 immich-memories generate \
   --person "Emma" \
-  --year 2024 \
+  --year 2025 \
   --birthday 07-21 \
   --duration 600
 ```
 
-The `--birthday` flag makes the year run from birthday to birthday (e.g., Jul 21, 2024 through Jul 20, 2025) instead of January to December.
+`--year` names the birthday being celebrated, not a calendar year to run forward from.
 
 Give the date as `MM-DD` — that form has only one reading. A slashed `DD/MM` works too and is read day-first, the same way `--start` and `--end` read `DD/MM/YYYY`.
 
+29 February is celebrated on the 28th in a year that has no 29th, and the ±1 day cutaways still reach the 29th in the years that do.
+
 ## UI
 
-There is no "Birthday" card. Two paths get you a birthday-to-birthday range:
+There is no "Birthday" card. Two paths get you a birthday-anchored range:
 
 - **Person Spotlight** card: pick the person, then tick **Birthday to birthday**. If Immich
-  has a birth date on that person, the checkbox turns itself on when you select them.
+  has a birth date on that person the checkbox turns itself on when you select them; without
+  one it stays greyed out and says so.
 - **Custom** card → **Year** tab → **From Birthday**, which gives you a Birthday date field
-  and computes the range from it.
+  and computes the rolling year from it. This one is the year only — no earlier-birthday
+  cutaways.
 
-Either way the range runs birthday to birthday rather than January to December. See
-[Step 1: Configuration](../web-ui/step1-configuration.mdx).
+See [Step 1: Configuration](../web-ui/step1-configuration.mdx).
 
 ## Tips
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -260,7 +260,7 @@ immich-memories generate [OPTIONS]
 | `--start` | text | - | Start date (YYYY-MM-DD or DD/MM/YYYY) |
 | `--end` | text | - | End date (use with --start) |
 | `--period` | text | - | Period from start date (e.g., 6m, 1y, 2w) |
-| `--birthday`, `-b` | text | - | Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15) |
+| `--birthday`, `-b` | text | - | Run the year up to a birthday, plus earlier birthdays (reads Immich's birth date, or override with MM-DD, e.g. 03-15) |
 | `--from-album` | text | - | Generate from an Immich album (name or ID) instead of a date range |
 | `--person`, `-p` | text | - | Person name (repeatable) |
 | `--memory-type` | choice: `year_in_review` \| `season` \| `person_spotlight` \| `multi_person` \| `monthly_highlights` \| `on_this_day` \| `trip` \| `holiday` \| `then_and_now` \| `special_day` | - | Memory type preset |
@@ -299,7 +299,7 @@ immich-memories generate [OPTIONS]
 | `--analysis-depth` | choice: `auto` \| `fast` \| `thorough` | - | Analysis depth: auto (full analysis for manageable pools), fast (favorites first), or thorough (every eligible clip) |
 | `--trip-index` | integer | - | Select a specific trip by index (use with --memory-type trip) |
 | `--all-trips` | boolean | false | Generate a video for every detected trip (use with --memory-type trip) |
-| `--years-back` | integer | - | Years to look back for on_this_day, holiday or then_and_now |
+| `--years-back` | integer | - | Years to look back for --birthday, on_this_day, holiday or then_and_now |
 | `--near-date` | text | - | Select trip closest to this date (YYYY-MM-DD, use with --memory-type trip) |
 | `--day` | datetime | - | The catalogued day to generate (YYYY-MM-DD, use with --memory-type special_day). Its title comes from the catalogue, not from here: run `immich-memories days-due` to see which days are in it |
 | `--quiet` | boolean | false | Suppress interactive progress, emit log lines |

--- a/src/immich_memories/automation/calendar_detectors.py
+++ b/src/immich_memories/automation/calendar_detectors.py
@@ -16,7 +16,7 @@ from immich_memories.automation.candidates import (
 )
 from immich_memories.config_loader import Config
 from immich_memories.i18n import get_ordinal
-from immich_memories.timeperiod import birthday_year
+from immich_memories.timeperiod import birthday_year, same_day_in_year
 
 
 class MonthlyDetector:
@@ -296,14 +296,14 @@ class BirthdayDetector:
 
             bday = person.birth_date
             # WHY: 2-day minimum buffer after birthday to let photo sync happen
-            most_recent_bday = birthday_year(bday, today.year).start.date()
+            most_recent_bday = same_day_in_year(bday, today.year)
             if most_recent_bday > today:
-                most_recent_bday = birthday_year(bday, today.year - 1).start.date()
+                most_recent_bday = same_day_in_year(bday, today.year - 1)
             days_since = (today - most_recent_bday).days
             if days_since < 2 or days_since > self.WINDOW_DAYS:
                 continue
 
-            completed_birthday_year = birthday_year(bday, most_recent_bday.year - 1)
+            completed_birthday_year = birthday_year(bday, most_recent_bday.year)
             start = completed_birthday_year.start.date()
             end = completed_birthday_year.end.date()
             name_lower = person.name.lower()

--- a/src/immich_memories/automation/candidate_discovery.py
+++ b/src/immich_memories/automation/candidate_discovery.py
@@ -15,7 +15,7 @@ from immich_memories.automation.trip_input_cache import load_or_fetch_trip_asset
 from immich_memories.automation.variety import VarietyDecision, apply_variety_rules
 from immich_memories.config_loader import Config
 from immich_memories.config_models_automation import AutomationConfig
-from immich_memories.timeperiod import DateRange, birthday_year
+from immich_memories.timeperiod import DateRange, same_day_in_year
 from immich_memories.tracking.models import RunMetadata
 
 
@@ -113,9 +113,9 @@ def _compute_upcoming_birthday_ids(people: list, today: date, lookahead_days: in
         if not getattr(person, "birth_date", None):
             continue
         bday = person.birth_date
-        next_bday = birthday_year(bday, today.year).start.date()
+        next_bday = same_day_in_year(bday, today.year)
         if next_bday < today:
-            next_bday = birthday_year(bday, today.year + 1).start.date()
+            next_bday = same_day_in_year(bday, today.year + 1)
         days_until = (next_bday - today).days
         if 0 <= days_until <= lookahead_days:
             ids.add(person.id)

--- a/src/immich_memories/automation/generation_request.py
+++ b/src/immich_memories/automation/generation_request.py
@@ -81,7 +81,10 @@ class GenerationRequest:
                 argv.extend(["--year", str(self.start.year)])
                 argv.extend(f"--person={name}" for name in self.people)
             case CandidateCategory.BIRTHDAY:
-                argv.extend(["--year", str(self.start.year), "--birthday"])
+                # WHY end and not start: --year names the birthday being
+                # celebrated, and a birthday memory is the year *leading up to*
+                # it -- so the year the window ends in is the one to ask for.
+                argv.extend(["--year", str(self.end.year), "--birthday"])
                 argv.extend(f"--person={name}" for name in self.people)
             case CandidateCategory.MULTI_PERSON:
                 argv.extend(["--year", str(self.start.year)])

--- a/src/immich_memories/cli/_asset_fetch.py
+++ b/src/immich_memories/cli/_asset_fetch.py
@@ -66,12 +66,23 @@ def _empty_window_warning(label: str, anchor: str | None) -> str:
     return f"no videos found for {label} — that window contributes nothing"
 
 
-def _report_per_window(assets: list, date_ranges: list[DateRange], person_ids: list[str]) -> None:
+def _report_per_window(
+    assets: list,
+    date_ranges: list[DateRange],
+    person_ids: list[str],
+    history_from: int | None = None,
+) -> None:
     """Say what each window contributed, and shout when one contributed nothing.
 
     A combined total hides the failure that matters on a multi-window memory: a
     then-and-now whose older half is empty still renders, as a memory of the
     recent half alone, and without this it looks like a clean run.
+
+    ``history_from`` marks where a memory's expected-sparse tail begins. A
+    birthday memory looks at the same single day in several earlier years, and
+    most of those days hold nothing — warning once per empty year would bury
+    the one warning that means something, so the tail is counted instead of
+    listed. Everything before the mark keeps its own warning.
     """
     if len(date_ranges) < 2:
         return
@@ -81,10 +92,29 @@ def _report_per_window(assets: list, date_ranges: list[DateRange], person_ids: l
     counts = count_by_era([a.file_created_at for a in assets], date_ranges)
     labels = [_window_label(r) for r in date_ranges]
     anchor = _anchor_name(assets, person_ids)
-    print_info(" · ".join(f"{label}: {n}" for label, n in zip(labels, counts, strict=True)))
-    for label, n in zip(labels, counts, strict=True):
+
+    reported = len(counts) if history_from is None else history_from
+    print_info(
+        " · ".join(
+            f"{label}: {n}" for label, n in zip(labels[:reported], counts[:reported], strict=True)
+        )
+    )
+    for label, n in zip(labels[:reported], counts[:reported], strict=True):
         if n == 0:
             print_warning(_empty_window_warning(label, anchor))
+
+    history = counts[reported:]
+    if history:
+        _report_history(history, anchor)
+
+
+def _report_history(counts: list[int], anchor: str | None) -> None:
+    """One line for the whole tail, and a warning only if none of it landed."""
+    held = sum(1 for n in counts if n)
+    print_info(f"history: {held} of {len(counts)} earlier windows hold material")
+    if held == 0:
+        who = f"{anchor} appears in none" if anchor else "nothing was found in any"
+        print_warning(f"{who} of the {len(counts)} earlier windows — the memory has no history")
 
 
 def fetch_photos(
@@ -127,6 +157,7 @@ def fetch_videos(
     progress: ProgressDisplay,
     date_ranges: list[DateRange],
     person_ids: list[str],
+    history_from: int | None = None,
 ) -> list:
     """Fetch the video assets for the memory's windows.
 
@@ -134,6 +165,9 @@ def fetch_videos(
     photographs, because that is what they are; the video half is dropped from
     this pool once the photographs are known
     (live_photo_pipeline.drop_live_photo_components).
+
+    ``history_from`` names where the memory's expected-sparse windows start, so
+    the per-window report can summarise them rather than warn about each.
     """
     task = progress.add_task("Fetching videos...", total=None)
 
@@ -151,6 +185,6 @@ def fetch_videos(
 
     progress.update(task, completed=True)
     print_success(f"Found {len(assets)} videos")
-    _report_per_window(assets, date_ranges, person_ids)
+    _report_per_window(assets, date_ranges, person_ids, history_from)
 
     return assets

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -9,7 +9,6 @@ import click
 
 from immich_memories.timeperiod import (
     DateRange,
-    birthday_year,
     calendar_year,
     custom_range,
     from_period,
@@ -50,6 +49,26 @@ def _parse_birthday(value: str) -> date:
         f"Cannot parse birthday: '{value}'. Expected MM-DD (e.g. 03-15), "
         "DD/MM, or a full date such as YYYY-MM-DD."
     )
+
+
+def _birthday_windows(
+    birthday: str,
+    year: int | None,
+    years_back: int | None,
+) -> list[DateRange]:
+    """The CLI's --birthday, answered by the builder the wizard's card uses.
+
+    One builder, so a birthday memory is the same memory whichever way it was
+    asked for (#659, #724). The parse stays here because only the CLI has a
+    string to read: the wizard picks a date.
+    """
+    from immich_memories.memory_types.date_builders import build_birthday_windows
+
+    try:
+        anchor = _parse_birthday(birthday)
+    except ValueError as e:
+        raise click.UsageError(str(e))
+    return build_birthday_windows(anchor, year, years_back)
 
 
 def _resolve_manual_dates(
@@ -133,6 +152,13 @@ def resolve_date_range(
     special day's window comes out of the catalogue, not off the command line.
     """
     if memory_type:
+        # Ahead of the other types because a birthday memory is the one that
+        # does not need --year: with none given the builder celebrates the most
+        # recent birthday, which is what "make Emma's birthday video" means.
+        if memory_type == "person_spotlight" and birthday:
+            return _resolve_manual_dates(start, end, period) or _birthday_windows(
+                birthday, year, years_back
+            )
         default_range = _resolve_memory_type_dates(
             memory_type,
             year,
@@ -147,11 +173,6 @@ def resolve_date_range(
         manual_range = _resolve_manual_dates(start, end, period)
         if manual_range:
             return manual_range
-        if memory_type == "person_spotlight" and birthday:
-            try:
-                return birthday_year(_parse_birthday(birthday), year)
-            except ValueError as e:
-                raise click.UsageError(str(e))
         return default_range
 
     manual = _resolve_manual_dates(start, end, period)
@@ -160,10 +181,7 @@ def resolve_date_range(
 
     if year:
         if birthday:
-            try:
-                return birthday_year(_parse_birthday(birthday), year)
-            except ValueError as e:
-                raise click.UsageError(str(e))
+            return _birthday_windows(birthday, year, years_back)
         return calendar_year(year)
 
     raise click.UsageError(
@@ -309,6 +327,7 @@ def default_duration_for_type(
     memory_type: str | None,
     date_range: DateRange | None,
     preset_params: dict | None = None,
+    primary_window: DateRange | None = None,
 ) -> float | None:
     """Get default duration in seconds for a memory type.
 
@@ -321,6 +340,11 @@ def default_duration_for_type(
     ``preset_params`` is forwarded to the preset factory for the types whose
     length depends on more than the dates: a special day needs the day it
     happened on and how long it stayed awake.
+
+    ``primary_window`` is the window a memory is actually made of, when that is
+    narrower than the span it displays. A birthday memory shows decades and is
+    a single year; measured off the display span the curve returns the 30-second
+    floor (#511, #719).
     """
     if not memory_type:
         return None
@@ -337,7 +361,7 @@ def default_duration_for_type(
     if memory_type in ("person_spotlight", "multi_person"):
         if date_range is None:
             return 120.0
-        return duration_from_date_range(date_range)
+        return duration_from_date_range(primary_window or date_range)
 
     # Everything else: scale by date range
     if date_range is not None:

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -43,6 +43,7 @@ from immich_memories.cli.generate_resolution import (
     resolve_special_day,
 )
 from immich_memories.filename_builder import build_memory_output_path, normalize_output_path
+from immich_memories.memory_types.date_builders import BIRTHDAY_HISTORY_FROM, birthday_anchor
 from immich_memories.processing.encoding_plan import resolve_output_selection
 from immich_memories.timeperiod import DateRange, parse_date
 
@@ -215,12 +216,22 @@ def register_generate_commands(main: click.Group) -> None:
             print_error("--near-date requires --memory-type trip")
             sys.exit(1)
 
-        if years_back is not None and memory_type not in (
-            "on_this_day",
-            "holiday",
-            "then_and_now",
+        # A birthday memory reaches back over earlier birthdays, so --years-back
+        # means something to it too -- how many of them to look for.
+        if (
+            years_back is not None
+            and not birthday
+            and memory_type
+            not in (
+                "on_this_day",
+                "holiday",
+                "then_and_now",
+            )
         ):
-            print_error("--years-back requires --memory-type on_this_day, holiday or then_and_now")
+            print_error(
+                "--years-back requires --birthday, or --memory-type on_this_day, "
+                "holiday or then_and_now"
+            )
             sys.exit(1)
 
         # The catalogue, not the command line, knows what the day was called.
@@ -293,7 +304,12 @@ def register_generate_commands(main: click.Group) -> None:
         # Resolve duration: CLI --duration > memory type default > date-range scaling
         # Album mode defers to the pipeline, which sizes it from the album's media.
         if duration is None and not from_album:
-            duration = default_duration_for_type(memory_type, date_range, special_day)
+            duration = default_duration_for_type(
+                memory_type,
+                date_range,
+                special_day,
+                primary_window=next(iter(date_ranges), None),
+            )
             if duration is None:
                 duration = duration_from_date_range(date_range)
 
@@ -450,52 +466,62 @@ def register_generate_commands(main: click.Group) -> None:
                             progress.update(task, completed=True)
                             print_success(f"Found person: {found_person.name}")
 
-                    # When --birthday flag used without value, detect from Immich
+                    # Immich holds the birth date; the bare --birthday flag is
+                    # how a run says "use it". Curating one there is what makes
+                    # every birthday memory land on the right week.
                     if birthday == "auto" and person_names:
                         found = client.get_person_by_name(person_names[0])
-                        if found and found.birth_date:
-                            birthday = found.birth_date.strftime(BIRTHDAY_FLAG_FORMAT)
-                            print_success(f"Using birthday: {birthday}")
-                        else:
-                            print_error(f"No birthday found in Immich for {person_names[0]}")
-                            sys.exit(1)
-
-                        # Re-resolve date range with detected birthday
-                        if birthday and birthday != "auto":
-                            date_result = resolve_date_range(
-                                year,
-                                start,
-                                end,
-                                period,
-                                birthday,
-                                memory_type=memory_type,
-                                season=season,
-                                month=month,
-                                hemisphere=hemisphere,
-                                years_back=years_back,
-                                on_this_day_target=exact_on_this_day,
+                        try:
+                            anchor = birthday_anchor(
+                                found.birth_date if found else None,
+                                None,
+                                person_name=person_names[0],
                             )
-                            if isinstance(date_result, list):
-                                date_ranges = date_result
-                                date_range = DateRange(
-                                    start=date_ranges[-1].start, end=date_ranges[0].end
-                                )
-                            else:
-                                date_range = date_result
-                                date_ranges = [date_result]
-                            print_info(f"Memory window: {date_range.description}")
-                            # The file was named before the birthday was known,
-                            # off the stand-in calendar year used until now.
-                            if not output:
-                                output_path = build_memory_output_path(
-                                    output_dir=config.output.output_path,
-                                    person_names=person_names,
-                                    memory_type=memory_type,
-                                    date_range=date_range,
-                                    container=output_selection.container,
-                                )
+                        except ValueError as exc:
+                            print_error(str(exc))
+                            sys.exit(1)
+                        birthday = anchor.strftime(BIRTHDAY_FLAG_FORMAT)
+                        print_success(f"Using birthday: {birthday}")
 
+                        # The first resolution ran before the birthday was known
+                        # and yielded a stand-in calendar year, so both the
+                        # window and the file named after it are redone here.
+                        date_result = resolve_date_range(
+                            year,
+                            start,
+                            end,
+                            period,
+                            birthday,
+                            memory_type=memory_type,
+                            season=season,
+                            month=month,
+                            hemisphere=hemisphere,
+                            years_back=years_back,
+                            on_this_day_target=exact_on_this_day,
+                        )
+                        if isinstance(date_result, list):
+                            date_ranges = date_result
+                            date_range = DateRange(
+                                start=date_ranges[-1].start, end=date_ranges[0].end
+                            )
+                        else:
+                            date_range = date_result
+                            date_ranges = [date_result]
+                        print_info(f"Memory window: {date_range.description}")
+                        if not output:
+                            output_path = build_memory_output_path(
+                                output_dir=config.output.output_path,
+                                person_names=person_names,
+                                memory_type=memory_type,
+                                date_range=date_range,
+                                container=output_selection.container,
+                            )
+
+                    # A birthday memory's flashback windows are single days years
+                    # apart, so most of them are empty and #661's per-window
+                    # warning would bury the one that matters — the rolling year.
                     assets = fetch_videos(
+                        history_from=BIRTHDAY_HISTORY_FROM if birthday else None,
                         client=client,
                         progress=progress,
                         date_ranges=date_ranges,

--- a/src/immich_memories/cli/generate_options.py
+++ b/src/immich_memories/cli/generate_options.py
@@ -47,7 +47,10 @@ def scope_options(command: FC) -> FC:
             is_flag=False,
             flag_value="auto",
             default=None,
-            help="Use birthday-based year (auto-detects from Immich, or specify MM-DD, e.g. 03-15)",
+            help=(
+                "Run the year up to a birthday, plus earlier birthdays "
+                "(reads Immich's birth date, or override with MM-DD, e.g. 03-15)"
+            ),
         ),
         click.option(
             "--from-album",
@@ -323,7 +326,7 @@ def per_memory_type_options(command: FC) -> FC:
             "--years-back",
             type=int,
             default=None,
-            help="Years to look back for on_this_day, holiday or then_and_now",
+            help="Years to look back for --birthday, on_this_day, holiday or then_and_now",
         ),
         click.option(
             "--near-date",

--- a/src/immich_memories/memory_types/date_builders.py
+++ b/src/immich_memories/memory_types/date_builders.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import calendar
 from datetime import date, datetime, timedelta
 
-from immich_memories.timeperiod import DateRange, calendar_year
+from immich_memories.timeperiod import DateRange, birthday_year, calendar_year, same_day_in_year
 
 # Northern hemisphere season definitions: season -> (start_month, end_month)
 # Winter spans two calendar years (Dec of year to Feb of year+1).
@@ -133,7 +133,7 @@ def build_on_this_day(
         past_year = target_date.year - i
 
         # Resolve the target day in the past year
-        center = _resolve_date_in_year(target_date, past_year)
+        center = same_day_in_year(target_date, past_year)
 
         day_before = _subtract_one_day(center)
         day_after = _add_one_day(center)
@@ -146,6 +146,92 @@ def build_on_this_day(
         )
 
     return ranges
+
+
+# build_birthday_windows returns the rolling year first and the flashbacks after
+# it, so this is where the expected-sparse tail of the list begins. A caller
+# reporting per-window emptiness needs it: one empty rolling year is a real
+# failure, a handful of empty single days is what a library looks like.
+BIRTHDAY_HISTORY_FROM = 1
+
+# How many earlier birthdays to look for, matching what On This Day and Holiday
+# ask for. The builder's own thirty-year ceiling is still reachable with
+# --years-back, but as a default it turns every birthday memory into a
+# decades-wide fetch and names the file after a span it barely uses.
+BIRTHDAY_HISTORY_YEARS = 5
+
+
+def build_birthday_windows(
+    birthday: date,
+    year: int | None = None,
+    years_back: int | None = None,
+    today: date | None = None,
+) -> list[DateRange]:
+    """Everything a memory anchored on a birthday covers, most recent first.
+
+    Two kinds of window. The rolling year is the twelve months ending on the
+    birthday being celebrated, and the flashbacks are ±1 day around that
+    birthday in each earlier year — the same shape On This Day builds, so a
+    birthday's history and a date's history are the same thing seen twice, leap
+    day included.
+
+    ``year`` names the birthday celebrated rather than a calendar year to run
+    forward from. With no year the most recent birthday on or before ``today``
+    is the one celebrated, so a run in August is still about February's, and a
+    run on the day itself is about that morning's party. A year the caller named
+    is a choice and is honoured even if it has not happened yet — the same rule
+    ``build_holiday`` follows.
+
+    Most recent first, so the display span the callers derive as
+    ``ranges[-1].start`` to ``ranges[0].end`` reaches from the oldest flashback
+    to the birthday.
+    """
+    celebrated = (
+        same_day_in_year(birthday, year)
+        if year is not None
+        else _last_occurrence(birthday, today or date.today())
+    )
+    reach = BIRTHDAY_HISTORY_YEARS if years_back is None else years_back
+    return [
+        birthday_year(birthday, celebrated.year),
+        *build_on_this_day(celebrated, reach),
+    ]
+
+
+def birthday_anchor(
+    immich_birth_date: date | None,
+    override: date | None,
+    *,
+    person_name: str,
+) -> date:
+    """The event a birthday memory is anchored on, and where it came from.
+
+    Immich is the source of truth: a birth date curated on the person is what
+    every surface reads, so filling one in has a visible payoff. A date given
+    for one run — ``--birthday MM-DD``, the wizard's picker — is an override
+    and wins, because the only reason to type one is that the stored value is
+    absent or wrong.
+
+    With neither, this refuses rather than inventing an anchor, and the message
+    says where to put one: a memory quietly rendered off a guessed date is
+    worse than a memory that did not render.
+    """
+    chosen = override if override is not None else immich_birth_date
+    if chosen is None:
+        raise ValueError(
+            f"{person_name} has no birth date, so there is no birthday to anchor the "
+            f"memory on. Set one in Immich — People → {person_name} → edit → birth "
+            "date — and every birthday memory will follow it from then on."
+        )
+    return date(chosen.year, chosen.month, chosen.day)
+
+
+def _last_occurrence(birthday: date, reference: date) -> date:
+    """The birthday on or before ``reference`` — today's counts as celebrated."""
+    this_year = same_day_in_year(birthday, reference.year)
+    if this_year <= reference:
+        return this_year
+    return same_day_in_year(birthday, reference.year - 1)
 
 
 def build_then_and_now(year: int, years_back: int) -> list[DateRange]:
@@ -174,15 +260,6 @@ def build_then_and_now(year: int, years_back: int) -> list[DateRange]:
     if years_back <= 0:
         raise ValueError("years_back must be at least 1 for a then-and-now memory")
     return [calendar_year(year), calendar_year(year - years_back)]
-
-
-def _resolve_date_in_year(target: date, year: int) -> date:
-    """Resolve a date into a specific year, handling Feb 29."""
-    try:
-        return date(year, target.month, target.day)
-    except ValueError:
-        # Feb 29 in a non-leap year -> use Feb 28
-        return date(year, 2, 28)
 
 
 def _subtract_one_day(d: date) -> date:

--- a/src/immich_memories/memory_types/factory.py
+++ b/src/immich_memories/memory_types/factory.py
@@ -11,6 +11,7 @@ from datetime import date, datetime
 
 from immich_memories.memory_types.date_builders import (
     KNOWN_HOLIDAYS,
+    build_birthday_windows,
     build_holiday,
     build_month,
     build_on_this_day,
@@ -26,7 +27,12 @@ from immich_memories.memory_types.presets import (
     person_filter_for,
 )
 from immich_memories.memory_types.registry import MemoryType
-from immich_memories.timeperiod import birthday_year, calendar_year
+from immich_memories.timeperiod import calendar_year
+
+# A birthday memory is a year plus a stack of flashbacks, and #703's use case
+# asks for five to ten minutes of it. Ten is what the CLI's span curve already
+# returns for a year with one person, so both surfaces land on the same number.
+BIRTHDAY_MEMORY_SECONDS = 600.0
 
 # Registry: maps MemoryType -> factory callable
 _REGISTRY: dict[MemoryType, Callable[..., MemoryPreset]] = {}
@@ -137,21 +143,39 @@ def _season(
     description="A year focused on one person",
 )
 def _person_spotlight(
-    year: int,
+    year: int | None = None,
     person_names: list[str] | None = None,
     use_birthday: bool = False,
     birthday: date | None = None,
+    years_back: int | None = None,
     **kwargs,  # noqa: ARG001
 ) -> MemoryPreset:
+    """A year with one person — a calendar one, or the one between two birthdays.
+
+    Anchored on a birthday it is a different memory: the rolling year ending on
+    the party, plus that birthday in every earlier year the library reaches.
+    Long enough to be a story rather than a montage, which is why it asks for
+    ten minutes where the calendar year asks for two.
+    """
     if not person_names:
         raise ValueError("person_names is required for PERSON_SPOTLIGHT memory type")
     name = person_names[0]
-    date_range = birthday_year(birthday, year) if use_birthday and birthday else calendar_year(year)
+    if use_birthday and birthday:
+        return MemoryPreset(
+            memory_type=MemoryType.PERSON_SPOTLIGHT,
+            name=f"{name}'s Year",
+            description=f"A year with {name}, birthday to birthday",
+            date_ranges=build_birthday_windows(birthday, year, years_back),
+            person_filter=person_filter_for([name]),
+            default_duration_seconds=BIRTHDAY_MEMORY_SECONDS,
+        )
+    if year is None:
+        raise ValueError("year is required for a PERSON_SPOTLIGHT that is not birthday-anchored")
     return MemoryPreset(
         memory_type=MemoryType.PERSON_SPOTLIGHT,
         name=f"Your Year with {name}",
         description=f"Best moments with {name} in {year}",
-        date_ranges=[date_range],
+        date_ranges=[calendar_year(year)],
         # A spotlight is one person by definition, so extra names name a
         # different memory -- Multi-Person -- rather than narrowing this one.
         person_filter=person_filter_for([name]),

--- a/src/immich_memories/timeperiod.py
+++ b/src/immich_memories/timeperiod.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import contextlib
 import re
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from enum import StrEnum
 from typing import NamedTuple
 
@@ -166,46 +166,46 @@ def calendar_year(year: int) -> DateRange:
     )
 
 
+def same_day_in_year(day: date, year: int) -> date:
+    """The day an annual date falls on in a given year.
+
+    29 February lands on the 28th in a year that has no 29th, which is the
+    reading a birthday takes everywhere else in the world.
+    """
+    try:
+        return date(year, day.month, day.day)
+    except ValueError:
+        return date(year, 2, 28)
+
+
 def birthday_year(
     birthday: date | datetime,
     year: int | None = None,
 ) -> DateRange:
-    """Get date range for a year starting from a birthday.
+    """The year of a person's life that ends on one of their birthdays.
 
-    Args:
-        birthday: The birthday date (only month/day used)
-        year: The starting year. If None, uses current year.
+    ``year`` names the birthday being celebrated, not a calendar year to run
+    forward from: the window starts the day *after* the previous birthday and
+    ends on this one. A birthday memory is about the year leading up to the
+    party, and the party itself belongs in it.
 
-    Returns:
-        DateRange from birthday to day before next birthday
+    Running forward instead put the celebrated birthday outside its own memory
+    and last year's inside it, and made the twelve months you got depend on
+    which year number the request happened to name rather than on the event
+    (#719).
 
     Example:
-        birthday_year(date(1990, 2, 7), 2024)
-        -> Feb 7, 2024 to Feb 6, 2025
+        birthday_year(date(1990, 2, 7), 2026)
+        -> Feb 8, 2025 to Feb 7, 2026
     """
     if year is None:
         year = datetime.now().year
 
-    # Extract month and day from birthday
-    month = birthday.month
-    day = birthday.day
+    celebrated = same_day_in_year(birthday, year)
+    previous = same_day_in_year(birthday, year - 1)
 
-    # Handle Feb 29 birthdays on non-leap years
-    import calendar
-
-    if month == 2 and day == 29 and not calendar.isleap(year):
-        day = 28
-
-    start = datetime(year, month, day, 0, 0, 0)
-
-    # End is one day before next birthday
-    next_year = year + 1
-    next_day = birthday.day
-    if month == 2 and birthday.day == 29 and not calendar.isleap(next_year):
-        next_day = 28
-
-    end = datetime(next_year, month, next_day, 23, 59, 59) - timedelta(days=1)
-
+    start = datetime.combine(previous + timedelta(days=1), time.min)
+    end = datetime.combine(celebrated, time(23, 59, 59))
     return DateRange(start=start, end=end)
 
 

--- a/src/immich_memories/ui/pages/step1_people.py
+++ b/src/immich_memories/ui/pages/step1_people.py
@@ -101,10 +101,12 @@ def render_person_spotlight_params(state: AppState, apply: ApplyPreset) -> None:
             if selected:
                 state.memory_preset_params["person_id"] = selected.id
                 state.memory_preset_params["person_names"] = [e.value]
-                # Auto-enable birthday mode if person has a birth_date
-                if selected.birth_date:
-                    state.memory_preset_params["use_birthday"] = True
-                    state.memory_preset_params["birthday"] = selected.birth_date
+                # Immich is the source of truth for the anchor, so the mode
+                # follows the birth date -- and drops with it, rather than
+                # leaving the previous person's date behind to silently
+                # decide the window.
+                state.memory_preset_params["birthday"] = selected.birth_date
+                state.memory_preset_params["use_birthday"] = bool(selected.birth_date)
             apply(MemoryType.PERSON_SPOTLIGHT)
 
         ui.select(
@@ -118,11 +120,16 @@ def render_person_spotlight_params(state: AppState, apply: ApplyPreset) -> None:
         state.memory_preset_params["use_birthday"] = e.value
         apply(MemoryType.PERSON_SPOTLIGHT)
 
+    anchored = state.memory_preset_params.get("birthday") is not None
     ui.checkbox(
         "Birthday to birthday",
-        value=state.memory_preset_params.get("use_birthday", False),
+        value=bool(state.memory_preset_params.get("use_birthday")) and anchored,
         on_change=on_birthday_toggle,
-    ).classes("mt-2").tooltip("Year runs from birthday to birthday instead of January to December")
+    ).classes("mt-2").props("" if anchored else "disable").tooltip(
+        "The year runs up to the birthday, and earlier birthdays come with it"
+        if anchored
+        else "This person has no birth date in Immich — add one under People to unlock this"
+    )
 
     state.memory_preset_params.setdefault("year", saved_year)
     apply(MemoryType.PERSON_SPOTLIGHT)

--- a/tests/test_auto_runner.py
+++ b/tests/test_auto_runner.py
@@ -326,8 +326,10 @@ class TestSuggestReturnsCandidates:
             candidates = AutoRunner(config).suggest(limit=10)
 
         birthday = next(c for c in candidates if c.category is CandidateCategory.BIRTHDAY)
-        assert birthday.date_range_start == date(2024, 2, 29)
-        assert birthday.date_range_end == date(2025, 2, 27)
+        # The year runs from the day after the leap birthday to the 28th, which
+        # is where a 29 February birthday lands in a year that has no 29th.
+        assert birthday.date_range_start == date(2024, 3, 1)
+        assert birthday.date_range_end == date(2025, 2, 28)
 
     def test_upcoming_january_birthday_suppresses_december_spotlight(self, config: Config) -> None:
         """Discovery looks into next year when rotating people near New Year."""

--- a/tests/test_birthday_memory.py
+++ b/tests/test_birthday_memory.py
@@ -1,0 +1,265 @@
+"""A birthday memory runs birthday to birthday, whatever month it is today.
+
+The windows are event-anchored: the rolling year ends on the birthday being
+celebrated, and the flashbacks sit on that birthday in earlier years. Nothing
+here is allowed to depend on which calendar year the request happened to name.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from immich_memories.automation.calendar_detectors import BirthdayDetector
+from immich_memories.automation.generation_request import GenerationRequest
+from immich_memories.cli._asset_fetch import fetch_videos
+from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
+from immich_memories.cli._helpers import set_active_display
+from immich_memories.memory_types.date_builders import (
+    BIRTHDAY_HISTORY_FROM,
+    birthday_anchor,
+    build_birthday_windows,
+)
+from immich_memories.memory_types.factory import create_preset
+from immich_memories.memory_types.registry import MemoryType
+from immich_memories.timeperiod import DateRange
+
+
+class TestRollingYear:
+    """The recent window is the year that ends on the birthday."""
+
+    def test_february_birthday_runs_february_to_february(self):
+        """The bug that named the issue: a 7 February birthday, a July window.
+
+        The window used to be picked by a calendar year number and run forward
+        from it, so the birthday the memory is named for fell outside it.
+        """
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026)
+
+        assert windows[0].start == datetime(2025, 2, 8)
+        assert windows[0].end == datetime(2026, 2, 7, 23, 59, 59)
+
+    def test_the_birthday_being_celebrated_is_inside_the_memory(self):
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026)
+
+        assert windows[0].contains(datetime(2026, 2, 7, 12, 0))
+
+    def test_the_previous_birthday_belongs_to_the_previous_memory(self):
+        """The rolling year starts the day after, so last year's party is history."""
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026)
+
+        assert not windows[0].contains(datetime(2025, 2, 7, 12, 0))
+
+    def test_no_year_celebrates_the_most_recent_birthday(self):
+        """A run in August is still about February's birthday, not next year's."""
+        windows = build_birthday_windows(date(2018, 2, 7), today=date(2026, 8, 25))
+
+        assert windows[0].end == datetime(2026, 2, 7, 23, 59, 59)
+
+    def test_a_run_on_the_birthday_itself_celebrates_it(self):
+        windows = build_birthday_windows(date(2018, 2, 7), today=date(2026, 2, 7))
+
+        assert windows[0].end == datetime(2026, 2, 7, 23, 59, 59)
+
+    def test_the_cli_does_not_demand_a_year_for_a_birthday_memory(self):
+        """Every other spotlight needs --year; this one knows which birthday."""
+        windows = resolve_date_range(
+            year=None,
+            start=None,
+            end=None,
+            period=None,
+            birthday="02-07",
+            memory_type="person_spotlight",
+        )
+
+        assert isinstance(windows, list)
+        assert windows[0].end.month == 2
+        assert windows[0].end.day == 7
+
+
+class TestHistory:
+    """The flashbacks sit on the birthday in each earlier year."""
+
+    def test_each_earlier_birthday_gets_its_own_window(self):
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026, years_back=3)
+
+        assert [w.start.year for w in windows[BIRTHDAY_HISTORY_FROM:]] == [2025, 2024, 2023]
+
+    def test_a_flashback_is_the_birthday_plus_or_minus_a_day(self):
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026, years_back=1)
+
+        assert windows[BIRTHDAY_HISTORY_FROM].start == datetime(2025, 2, 6)
+        assert windows[BIRTHDAY_HISTORY_FROM].end == datetime(2025, 2, 8, 23, 59, 59)
+
+    def test_the_default_reach_matches_on_this_day(self):
+        """One convention for how far back a memory that spans years looks."""
+        on_this_day = create_preset(MemoryType.ON_THIS_DAY, target_date=date(2026, 2, 7))
+        windows = build_birthday_windows(date(1990, 2, 7), year=2026)
+
+        assert len(windows) - BIRTHDAY_HISTORY_FROM == len(on_this_day.date_ranges)
+
+    def test_the_display_span_reaches_from_the_oldest_flashback_to_the_birthday(self):
+        windows = build_birthday_windows(date(2018, 2, 7), year=2026, years_back=4)
+
+        assert windows[-1].start == datetime(2022, 2, 6)
+        assert windows[0].end == datetime(2026, 2, 7, 23, 59, 59)
+
+    def test_no_history_asked_for_leaves_the_rolling_year_alone(self):
+        assert len(build_birthday_windows(date(2018, 2, 7), year=2026, years_back=0)) == 1
+
+
+class TestWhereTheBirthdayComesFrom:
+    """Immich is the source of truth; a typed date is an override for one run."""
+
+    def test_the_immich_birth_date_anchors_the_memory(self):
+        assert birthday_anchor(datetime(2018, 2, 7, 0, 0), None, person_name="Alice") == date(
+            2018, 2, 7
+        )
+
+    def test_a_typed_date_overrides_what_immich_holds(self):
+        anchor = birthday_anchor(datetime(2018, 2, 7), date(2000, 11, 20), person_name="Alice")
+
+        assert anchor == date(2000, 11, 20)
+
+    def test_a_typed_date_still_answers_when_immich_holds_nothing(self):
+        assert birthday_anchor(None, date(2000, 11, 20), person_name="Alice") == date(2000, 11, 20)
+
+    def test_neither_is_an_error_that_says_where_to_set_it(self):
+        """Refuse over fake: the error is how the user learns Immich drives this."""
+        with pytest.raises(ValueError, match="People") as caught:
+            birthday_anchor(None, None, person_name="Alice")
+
+        assert "Alice" in str(caught.value)
+        assert "birth date" in str(caught.value)
+
+
+class _EmptyLibrary:
+    """Stands in for the Immich HTTP API, which has nothing to offer.
+
+    WHY: the only boundary the fetch crosses, and an empty library is what
+    makes every history window report zero — which is the case under test.
+    """
+
+    def get_videos_for_person_and_date_range(self, _person_id, _date_range) -> list:
+        return []
+
+    def get_videos_for_date_range(self, _date_range) -> list:
+        return []
+
+
+class _RecordingDisplay:
+    """The terminal the CLI's print helpers write to, keeping what they said.
+
+    WHY: set_active_display is the seam the helpers already route through, and
+    it does not depend on which stdout the module-level Rich console bound to
+    when it was imported — which is what made reading this back through capsys
+    depend on test ordering.
+    """
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def print_message(self, message: str) -> None:
+        self.lines.append(message)
+
+    def add_task(self, _description: str, **_fields) -> int:
+        return 0
+
+    def update(self, _task_id: int, **_kwargs) -> None:
+        return None
+
+
+class TestSparseHistoryReporting:
+    """Five empty flashbacks are a library; an empty rolling year is a bug."""
+
+    def _report(self, *, history_from: int | None) -> str:
+        display = _RecordingDisplay()
+        set_active_display(display)
+        try:
+            fetch_videos(
+                client=_EmptyLibrary(),
+                progress=display,
+                date_ranges=build_birthday_windows(date(2018, 2, 7), year=2026),
+                person_ids=["person-alice"],
+                history_from=history_from,
+            )
+        finally:
+            set_active_display(None)
+        return "\n".join(display.lines)
+
+    def test_the_flashbacks_are_summarised_rather_than_warned_about(self):
+        out = self._report(history_from=BIRTHDAY_HISTORY_FROM)
+
+        assert "history: 0 of 5 earlier windows hold material" in out
+
+    def test_an_empty_rolling_year_still_gets_its_own_warning(self):
+        out = self._report(history_from=BIRTHDAY_HISTORY_FROM)
+
+        assert "2025-02-08..2026-02-07" in out
+
+    def test_without_the_mark_every_window_shouts(self):
+        """The behaviour the mark exists to avoid, pinned so it stays avoided."""
+        out = self._report(history_from=None)
+
+        assert out.count("no videos found for") == 6
+
+
+class TestAutomationRoundTrip:
+    """What the nightly runner proposes is what the CLI it spawns renders."""
+
+    def test_the_candidate_window_survives_the_argv(self):
+        """--year names the celebrated birthday, so it must be read off the end.
+
+        The detector picks a completed birthday year and hands the child
+        process a year number; taking that from the start of the window would
+        render the year before the one the runner proposed, silently.
+        """
+        person = SimpleNamespace(id="p1", name="Alice", birth_date=date(2000, 2, 7))
+
+        # WHY: BirthdayDetector reads no config field on this path; the object
+        # is only there to satisfy the signature.
+        candidate = BirthdayDetector().detect(
+            {}, [person], set(), MagicMock(), date(2026, 2, 20), person_asset_counts={"p1": 40}
+        )[0]
+        argv = GenerationRequest.from_candidate(candidate, upload=False).to_argv()
+        year = int(argv[argv.index("--year") + 1])
+
+        rolling = build_birthday_windows(person.birth_date, year)[0]
+
+        assert rolling.start.date() == candidate.date_range_start
+        assert rolling.end.date() == candidate.date_range_end
+
+
+class TestLength:
+    """The memory is a year long, whatever the flashbacks reach back over."""
+
+    def test_the_flashbacks_do_not_shrink_it_to_the_floor(self):
+        """The span curve goes negative past ~40 months and clamps to 30s (#511).
+
+        Collapsed for display, a birthday memory spans decades; what it is
+        actually made of is the rolling year.
+        """
+        windows = build_birthday_windows(date(1990, 2, 7), year=2026)
+        display = DateRange(start=windows[-1].start, end=windows[0].end)
+
+        length = default_duration_for_type("person_spotlight", display, primary_window=windows[0])
+
+        assert length == pytest.approx(600.0)
+
+
+class TestLeapDay:
+    """A 29 February birthday is celebrated on the 28th in an ordinary year."""
+
+    def test_the_rolling_year_ends_on_the_twenty_eighth(self):
+        windows = build_birthday_windows(date(2000, 2, 29), year=2026)
+
+        assert windows[0].end == datetime(2026, 2, 28, 23, 59, 59)
+
+    def test_a_leap_year_flashback_still_reaches_the_twenty_ninth(self):
+        """±1 day around the 28th covers the 29th in the years that have one."""
+        windows = build_birthday_windows(date(2000, 2, 29), year=2026, years_back=2)
+
+        assert windows[-1].contains(datetime(2024, 2, 29, 12, 0))

--- a/tests/test_calendar_detectors.py
+++ b/tests/test_calendar_detectors.py
@@ -264,12 +264,12 @@ class TestBirthdayDetector:
         assert len(result) == 1
         assert result[0].memory_type == "person_spotlight"
         assert result[0].category is CandidateCategory.BIRTHDAY
-        assert result[0].date_range_start == date(2025, 3, 1)
-        assert result[0].date_range_end == date(2026, 2, 28)
+        assert result[0].date_range_start == date(2025, 3, 2)
+        assert result[0].date_range_end == date(2026, 3, 1)
         assert result[0].memory_key == make_memory_key(
             "person_spotlight",
-            date(2025, 3, 1),
-            date(2026, 2, 28),
+            date(2025, 3, 2),
+            date(2026, 3, 1),
             ["alice"],
         )
 
@@ -286,8 +286,8 @@ class TestBirthdayDetector:
         )
 
         assert len(result) == 1
-        assert result[0].date_range_start == date(2024, 2, 29)
-        assert result[0].date_range_end == date(2025, 2, 27)
+        assert result[0].date_range_start == date(2024, 3, 1)
+        assert result[0].date_range_end == date(2025, 2, 28)
 
     def test_uses_previous_year_occurrence_just_after_new_year(self):
         person = _make_person("New Year Eve", birth_date=date(2000, 12, 31))
@@ -303,12 +303,12 @@ class TestBirthdayDetector:
 
         assert len(result) == 1
         candidate = result[0]
-        assert candidate.date_range_start == date(2024, 12, 31)
-        assert candidate.date_range_end == date(2025, 12, 30)
+        assert candidate.date_range_start == date(2025, 1, 1)
+        assert candidate.date_range_end == date(2025, 12, 31)
         assert candidate.memory_key == make_memory_key(
             "person_spotlight",
-            date(2024, 12, 31),
-            date(2025, 12, 30),
+            date(2025, 1, 1),
+            date(2025, 12, 31),
             ["new year eve"],
         )
         assert "25 years old" in candidate.reason

--- a/tests/test_date_resolution.py
+++ b/tests/test_date_resolution.py
@@ -12,7 +12,15 @@ from immich_memories.cli._date_resolution import (
     resolve_date_range,
 )
 from immich_memories.cli._trip_display import _closest_trip_to_date, select_trips
+from immich_memories.memory_types.date_builders import BIRTHDAY_HISTORY_FROM
 from immich_memories.timeperiod import DateRange
+
+
+def _rolling_year(resolved: DateRange | list[DateRange]) -> DateRange:
+    """The year a birthday memory is made of, ahead of its flashback windows."""
+    assert isinstance(resolved, list), "a birthday memory resolves to several windows"
+    assert len(resolved) > BIRTHDAY_HISTORY_FROM, "the flashbacks are missing"
+    return resolved[0]
 
 
 class TestMonthNarrowsYearlyTypes:
@@ -296,102 +304,109 @@ class TestBackwardCompatibility:
         assert result.end.day == 31
 
     def test_no_memory_type_birthday_year(self):
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="07/21/2000",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="07/21/2000",
+            )
         )
-        assert isinstance(result, DateRange)
-        assert result.start.month == 7
-        assert result.start.day == 21
+        assert result.end.month == 7
+        assert result.end.day == 21
 
     def test_person_spotlight_birthday_selector_overrides_calendar_year(self):
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="2000-03-01",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="2000-03-01",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 3, 1)
-        assert result.end == datetime(2026, 2, 28, 23, 59, 59)
+        assert result.start == datetime(2024, 3, 2)
+        assert result.end == datetime(2025, 3, 1, 23, 59, 59)
 
     def test_ambiguous_slash_birthday_reads_day_first_like_every_other_date(self):
         """07/02 is 7 February here, exactly as it is for --start and --end."""
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="07/02",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="07/02",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 2, 7)
-        assert result.end == datetime(2026, 2, 6, 23, 59, 59)
+        assert result.start == datetime(2024, 2, 8)
+        assert result.end == datetime(2025, 2, 7, 23, 59, 59)
 
     def test_slash_birthday_that_can_only_be_month_first_still_parses(self):
         """21 cannot be a month, so 07/21 keeps its only possible reading."""
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="07/21",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="07/21",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 7, 21)
+        assert result.end == datetime(2025, 7, 21, 23, 59, 59)
 
     def test_dashed_birthday_is_month_day_like_the_holiday_flag(self):
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="02-07",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="02-07",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 2, 7)
+        assert result.end == datetime(2025, 2, 7, 23, 59, 59)
 
     def test_late_year_birthday_window_crosses_into_the_next_year(self):
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday="11-20",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday="11-20",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 11, 20)
-        assert result.end == datetime(2026, 11, 19, 23, 59, 59)
+        assert result.start == datetime(2024, 11, 21)
+        assert result.end == datetime(2025, 11, 20, 23, 59, 59)
 
     def test_birthday_detected_from_immich_round_trips_into_the_window(self):
         """What auto-detection writes must mean the same thing when read back."""
         detected = date(1990, 2, 7)
 
-        result = resolve_date_range(
-            year=2025,
-            start=None,
-            end=None,
-            period=None,
-            birthday=detected.strftime(BIRTHDAY_FLAG_FORMAT),
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2025,
+                start=None,
+                end=None,
+                period=None,
+                birthday=detected.strftime(BIRTHDAY_FLAG_FORMAT),
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2025, 2, 7)
+        assert result.end == datetime(2025, 2, 7, 23, 59, 59)
 
     def test_unparseable_birthday_is_a_usage_error(self):
         import click
@@ -407,18 +422,19 @@ class TestBackwardCompatibility:
             )
 
     def test_person_spotlight_auto_birthday_value_handles_leap_day(self):
-        result = resolve_date_range(
-            year=2024,
-            start=None,
-            end=None,
-            period=None,
-            birthday="02/29",
-            memory_type="person_spotlight",
+        result = _rolling_year(
+            resolve_date_range(
+                year=2024,
+                start=None,
+                end=None,
+                period=None,
+                birthday="02/29",
+                memory_type="person_spotlight",
+            )
         )
 
-        assert isinstance(result, DateRange)
-        assert result.start == datetime(2024, 2, 29)
-        assert result.end == datetime(2025, 2, 27, 23, 59, 59)
+        assert result.start == datetime(2023, 3, 1)
+        assert result.end == datetime(2024, 2, 29, 23, 59, 59)
 
     def test_no_options_raises_usage_error(self):
         import click

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1138,4 +1138,46 @@ class TestBirthdayFlagNamesTheWindowItRenders:
             )
 
         assert result.exit_code == 0, result.output
-        assert captured["output_path"].name == "person_a_person_spotlight_20250315-20260314.mp4"
+        # --year names the birthday celebrated, so the memory ends on 15 March
+        # 2025 and reaches back to the oldest flashback window it looks in.
+        assert captured["output_path"].name == "person_a_person_spotlight_20200314-20250315.mp4"
+
+    def test_a_person_with_no_birth_date_is_told_where_to_put_one(self, tmp_path: Path) -> None:
+        """Refuse over fake, and make the refusal teach the Immich workflow."""
+        from click.testing import CliRunner
+
+        from immich_memories.cli import main
+
+        config = Config(immich={"url": "https://immich.example.com", "api_key": "k"})
+        config.output.directory = str(tmp_path)
+
+        person = self._person()
+        person.birth_date = None
+        client = MagicMock()
+        client.__enter__.return_value = client
+        client.__exit__.return_value = False
+        client.get_person_by_name.return_value = person
+
+        # WHY: config on disk and the Immich HTTP client are external.
+        with (
+            patch("immich_memories.cli.get_config", return_value=config),
+            patch("immich_memories.api.immich.SyncImmichClient", return_value=client),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "generate",
+                    "--memory-type",
+                    "person_spotlight",
+                    "--person",
+                    "Person A",
+                    "--year",
+                    "2025",
+                    "--birthday",
+                    "--no-music",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "People" in result.output
+        assert "birth" in result.output

--- a/tests/test_generation_request.py
+++ b/tests/test_generation_request.py
@@ -126,7 +126,7 @@ def _candidate(
                 "--memory-type",
                 "person_spotlight",
                 "--year",
-                "2024",
+                "2025",
                 "--birthday",
                 "--person=Alice",
                 "--source=auto",

--- a/tests/test_memory_types/test_factory.py
+++ b/tests/test_memory_types/test_factory.py
@@ -100,7 +100,7 @@ class TestCreatePresetPersonSpotlight:
         assert preset.date_ranges[0].end == datetime(2024, 12, 31, 23, 59, 59)
 
     def test_birthday_range_when_enabled(self) -> None:
-        """With use_birthday=True and a birthday, uses birthday-to-birthday range."""
+        """With use_birthday=True, the year runs up to the birthday --year names."""
         preset = create_preset(
             MemoryType.PERSON_SPOTLIGHT,
             year=2024,
@@ -108,10 +108,19 @@ class TestCreatePresetPersonSpotlight:
             use_birthday=True,
             birthday=date(1990, 3, 15),
         )
-        # Should start on March 15, 2024
-        assert preset.date_ranges[0].start == datetime(2024, 3, 15, 0, 0, 0)
-        # Should end on March 14, 2025 (day before next birthday)
-        assert preset.date_ranges[0].end == datetime(2025, 3, 14, 23, 59, 59)
+        assert preset.date_ranges[0].start == datetime(2023, 3, 16, 0, 0, 0)
+        assert preset.date_ranges[0].end == datetime(2024, 3, 15, 23, 59, 59)
+
+    def test_birthday_spotlight_also_looks_at_earlier_birthdays(self) -> None:
+        preset = create_preset(
+            MemoryType.PERSON_SPOTLIGHT,
+            year=2024,
+            person_names=["Alice"],
+            use_birthday=True,
+            birthday=date(1990, 3, 15),
+            years_back=2,
+        )
+        assert [r.start.year for r in preset.date_ranges[1:]] == [2023, 2022]
 
     def test_birthday_flag_without_birthday_falls_back_to_calendar(self) -> None:
         """use_birthday=True but no birthday date falls back to calendar year."""

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -30,7 +30,11 @@ import pytest
 
 from immich_memories.api.models import Person
 from immich_memories.cli._asset_fetch import fetch_photos, fetch_videos
-from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
+from immich_memories.cli._date_resolution import (
+    BIRTHDAY_FLAG_FORMAT,
+    default_duration_for_type,
+    resolve_date_range,
+)
 from immich_memories.memory_types.factory import create_preset
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import DateRange
@@ -61,6 +65,16 @@ class MemorySpec:
     window: tuple[datetime, datetime] | None = None
     title: str | None = None
     active_hours: float | None = None
+    birthday: date | None = None
+
+    @property
+    def birthday_flag(self) -> str | None:
+        """The birthday as ``--birthday`` carries it.
+
+        Derived rather than written twice, so the flag the CLI reads and the
+        date the wizard picks cannot describe different days.
+        """
+        return self.birthday.strftime(BIRTHDAY_FLAG_FORMAT) if self.birthday else None
 
     def as_preset_params(self) -> dict:
         """The spec as the UI's ``memory_preset_params`` bag."""
@@ -74,6 +88,8 @@ class MemorySpec:
             "years_back": self.years_back,
             "target_date": self.on_this_day_target,
             "location_name": self.location_name,
+            "birthday": self.birthday,
+            "use_birthday": bool(self.birthday) or None,
             **self.as_cli_preset_params(),
         }
         return {key: value for key, value in params.items() if value is not None}
@@ -227,7 +243,7 @@ def _cli_resolution(memory_type: MemoryType, spec: MemorySpec) -> DateRange | li
         None,
         None,
         None,
-        None,
+        spec.birthday_flag,
         memory_type=str(memory_type),
         season=spec.season,
         month=spec.month,
@@ -251,10 +267,12 @@ def cli_duration(memory_type: MemoryType, spec: MemorySpec) -> float | None:
     one span before asking for a duration.
     """
     resolved = _cli_resolution(memory_type, spec)
-    if isinstance(resolved, list):
-        resolved = DateRange(start=resolved[-1].start, end=resolved[0].end)
+    windows = resolved if isinstance(resolved, list) else [resolved]
     return default_duration_for_type(
-        str(memory_type), resolved, spec.as_cli_preset_params() or None
+        str(memory_type),
+        DateRange(start=windows[-1].start, end=windows[0].end),
+        spec.as_cli_preset_params() or None,
+        primary_window=windows[0],
     )
 
 
@@ -310,6 +328,32 @@ class TestDateWindowParity:
     def test_windows_match(self, memory_type: MemoryType) -> None:
         spec = SPECS[memory_type]
         assert cli_windows(memory_type, spec) == ui_windows(memory_type, spec)
+
+    def test_a_birthday_spotlight_resolves_the_same_windows_on_both_surfaces(self) -> None:
+        """The CLI reads a flag and the wizard picks a date; one builder answers.
+
+        SPECS pins the calendar-year spotlight, which says nothing about the
+        birthday-anchored one -- and that is the variant that ran July to July
+        (#719). Both surfaces must land on the rolling year *and* every
+        flashback window, so a divergence in either half fails here.
+        """
+        spec = replace(SPECS[MemoryType.PERSON_SPOTLIGHT], birthday=date(2018, 2, 7))
+
+        windows = cli_windows(MemoryType.PERSON_SPOTLIGHT, spec)
+
+        assert windows == ui_windows(MemoryType.PERSON_SPOTLIGHT, spec)
+        assert len(windows) > 1, "a birthday memory looks at earlier birthdays too"
+        assert windows[0][1] == datetime(2024, 2, 7, 23, 59, 59), (
+            "the rolling year must end on the birthday --year names"
+        )
+
+    def test_a_birthday_spotlight_is_the_same_length_on_both_surfaces(self) -> None:
+        """The split #630 recorded is about the calendar-year card, not this one."""
+        spec = replace(SPECS[MemoryType.PERSON_SPOTLIGHT], birthday=date(2018, 2, 7))
+
+        cli = cli_duration(MemoryType.PERSON_SPOTLIGHT, spec)
+
+        assert cli == pytest.approx(ui_duration(MemoryType.PERSON_SPOTLIGHT, spec))
 
     def test_a_holiday_with_no_year_given_skips_the_one_that_has_not_happened(self) -> None:
         """Both surfaces default the year, so both must apply the same guard.

--- a/tests/test_timeperiod.py
+++ b/tests/test_timeperiod.py
@@ -193,13 +193,12 @@ class TestCalendarYear:
 
 
 class TestBirthdayYear:
-    """Tests for birthday_year function."""
+    """The year of someone's life that ends on the birthday the year names."""
 
     def test_birthday_year_basic(self):
-        """Test basic birthday year generation."""
         dr = birthday_year(date(1990, 2, 7), 2024)
-        assert dr.start == datetime(2024, 2, 7, 0, 0, 0)
-        assert dr.end == datetime(2025, 2, 6, 23, 59, 59)
+        assert dr.start == datetime(2023, 2, 8, 0, 0, 0)
+        assert dr.end == datetime(2024, 2, 7, 23, 59, 59)
 
     def test_birthday_year_not_calendar_year(self):
         """Test that birthday year is not identified as calendar year."""
@@ -207,15 +206,14 @@ class TestBirthdayYear:
         assert not dr.is_calendar_year
 
     def test_birthday_year_leap_year_birthday(self):
-        """Test Feb 29 birthday on non-leap year."""
+        """A 29 February birthday is celebrated on the 28th in an ordinary year."""
         dr = birthday_year(date(2000, 2, 29), 2023)
-        # 2023 is not leap year, so Feb 28 is used
-        assert dr.start == datetime(2023, 2, 28, 0, 0, 0)
+        assert dr.end == datetime(2023, 2, 28, 23, 59, 59)
 
     def test_birthday_year_datetime_input(self):
         """Test with datetime input."""
         dr = birthday_year(datetime(1990, 2, 7, 12, 0, 0), 2024)
-        assert dr.start == datetime(2024, 2, 7, 0, 0, 0)
+        assert dr.end == datetime(2024, 2, 7, 23, 59, 59)
 
 
 class TestFromPeriod:
@@ -364,16 +362,16 @@ class TestDateRangeEdgeCases:
         assert dr.contains(datetime(2025, 1, 1, 0, 0, 0)) is False
 
     def test_birthday_year_jan_1_birthday(self):
-        """Jan 1 birthday year spans exactly one calendar year."""
+        """A New Year's Day birthday ends the memory on the first of the year."""
         dr = birthday_year(date(2000, 1, 1), 2024)
-        assert dr.start == datetime(2024, 1, 1, 0, 0, 0)
-        assert dr.end == datetime(2024, 12, 31, 23, 59, 59)
+        assert dr.start == datetime(2023, 1, 2, 0, 0, 0)
+        assert dr.end == datetime(2024, 1, 1, 23, 59, 59)
 
     def test_birthday_year_dec_31_birthday(self):
-        """Dec 31 birthday wraps to next year."""
+        """A 31 December birthday makes the memory a calendar year exactly."""
         dr = birthday_year(date(2000, 12, 31), 2024)
-        assert dr.start == datetime(2024, 12, 31, 0, 0, 0)
-        assert dr.end == datetime(2025, 12, 30, 23, 59, 59)
+        assert dr.start == datetime(2024, 1, 1, 0, 0, 0)
+        assert dr.end == datetime(2024, 12, 31, 23, 59, 59)
 
     def test_custom_range_single_day_has_one_day(self):
         """Same start and end date produces exactly 1 day."""


### PR DESCRIPTION
Part of #719 — the standalone bug half. The cross-account `event_rule`, `identities:` config and floating-event support stay with the identities ladder (#717 / #718 / #720); nothing here adds an `identities:` block.

Reference implementation credit: the model comes from @Mike7154's `annual_story_scope` in the fork attached to #703, adapted to this codebase's builders.

## The diagnosis: where July came from, and what survived the fix

Two separate defects wore the same symptom.

**The one that is already fixed (#655 → #657): the parse dialect.** `--birthday` read slashes month-first while every other date flag read them day-first, so `07/02` meant 2 July to `--birthday` and 7 February to `--start`. A February birthday produced a July-to-July window and nothing errored.

**The one this PR fixes: the window model.** `birthday_year(birthday, year)` ran **forward** from the calendar year it was handed:

```
--year 2026 --birthday 02-07   →   Feb 7 2026 … Feb 6 2027
```

Three things wrong with that, all the same root cause — the window is anchored to a **year number the user types**, not to the **event**:

1. **The birthday the memory is named for is not in it.** The window *ends* the day before Feb 7 2027 and *starts* on Feb 7 2026 — so with `--year 2025` (the year you would type to get a memory ending at the recent birthday) you get Feb 7 2025 … Feb 6 2026: **last year's party is in the video, this year's is not.**
2. **Half the window is in the future.** Run in August 2026 with `--year 2026`, five months of the window cannot contain anything.
3. **Which twelve months you get depends on a guess.** There is no year number that produces "the year leading up to the birthday", because the function only knows how to run forwards.

The July-to-July report is what a user sees when either defect fires; #657 removed one source and left the other, which is why #719 exists.

## The model implemented

`memory_types/date_builders.build_birthday_windows(birthday, year, years_back, today)` returns windows most recent first:

| # | Window | Span |
|---|---|---|
| 0 | The rolling year | day **after** the previous birthday → **the** birthday |
| 1…n | Each earlier birthday | ±1 day around it |

- **Event to event, never calendar.** `--year` names the birthday being *celebrated*. With no year at all the most recent birthday on or before today is celebrated (`--birthday` no longer requires `--year`), so a run in August is still about February's — no today-anchored drift, because the *boundaries* are still occurrences.
- **History reuses `build_on_this_day`** — one mechanism for "the same day across years", not a second copy.
- **Leap-day safe.** 29 February is celebrated on the 28th in a year without a 29th (`timeperiod.same_day_in_year`, now the single leap rule; the two automation sites that were abusing `birthday_year(...).start.date()` to get an occurrence date now call it directly). The ±1 day padding means a flashback centred on Feb 28 still reaches Feb 29 in the years that have one.
- **One combined display range**, derived the way every other multi-window type derives it (`ranges[-1].start` … `ranges[0].end`); the list drives the fetch.

`birthday_year` itself now means "the year of someone's life that ends on this birthday", so the wizard's Custom → Year → From Birthday tab and the automation detector move with it rather than becoming a second competing rule.

## Immich is the source of truth for the anchor

`birthday_anchor(immich_birth_date, override, person_name)`, called by both surfaces:

1. **Override wins** — a date typed for one run (`--birthday MM-DD`, the wizard's picker). Precedence chosen as **override**, not legacy-fallback: there is no birthday key in the config schema, so the only "local" spelling is a value the user typed *this run*, and the only reason to type one is that the stored value is missing or wrong.
2. **Otherwise Immich's `Person.birth_date`.**
3. **Neither → refuse**, naming the fix: *"Set one in Immich — People → {name} → edit → birth date — and every birthday memory will follow it from then on."* The wizard's **Birthday to birthday** checkbox greys out with the same sentence. Adding a birth date in Immich is meant to visibly pay off.

Also fixed while here: selecting a person with no birth date used to leave the *previous* person's date in `memory_preset_params`, silently deciding the window.

## Sparse history reporting

`_report_per_window` takes `history_from` — the index where a memory's expected-sparse tail begins (`BIRTHDAY_HISTORY_FROM`). Windows before it keep #661's per-window warning; the tail becomes one line:

```
2025-02-08..2026-02-07: 84
history: 2 of 5 earlier windows hold material
```

An empty **rolling year** still warns — a birthday memory whose year is empty is a real failure. The tail only warns if *none* of it landed. Wording is surface-neutral ("earlier windows") because the reporter is shared. `cli/_asset_fetch.py` gained one optional parameter and one 6-line helper; nothing under `analysis/` or `photos/` was touched.

## Years-back default: 5, not 30

#719 mentions a 30-year default. Reusing the **preset** convention instead — `on_this_day` and `holiday` both default to 5. Thirty means 31 windows per fetch type, a decades-wide display range and filenames like `alice_person_spotlight_19960206-20260207.mp4` on every birthday run. `--years-back` still reaches 30. No new config key.

## Length

The collapsed display span of a birthday memory is years wide, and `duration_from_date_range`'s curve is fitted on 1–12 months and returns the 30-second floor past ~40 of them (#511) — so a birthday story would have rendered as half a minute. `default_duration_for_type` takes `primary_window`: the window the memory is actually made of. 600s on both surfaces, which is what #703's use case asked for; the recorded `person_spotlight` calendar-year split (cli 600 / ui 120) is untouched.

## Surface parity

`MemorySpec` gained `birthday`, with the `--birthday` flag string derived from it via `BIRTHDAY_FLAG_FORMAT` so the flag the CLI reads and the date the wizard picks cannot describe different days. Two new specs assert the birthday variant resolves to the same windows *and* the same length on both surfaces — the calendar-year spotlight in `SPECS` said nothing about it, which is how this shipped divergent.

## Tests

RED-first throughout. New `tests/test_birthday_memory.py` (21 cases): the Feb-7 regression, the celebrated birthday being inside its own memory and the previous one outside it, no-year and on-the-day resolution, flashback shape and reach, leap day both directions, anchor precedence and the actionable refusal, the sparse-history summary (and the six-warning behaviour it replaces, pinned so it stays replaced), the length floor, and an automation round-trip proving the candidate window survives `to_argv` → `resolve_date_range`.

Updated: `test_timeperiod`, `test_date_resolution`, `test_calendar_detectors`, `test_auto_runner`, `test_generation_request`, `test_memory_types/test_factory` — each to the new semantics, keeping what they were really testing (the parse dialect assertions now read the rolling year's end).

## Checks

`make ci` green locally (lint, format, mypy, file-length, xenon, complexipy, vulture, bandit, semgrep, refurb, deptry, import-linter, jscpd, critique, docs drift, 5857 tests). `make docs-build` passes.

Docs: `create/recipes/birthday-compilations.md` rewritten (what the video covers, setting the date in Immich, the sparse line, leap day), plus `create/memory-types/monthly-person-season.mdx`, `create/cli/generate.md` and the generated CLI reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f
