### PR TITLE
fix(trace): the stages that run before the pipeline are on the record too

### DIFF
--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -262,7 +262,20 @@ def _dropped_at(stage: str, dropped: list[str]) -> list[str]:
 
 
 def _facts_of(item: object) -> str:
-    """One line saying what a clip is, for the account."""
+    """One line saying what a clip is, for the account.
+
+    The account is diagnostic. It may describe a candidate poorly; it may
+    never take a run down with it — and now that the pool's own stages record,
+    it sees candidates far earlier and from more call sites than the funnel
+    ever did.
+    """
+    try:
+        return _described(item)
+    except Exception:  # WHY broad: any field of any shape, and none worth a crash
+        return _asset_id(item)[:8] or "an unreadable candidate"
+
+
+def _described(item: object) -> str:
     clip = getattr(item, "clip", item)
     asset = getattr(clip, "asset", clip)
     when = getattr(asset, "file_created_at", None)
@@ -280,13 +293,26 @@ def _facts_of(item: object) -> str:
         value = getattr(source, attr, None)
         if value is not None:
             bits.append(f"{label}{value:g}" if isinstance(value, float) else f"{label}{value}")
-    return "  ".join(bits)
+    return "  ".join(str(bit) for bit in bits)
 
 
 def _is_favorite(item: object) -> bool:
     clip = getattr(item, "clip", item)
     asset = getattr(clip, "asset", clip)
     return bool(getattr(asset, "is_favorite", False))
+
+
+def path_from_env() -> Path | None:
+    """Where this run should write its trace, if the caller asked for one.
+
+    Read here rather than at each call site because two layers now open a
+    context — the CLI runner, so the pool's own filters are on the record, and
+    the pipeline, so a UI run still traces — and they must agree on the file.
+    """
+    import os
+
+    configured = os.environ.get("IMMICH_MEMORIES_SELECTION_TRACE")
+    return Path(configured) if configured else None
 
 
 def active() -> Trace | None:
@@ -349,12 +375,28 @@ class tracing:  # noqa: N801 - reads as a context manager at the call site
         self.path = path
         self.trace = Trace()
         self._token: Token[Trace | None] | None = None
+        self._joined = False
 
     def __enter__(self) -> Trace:
+        """Start a trace, or join the one already running.
+
+        The pipeline opens a context of its own, and stages that run before it
+        — the source-quality drop, the subject policy — can only be recorded
+        by a caller opening one earlier. Two independent traces would put those
+        stages in a report nobody writes out, so the inner context joins the
+        outer instead: one trace, one file, whichever layer asked first.
+        """
+        already = _active.get()
+        if already is not None:
+            self.trace = already
+            self._joined = True
+            return already
         self._token = _active.set(self.trace)
         return self.trace
 
     def __exit__(self, *_exc: object) -> None:
+        if self._joined:
+            return
         if self._token is not None:
             _active.reset(self._token)
         if self.path is not None:

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -423,8 +422,7 @@ class SmartPipeline:
         # WHY an environment variable rather than an argument: every caller of
         # this method — CLI, UI, scripts — would otherwise need a parameter it
         # does not use, to carry a debugging concern four layers down.
-        trace_path = os.environ.get("IMMICH_MEMORIES_SELECTION_TRACE")
-        with trace.tracing(Path(trace_path) if trace_path else None):
+        with trace.tracing(trace.path_from_env()):
             return self._run_selection(analyzed, verify=verify)
 
     def _run_selection(

--- a/src/immich_memories/cli/_candidate_pool.py
+++ b/src/immich_memories/cli/_candidate_pool.py
@@ -15,6 +15,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.analysis import selection_trace as trace
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -147,6 +149,7 @@ def _drop_reencoded_sources(candidates: list, *, config: Config) -> list:
             min_short_side=floor,
         )
     ]
+    trace.record("source quality", candidates, kept)
     if len(kept) < len(candidates):
         logger.info(
             "Source quality: dropped %d clips under %dp with no camera EXIF",
@@ -174,13 +177,15 @@ def _apply_subject_policy(
 
     from immich_memories.analysis.subject_policy import filter_candidates_by_subject
 
-    return filter_candidates_by_subject(
+    kept = filter_candidates_by_subject(
         candidates,
         animal_ratio=config.analysis.max_animal_ratio,
         object_ratio=config.analysis.max_object_ratio,
         content_budget_seconds=content_budget_seconds,
         photo_asset_ids={a.id for a in photo_assets or []},
     )
+    trace.record("subject policy", candidates, kept)
+    return kept
 
 
 def _drop_photos_already_shown_as_motion(

--- a/src/immich_memories/cli/_pipeline_runner.py
+++ b/src/immich_memories/cli/_pipeline_runner.py
@@ -261,6 +261,58 @@ class _AttemptPhaseReporter:
 
 
 @llm_metrics.collects
+def _pool_and_select(
+    pipeline,
+    analyzed_videos: list,
+    *,
+    phases,
+    photo_assets: list | None,
+    include_photos: bool,
+    use_live_photos: bool,
+    config,
+    client,
+    work_dir: Path,
+    dry_run: bool,
+    thumbnail_cache,
+    content_budget_seconds: float,
+) -> tuple[list, object]:
+    """Build the pool, then choose from it, with ONE trace over both.
+
+    The trace is opened here rather than inside `run_selection` because the
+    pool's own filters run before the pipeline is entered. Recorded from in
+    there they land in no context at all, which is how a stage that removed
+    eleven candidates — including a life-event photograph — stayed invisible
+    in the funnel across four renders. The pipeline still opens a context of
+    its own for callers that have not (the UI); nesting joins rather than
+    starting a second trace.
+    """
+    from immich_memories.analysis import selection_trace as trace
+    from immich_memories.operations.phases import OperationalPhase
+
+    with trace.tracing(trace.path_from_env()):
+        candidates = _merge_photos_into_pool(
+            analyzed_videos,
+            photo_assets=photo_assets,
+            include_photos=include_photos,
+            use_live_photos=use_live_photos,
+            config=config,
+            client=client,
+            work_dir=work_dir,
+            provider_circuit=pipeline.provider_circuit,
+            dry_run=dry_run,
+            thumbnail_cache=thumbnail_cache,
+        )
+        candidates = _drop_reencoded_sources(candidates, config=config)
+        candidates = _apply_subject_policy(
+            candidates,
+            config=config,
+            content_budget_seconds=content_budget_seconds,
+            photo_assets=photo_assets,
+        )
+        phases.emit(OperationalPhase.SELECTION, 0, len(candidates), "Selecting clips")
+        return candidates, pipeline.run_selection(candidates, verify=not dry_run)
+
+
 def run_pipeline_and_generate(
     *,
     assets: list,
@@ -427,31 +479,20 @@ def run_pipeline_and_generate(
         dry_run=dry_run,
     )
 
-    # Merge photos into the unified selection pool (if enabled)
-    all_candidates = _merge_photos_into_pool(
+    all_candidates, pipeline_result = _pool_and_select(
+        pipeline,
         analyzed_videos,
+        phases=phases,
         photo_assets=photo_assets,
         include_photos=include_photos,
         use_live_photos=use_live_photos,
         config=config,
         client=client,
         work_dir=output_path.parent,
-        provider_circuit=pipeline.provider_circuit,
         dry_run=dry_run,
         thumbnail_cache=thumbnail_cache,
-    )
-
-    all_candidates = _drop_reencoded_sources(all_candidates, config=config)
-    all_candidates = _apply_subject_policy(
-        all_candidates,
-        config=config,
         content_budget_seconds=timeline_plan.content_budget,
-        photo_assets=photo_assets,
     )
-
-    # Phase 4: Unified selection (videos + photos compete together)
-    phases.emit(OperationalPhase.SELECTION, 0, len(all_candidates), "Selecting clips")
-    pipeline_result = pipeline.run_selection(all_candidates, verify=not dry_run)
     _analysis_time = _time.monotonic() - _pipeline_start
     selected_clips = pipeline_result.selected_clips
     clip_segments = pipeline_result.clip_segments

--- a/tests/test_pool_stages_are_on_the_record.py
+++ b/tests/test_pool_stages_are_on_the_record.py
@@ -1,0 +1,108 @@
+"""The stages that run before the pipeline opens its own trace.
+
+The funnel report begins at the per-day photo cap because that is where
+`SmartPipeline.run_selection` opens its tracing context. Two stages run before
+it — the source-quality drop and the subject policy — and neither appears
+anywhere in the report. On one real month the subject policy removed eleven
+candidates (2 animal, 4 object, 5 screen) and the funnel could not name the
+stage, let alone the clips.
+
+That blind spot is where a life-event photograph was lost across four renders:
+the trace showed a clean funnel above it and the kill was in the dark.
+"""
+
+from __future__ import annotations
+
+from immich_memories.analysis import selection_trace as trace
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import VideoClipInfo
+from tests.conftest import make_asset
+
+
+def _candidate(asset_id: str, *, width: int = 1920, height: int = 1080, **asset_kwargs):
+    asset_kwargs.setdefault("original_file_name", f"{asset_id}.MOV")
+    asset = make_asset(asset_id, **asset_kwargs)
+    asset.width, asset.height = width, height
+    clip = VideoClipInfo(asset=asset, duration_seconds=4.0, width=width, height=height)
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.5)
+
+
+class TestOneTracePerRun:
+    def test_a_nested_context_joins_the_trace_already_open(self, tmp_path):
+        """The pipeline opens its own context inside the runner's.
+
+        Recording a pool stage is worthless if the pipeline then starts a
+        second trace and writes only that one out: the stage lands in a trace
+        nobody reads, and the report looks exactly as it does today.
+        """
+        outer, inner = tmp_path / "outer.md", tmp_path / "inner.md"
+        kept, lost = _candidate("kept"), _candidate("lost")
+
+        with trace.tracing(outer), trace.tracing(inner):
+            trace.record("a stage inside the pipeline", [kept, lost], [kept])
+
+        assert "a stage inside the pipeline" in outer.read_text()
+        assert not inner.exists()
+
+
+class TestThePoolStagesSayWhatTheyTook:
+    def test_the_source_quality_drop_names_what_it_dropped(self, tmp_path):
+        """A messaging re-encode leaves the pool before selection starts."""
+        from immich_memories.cli._candidate_pool import _drop_reencoded_sources
+        from immich_memories.config import Config
+
+        kept = _candidate("from-the-camera")
+        forwarded = _candidate("forwarded", width=640, height=480, exif_make=None, exif_model=None)
+        report_path = tmp_path / "trace.md"
+
+        with trace.tracing(report_path):
+            survivors = _drop_reencoded_sources([kept, forwarded], config=Config())
+
+        assert [c.clip.asset.id for c in survivors] == ["from-the-camera"]
+        report = report_path.read_text()
+        assert "source quality" in report
+        assert "forwarded.MOV" in report
+
+    def test_the_subject_policy_names_what_it_dropped(self, tmp_path):
+        """The stage a life-event photograph died in, four renders running."""
+        from immich_memories.cli._candidate_pool import _apply_subject_policy
+        from immich_memories.config import Config
+
+        pool = [_candidate(f"person-{n}") for n in range(3)]
+        for member in pool:
+            member.clip.llm_category = "people"
+            member.score = 0.8
+        screen = _candidate("a-screenshot")
+        screen.clip.llm_category = "screen"
+        screen.score = 0.5
+        report_path = tmp_path / "trace.md"
+
+        with trace.tracing(report_path):
+            survivors = _apply_subject_policy(
+                [*pool, screen], config=Config(), content_budget_seconds=60.0
+            )
+
+        assert "a-screenshot" not in {c.clip.asset.id for c in survivors}
+        report = report_path.read_text()
+        assert "subject policy" in report
+        assert "a-screenshot.MOV" in report
+
+
+class TestTheTraceNeverTakesTheRunDown:
+    def test_a_candidate_it_cannot_describe_is_still_recorded(self, tmp_path):
+        """Diagnostics may describe something badly; they may not raise.
+
+        Now that the pool's stages record, the trace sees candidates far
+        earlier and from more call sites than the funnel ever did.
+        """
+        from unittest.mock import MagicMock
+
+        report_path = tmp_path / "trace.md"
+
+        with trace.tracing(report_path):
+            # WHY MagicMock: stands in for any candidate whose fields are not
+            # the types the account assumes — the boundary being replaced is
+            # "an object the trace has never seen before".
+            trace.record("a stage", [MagicMock()], [])
+
+        assert "a stage" in report_path.read_text()


### PR DESCRIPTION
The funnel report begins at the per-day photo cap, because that is where
`run_selection` opens its tracing context. Two stages run before it — the
source-quality drop and the subject policy — and neither appeared anywhere in
the report.

On one real month the subject policy removed **85 candidates, 13 of them
starred**, and the funnel could not name the stage, let alone the clips. That
blind spot is where a life-event photograph was lost across four renders: the
trace showed a clean funnel above the kill.

## Recording from those stages was not enough on its own

`trace.record` is a no-op with no active context, and the only context was
opened by `run_selection` — *after* the pool filters had already run. A call
added inside `_candidate_pool` would have compiled, passed a unit test on the
helper, and recorded nothing in production.

So the CLI runner now opens the trace around the pool build and the selection
together, and `tracing` **joins** a context already open instead of starting a
second one. One trace, one file, whichever layer asked first. The UI path,
which has no outer context, still opens its own.

## Two consequences worth naming in review

- `_pool_and_select` extracts four statements out of `run_pipeline_and_generate`
  so the new `with` does not deepen a function that is already long. The
  runner's own complexity goes **down**, not up.
- The account now meets candidates far earlier and from more call sites than
  the funnel ever did, and it met objects whose fields are not the types it
  assumed. A trace is diagnostic: it may describe a candidate poorly, it may
  never take a run down with it. `_facts_of` falls back to naming the clip.

## Verification

`make ci` green. The instrumentation is what exposed the 13-favourites finding
now recorded in #764 — it paid for itself within the hour.

Stacked on #763. Part of #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL
