### PR TITLE
feat(tools): the contact sheet says when a burst renders as the stitch

### DIFF
--- a/scripts/contact_sheet.py
+++ b/scripts/contact_sheet.py
@@ -51,7 +51,15 @@ def _collect(rows: list[dict]):
                     "video_id": getattr(clip.asset, "live_photo_video_id", None),
                     "when": taken.strftime("%d %b %H:%M") if taken else "?",
                     "day": taken.strftime("%Y-%m-%d") if taken else "?",
-                    "kind": "PHO" if "IMAGE" in str(getattr(clip.asset, "type", "")) else "VID",
+                    # LVS = a Live Photo burst the pipeline chose to render as
+                    # motion (the stitch), distinct from a plain still (PHO).
+                    "kind": (
+                        "LVS"
+                        if getattr(clip, "live_burst_video_ids", None)
+                        else "PHO"
+                        if "IMAGE" in str(getattr(clip.asset, "type", ""))
+                        else "VID"
+                    ),
                     "city": (clip.asset.exif_info.city if clip.asset.exif_info else None) or "",
                     "score": round(member.score, 2) if member else 0.0,
                     "secs": round(end - start, 1),


### PR DESCRIPTION
Owner request from the v9 ladder: pick 8 on the June sheet was labeled PHO while actually rendering as the Live Photo stitch the owner personally knows is good — the sheet hid the motion-rendering decision. Kinds are now **PHO / VID / LVS**, with LVS read off `clip.live_burst_video_ids` (set by the carrying candidate since #743). Tooling-only, selection-inert; sheets pick it up from the next render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHnUMhrYipDhq2TCLygQ8f