### PR TITLE
fix(review): a clip nobody could read is not a clip nobody looked at

### DIFF
--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -245,7 +245,14 @@ class SelectionQuality:
 
         by_id = {c.clip.asset.id: c for c in analyzed}
         selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = set(review_selection(selected, self._app_config.llm, cache_path=self._verdicts))
+        drops = set(
+            review_selection(
+                selected,
+                self._app_config.llm,
+                cache_path=self._verdicts,
+                unreadable_ids=self._unreadable_ids(selected),
+            )
+        )
         if not drops:
             return result, analyzed
 
@@ -267,6 +274,21 @@ class SelectionQuality:
             },
         )
         return trimmed, [c for c in analyzed if c.clip.asset.id not in drops]
+
+    def _unreadable_ids(self, selected: list[ClipWithSegment]) -> frozenset[str]:
+        """Clips verification has already tried, and still cannot describe.
+
+        Verify never re-queues an attempt — deliberately, so a clip whose
+        analysis fails cannot loop forever. That termination guarantee is also
+        a blind spot: the clip keeps reaching the review as a bare line, and
+        the rule protecting clips nobody has looked at protects it too. Naming
+        them lets the review tell the two silences apart.
+        """
+        return frozenset(
+            member.clip.asset.id
+            for member in selected
+            if member.clip.asset.id in self._verify_attempted and self._needs_a_real_look(member)
+        )
 
     def _needs_a_real_look(self, member: ClipWithSegment) -> bool:
         """Would the LLM review be judging this clip blind?
@@ -414,7 +436,12 @@ class SelectionQuality:
 
         by_id = {c.clip.asset.id: c for c in analyzed}
         selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        drops = review_selection(selected, self._app_config.llm, cache_path=self._verdicts)
+        drops = review_selection(
+            selected,
+            self._app_config.llm,
+            cache_path=self._verdicts,
+            unreadable_ids=self._unreadable_ids(selected),
+        )
         if not drops:
             trace.record("llm review", selected, selected)
             return result, analyzed, False

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -121,6 +121,12 @@ A clip with no description has not been analysed yet. That says nothing about
 whether it is any good: never drop a clip for missing information, and never
 treat it as a duplicate on those grounds.
 
+`unreadable=yes` is different, and the rule above does not cover it. That clip
+WAS looked at and could not be described. Nothing will ever describe it, so it
+cannot be judged on what it shows and cannot answer the question. Shipping
+something nobody can describe is worse than a shorter memory: drop it unless
+the rest of the line gives you a reason to keep it.
+
 Most good selections need no changes. Answer with STRICT JSON only, no prose:
 {{"drop": [{{"index": <clip number>, "reason": "<short reason>"}}]}}
 Use an empty list when the set is good."""
@@ -177,7 +183,13 @@ def _place_for_llm(exif: object) -> str | None:
     return ", ".join(named) if named else None
 
 
-def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -> str:
+def _clip_line(
+    index: int,
+    member: ClipWithSegment,
+    moment: str | None = None,
+    *,
+    unreadable: bool = False,
+) -> str:
 
     clip = member.clip
     parts = [f"Clip {index}:"]
@@ -206,6 +218,11 @@ def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -
     if where:
         parts.append(f"place={where}")
     parts.append(f"score={member.score:.2f}")
+    if unreadable and not getattr(clip, "llm_description", None):
+        # Looked at, and could not be described. Distinct from silence: the
+        # rule that protects a clip nobody has queued would otherwise protect
+        # this one forever, and verify never re-queues an attempt.
+        parts.append("unreadable=yes")
     for label, attr in (
         ("description", "llm_description"),
         ("emotion", "llm_emotion"),
@@ -219,7 +236,10 @@ def _clip_line(index: int, member: ClipWithSegment, moment: str | None = None) -
     return " ".join(parts)
 
 
-def _clips_block(selected: list[ClipWithSegment]) -> str:
+def _clips_block(
+    selected: list[ClipWithSegment],
+    unreadable_ids: set[str] | frozenset[str] = frozenset(),
+) -> str:
     """Every clip as the judge sees it, each one told which moment it is in.
 
     Occasions come from the shared time-and-place grouping rather than a
@@ -227,7 +247,12 @@ def _clips_block(selected: list[ClipWithSegment]) -> str:
     the rest of the pipeline reasons about.
     """
     return "\n".join(
-        _clip_line(index + 1, member, episode)
+        _clip_line(
+            index + 1,
+            member,
+            episode,
+            unreadable=member.clip.asset.id in unreadable_ids,
+        )
         for index, (member, episode) in enumerate(
             zip(selected, _episode_labels(selected), strict=True)
         )
@@ -313,6 +338,7 @@ def review_selection(
     *,
     timeout_seconds: int = 45,
     cache_path: Path | None = None,
+    unreadable_ids: set[str] | frozenset[str] = frozenset(),
 ) -> list[str]:
     """Asset ids the LLM says to drop from the selection; [] on any doubt.
 
@@ -326,7 +352,7 @@ def review_selection(
     if len(selected) < 3:
         logger.debug("Selection review: %d clips is too few to judge as a set", len(selected))
         return []
-    clips_block = _clips_block(selected)
+    clips_block = _clips_block(selected, unreadable_ids)
     prompt = _PROMPT.format(clips=clips_block)
     try:
         raw = _ask(prompt, llm_config, timeout_seconds, cache_path)

--- a/tests/test_unreadable_is_not_unseen.py
+++ b/tests/test_unreadable_is_not_unseen.py
@@ -1,0 +1,66 @@
+"""A clip nobody looked at, and a clip nobody could read, are not the same.
+
+The review is told — correctly — never to drop a clip for missing information:
+a third of a real pool has no analysis yet, and treating silence as a verdict
+would gut the memory. The cost is that a bare line is immune to the only
+quality judgment in the pipeline.
+
+Verify exists to make sure no bare line ever reaches the judge. But a clip it
+has already attempted is never queued again — deliberately, so a clip whose
+analysis fails cannot loop forever. Those two rules meet badly: a clip that was
+looked at and could not be described is skipped by verify AND protected by the
+review, permanently. June shipped a 2.5s window frame and a dark screen that
+way, three renders running.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from immich_memories.analysis.selection_review import _clips_block
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+
+WHEN = datetime(2023, 6, 14, 15, 7, tzinfo=UTC)
+
+
+def _clip(asset_id: str, *, description: str | None = None) -> ClipWithSegment:
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=WHEN,
+        fileModifiedAt=WHEN,
+        updatedAt=WHEN,
+    )
+    clip = VideoClipInfo(asset=asset, duration_seconds=4.0)
+    clip.llm_description = description
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.5)
+
+
+class TestTheJudgeIsToldWhichSilenceIsWhich:
+    def test_a_clip_that_could_not_be_read_says_so(self):
+        """It was looked at. It has had its chance."""
+        block = _clips_block([_clip("murky")], unreadable_ids={"murky"})
+
+        assert "unreadable=yes" in block
+
+    def test_a_clip_nobody_has_looked_at_yet_does_not(self):
+        """Silence from a clip nobody queued is not a verdict, and must not
+        read like one — this is the protection that exists for good reason."""
+        block = _clips_block([_clip("unseen")], unreadable_ids=set())
+
+        assert "unreadable" not in block
+
+    def test_a_described_clip_is_never_marked(self):
+        block = _clips_block([_clip("seen", description="a harbour")], unreadable_ids={"seen"})
+
+        assert "unreadable" not in block
+
+
+class TestThePromptSeparatesTheTwo:
+    def test_the_protection_is_scoped_to_the_unlooked_at(self):
+        """Both rules must be present, or one swallows the other."""
+        from immich_memories.analysis.selection_review import _PROMPT
+
+        assert "never drop a clip for missing information" in _PROMPT
+        assert "unreadable=yes" in _PROMPT


### PR DESCRIPTION
Refs #755. The third hole — and **not** where it was thought to be. `make ci` green.

## The ordering was already right

Verify runs inside `stabilize`, and `stabilize` runs before the loop and after
every changed review round. Making verify "run before every review round" would
have changed nothing, because it already does.

What it skips is the **attempted**.

## The actual hole: two right rules meeting badly

- The review is told **never to drop a clip for missing information** — correct:
  a third of a real pool has no analysis yet, and treating silence as a verdict
  would gut the memory.
- Verify **never re-queues a clip it has already attempted** — also correct, and
  documented: *"A clip whose analysis fails keeps its fallback score but stops
  being re-queued, so the loop always terminates."*

A clip that was looked at and **could not be described** falls between them:
skipped by verify because it was attempted, protected by the review because it
has no description. Permanently, every round, for the rest of the run.

`final_review_drop`'s claim that *"Nothing is judged blind, so the rule never has
to protect anything that shipped"* holds only for clips verification **succeeded**
on. For failures it is false — which is exactly the 2.5s window frame and the
dark screen that survived three renders.

## The fix: tell the judge which silence is which

A clip already attempted and still undescribed is marked `unreadable=yes`, and
the prompt scopes the protection to the other kind:

> `unreadable=yes` is different, and the rule above does not cover it. That clip
> WAS looked at and could not be described. Nothing will ever describe it, so it
> cannot be judged on what it shows and cannot answer the question. Shipping
> something nobody can describe is worse than a shorter memory.

Clips nobody has queued keep their protection **exactly** as before. That rule is
not weakened — it is bounded to the case it was written for.

Shrink-over-pad again, now applied to describability.

## Why not the specified shape

The specified fix (verify before every round + a `NO DESCRIPTION` belt) would
have added a pass that already happens, and the belt alone would still have left
the clip protected — the review would have read `NO DESCRIPTION` and applied the
never-drop rule to it, which is precisely what it did with a bare line.
The separation of *unseen* from *unreadable* is the part that changes an outcome.

## Tests

Marked when attempted-and-undescribed; **not** marked when never queued (the
protection that exists for good reason); never marked when described; and both
rules present in the prompt, since either alone swallows the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL