### PR TITLE
fix(backfill): stop restocking the shelf the judge keeps clearing

### DIFF
--- a/src/immich_memories/analysis/clip_backfill.py
+++ b/src/immich_memories/analysis/clip_backfill.py
@@ -61,6 +61,7 @@ def _is_backfill_candidate_admissible(
     remaining_budget: float,
     enforce_favorite_ratio: bool = True,
     enforce_temporal_spacing: bool = True,
+    enforce_occasion_spacing: bool = True,
 ) -> bool:
     """Return whether a leftover preserves active selection constraints."""
     from immich_memories.analysis.clip_scaler import is_same_moment
@@ -74,6 +75,22 @@ def _is_backfill_candidate_admissible(
     # the whole point of the ladder is to find something else — and the
     # highest-scoring leftover is usually the near-duplicate just dropped.
     if candidate.clip.asset.id in context.refused_ids:
+        return False
+
+    # Shrink over pad, extended to quality: a memory that cannot fill runs
+    # short, it does not fill with a screen. This is the door June's residue
+    # came through — the judge threw out a sibling of every piece of it and
+    # the supply restocked until the budget ran out. Never conceded: there is
+    # no gap worth a photograph of a monitor.
+    if _is_never_worth_padding(candidate):
+        return False
+
+    # An occasion already in the cut is not a gap. The rung below measures a
+    # moment; a site visit runs over an hour, so its later shots looked like
+    # fresh material and were offered again after each drop. Strict only —
+    # conceded first, because a wedding is one occasion all day and a hard
+    # rule would starve it.
+    if enforce_occasion_spacing and _is_same_occasion(candidate, context):
         return False
 
     # Conceding temporal spacing relaxes the window back to the configured
@@ -123,6 +140,7 @@ def _admissible_backfill_candidates(
     remaining_budget: float,
     enforce_favorite_ratio: bool = True,
     enforce_temporal_spacing: bool = True,
+    enforce_occasion_spacing: bool = True,
 ) -> list[ClipWithSegment]:
     """Filter leftovers through the active backfill constraints."""
     return [
@@ -135,6 +153,7 @@ def _admissible_backfill_candidates(
             remaining_budget=remaining_budget,
             enforce_favorite_ratio=enforce_favorite_ratio,
             enforce_temporal_spacing=enforce_temporal_spacing,
+            enforce_occasion_spacing=enforce_occasion_spacing,
         )
     ]
 
@@ -156,6 +175,19 @@ def _resolve_backfill_candidates(
     if exact:
         return _BackfillCandidates(exact, active_photo_limit)
 
+    # Cheapest concession, and the first: an occasion already in the cut may
+    # be revisited. This is exactly the behaviour that shipped before the
+    # occasion rung existed, so nothing is lost when supply is thin.
+    revisits = _admissible_backfill_candidates(
+        available,
+        context=context,
+        photo_limit=active_photo_limit,
+        remaining_budget=remaining_budget,
+        enforce_occasion_spacing=False,
+    )
+    if revisits:
+        return _BackfillCandidates(revisits, active_photo_limit, "occasion_revisit")
+
     # Order of concessions, worst-last. Loosening who appears (non-favorites)
     # barely shows. Admitting a few more stills shows a little. Admitting a
     # clip from a moment already in the cut shows most of all: a real August
@@ -170,6 +202,7 @@ def _resolve_backfill_candidates(
         photo_limit=active_photo_limit,
         remaining_budget=remaining_budget,
         enforce_favorite_ratio=False,
+        enforce_occasion_spacing=False,
     )
     if relaxed_favorites:
         return _BackfillCandidates(relaxed_favorites, active_photo_limit, "favorite_ratio")
@@ -183,6 +216,7 @@ def _resolve_backfill_candidates(
             photo_limit=relaxed_photo_limit,
             remaining_budget=remaining_budget,
             enforce_favorite_ratio=False,
+            enforce_occasion_spacing=False,
         )
         if relaxed_photos:
             return _BackfillCandidates(relaxed_photos, relaxed_photo_limit, "photo_ratio_70")
@@ -193,6 +227,7 @@ def _resolve_backfill_candidates(
         photo_limit=relaxed_photo_limit,
         remaining_budget=remaining_budget,
         enforce_favorite_ratio=False,
+        enforce_occasion_spacing=False,
         enforce_temporal_spacing=False,
     )
     if relaxed_temporal:
@@ -205,6 +240,7 @@ def _resolve_backfill_candidates(
             photo_limit=None,
             remaining_budget=remaining_budget,
             enforce_favorite_ratio=False,
+            enforce_occasion_spacing=False,
             enforce_temporal_spacing=False,
         )
         if unlimited_photos:
@@ -216,6 +252,7 @@ def _resolve_backfill_candidates(
         photo_limit=None,
         remaining_budget=remaining_budget + 2.0,
         enforce_favorite_ratio=False,
+        enforce_occasion_spacing=False,
         enforce_temporal_spacing=False,
     )
     return _BackfillCandidates(
@@ -375,6 +412,7 @@ def _log_backfill_resolution(
             "relaxing photo ratio from %.0f%% to 70%%",
             (original_photo_limit * 100,),
         ),
+        "occasion_revisit": ("revisiting an occasion already in the cut", ()),
         "favorite_ratio": ("allowing additional non-favorites", ()),
         "temporal_spacing": ("allowing a nearby moment", ()),
         "photo_ratio_unlimited": ("allowing photos beyond the ratio cap", ()),
@@ -407,3 +445,39 @@ def _log_backfill_summary(
             "Post-filter backfill: no valid leftover fits the remaining %.1fs",
             max_duration - total_duration,
         )
+
+
+def _is_never_worth_padding(candidate: ClipWithSegment) -> bool:
+    """Whether this is a thing rather than a moment.
+
+    Only screens and objects, and only for PADDING — selection may still pick
+    one on its merits. Scenery and animals are kept (scenery earns its place,
+    animals are a garnish), and an unlabelled clip is kept because a third of a
+    real pool has no analysis yet and reading that silence as junk would empty
+    the quiet months that need backfill most.
+    """
+    from immich_memories.analysis.subject_policy import SubjectCategory, classify_subject
+
+    subject = classify_subject(
+        tagged_people=len(candidate.clip.asset.people),
+        category=candidate.clip.llm_category,
+    )
+    return subject in (SubjectCategory.SCREEN, SubjectCategory.OBJECT)
+
+
+def _is_same_occasion(candidate: ClipWithSegment, context: _BackfillContext) -> bool:
+    """Whether an occasion already in the cut covers this clip.
+
+    Distance from what is already selected, like the moment rung it sits above
+    — not the place-aware grouping, because this runs per candidate and needs
+    no new state. The window is the episode one, never narrower than the
+    moment window already in force, so a long memory is unaffected. A zero
+    window still means no deduplication at all.
+    """
+    from immich_memories.analysis.clip_scaler import is_same_moment
+    from immich_memories.analysis.moment_grouping import EPISODE_WINDOW_MINUTES
+
+    if context.temporal_window <= 0:
+        return False
+    spacing = max(EPISODE_WINDOW_MINUTES, context.temporal_window)
+    return is_same_moment(candidate.clip.asset.file_created_at, context.occupied_moments, spacing)

--- a/tests/test_backfill_reallocation.py
+++ b/tests/test_backfill_reallocation.py
@@ -24,13 +24,18 @@ from immich_memories.analysis.clip_backfill import (
 from immich_memories.analysis.smart_pipeline import PipelineConfig
 
 
-def _clip(asset_id: str, minute: int, score: float, duration: float = 4.0):
-    when = datetime(2011, 8, 4, 12, minute, tzinfo=UTC)
+def _clip(asset_id: str, minute: int, score: float, duration: float = 4.0, *, day: int = 4):
+    when = datetime(2011, 8, day, 12, minute, tzinfo=UTC)
     return SimpleNamespace(
         clip=SimpleNamespace(
             asset=SimpleNamespace(
-                id=asset_id, is_favorite=False, file_created_at=when, type="VIDEO"
+                id=asset_id,
+                is_favorite=False,
+                file_created_at=when,
+                type="VIDEO",
+                people=[],
             ),
+            llm_category=None,
             duration_seconds=duration,
         ),
         start_time=0.0,
@@ -69,9 +74,14 @@ def test_a_refused_clip_stays_refused_even_when_spacing_is_relaxed() -> None:
 
 
 def test_an_unrefused_clip_elsewhere_is_still_admissible() -> None:
-    """Freed seconds go somewhere — just not backwards."""
+    """Freed seconds go somewhere — just not backwards.
+
+    Elsewhere means another occasion. Forty-five minutes later is the same
+    afternoon, and the strict pass now says so; a different day is the
+    "somewhere" this rule was always about.
+    """
     kept = _clip("kept", minute=0, score=0.80)
-    elsewhere = _clip("elsewhere", minute=45, score=0.55)
+    elsewhere = _clip("elsewhere", minute=45, score=0.55, day=6)
 
     assert _admissible(elsewhere, selected=[kept], refused={"near-dup"}, relax_spacing=False)
 
@@ -79,6 +89,6 @@ def test_an_unrefused_clip_elsewhere_is_still_admissible() -> None:
 def test_nothing_is_refused_by_default() -> None:
     """An empty refusal set must not change today's behaviour."""
     kept = _clip("kept", minute=0, score=0.80)
-    other = _clip("other", minute=45, score=0.55)
+    other = _clip("other", minute=45, score=0.55, day=6)
 
     assert _admissible(other, selected=[kept], refused=set(), relax_spacing=False)

--- a/tests/test_backfill_stops_restocking.py
+++ b/tests/test_backfill_stops_restocking.py
@@ -1,0 +1,126 @@
+"""Backfill may not restock what the judge keeps throwing out.
+
+June 2023 was rejected twice. The judge worked — eleven drops, and it caught a
+sibling of every piece of residue — but the supply outlasted it: drop a
+pavilion, the refill offers another pavilion; drop a screen, the refill offers
+another screen. Seventeen rounds, ending "budget spent, dropping 1 unreviewed
+clip(s) rather than shipping them".
+
+Backfill decides what may be offered. Two things it never asked: whether the
+occasion is already in the cut, and what the clip is OF.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from immich_memories.analysis.clip_backfill import (
+    _build_backfill_context,
+    _is_backfill_candidate_admissible,
+    _resolve_backfill_candidates,
+)
+from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+
+VISIT = datetime(2023, 6, 14, 15, 7, tzinfo=UTC)
+
+
+def _clip(
+    asset_id: str,
+    when: datetime,
+    *,
+    category: str | None = None,
+    score: float = 0.5,
+    seconds: float = 4.0,
+) -> ClipWithSegment:
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=when,
+        fileModifiedAt=when,
+        updatedAt=when,
+    )
+    clip = VideoClipInfo(asset=asset, duration_seconds=seconds)
+    clip.llm_category = category
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=seconds, score=score)
+
+
+def _context(selected: list[ClipWithSegment]):
+    return _build_backfill_context(
+        selected,
+        config=PipelineConfig(target_clips=8),
+        temporal_window=5.0,
+        occupied_moments=[c.clip.asset.file_created_at for c in selected],
+    )
+
+
+def _admissible(candidate: ClipWithSegment, selected: list[ClipWithSegment]) -> bool:
+    return _is_backfill_candidate_admissible(
+        candidate,
+        context=_context(selected),
+        photo_limit=None,
+        remaining_budget=60.0,
+    )
+
+
+class TestBackfillWillNotPadWithJunk:
+    """A memory that cannot fill runs short. It does not fill with a screen."""
+
+    def test_a_screen_is_never_padded_in(self):
+        assert not _admissible(_clip("screen", VISIT + timedelta(days=2), category="screen"), [])
+
+    def test_an_object_is_never_padded_in(self):
+        assert not _admissible(_clip("thing", VISIT + timedelta(days=2), category="object"), [])
+
+    def test_an_unlabelled_clip_is_still_offered(self):
+        """A third of a real pool has no analysis. Silence is not a verdict.
+
+        Reading it as junk would empty exactly the quiet months that need
+        backfill most.
+        """
+        assert _admissible(_clip("unseen", VISIT + timedelta(days=2), category=None), [])
+
+    def test_scenery_and_animals_are_still_offered(self):
+        """Scenery earns its place by being good; animals are a garnish."""
+        assert _admissible(_clip("view", VISIT + timedelta(days=2), category="landscape"), [])
+        assert _admissible(_clip("cat", VISIT + timedelta(days=3), category="animal"), [])
+
+
+class TestBackfillPrefersAnUnrepresentedOccasion:
+    def test_a_clip_from_an_occasion_already_in_the_cut_is_not_the_strict_choice(self):
+        """The pavilion case: 15:07 is in the cut, 15:49 is the same visit.
+
+        Forty-two minutes apart is outside every same-moment window, so the
+        old strict pass offered it and the judge had to throw it out again.
+        """
+        in_cut = [_clip("kept", VISIT)]
+        same_visit = _clip("another-pavilion", VISIT + timedelta(minutes=42))
+        other_day = _clip("elsewhere", VISIT + timedelta(days=2))
+
+        resolved = _resolve_backfill_candidates(
+            [same_visit, other_day],
+            context=_context(in_cut),
+            active_photo_limit=None,
+            remaining_budget=60.0,
+        )
+
+        assert resolved.tier == "strict"
+        assert [c.clip.asset.id for c in resolved.items] == ["elsewhere"]
+
+    def test_when_only_the_same_occasion_is_left_it_still_fills(self):
+        """Prefer, never refuse: a wedding is one or two occasions all day.
+
+        A hard rule would starve it. The ladder concedes instead, and says so.
+        """
+        in_cut = [_clip("kept", VISIT)]
+        same_visit = _clip("another-pavilion", VISIT + timedelta(minutes=42))
+
+        resolved = _resolve_backfill_candidates(
+            [same_visit],
+            context=_context(in_cut),
+            active_photo_limit=None,
+            remaining_budget=60.0,
+        )
+
+        assert [c.clip.asset.id for c in resolved.items] == ["another-pavilion"]
+        assert resolved.tier != "strict"


### PR DESCRIPTION
Refs #755. **PR A — the supply side.** June was rejected twice with the judge
working correctly; this is the half we have been circling.

## The judge was not wrong, it was outnumbered

Eleven drops, and it caught a **sibling of every piece of residue** on Sam's
list. Then the refill offered another one. Drop a pavilion, get a pavilion;
drop a screen, get a screen. Seventeen rounds, ending:

```
budget spent, dropping 1 unreviewed clip(s) rather than shipping them
```

Asset-granular refusal against an episode-granular supply. Backfill decides
what may be offered, and it never asked two questions.

## 1. Is this occasion already in the cut?

It asks whether the *moment* is — `_occupied_moments` and `is_same_moment` have
always been there, and the shape is right. But **a month measures a moment in
five minutes** and a site visit runs over an hour, so its later shots looked
like fresh material and were offered again after every drop.

A stricter rung now asks at the episode window, never narrower than the moment
window already in force (long memories unaffected), and a zero window still
means no deduplication at all.

## 2. What is this clip OF?

Nothing here consulted the subject policy, though the pool does — backfill was
category-blind. A **screen or an object never fills a gap now**, and this rung
is never conceded: there is no gap worth a photograph of a monitor. Shrink-over-
pad, extended from duplication to quality.

Kept fillable, deliberately: **scenery and animals** (scenery earns its place,
animals are a garnish) and **unlabelled clips** — a third of a real pool has no
analysis yet, and reading that silence as junk would empty exactly the quiet
months that need backfill most.

## Why rungs, and not a wider window

`temporal_window` is shared: `clip_refiner` hands the same value to the dedup
stage. Widening it would have moved dedup's `keep_per_moment` arithmetic with it
and regressed the long memories `_clips_per_moment` was calibrated for. Both
changes are additive rungs on the existing relaxation ladder; nothing existing
changes meaning.

The occasion rung is **conceded first and cheapest** — straight back to the
behaviour that shipped before it existed — because a wedding is one occasion all
day and a hard rule would starve it. It logs itself when it fires.

## What the test suite caught

**Concessions must accumulate.** Tiers below the occasion rung were still
enforcing it, so a conceded candidate got blocked three tiers later and the
ladder could not reach its own bottom — a year-span memory expecting the
temporal concession got nothing. Found by an existing test, not by me.

Two fixtures were updated rather than the code bent around them: a stub asset
predating the subject rung gained `people`, and "elsewhere" moved from
*forty-five minutes later* to *another day*, because under the occasion model
forty-five minutes is the same afternoon — which is the whole point.

## Acceptance

Per the agreed metrics: **rounds-used** (symptom) and **backfilled clips from an
already-represented episode** (the mole). The second should fall to near zero.

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL