### PR TITLE
fix(review): tell the judge when a clip was taken, and which moment it is in

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -37,11 +37,20 @@ _REVIEW_MAX_TOKENS = 8000
 _PROMPT = """You are reviewing the final cut of a personal memory video.
 Below is every clip in timeline order, with everything we can see and hear.
 
+Each clip carries `when=` (its timestamp) and `moment=` (which moment it
+belongs to). Clips sharing a moment name were shot in the same place within
+minutes of each other — they ARE the same moment, whatever their descriptions
+say. Two clips can also show one scene under different dates: cameras keep
+their own clocks and one of them is often wrong by hours or a day, so trust
+what the descriptions show over what the dates imply.
+
 {clips}
 
 Judge the SET as a whole: feel, coherence, variety. Drop a clip when it is
 
 - REDUNDANT: the same moment, scene or kind of shot is already in the set.
+  Two clips sharing a `moment=` name are the same moment: keep the better one
+  unless each shows something the other does not.
   Self-portraits and mirror shots repeat hard — three of them from three days
   is one idea shown three times, however different the days were. A selfie of
   one person alone is the weakest way to record a day: prefer the clip that
@@ -129,7 +138,7 @@ def _place_for_llm(exif: object) -> str | None:
     return ", ".join(named) if named else None
 
 
-def _clip_line(index: int, member: ClipWithSegment) -> str:
+def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -> str:
 
     clip = member.clip
     parts = [f"Clip {index}:"]
@@ -137,7 +146,12 @@ def _clip_line(index: int, member: ClipWithSegment) -> str:
     # VideoClipInfo — reading them off the clip silently sent nothing (#475).
     taken = getattr(clip.asset, "file_created_at", None)
     if taken:
-        parts.append(f"date={taken.date().isoformat()}")
+        # The time of day, not just the date. Asked to drop "the same moment",
+        # the judge was shown date=2011-08-04 twice and could not tell ten
+        # minutes from ten hours: a ship-deck performance shipped three times.
+        parts.append(f"when={taken.isoformat(timespec='minutes')}")
+    if moment:
+        parts.append(f"moment={moment}")
     where = _place_for_llm(getattr(clip.asset, "exif_info", None))
     if where:
         parts.append(f"place={where}")
@@ -153,6 +167,33 @@ def _clip_line(index: int, member: ClipWithSegment) -> str:
         if value:
             parts.append(f"{label}={value!s}")
     return " ".join(parts)
+
+
+def _clips_block(selected: list[ClipWithSegment]) -> str:
+    """Every clip as the judge sees it, each one told which moment it is in.
+
+    Moments come from the shared time-and-place grouping rather than a window
+    invented here, so "the same moment" means the same thing to the judge as
+    it does to the stages that built the cut.
+    """
+    return "\n".join(
+        _clip_line(index + 1, member, moment)
+        for index, (member, moment) in enumerate(
+            zip(selected, _moment_labels(selected), strict=True)
+        )
+    )
+
+
+def _moment_labels(selected: list[ClipWithSegment]) -> list[str]:
+    """A moment name per clip, in the order given."""
+    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+
+    assets = [m.clip.asset for m in selected]
+    by_asset: dict[str, str] = {}
+    for number, moment in enumerate(_group_by_time_and_place(assets), start=1):
+        for asset in moment:
+            by_asset[asset.id] = f"M{number}"
+    return [by_asset.get(m.clip.asset.id, "M?") for m in selected]
 
 
 def _verdict_in(raw: str | None) -> list | None:
@@ -222,7 +263,7 @@ def review_selection(
     if len(selected) < 3:
         logger.debug("Selection review: %d clips is too few to judge as a set", len(selected))
         return []
-    clips_block = "\n".join(_clip_line(i + 1, m) for i, m in enumerate(selected))
+    clips_block = _clips_block(selected)
     prompt = _PROMPT.format(clips=clips_block)
     try:
         raw = _ask(prompt, llm_config, timeout_seconds, cache_path)

--- a/tests/test_judge_sees_moments.py
+++ b/tests/test_judge_sees_moments.py
@@ -1,0 +1,57 @@
+"""The judge is told to drop "the same moment" — and cannot see moments.
+
+Its clip lines carried `date=2011-08-04` and nothing finer, so two clips ten
+minutes apart looked like two clips on a Thursday. A real ship-deck
+performance shipped three times: 03 Aug 16:23 from one camera, 04 Aug 15:32
+and 15:42 from another. Nothing in the judge's view could have told it.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.selection_review import _clips_block
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+
+DECK = datetime(2011, 8, 4, 15, 32, tzinfo=UTC)
+
+
+def _clip(asset_id: str, when: datetime, description: str) -> ClipWithSegment:
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=when,
+        fileModifiedAt=when,
+        updatedAt=when,
+    )
+    clip = VideoClipInfo(asset=asset, duration_seconds=5.0)
+    clip.llm_description = description
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=0.5)
+
+
+def _moment_of(line: str) -> str | None:
+    found = re.search(r"moment=(\S+)", line)
+    return found.group(1) if found else None
+
+
+def test_the_judge_is_told_the_time_of_day() -> None:
+    """A date alone cannot separate ten minutes from ten hours."""
+    block = _clips_block([_clip("a", DECK, "a performance on deck")])
+
+    assert "15:32" in block
+
+
+def test_two_clips_ten_minutes_apart_are_named_as_one_moment() -> None:
+    """The judge's own rule says drop the same moment; give it the moment."""
+    lines = _clips_block(
+        [
+            _clip("first", DECK, "a performance on deck"),
+            _clip("second", DECK + timedelta(minutes=10), "the same performance on deck"),
+            _clip("elsewhere", DECK + timedelta(days=3), "a harbour at dawn"),
+        ]
+    ).splitlines()
+
+    assert _moment_of(lines[0]) == _moment_of(lines[1])
+    assert _moment_of(lines[2]) != _moment_of(lines[0])


### PR DESCRIPTION
Refs #751. **This is the slice that addresses the observed August cut.** It
changes nothing about what selection picks — it changes what the judge is shown.

## The judge was asked a question it could not answer

Its prompt says to drop a clip that is *"REDUNDANT: the same moment, scene or
kind of shot is already in the set."*

Its clip lines carried `date=2011-08-04` and nothing finer. Two clips ten
minutes apart looked like two clips on a Thursday.

August shipped one ship-deck performance three times: **03 Aug 16:23** from one
camera, **04 Aug 15:32** and **15:42** from another. And nothing upstream could
have caught it:

- the two ten minutes apart are **outside the five-minute** same-moment window a
  month uses (`temporal_dedup_window_minutes = 5.0`, floored by the span table)
- the third is a **day away**, because the two cameras disagree about the time

The judge is the only stage that sees the whole cut at once, and it was the one
stage told nothing about time.

## What changed

Each line now carries `when=` to the minute and `moment=`. The moment name comes
from the **shared time-and-place grouping** (`moment_grouping`), not a window
invented here, so "the same moment" means the same thing to the judge as to the
stages that built the cut.

The prompt now says what both mean — and says out loud that one scene can appear
under different dates because cameras keep their own clocks and one is often
wrong. Without that, the dates argue against the descriptions and the dates are
what a model trusts.

No detector, no new grouping, no change to selection. The judge is shown what it
was already being asked about.

## What I got wrong, on the record

My earlier diagnosis of #751 — event-period slots picked by score alone and then
protected from dedup — **does not explain this cut.** Sam's eye-judgment showed
the picks are not one instant. Picks 2 and 3 are 10 minutes apart, so the
same-moment dedup could never have caught them, and neither would the spread fix
I had written (it uses the same 5-minute window).

That spread fix addresses a **real latent defect** which I did reproduce in a
unit test, and it is held back deliberately rather than folded in here: it
perturbs which clips get selected, and Sam is judging one label at a time. If
both shipped together and August improved, we could not tell which did it. It
follows as its own PR.

## Also verified, and needing no change

"Review drops as refusals" is **already implemented** — `selection_quality.review`
shrinks the analysed pool, with a comment saying why: *"a later stabilization
re-refines from the pool — returning the old one would resurrect the LLM's
drops."*

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL