### PR TITLE
fix(live-photos): a tagged burst frame brings the rest of its burst

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -778,7 +778,7 @@
         "name": "register_generate_commands",
         "complexity": 158,
         "line_start": 50,
-        "line_end": 602,
+        "line_end": 603,
         "line_complexities": [
           {
             "line": 138,
@@ -1109,59 +1109,59 @@
             "complexity": 0
           },
           {
-            "line": 513,
+            "line": 514,
             "complexity": 6
           },
           {
-            "line": 518,
+            "line": 519,
             "complexity": 0
           },
           {
-            "line": 520,
+            "line": 521,
             "complexity": 6
           },
           {
-            "line": 525,
+            "line": 526,
             "complexity": 0
           },
           {
-            "line": 527,
+            "line": 528,
             "complexity": 5
           },
           {
-            "line": 531,
+            "line": 532,
             "complexity": 5
           },
           {
-            "line": 534,
+            "line": 535,
             "complexity": 1
           },
           {
-            "line": 536,
+            "line": 537,
             "complexity": 0
           },
           {
-            "line": 538,
+            "line": 539,
             "complexity": 0
           },
           {
-            "line": 585,
+            "line": 586,
             "complexity": 1
           },
           {
-            "line": 588,
-            "complexity": 1
-          },
-          {
-            "line": 591,
+            "line": 589,
             "complexity": 1
           },
           {
             "line": 592,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 593,
+            "complexity": 0
+          },
+          {
+            "line": 594,
             "complexity": 1
           }
         ]

--- a/docs-site/docs/create/pipeline/live-photos.md
+++ b/docs-site/docs/create/pipeline/live-photos.md
@@ -46,7 +46,8 @@ that position, of which only 8 bursts were long enough to become clips.
 
 ## How it works
 
-1. **Discovery**: Live Photo stills come back with the photographs; nothing is fetched twice
+1. **Discovery**: Live Photo stills come back with the photographs; the only second
+   read is the burst-neighbour top-up under a person filter (below)
 2. **Video components**: the video half of a Live Photo is dropped from the video pool — it is part of a photograph, not footage somebody shot
 3. **Clustering**: photos taken within a configurable window (default 10.0s) form a burst
 4. **Rendering choice**: a burst that stitches to at least `live_photo_min_clip_seconds` (default 3.5s) renders as motion; anything shorter renders as the photograph it is
@@ -67,10 +68,12 @@ instant twice with a camera shift scored 0.63. Duration is structural and free;
 motion is a signal for later, never a gate.
 
 :::note Person-filtered memories
-Immich tags one frame of a burst with a person, not all of them. In a memory
-filtered by person only the tagged frames are fetched, so a burst usually has
-one frame and renders as a photograph rather than as motion. The photographs
-themselves are always selectable.
+Immich tags one frame of a burst with a person, not all of them. A memory
+filtered by person would otherwise get that frame alone — the burst would have
+nothing to stitch to and every one of them would render as a still. So when a
+person filter is active and a Live Photo comes back, the window's Live Photos
+are read once more unfiltered and the untagged frames beside a tagged one are
+pulled in. A person's plain photographs cost no extra request.
 :::
 
 ## Burst merging: spectrogram-aligned shutter-centered cuts

--- a/src/immich_memories/analysis/live_photo_pipeline.py
+++ b/src/immich_memories/analysis/live_photo_pipeline.py
@@ -6,13 +6,18 @@ motion is a rendering question asked later
 (analysis/motion_rendering.py). All this has to do is keep the video half out
 of the video pool, where it would compete as footage against its own still.
 
+One thing does need doing: Immich tags ONE frame of a burst with a person, so
+a memory filtered by person gets that frame alone and the burst has nothing to
+stitch to. The neighbours are pulled back in here, or a person memory silently
+loses the motion its moments actually had.
+
 Shared between CLI and UI — no NiceGUI imports allowed here.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from immich_memories.api.models import Asset
@@ -40,3 +45,76 @@ def drop_live_photo_components(videos: list[Asset], photos: list[Asset]) -> list
             len(videos) - len(kept),
         )
     return kept
+
+
+def expand_to_neighbors(
+    tagged: list,
+    all_live: list,
+    *,
+    merge_window_seconds: float = 10.0,
+) -> list:
+    """Include untagged live photos that are near tagged ones.
+
+    If photos 1, 2, 3 were taken within the merge window and only 2 is
+    tagged with the person, 1 and 3 are clearly from the same moment and
+    should be included too.
+    """
+    window = merge_window_seconds
+
+    tagged_ids = {a.id for a in tagged}
+    tagged_times = [a.file_created_at for a in tagged]
+
+    result_ids = tagged_ids.copy()
+    for asset in all_live:
+        if asset.id in result_ids:
+            continue
+        for t in tagged_times:
+            diff = abs((asset.file_created_at - t).total_seconds())
+            if diff <= window:
+                result_ids.add(asset.id)
+                break
+
+    by_id = {a.id: a for a in all_live}
+    by_id.update({a.id: a for a in tagged})
+    result = [by_id[aid] for aid in result_ids if aid in by_id]
+    result.sort(key=lambda a: a.file_created_at)
+    return result
+
+
+def with_burst_neighbours(
+    client: Any,
+    photos: list[Asset],
+    *,
+    date_ranges: list[Any],
+    merge_window_seconds: float,
+) -> list[Asset]:
+    """Add the untagged frames of any burst a fetched photograph belongs to.
+
+    Only asked when a Live Photo actually came back, so a person's plain
+    photographs cost no extra request. A window that cannot be read costs its
+    neighbours, not the run.
+    """
+    if not any(getattr(p, "live_photo_video_id", None) for p in photos):
+        return photos
+
+    from immich_memories.api.immich import ImmichAPIError
+
+    all_live: list[Asset] = []
+    for date_range in date_ranges:
+        try:
+            all_live.extend(client.get_live_photos_for_date_range(date_range))
+        except (ImmichAPIError, OSError, RuntimeError, ValueError) as exc:
+            logger.warning("Could not read a window's Live Photos: %s", exc, exc_info=True)
+
+    if not all_live:
+        return photos
+
+    known = {p.id for p in photos}
+    expanded = expand_to_neighbors(photos, all_live, merge_window_seconds=merge_window_seconds)
+    gained = [a for a in expanded if a.id not in known]
+    if gained:
+        logger.info(
+            "Live Photos: %d untagged burst frame(s) pulled in beside a tagged one",
+            len(gained),
+        )
+    return [*photos, *gained]

--- a/src/immich_memories/cli/_asset_fetch.py
+++ b/src/immich_memories/cli/_asset_fetch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from immich_memories.analysis.live_photo_pipeline import with_burst_neighbours
 from immich_memories.api.person_scope import stills_person_args, videos_in_window
 from immich_memories.cli._helpers import print_info, print_success, print_warning
 from immich_memories.timeperiod import DateRange
@@ -92,6 +93,7 @@ def fetch_photos(
     client: SyncImmichClient,
     date_ranges: list[DateRange],
     person_ids: list[str],
+    merge_window_seconds: float = 10.0,
 ) -> list:
     """Fetch every photograph in the memory's windows, honouring the person filter.
 
@@ -118,6 +120,16 @@ def fetch_photos(
             if photo.id not in seen:
                 seen.add(photo.id)
                 photos.append(photo)
+
+    # Immich tags one frame of a burst, so a person filter returns that frame
+    # alone and the burst has nothing to stitch to.
+    if person_ids:
+        photos = with_burst_neighbours(
+            client,
+            photos,
+            date_ranges=date_ranges,
+            merge_window_seconds=merge_window_seconds,
+        )
     return photos
 
 

--- a/src/immich_memories/cli/generate.py
+++ b/src/immich_memories/cli/generate.py
@@ -509,6 +509,7 @@ def register_generate_commands(main: click.Group) -> None:
                             client=client,
                             date_ranges=date_ranges,
                             person_ids=person_ids,
+                            merge_window_seconds=(config.analysis.live_photo_merge_window_seconds),
                         )
                         if fetched_photos:
                             print_info(f"Found {len(fetched_photos)} photos")

--- a/src/immich_memories/ui/pages/step2_loading.py
+++ b/src/immich_memories/ui/pages/step2_loading.py
@@ -152,7 +152,20 @@ def _fetch_photos(state) -> list:
                     date_range, person_id=person_id, person_ids=group_ids
                 )
             )
-        return _dedup_by_id(photos)
+        photos = _dedup_by_id(photos)
+
+        # Immich tags one frame of a burst, so a person filter returns that
+        # frame alone and the burst has nothing to stitch to.
+        if state.person_ids:
+            from immich_memories.analysis.live_photo_pipeline import with_burst_neighbours
+
+            photos = with_burst_neighbours(
+                client,
+                photos,
+                date_ranges=state.date_ranges,
+                merge_window_seconds=state.config.analysis.live_photo_merge_window_seconds,
+            )
+        return photos
 
 
 def _set_initial_selection(clips: list[VideoClipInfo], state) -> None:

--- a/tests/test_burst_neighbours.py
+++ b/tests/test_burst_neighbours.py
@@ -1,0 +1,101 @@
+"""A person memory must still see a burst as motion.
+
+Immich tags ONE frame of a burst with a person, not all of them. Fetching a
+person's photographs therefore returns that frame alone, the burst has nothing
+to stitch to, and it renders as a photograph — losing the motion the moment
+actually had.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from immich_memories.analysis.live_photo_pipeline import (
+    expand_to_neighbors,
+    with_burst_neighbours,
+)
+from tests.conftest import make_asset
+
+NOON = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+
+
+def _live(index: int, *, seconds: float = 0.0):
+    asset = make_asset(
+        f"still-{index}", file_created_at=NOON + timedelta(seconds=seconds), duration=None
+    )
+    asset.live_photo_video_id = f"video-{index}"
+    return asset
+
+
+class TestATaggedFrameBringsItsBurst:
+    def test_the_untagged_frames_of_a_tagged_burst_come_too(self):
+        """Photos 1, 2 and 3 are one burst; only 2 carries the person tag."""
+        burst = [_live(index, seconds=index * 2.0) for index in range(3)]
+        tagged = [burst[1]]
+
+        found = expand_to_neighbors(tagged, burst, merge_window_seconds=10.0)
+
+        assert [a.id for a in found] == ["still-0", "still-1", "still-2"]
+
+    def test_a_burst_nobody_tagged_stays_out(self):
+        """Expansion follows a tag; it does not import the whole day."""
+        here = [_live(0)]
+        elsewhere = [_live(9, seconds=6000)]
+
+        found = expand_to_neighbors(here, here + elsewhere, merge_window_seconds=10.0)
+
+        assert [a.id for a in found] == ["still-0"]
+
+    def test_the_fetch_only_asks_when_a_live_photo_was_tagged(self):
+        """A person's plain photographs cost no extra request."""
+        plain = make_asset("plain", file_created_at=NOON, duration=None)
+        client = MagicMock()
+
+        found = with_burst_neighbours(
+            client, [plain], date_ranges=[MagicMock()], merge_window_seconds=10.0
+        )
+
+        assert found == [plain]
+        client.get_live_photos_for_date_range.assert_not_called()
+
+
+class TestThePersonFetchBringsTheBurst:
+    """The wiring, through the fetch the CLI actually calls."""
+
+    def test_a_person_filtered_fetch_returns_the_whole_burst(self):
+        """One tagged frame comes back; all three reach the pool.
+
+        Without this a person memory's bursts stitch to the raw 3.0s, fall
+        under the 3.5s threshold, and every one of them renders as a still.
+        """
+        from immich_memories.cli._asset_fetch import fetch_photos
+
+        burst = [_live(index, seconds=index * 2.0) for index in range(3)]
+        client = MagicMock()
+        # WHY: the Immich server. Person search returns the tagged frame only;
+        # the unfiltered Live Photo search returns the whole burst.
+        client.get_photos_for_date_range.return_value = [burst[1]]
+        client.get_live_photos_for_date_range.return_value = burst
+
+        found = fetch_photos(
+            client=client,
+            date_ranges=[MagicMock()],
+            person_ids=["person-1"],
+            merge_window_seconds=10.0,
+        )
+
+        assert {a.id for a in found} == {"still-0", "still-1", "still-2"}
+
+    def test_an_unfiltered_fetch_asks_for_nothing_extra(self):
+        """With no person filter the window already holds every frame."""
+        from immich_memories.cli._asset_fetch import fetch_photos
+
+        burst = [_live(index, seconds=index * 2.0) for index in range(3)]
+        client = MagicMock()
+        client.get_photos_for_date_range.return_value = burst
+
+        found = fetch_photos(client=client, date_ranges=[MagicMock()], person_ids=[])
+
+        assert {a.id for a in found} == {"still-0", "still-1", "still-2"}
+        client.get_live_photos_for_date_range.assert_not_called()

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -31,6 +31,7 @@ import pytest
 from immich_memories.api.models import Person
 from immich_memories.cli._asset_fetch import fetch_photos, fetch_videos
 from immich_memories.cli._date_resolution import default_duration_for_type, resolve_date_range
+from immich_memories.config import Config
 from immich_memories.memory_types.factory import create_preset
 from immich_memories.memory_types.registry import MemoryType
 from immich_memories.timeperiod import DateRange
@@ -435,6 +436,10 @@ def _wizard_state(
     """
     spec = replace(SPECS[memory_type], people=people)
     state = AppState()
+    # The wizard always has a config by the time it fetches: step 1 sets it.
+    # Without it the fetch cannot read the burst merge window, and the two
+    # surfaces would differ over a fixture gap rather than a real divergence.
+    state.config = Config()
     state.people = list(people)
     state.apply_preset(create_preset(memory_type, **spec.as_preset_params()))
     assert _windows(state.date_ranges) == _windows(windows), (


### PR DESCRIPTION
The two items flagged as open at the end of the curation-engine program. One
needed a fix; the other turned out not to.

## 1. Person-filtered bursts lost their motion — fixed

Immich tags **one** frame of a burst with a person, not all of them. Since Live
Photo stills started arriving with the photographs (#743), a person-filtered
memory got that frame alone: the burst had nothing to stitch to, fell under the
3.5s threshold, and every one of them rendered as a still.

`expand_to_neighbors` used to prevent this, and went when the person-filtered
live search that used it went. It's back — and now sits where photographs are
actually fetched, so both the CLI and the wizard inherit it rather than one
remembering to ask.

- Only consulted when a Live Photo actually came back, so a person's plain
  photographs cost **no extra request**.
- A window that cannot be read costs its neighbours, not the run.
- Surface parity holds: both surfaces make the same calls.

The parity fixture gained the `config` the wizard always has by the time it
fetches (production sets it at step 1). Without it the two surfaces would have
differed over a fixture gap rather than a real divergence — and the alternative,
teaching production code to `getattr`-chain around a state that cannot happen,
is exactly the bug #743 fixed in `motion_rendering`.

## 2. Stills ranking ~1.2× above footage — investigated, no change needed

Deleting `photos.score_penalty` (#741) multiplied photo scores by 1/0.8 while
videos were never scaled, and I flagged that the balance was then held only by
`max_ratio`. Measured, it holds in both regimes:

| pool | outcome |
|---|---|
| no favourites — where the lift actually bites | `enforce_photo_cap` **binds exactly at 50%** |
| all photos starred | 75% stills — favourites bypass the cap **by the hard rule** |
| real month, photo scores 1.0× vs 0.8× | **identical selection** (10 clips, 2 video + 8 photo, 48.9s) |

The A/B is the decisive one: on 2026-08 the two score regimes produce the same
cut, because the final fit is dominated by favourites (`(is_favorite, score)`),
where the score multiplier never breaks a tie.

And the photo-heavy August result is not the lift — the trace shows favourites
9 → 9 with 9 clips kept, i.e. **every selected clip was a favourite**. The cap
didn't fire because `enforce_photo_cap` protects favourites unconditionally,
which its own comment explains: *"a February of newborn photos lost three
starred clips here to a ratio meant to stop a film becoming a slideshow, when a
slideshow of exactly those photos is what was asked for."*

So the memory shipped 8 photographs the owner had starred. That is the law
working, not the policy failing. No code change.

`make ci` green (5842 passed), `make docs-build` green, rebased onto main after
#746. The Live Photos page's person-filter note said the opposite of the truth
after this change and is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL