### PR TITLE
fix(review): the judge weighs an occasion, and knows what the owner starred

### DIFF
--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -37,20 +37,32 @@ _REVIEW_MAX_TOKENS = 8000
 _PROMPT = """You are reviewing the final cut of a personal memory video.
 Below is every clip in timeline order, with everything we can see and hear.
 
-Each clip carries `when=` (its timestamp) and `moment=` (which moment it
-belongs to). Clips sharing a moment name were shot in the same place within
-minutes of each other — they ARE the same moment, whatever their descriptions
-say. Two clips can also show one scene under different dates: cameras keep
-their own clocks and one of them is often wrong by hours or a day, so trust
-what the descriptions show over what the dates imply.
+Each clip carries `when=` (its timestamp), `episode=` (which occasion it
+belongs to) and `starred=yes` when the owner marked it a favourite.
+
+Clips sharing an episode name happened in one place across one stretch of
+time — one site visit, one party, one hike. They are ONE OCCASION however
+different their descriptions read: three brick pavilions from one afternoon
+are one visit, not architectural variety.
+
+Two clips can also show one scene under different dates: cameras keep their
+own clocks and one of them is often wrong by hours or a day, so trust what the
+descriptions show over what the dates imply.
+
+`starred=yes` is the owner's own judgment and outranks yours. Never drop a
+starred clip in favour of an unstarred one from the same episode. When one
+episode holds SEVERAL starred clips, choose between THOSE — an occasion the
+owner starred repeatedly still earns one place, not one each, and that is the
+only case where dropping a starred clip is right.
 
 {clips}
 
 Judge the SET as a whole: feel, coherence, variety. Drop a clip when it is
 
 - REDUNDANT: the same moment, scene or kind of shot is already in the set.
-  Two clips sharing a `moment=` name are the same moment: keep the better one
-  unless each shows something the other does not.
+  An episode earns ONE place unless each of its clips shows something the
+  others genuinely do not. The same occasion photographed over and over is one
+  idea shown many times, however much its descriptions differ.
   Self-portraits and mirror shots repeat hard — three of them from three days
   is one idea shown three times, however different the days were. A selfie of
   one person alone is the weakest way to record a day: prefer the clip that
@@ -151,7 +163,13 @@ def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -
         # minutes from ten hours: a ship-deck performance shipped three times.
         parts.append(f"when={taken.isoformat(timespec='minutes')}")
     if moment:
-        parts.append(f"moment={moment}")
+        parts.append(f"episode={moment}")
+    if getattr(clip.asset, "is_favorite", False):
+        # Several starred clips in one occasion are a battle to judge between.
+        # Not saying so let the review drop a favourite and keep the unstarred
+        # clip beside it — and the review shrinks the pool, so nothing
+        # downstream could put it back.
+        parts.append("starred=yes")
     where = _place_for_llm(getattr(clip.asset, "exif_info", None))
     if where:
         parts.append(f"place={where}")
@@ -172,28 +190,41 @@ def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -
 def _clips_block(selected: list[ClipWithSegment]) -> str:
     """Every clip as the judge sees it, each one told which moment it is in.
 
-    Moments come from the shared time-and-place grouping rather than a window
-    invented here, so "the same moment" means the same thing to the judge as
-    it does to the stages that built the cut.
+    Occasions come from the shared time-and-place grouping rather than a
+    window invented here, so what the judge is asked to judge is the same unit
+    the rest of the pipeline reasons about.
     """
     return "\n".join(
-        _clip_line(index + 1, member, moment)
-        for index, (member, moment) in enumerate(
-            zip(selected, _moment_labels(selected), strict=True)
+        _clip_line(index + 1, member, episode)
+        for index, (member, episode) in enumerate(
+            zip(selected, _episode_labels(selected), strict=True)
         )
     )
 
 
-def _moment_labels(selected: list[ClipWithSegment]) -> list[str]:
-    """A moment name per clip, in the order given."""
-    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+def _episode_labels(selected: list[ClipWithSegment]) -> list[str]:
+    """An occasion name per clip, in the order given.
+
+    The EPISODE window, not the moment one. A site visit ran 15:07, 15:22 and
+    16:04 in one place: fifteen and forty-two minutes apart, so every
+    same-moment window called them three different things and the judge, shown
+    three labels on one day, had no basis to object. "Three brick pavilions"
+    reads as architectural variety in text. An episode is the block a moment
+    sits in — an afternoon somewhere, a party, a hike — which is the unit a
+    memory should show once.
+    """
+    from immich_memories.analysis.moment_grouping import (
+        EPISODE_WINDOW_MINUTES,
+        _group_by_time_and_place,
+    )
 
     assets = [m.clip.asset for m in selected]
     by_asset: dict[str, str] = {}
-    for number, moment in enumerate(_group_by_time_and_place(assets), start=1):
-        for asset in moment:
-            by_asset[asset.id] = f"M{number}"
-    return [by_asset.get(m.clip.asset.id, "M?") for m in selected]
+    grouped = _group_by_time_and_place(assets, window_minutes=EPISODE_WINDOW_MINUTES)
+    for number, episode in enumerate(grouped, start=1):
+        for asset in episode:
+            by_asset[asset.id] = f"E{number}"
+    return [by_asset.get(m.clip.asset.id, "E?") for m in selected]
 
 
 def _verdict_in(raw: str | None) -> list | None:

--- a/tests/test_judge_sees_moments.py
+++ b/tests/test_judge_sees_moments.py
@@ -1,4 +1,4 @@
-"""The judge is told to drop "the same moment" — and cannot see moments.
+"""What the judge can see about when a clip happened, and who starred it.
 
 Its clip lines carried `date=2011-08-04` and nothing finer, so two clips ten
 minutes apart looked like two clips on a Thursday. A real ship-deck
@@ -31,8 +31,8 @@ def _clip(asset_id: str, when: datetime, description: str) -> ClipWithSegment:
     return ClipWithSegment(clip=clip, start_time=0.0, end_time=5.0, score=0.5)
 
 
-def _moment_of(line: str) -> str | None:
-    found = re.search(r"moment=(\S+)", line)
+def _episode_of(line: str) -> str | None:
+    found = re.search(r"episode=(\S+)", line)
     return found.group(1) if found else None
 
 
@@ -43,7 +43,7 @@ def test_the_judge_is_told_the_time_of_day() -> None:
     assert "15:32" in block
 
 
-def test_two_clips_ten_minutes_apart_are_named_as_one_moment() -> None:
+def test_two_clips_ten_minutes_apart_are_named_as_one_occasion() -> None:
     """The judge's own rule says drop the same moment; give it the moment."""
     lines = _clips_block(
         [
@@ -53,5 +53,51 @@ def test_two_clips_ten_minutes_apart_are_named_as_one_moment() -> None:
         ]
     ).splitlines()
 
-    assert _moment_of(lines[0]) == _moment_of(lines[1])
-    assert _moment_of(lines[2]) != _moment_of(lines[0])
+    assert _episode_of(lines[0]) == _episode_of(lines[1])
+    assert _episode_of(lines[2]) != _episode_of(lines[0])
+
+
+def _starred(clip: ClipWithSegment) -> ClipWithSegment:
+    clip.clip.asset.is_favorite = True
+    return clip
+
+
+def test_one_site_visit_is_one_occasion_however_it_is_spread() -> None:
+    """Three favourites from one afternoon at one place: 15:07, 15:22, 16:04.
+
+    Fifteen and forty-two minutes apart — outside every same-moment window, so
+    the judge was shown three different labels on one day and had no basis to
+    object. "Three brick pavilions" reads as architectural variety in text.
+    An occasion is the block a moment sits in, not the moment.
+    """
+    visit = datetime(2023, 6, 14, 15, 7, tzinfo=UTC)
+    lines = _clips_block(
+        [
+            _starred(_clip("pavilion-a", visit, "a brick pavilion")),
+            _starred(_clip("pavilion-b", visit + timedelta(minutes=15), "another brick pavilion")),
+            _starred(_clip("pavilion-c", visit + timedelta(minutes=57), "a third brick pavilion")),
+        ]
+    ).splitlines()
+
+    labels = {_episode_of(line) for line in lines}
+    assert labels != {None}, "the judge was told nothing about the occasion"
+    assert len(labels) == 1
+
+
+def test_the_judge_is_told_which_clips_the_owner_starred() -> None:
+    """Several starred clips in one occasion are a battle to judge between.
+
+    Without knowing which are starred the judge can drop a favourite and keep
+    the unstarred clip beside it — and because the review shrinks the pool,
+    nothing downstream can put it back.
+    """
+    visit = datetime(2023, 6, 14, 15, 7, tzinfo=UTC)
+    lines = _clips_block(
+        [
+            _starred(_clip("kept", visit, "a brick pavilion")),
+            _clip("plain", visit + timedelta(minutes=15), "a corridor"),
+        ]
+    ).splitlines()
+
+    assert "starred" in lines[0]
+    assert "starred" not in lines[1]


### PR DESCRIPTION
Refs #755, part 1. **Stage 3's single variable** — the fix for the named June
complaint. Selection picks exactly what it picked before; only the judge's view
changes, so the re-render attributes cleanly.

## Why June shipped one site visit three times

Three favourites at **15:07, 15:22, 16:04**, one place. Fifteen and forty-two
minutes apart — outside *every* same-moment window in the pipeline. So:

- the judge was shown **three different labels on one day** and had no basis to
  object, and "three brick pavilions" reads as architectural variety in text
- the favourites law protected each one inside its own ten-minute box

Every mechanism worked as built. The **granularity** was wrong.

## The judge now weighs episodes

An episode is the block a moment sits in — an afternoon somewhere, a party, a
hike — from the shared time-and-place grouping at its episode window, not a
window invented in the review. An episode earns one place unless each of its
clips genuinely shows something the others do not.

The finer moment label is **gone rather than shown alongside**: seeing that
three clips were three different moments is precisely what licensed keeping all
three.

What the judge sees for the June case now:

```
Clip 1: when=2023-06-14T15:07+00:00 episode=E1 starred=yes ... a brick pavilion
Clip 2: when=2023-06-14T15:22+00:00 episode=E1 starred=yes ... another brick pavilion
Clip 3: when=2023-06-14T16:04+00:00 episode=E1 starred=yes ... a third brick pavilion
Clip 4: when=2023-06-16T15:07+00:00 episode=E2            ... a harbour at dawn
```

## And it now knows what was starred — which closes a hole

`_clip_line` never carried favourite status. That matters in **both** directions,
and the second one is a live defect:

- the review **may** drop a favourite (`spared` guards the mechanical judge, not
  this pass), and it **shrinks the pool** afterwards — so `let_the_favourite_win`
  re-runs against a pool the clip has already left and cannot restore it
- unable to tell starred from unstarred, the review could quietly overrule the
  owner and #746's law could not catch it

The prompt now says a star outranks the model's judgment, that a starred clip is
never dropped in favour of an unstarred one from the same episode, and that
several starred clips in one episode are a battle to judge between **those** —
the owner's multi-favourite rule landing at the granularity it was always meant
for.

## Not in this PR

Rule 2 (the fill floor) is the **next** single variable, and the owner's
calibration reshapes it: a numeric threshold cannot work, because the accepted
cat scores 0.38 and the rejected room shot 0.53. It is content **class**, not
score — and the classes are vocabulary the judge already speaks. That points at
applying its not-a-memory taxonomy at backfill time from cached verdicts rather
than inventing a floor.

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL