### PR TITLE
fix(selection): an event period spends its slots on several moments, not one

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,43 +6,31 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 262,
-        "line_end": 305,
+        "line_start": 266,
+        "line_end": 309,
         "line_complexities": [
           {
-            "line": 272,
-            "complexity": 0
-          },
-          {
-            "line": 273,
-            "complexity": 1
-          },
-          {
-            "line": 274,
+            "line": 276,
             "complexity": 0
           },
           {
             "line": 277,
-            "complexity": 0
-          },
-          {
-            "line": 278,
             "complexity": 1
           },
           {
-            "line": 279,
+            "line": 278,
+            "complexity": 0
+          },
+          {
+            "line": 281,
             "complexity": 0
           },
           {
             "line": 282,
-            "complexity": 0
+            "complexity": 1
           },
           {
             "line": 283,
-            "complexity": 0
-          },
-          {
-            "line": 285,
             "complexity": 0
           },
           {
@@ -51,50 +39,62 @@
           },
           {
             "line": 287,
-            "complexity": 1
-          },
-          {
-            "line": 288,
             "complexity": 0
           },
           {
             "line": 289,
-            "complexity": 2
+            "complexity": 0
+          },
+          {
+            "line": 290,
+            "complexity": 0
           },
           {
             "line": 291,
+            "complexity": 1
+          },
+          {
+            "line": 292,
             "complexity": 0
           },
           {
             "line": 293,
-            "complexity": 0
-          },
-          {
-            "line": 294,
-            "complexity": 1
-          },
-          {
-            "line": 295,
             "complexity": 2
           },
           {
-            "line": 296,
+            "line": 295,
             "complexity": 0
           },
           {
             "line": 297,
-            "complexity": 3
+            "complexity": 0
+          },
+          {
+            "line": 298,
+            "complexity": 1
           },
           {
             "line": 299,
-            "complexity": 4
+            "complexity": 2
           },
           {
             "line": 300,
+            "complexity": 0
+          },
+          {
+            "line": 301,
+            "complexity": 3
+          },
+          {
+            "line": 303,
+            "complexity": 4
+          },
+          {
+            "line": 304,
             "complexity": 5
           },
           {
-            "line": 305,
+            "line": 309,
             "complexity": 0
           }
         ]

--- a/src/immich_memories/analysis/clip_distribution.py
+++ b/src/immich_memories/analysis/clip_distribution.py
@@ -162,6 +162,47 @@ def _event_periods_of(clips: list[ClipWithSegment]) -> set[str]:
     return _event_periods(by_period)
 
 
+def spread_across_moments(
+    period_clips: list[ClipWithSegment],
+    take: int,
+    window_minutes: float,
+) -> list[ClipWithSegment]:
+    """A period's best `take` clips, drawn from as many of its moments as it has.
+
+    Best-by-score alone spends an event's slots on a single instant. A burst IS
+    one moment photographed over and over, so it holds the period's top scores
+    — and those picks then join coverage_ids, which the same-moment dedup may
+    not touch. Nothing downstream could undo it, and a month with no favourites
+    shipped three clips of the same second.
+
+    Moments are ranked by their best clip and taken one at a time, so a period
+    with fewer moments than slots still fills them, from its best frames. Same
+    window as the dedup stage, so what this calls distinct is what that would.
+    """
+    from immich_memories.analysis.clip_scaler import group_by_moment
+
+    ranked_by_score = sorted(period_clips, key=lambda c: c.score, reverse=True)
+    if take <= 1 or window_minutes <= 0:
+        return ranked_by_score[:take]
+
+    moments = [
+        sorted(moment, key=lambda c: c.score, reverse=True)
+        for moment in group_by_moment(period_clips, window_minutes)
+    ]
+    moments.sort(key=lambda moment: moment[0].score, reverse=True)
+
+    picked: list[ClipWithSegment] = []
+    depth = 0
+    while len(picked) < take and any(len(moment) > depth for moment in moments):
+        for moment in moments:
+            if len(picked) >= take:
+                break
+            if len(moment) > depth:
+                picked.append(moment[depth])
+        depth += 1
+    return picked
+
+
 def _fill_gap_periods(
     unselected_by_period: dict[str, list[ClipWithSegment]],
     covered: set[str],

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -40,6 +40,7 @@ from immich_memories.analysis.clip_distribution import (
     moment_window_for,
     photos_per_day_for,
     span_days_of,
+    spread_across_moments,
 )
 from immich_memories.analysis.favourite_law import let_the_favourite_win
 
@@ -138,10 +139,13 @@ class ClipRefiner:
         selected_ids: set[str] = set()
         coverage_ids: set[str] = set()
         events = event_periods
+        # An event's several slots go to several of its moments. Taking the
+        # top N by score gave them all to one instant, and coverage protection
+        # then forbade dedup from noticing.
+        window = moment_window_for(span_days_of(clips), self.config.temporal_dedup_window_minutes)
         for period in densest_first[:reserved]:
             take = _EVENT_CLIPS_PER_PERIOD if period in events else 1
-            ranked = sorted(by_period[period], key=lambda c: c.score, reverse=True)
-            for best in ranked[:take]:
+            for best in spread_across_moments(by_period[period], take, window):
                 selected.append(best)
                 selected_ids.add(best.clip.asset.id)
                 coverage_ids.add(best.clip.asset.id)

--- a/tests/test_event_period_moments.py
+++ b/tests/test_event_period_moments.py
@@ -1,0 +1,120 @@
+"""A dense day earns several slots. It must not spend them on one instant.
+
+An event period — one holding at least three times the median period's
+material — is granted _EVENT_CLIPS_PER_PERIOD slots so a real event is not
+reduced to a single frame. Those slots were filled by score alone, and every
+one of them joined coverage_ids, which the same-moment dedup is forbidden to
+touch. On a month with no favourites and dozens of pictures of one event, that
+shipped three clips of the same instant.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.clip_distribution import _event_periods_of
+from immich_memories.analysis.clip_refiner import ClipRefiner
+from immich_memories.analysis.clip_scaler import ClipScaler
+from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+from immich_memories.api.models import Asset, AssetType, Person, VideoClipInfo
+
+EVENT_DAY = datetime(2011, 8, 15, 12, 0, tzinfo=UTC)
+
+
+def _clip(asset_id: str, when: datetime, score: float, *, peopled: bool = False) -> ClipWithSegment:
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=when,
+        fileModifiedAt=when,
+        updatedAt=when,
+        isFavorite=False,
+        # An event period must show people: density alone once promoted 130
+        # photos of an empty apartment over the month's real days.
+        people=[Person(id="p1", name="Someone")] if peopled else [],
+    )
+    return ClipWithSegment(
+        clip=VideoClipInfo(asset=asset, duration_seconds=5.0),
+        start_time=0.0,
+        end_time=5.0,
+        score=score,
+    )
+
+
+def _pool() -> list[ClipWithSegment]:
+    """One dense event day of four moments, plus ten ordinary days.
+
+    The event's best three frames all sit inside its first moment, which is
+    what a burst looks like: the same instant photographed over and over.
+    """
+    clips: list[ClipWithSegment] = []
+    for moment in range(4):
+        for frame in range(3):
+            when = EVENT_DAY + timedelta(minutes=moment * 40 + frame)
+            score = 0.9 if moment == 0 else 0.5
+            clips.append(_clip(f"event-m{moment}-f{frame}", when, score, peopled=True))
+    for day in range(10):
+        clips.append(_clip(f"ordinary-{day}", EVENT_DAY - timedelta(days=day + 1), 0.4))
+    return clips
+
+
+def _moment_of(clip: ClipWithSegment) -> tuple:
+    when = clip.clip.asset.file_created_at
+    return (when.date(), when.hour, when.minute // 10)
+
+
+def test_an_event_periods_slots_span_more_than_one_moment() -> None:
+    """Three slots, three different moments — not three frames of one."""
+    clips = _pool()
+    refiner = ClipRefiner(PipelineConfig(target_clips=8), ClipScaler())
+
+    selected = refiner._select_without_favorites(
+        clips, clips, target_count=8, event_periods=_event_periods_of(clips)
+    )
+
+    reserved = [c for c in selected if c.clip.asset.id in refiner._coverage_ids]
+    from_event = [c for c in reserved if c.clip.asset.file_created_at.date() == EVENT_DAY.date()]
+
+    assert len(from_event) == 3, "the event period should still earn its three slots"
+    assert len({_moment_of(c) for c in from_event}) >= 2
+
+
+def test_a_period_with_fewer_moments_than_slots_still_fills_them() -> None:
+    """Spreading must not shrink an event that genuinely happened in one place.
+
+    Two moments and three slots: the third comes from the better moment's
+    second-best frame rather than being given up.
+    """
+    from immich_memories.analysis.clip_distribution import spread_across_moments
+
+    early = [_clip(f"early-{n}", EVENT_DAY + timedelta(minutes=n), 0.9 - n / 100) for n in range(3)]
+    later = [_clip(f"later-{n}", EVENT_DAY + timedelta(minutes=40 + n), 0.5) for n in range(2)]
+
+    picked = spread_across_moments(early + later, 3, window_minutes=10.0)
+
+    assert len(picked) == 3
+    assert len({_moment_of(c) for c in picked}) == 2
+
+
+def test_the_best_moment_is_served_first() -> None:
+    """Spreading changes which frames are taken, never that the best leads."""
+    from immich_memories.analysis.clip_distribution import spread_across_moments
+
+    dull = [_clip(f"dull-{n}", EVENT_DAY + timedelta(minutes=n), 0.2) for n in range(3)]
+    best = [_clip(f"best-{n}", EVENT_DAY + timedelta(minutes=40 + n), 0.9) for n in range(3)]
+
+    picked = spread_across_moments(dull + best, 2, window_minutes=10.0)
+
+    assert picked[0].clip.asset.id == "best-0"
+    assert len({_moment_of(c) for c in picked}) == 2
+
+
+def test_a_single_slot_is_still_the_periods_best() -> None:
+    """An ordinary period gets one clip, and spreading must not change which."""
+    from immich_memories.analysis.clip_distribution import spread_across_moments
+
+    clips = [_clip(f"c-{n}", EVENT_DAY + timedelta(minutes=n * 20), 0.1 * n) for n in range(5)]
+
+    picked = spread_across_moments(clips, 1, window_minutes=10.0)
+
+    assert [c.clip.asset.id for c in picked] == ["c-4"]


### PR DESCRIPTION
Refs #751. **Stage 2's single variable**, held back from #753 on purpose and
shipping now that August is accepted.

## The defect

A period holding ≥3× the median period's material is an "event period" and is
granted `_EVENT_CLIPS_PER_PERIOD` (3) slots, so a real event is not reduced to
a single frame. That feature is right.

Those slots were filled **by score alone** — and a burst *is* one moment
photographed over and over, so it holds the period's top scores. All three
picks then joined `coverage_ids`, which the same-moment dedup "may not drop".
Nothing downstream could undo it.

Reproduced before fixing: a zero-favourites pool with one dense peopled day
whose best three frames share a moment selects all three from that one moment.

## The fix

Slots are drawn from as many of the period's moments as it has, ranked by each
moment's best clip and taken one at a time. Pinned by tests:

- a period with **fewer moments than slots still fills them**, from its best
  frames — an event that genuinely happened in one place is not thinned
- the **best moment is served first** — spreading changes which frames are
  taken, never that the best leads
- a **single-slot period still gets its best clip** — ordinary periods unchanged

The window is the one the dedup stage uses, so what this calls distinct is what
that would.

## Scope, honestly

This is **not** what caused the August cut that prompted #751 — that was the
judge being shown a date with no time on it (#753), and Sam's eye-judgment
disproved my original diagnosis. This fixes a real latent defect found while
looking for that one.

It was held back deliberately because it changes which clips selection picks,
and August was being judged on #753 alone. Shipping both at once would have
made that result unattributable.

`make ci` green, rebased onto main after #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL