### PR TITLE
fix(cli): one date format everywhere — RFC 3339, no dialects

### DIFF
--- a/docs-site/docs/create/cli/generate.md
+++ b/docs-site/docs/create/cli/generate.md
@@ -20,7 +20,7 @@ immich-memories generate [OPTIONS]
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--year` | `-y` | int | — | Year to generate (calendar year by default) |
-| `--start` | — | string | — | Start date (`YYYY-MM-DD` or `DD/MM/YYYY`). Overrides memory type date range when combined with `--end` |
+| `--start` | — | string | — | Start date (`YYYY-MM-DD`). Overrides memory type date range when combined with `--end` |
 | `--end` | — | string | — | End date (use with `--start`) |
 | `--period` | — | string | — | Period from start date (e.g., `6m`, `1y`, `2w`, `30d`) |
 
@@ -328,7 +328,7 @@ immich-memories generate --year 2024 --include-photos --photo-duration 5.0
 | Period from start | `--start 2024-01-01 --period 6m` | 6 months from the start date |
 | Override preset | `--memory-type season --season summer --start 2024-07-01 --end 2024-07-31` | Custom dates with preset scoring |
 
-Date formats: `YYYY-MM-DD` or `DD/MM/YYYY`. `--birthday` also takes the year-less `MM-DD` and `DD/MM` short forms.
+Dates are RFC 3339: `YYYY-MM-DD`, always. `--birthday` also takes the year-less `MM-DD` short form — same order, no year. Slashed and day-first forms are rejected with an error naming the format, never guessed.
 
 Period format: number + unit (`d` days, `w` weeks, `m` months, `y` years). Examples: `90d`, `2w`, `6m`, `1y`.
 

--- a/docs-site/docs/create/recipes/birthday-compilations.md
+++ b/docs-site/docs/create/recipes/birthday-compilations.md
@@ -48,7 +48,7 @@ immich-memories generate \
 
 `--year` names the birthday being celebrated, not a calendar year to run forward from.
 
-Give the date as `MM-DD` — that form has only one reading. A slashed `DD/MM` works too and is read day-first, the same way `--start` and `--end` read `DD/MM/YYYY`.
+Give the date as `MM-DD` — month first, matching every other date in the project (RFC 3339 order). Slashed forms are rejected rather than guessed.
 
 29 February is celebrated on the 28th in a year that has no 29th, and the ±1 day cutaways still reach the 29th in the years that do.
 

--- a/docs-site/docs/reference/cli-reference.md
+++ b/docs-site/docs/reference/cli-reference.md
@@ -257,7 +257,7 @@ immich-memories generate [OPTIONS]
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--year`, `-y` | integer | - | Year to generate video for (calendar year by default) |
-| `--start` | text | - | Start date (YYYY-MM-DD or DD/MM/YYYY) |
+| `--start` | text | - | Start date (YYYY-MM-DD) |
 | `--end` | text | - | End date (use with --start) |
 | `--period` | text | - | Period from start date (e.g., 6m, 1y, 2w) |
 | `--birthday`, `-b` | text | - | Run the year up to a birthday, plus earlier birthdays (reads Immich's birth date, or override with MM-DD, e.g. 03-15) |

--- a/src/immich_memories/cli/_date_resolution.py
+++ b/src/immich_memories/cli/_date_resolution.py
@@ -25,15 +25,11 @@ BIRTHDAY_FLAG_FORMAT = "%m-%d"
 
 
 def _parse_birthday(value: str) -> date:
-    """Read --birthday in the same date dialect as every other date flag.
+    """Read --birthday as RFC 3339 order: MM-DD, or a full YYYY-MM-DD.
 
-    parse_date handles anything carrying a year. The short forms do not, so
-    they get their own attempt: dashes are month-day, matching --holiday's
-    MM-DD; slashes are day-first, matching parse_date's DD/MM/YYYY, and fall
-    back to month-first only when day-first cannot be a date.
-
-    This flag alone used to read slashes month-first, so 07/02 meant July for
-    a 7 February birthday and the memory covered the wrong half of two years.
+    This flag once read slashes month-first while every other flag read them
+    day-first, so 07/02 meant July for a 7 February birthday. Slash dialects
+    are gone everywhere (#748): big-endian or rejected, never guessed.
     """
     with contextlib.suppress(ValueError):
         return parse_date(value)
@@ -41,13 +37,9 @@ def _parse_birthday(value: str) -> date:
     with contextlib.suppress(ValueError):
         return datetime.strptime(f"{_BIRTHDAY_FILLER_YEAR}-{value}", "%Y-%m-%d").date()
 
-    for date_format in ("%d/%m/%Y", "%m/%d/%Y"):
-        with contextlib.suppress(ValueError):
-            return datetime.strptime(f"{value}/{_BIRTHDAY_FILLER_YEAR}", date_format).date()
-
     raise ValueError(
-        f"Cannot parse birthday: '{value}'. Expected MM-DD (e.g. 03-15), "
-        "DD/MM, or a full date such as YYYY-MM-DD."
+        f"Cannot parse birthday: '{value}'. Dates are RFC 3339 order: "
+        "MM-DD (for example 02-07), or a full date YYYY-MM-DD."
     )
 
 

--- a/src/immich_memories/cli/generate_options.py
+++ b/src/immich_memories/cli/generate_options.py
@@ -38,7 +38,7 @@ def scope_options(command: FC) -> FC:
         click.option(
             "--year", "-y", type=int, help="Year to generate video for (calendar year by default)"
         ),
-        click.option("--start", type=str, help="Start date (YYYY-MM-DD or DD/MM/YYYY)"),
+        click.option("--start", type=str, help="Start date (YYYY-MM-DD)"),
         click.option("--end", type=str, help="End date (use with --start)"),
         click.option("--period", type=str, help="Period from start date (e.g., 6m, 1y, 2w)"),
         click.option(

--- a/src/immich_memories/processing/assembly_config.py
+++ b/src/immich_memories/processing/assembly_config.py
@@ -123,7 +123,6 @@ class AssemblySettings:
     music_other_path: Path | None = None  # Other instruments stem
     add_date_overlay: bool = False
     add_place_overlay: bool = False
-    date_format: str = "%B %d, %Y"
     preserve_framerate: bool = True  # Keep original frame rate (e.g., 60fps)
     target_framerate: int | None = None  # Force specific frame rate (None = auto)
     # Resolution settings

--- a/src/immich_memories/timeperiod.py
+++ b/src/immich_memories/timeperiod.py
@@ -9,7 +9,6 @@ Supports:
 
 from __future__ import annotations
 
-import contextlib
 import re
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
@@ -273,44 +272,20 @@ def custom_range(
 
 
 def parse_date(date_str: str) -> date:
-    """Parse a date string in various formats.
+    """Parse an RFC 3339 full date: YYYY-MM-DD, and nothing else.
 
-    Supported formats:
-    - YYYY-MM-DD (ISO format)
-    - DD/MM/YYYY
-    - MM/DD/YYYY (if unambiguous or month > 12)
-    - YYYY/MM/DD
-
-    Args:
-        date_str: Date string to parse
-
-    Returns:
-        Parsed date object
-
-    Raises:
-        ValueError: If date string cannot be parsed
+    07/02 meant July to one flag and February to another until the dialects
+    were removed (#748). A rejected date names the format; a guessed one
+    silently builds the wrong memory.
     """
     date_str = date_str.strip()
-
-    # Try ISO format first (YYYY-MM-DD)
-    with contextlib.suppress(ValueError):
+    try:
         return datetime.strptime(date_str, "%Y-%m-%d").date()
-
-    # Try YYYY/MM/DD
-    with contextlib.suppress(ValueError):
-        return datetime.strptime(date_str, "%Y/%m/%d").date()
-
-    # Try DD/MM/YYYY (European format)
-    with contextlib.suppress(ValueError):
-        return datetime.strptime(date_str, "%d/%m/%Y").date()
-
-    # Try MM/DD/YYYY (US format)
-    with contextlib.suppress(ValueError):
-        return datetime.strptime(date_str, "%m/%d/%Y").date()
-
-    raise ValueError(
-        f"Cannot parse date: '{date_str}'. Expected format: YYYY-MM-DD, DD/MM/YYYY, or MM/DD/YYYY"
-    )
+    except ValueError:
+        raise ValueError(
+            f"Cannot parse date: '{date_str}'. Dates are RFC 3339: YYYY-MM-DD "
+            f"(for example 2024-02-07)."
+        ) from None
 
 
 def available_years(

--- a/tests/test_date_resolution.py
+++ b/tests/test_date_resolution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
+import click
 import pytest
 
 from immich_memories.cli._date_resolution import (
@@ -310,7 +311,7 @@ class TestBackwardCompatibility:
                 start=None,
                 end=None,
                 period=None,
-                birthday="07/21/2000",
+                birthday="2000-07-21",
             )
         )
         assert result.end.month == 7
@@ -331,36 +332,22 @@ class TestBackwardCompatibility:
         assert result.start == datetime(2024, 3, 2)
         assert result.end == datetime(2025, 3, 1, 23, 59, 59)
 
-    def test_ambiguous_slash_birthday_reads_day_first_like_every_other_date(self):
-        """07/02 is 7 February here, exactly as it is for --start and --end."""
-        result = _rolling_year(
-            resolve_date_range(
-                year=2025,
-                start=None,
-                end=None,
-                period=None,
-                birthday="07/02",
-                memory_type="person_spotlight",
-            )
-        )
+    def test_slash_birthdays_are_rejected_not_guessed(self):
+        """07/02 once meant July here and February everywhere else (#655).
 
-        assert result.start == datetime(2024, 2, 8)
-        assert result.end == datetime(2025, 2, 7, 23, 59, 59)
-
-    def test_slash_birthday_that_can_only_be_month_first_still_parses(self):
-        """21 cannot be a month, so 07/21 keeps its only possible reading."""
-        result = _rolling_year(
-            resolve_date_range(
-                year=2025,
-                start=None,
-                end=None,
-                period=None,
-                birthday="07/21",
-                memory_type="person_spotlight",
-            )
-        )
-
-        assert result.end == datetime(2025, 7, 21, 23, 59, 59)
+        The dialect machinery is deleted (#748): slashes are an error naming
+        the RFC 3339 forms, whichever reading they might have had.
+        """
+        for dialect in ("07/02", "07/21", "07/02/2024"):
+            with pytest.raises(click.UsageError, match="RFC 3339"):
+                resolve_date_range(
+                    year=2025,
+                    start=None,
+                    end=None,
+                    period=None,
+                    birthday=dialect,
+                    memory_type="person_spotlight",
+                )
 
     def test_dashed_birthday_is_month_day_like_the_holiday_flag(self):
         result = _rolling_year(
@@ -428,7 +415,7 @@ class TestBackwardCompatibility:
                 start=None,
                 end=None,
                 period=None,
-                birthday="02/29",
+                birthday="02-29",
                 memory_type="person_spotlight",
             )
         )

--- a/tests/test_timeperiod.py
+++ b/tests/test_timeperiod.py
@@ -291,22 +291,16 @@ class TestParseDate:
         result = parse_date("2024-02-07")
         assert result == date(2024, 2, 7)
 
-    def test_parse_slash_ymd(self):
-        """Test YYYY/MM/DD format."""
-        result = parse_date("2024/02/07")
-        assert result == date(2024, 2, 7)
+    def test_every_slash_dialect_is_rejected_not_guessed(self):
+        """07/02/2024 meant February to one flag and July to another once.
 
-    def test_parse_european_format(self):
-        """Test DD/MM/YYYY format."""
-        result = parse_date("07/02/2024")
-        assert result == date(2024, 2, 7)
-
-    def test_parse_us_format(self):
-        """Test MM/DD/YYYY format when unambiguous (month > 12)."""
-        # Note: When day and month are both <= 12, DD/MM/YYYY is tried first
-        # Use a date where month > 12 is invalid to force MM/DD interpretation
-        result = parse_date("12/25/2024")  # December 25th
-        assert result == date(2024, 12, 25)
+        The dialects are gone (#748): anything that is not YYYY-MM-DD is an
+        error naming the format, because a guessed date silently builds the
+        wrong memory.
+        """
+        for dialect in ("2024/02/07", "07/02/2024", "12/25/2024"):
+            with pytest.raises(ValueError, match="RFC 3339"):
+                parse_date(dialect)
 
     def test_parse_with_whitespace(self):
         """Test parsing with whitespace."""


### PR DESCRIPTION
Owner ruling: RFC 3339, year-month-day, always. Closes #748.

parse_date carried four dialects including a month-first-if-unambiguous guess; --start's help advertised day-first slashes; --birthday accepted both slash orders. All dialect machinery is deleted: YYYY-MM-DD for full dates, MM-DD for the year-less birthday (same order), everything else rejected with an error naming the format — a guessed date silently builds the wrong memory, an error is the migration guide. Docs and generated CLI reference updated; dialect tests rewritten as rejection tests.

Bonus dead code: deleting the old dialect loop unmasked `assembly_config.date_format` as a field nothing ever read (a name collision had hidden it from Vulture); it dies with the dialects.

Full `make ci` green locally (5,862 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f