### PR TITLE
refactor(review): the judge answers with the cut, and its answer stands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ The four core orchestrators and their composed services:
 - `PreviewBuilder` (preview_builder.py): extract preview segments
 - `ClipRefiner` (clip_refiner.py): select and distribute final clips
 - `ClipScaler` (clip_scaler.py): scale to target duration, deduplicate
-- `SelectionQuality` (selection_quality.py): verify, judge and review the finished cut
+- `SelectionQuality` (selection_quality.py): verify, judge, and make the cut
 
 It also owns a `ProviderCircuit` (provider_health.py, LLM provider circuit breaker) and an
 optional `VideoDownloadCache`. The density-proportional asset budget is a plain function,
@@ -125,8 +125,8 @@ src/immich_memories/
 │   ├── clip_analyzer.py        # ClipAnalyzer: download + analyze + score
 │   ├── clip_refiner.py         # ClipRefiner: final selection + distribution
 │   ├── clip_scaler.py          # ClipScaler: duration scaling + dedup
-│   ├── selection_quality.py    # SelectionQuality: verify + judge + review
-│   ├── selection_review.py     # LLM holistic pass over the finished cut: redundant / clashing clips
+│   ├── selection_quality.py    # SelectionQuality: verify + judge + cut
+│   ├── selection_review.py     # LLM holistic pass that MAKES the cut: which clips belong, which do not
 │   ├── selection_trace.py      # Per-stage funnel record: what each filter received and let through
 │   ├── clip_selection.py       # Standalone clip selection functions
 │   ├── clip_distribution.py    # Which periods make the cut (per-period caps, applied after ranking)

--- a/docs-site/docs/create/pipeline/pipeline-overview.md
+++ b/docs-site/docs/create/pipeline/pipeline-overview.md
@@ -410,9 +410,15 @@ Read that again: on a warm run, the analysis the pipeline is named after costs
 two seconds. Everything else is waiting on someone else's HTTP.
 
 The 11 calls are not per-clip analysis — that is all cached. They are the
-selection loop: each holistic review pass, plus each verify pass that hits a
-clip with no LLM description. `max_refinement_passes` is 10 and every round can
-cost a review call, so that bound is the main dial, and it is one you can turn.
+selection loop: verify passes that hit a clip with no LLM description, and the
+holistic review.
+
+That measurement predates the review answering with the cut. It used to veto a
+finished selection a couple of clips at a time, refill the gap, and run again
+because the refill had never been judged — so `max_refinement_passes` (10)
+bounded a review call per round, and most of those 11 calls were the same
+question asked over and over. The review now makes the cut in one pass. The
+bound still applies to verifying, which is where a cold pool spends its calls.
 
 ### What to actually do about it
 
@@ -426,10 +432,11 @@ If warm runs feel slow:
    server, or a smaller model, cuts the largest single line item without
    touching anything else. This is the highest-leverage change available.
 2. **Ask for fewer rounds.** `--refinement-passes 3`, or
-   `advanced.analysis.max_refinement_passes: 3` in YAML, caps the loop at three
-   rounds instead of ten. That is what `preset: fast` sets, and the flag's own
-   help calls it the biggest dial on warm-run time. The cost is that a late
-   refill may ship less scrutinised than the clips around it.
+   `advanced.analysis.max_refinement_passes: 3` in YAML, caps the verify loop
+   at three rounds instead of ten. That is what `preset: fast` sets. The cost
+   is that a clip admitted late may reach the review undescribed, and the
+   review is told never to judge a clip on missing information — so it ships
+   without ever facing the only quality judgment in the pipeline.
 3. **Turn `content_analysis.enabled` off.** No LLM at all: no per-clip content
    analysis, no reviewer, no verify calls. Selection falls back to vision, audio
    and metadata, which is the default configuration anyway.

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -232,25 +232,34 @@ class SelectionQuality:
             result = self.refiner.phase_refine(list(by_id.values()), self.tracker)
         return [u for u in unverified if not looks_like_a_photograph(u.clip.asset)], result
 
-    def final_review_drop(
+    def cut(
         self,
         analyzed: list[ClipWithSegment],
         result: PipelineResult,
     ) -> tuple[PipelineResult, list[ClipWithSegment]]:
-        """One last review that drops without refilling.
+        """The one holistic pass, and its answer stands (#764).
 
-        The iterating review always leaves its own last refill unjudged: it
-        stops when the budget runs out, and by then it has just re-selected.
-        Refilling again would only admit more unseen clips, so this pass takes
-        the cut it has and removes what does not belong.
+        This used to be two methods and a loop. The review vetoed a finished
+        cut — at most a fifth of it per round — then selection refilled the
+        gap, and the refill had never been judged, so the whole thing ran
+        again. One real month took eight rounds to remove what the first round
+        had already named, and a clip it named three rounds running was capped
+        away twice before it went.
 
-        It looks at them first. The review is told — correctly — never to drop
-        a clip for missing information, since a third of a real pool has no
-        analysis yet and treating silence as a verdict would gut the memory.
-        The cost of that rule is that an unanalysed clip is immune to the only
-        quality judgment in the pipeline, and a rendered year recap shipped
-        whiteboards and desks on exactly that immunity. Nothing is judged
-        blind, so the rule never has to protect anything that shipped.
+        The pass now makes the cut. What it removes is not replaced: a memory
+        four seconds short beats one topped up with whatever ranked next,
+        which was where a games console and a shelf came from.
+
+        It looks at everything first. The review is told — correctly — never
+        to drop a clip for missing information, since a third of a real pool
+        has no analysis yet and treating silence as a verdict would gut the
+        memory. The cost of that rule is that an unanalysed clip is immune to
+        the only quality judgment in the pipeline. Nothing is judged blind, so
+        the rule never has to protect anything that ships.
+
+        The pool comes back whole. Only the cut changed, and every clip left
+        out of it has its reason on the record — the material is still there
+        for a later pass to reconsider.
         """
         if not self._app_config.content_analysis.enabled:
             return result, analyzed
@@ -267,17 +276,19 @@ class SelectionQuality:
             unreadable_ids=self._unreadable_ids(selected),
         )
         drops = set(verdict.drops)
-        if not drops:
-            trace.record("final review", selected, selected, verdict.fates)
+        kept = [c for c in result.selected_clips if c.asset.id not in drops]
+        if not drops or not kept:
+            trace.record("llm review", selected, selected, verdict.fates)
             return result, analyzed
 
-        kept = [c for c in result.selected_clips if c.asset.id not in drops]
-        if not kept:
-            return result, analyzed
         logger.info(
-            "Selection review: budget spent, dropping %d unreviewed clip(s) "
-            "rather than shipping them",
-            len(result.selected_clips) - len(kept),
+            "Selection review: the cut is %d clip(s) of %d", len(kept), len(result.selected_clips)
+        )
+        trace.record(
+            "llm review",
+            selected,
+            [c for c in selected if c.clip.asset.id not in drops],
+            verdict.fates,
         )
         trimmed = replace(
             result,
@@ -288,7 +299,7 @@ class SelectionQuality:
                 if asset_id not in drops
             },
         )
-        return trimmed, [c for c in analyzed if c.clip.asset.id not in drops]
+        return trimmed, analyzed
 
     def _unreadable_ids(self, selected: list[ClipWithSegment]) -> frozenset[str]:
         """Clips verification has already tried, and still cannot describe.
@@ -433,46 +444,3 @@ class SelectionQuality:
         ):
             offenders.add(ending.clip.asset.id)
         return offenders
-
-    def review(
-        self,
-        analyzed: list[ClipWithSegment],
-        result: PipelineResult,
-    ) -> tuple[PipelineResult, list[ClipWithSegment], bool]:
-        """One LLM pass over the finished cut (#468): redundancy and feel.
-
-        The mechanical judge sees scores; only something reading the
-        descriptions can see the same birthday candles twice. Optional by
-        construction — no LLM, no drops, selection unchanged.
-        """
-        if not self._app_config.content_analysis.enabled:
-            return result, analyzed, False
-        from immich_memories.analysis.selection_review import review_selection
-
-        by_id = {c.clip.asset.id: c for c in analyzed}
-        selected = [by_id[c.asset.id] for c in result.selected_clips if c.asset.id in by_id]
-        verdict = review_selection(
-            selected,
-            self._app_config.llm,
-            cache_path=self._verdicts,
-            unreadable_ids=self._unreadable_ids(selected),
-        )
-        if not verdict.drops:
-            # The ledger goes in even when nothing was dropped: "nothing to
-            # drop" and "everything it named was vetoed" are different, and
-            # they used to look identical from outside.
-            trace.record("llm review", selected, selected, verdict.fates)
-            return result, analyzed, False
-        dropped = set(verdict.drops)
-        trace.record(
-            "llm review",
-            selected,
-            [c for c in selected if c.clip.asset.id not in dropped],
-            verdict.fates,
-        )
-        remaining = [c for c in analyzed if c.clip.asset.id not in dropped]
-        if not remaining:
-            return result, analyzed, False
-        # WHY the pool shrinks too: a later stabilization re-refines from the
-        # pool — returning the old one would resurrect the LLM's drops.
-        return self.refiner.phase_refine(remaining, self.tracker), remaining, True

--- a/src/immich_memories/analysis/selection_quality.py
+++ b/src/immich_memories/analysis/selection_quality.py
@@ -275,6 +275,15 @@ class SelectionQuality:
             cache_path=self._verdicts,
             unreadable_ids=self._unreadable_ids(selected),
         )
+        if verdict.unanswered:
+            # The pass is fail-open and it is the only quality judgment left.
+            # Without this the trace reads "llm review, 0 dropped", which is
+            # what an approved cut looks like — and the whole uncut selection
+            # ships in silence.
+            trace.warn(
+                f"the fine cut never ran — {verdict.unanswered}. "
+                "Nothing was cut; this is NOT an approved cut."
+            )
         drops = set(verdict.drops)
         kept = [c for c in result.selected_clips if c.asset.id not in drops]
         if not drops or not kept:
@@ -289,6 +298,7 @@ class SelectionQuality:
             selected,
             [c for c in selected if c.clip.asset.id not in drops],
             verdict.fates,
+            verdict.reasons,
         )
         trimmed = replace(
             result,

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -266,14 +266,25 @@ def _clip_line(
 
 @dataclass(frozen=True)
 class ReviewVerdict:
-    """The drops that were carried out, and one line per entry saying why.
+    """The cut that was carried out, one line per entry saying why, and
+    whether a verdict exists at all.
 
     Returned rather than logged alone so the trace can carry the ledger into
     the file a rejection is diagnosed from.
+
+    `unanswered` is the field that separates "the model read the set and
+    approved it" from "the model never answered" — identical from outside for
+    as long as this pass has existed, and now the difference between a cut and
+    a whole uncut selection shipping in silence.
+
+    `reasons` is what the model said about each clip it actually cut, keyed by
+    asset id, so the account can answer the question it asks.
     """
 
     drops: list[str] = field(default_factory=list)
     fates: list[str] = field(default_factory=list)
+    reasons: dict[str, str] = field(default_factory=dict)
+    unanswered: str | None = None
 
 
 def _clips_block(
@@ -431,7 +442,7 @@ def review_selection(
     """
     if len(selected) < 3:
         logger.debug("Selection review: %d clips is too few to judge as a set", len(selected))
-        return ReviewVerdict()
+        return ReviewVerdict(unanswered=f"{len(selected)} clips is too few to judge as a set")
     clips_block = _clips_block(selected, unreadable_ids)
     prompt = _PROMPT.format(clips=clips_block)
     try:
@@ -439,7 +450,7 @@ def review_selection(
     except Exception as e:  # WHY broad: the review is optional; never break selection
         stop_if_this_is_our_bug(e, "selection review")
         logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
-        return ReviewVerdict()
+        return ReviewVerdict(unanswered=f"the model was unavailable ({type(e).__name__})")
 
     entries = _the_cut_in(raw, len(selected))
     if entries is None:
@@ -450,7 +461,7 @@ def review_selection(
             len(raw) if raw else 0,
             UNREADABLE_VERDICT_MARKER,
         )
-        return ReviewVerdict()
+        return ReviewVerdict(unanswered="the model's answer could not be read")
     verdict = _apply(entries, selected)
     for fate in verdict.fates:
         logger.info("Selection review: %s", fate)
@@ -496,12 +507,14 @@ def _apply(entries: list, selected: list[ClipWithSegment]) -> ReviewVerdict:
 
     drops: list[str] = []
     fates: list[str] = []
+    reasons: dict[str, str] = {}
     for entry in entries:
         dropped, fate = _fate_of(entry, selected, episodes, stars_left, plain_left, drops)
         fates.append(fate)
         if dropped is not None:
             drops.append(dropped)
-    return ReviewVerdict(drops=drops, fates=fates)
+            reasons[dropped] = str(entry.get("reason", "no reason given"))
+    return ReviewVerdict(drops=drops, fates=fates, reasons=reasons)
 
 
 def _fate_of(

--- a/src/immich_memories/analysis/selection_review.py
+++ b/src/immich_memories/analysis/selection_review.py
@@ -28,10 +28,6 @@ from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
 
 logger = logging.getLogger(__name__)
 
-# An overeager model must not gut the video: at most this share of the
-# selection can be dropped in one review, never below one allowed drop.
-_MAX_DROP_RATIO = 0.2
-
 # Enough room that the model answers rather than narrating; see _ask.
 _REVIEW_MAX_TOKENS = 8000
 
@@ -142,9 +138,13 @@ cannot be judged on what it shows and cannot answer the question. Shipping
 something nobody can describe is worse than a shorter memory: drop it unless
 the rest of the line gives you a reason to keep it.
 
-Most good selections need no changes. Answer with STRICT JSON only, no prose:
-{{"drop": [{{"index": <clip number>, "reason": "<short reason>"}}]}}
-Use an empty list when the set is good."""
+You are MAKING the cut, not vetoing one. Say which clips belong in the
+memory and which do not. Every clip must appear exactly once, in one list or
+the other. Keeping all of them is a legitimate answer when the set is good.
+
+Answer with STRICT JSON only, no prose:
+{{"keep": [<clip numbers>],
+ "cut": [{{"index": <clip number>, "reason": "<short reason>"}}]}}"""
 
 
 def _ask(
@@ -324,8 +324,8 @@ def _episode_labels(selected: list[ClipWithSegment]) -> list[str]:
     return [by_asset.get(m.clip.asset.id, "E?") for m in selected]
 
 
-def _verdict_in(raw: str | None) -> list | None:
-    r"""The drop list the model actually produced, or None if it produced none.
+def _the_cut_in(raw: str | None, clip_count: int) -> list | None:
+    r"""The clips the model cut, or None if it never answered the question.
 
     Not re.search(r"\{.*\}") over the whole answer. The prompt shows the model
     the shape it wants, and a model reasoning aloud quotes that shape back —
@@ -344,9 +344,47 @@ def _verdict_in(raw: str | None) -> list | None:
             payload = json.loads(candidate)
         except json.JSONDecodeError:
             continue
-        if isinstance(payload, dict) and isinstance(payload.get("drop"), list):
-            return payload["drop"]
+        entries = _accounted_for(payload, clip_count)
+        if entries is not None:
+            return entries
     return None
+
+
+def _accounted_for(payload: object, clip_count: int) -> list | None:
+    """The cut entries, but only if the answer accounts for every clip once.
+
+    Under keep-semantics silence is a kill, so the failure that used to cost a
+    verdict now costs a memory: an answer truncated after four kept clips would
+    cut everything it never reached. Requiring the two lists to partition
+    1..N turns truncation back into a parse failure, which the pass already
+    knows how to survive — it drops nothing and says the answer was unreadable.
+
+    It is also the cheapest check that the model answered about THIS cut. A
+    keep list of five against fourteen clips is not a strict edit; it is an
+    answer to some other question.
+    """
+    if not isinstance(payload, dict):
+        return None
+    keep, cut = payload.get("keep"), payload.get("cut")
+    if not isinstance(keep, list) or not isinstance(cut, list):
+        return None
+    if not keep:
+        # A memory with nothing in it is not an edit, whatever the model meant
+        # by it. Refusing here rather than downstream keeps the reason with
+        # the answer: this pass could not be read, so nothing was cut.
+        return None
+    kept = [n for n in keep if _is_a_clip_number(n)]
+    numbered = [entry.get("index") for entry in cut if isinstance(entry, dict)]
+    dropped = [n for n in numbered if _is_a_clip_number(n)]
+    if len(kept) != len(keep) or len(dropped) != len(cut):
+        return None
+    if sorted(kept + dropped) != list(range(1, clip_count + 1)):
+        return None
+    return cut
+
+
+def _is_a_clip_number(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _balanced_objects(text: str) -> list[str]:
@@ -403,7 +441,7 @@ def review_selection(
         logger.warning("Selection review unavailable (%s): nothing dropped", type(e).__name__)
         return ReviewVerdict()
 
-    entries = _verdict_in(raw)
+    entries = _the_cut_in(raw, len(selected))
     if entries is None:
         logger.warning(
             "Selection review: could not read a verdict from %d chars — nothing dropped. "
@@ -444,7 +482,6 @@ def _apply(entries: list, selected: list[ClipWithSegment]) -> ReviewVerdict:
     """
     from collections import Counter
 
-    max_drops = max(1, int(len(selected) * _MAX_DROP_RATIO))
     episodes = _episode_labels(selected)
     stars_left = Counter(
         episode
@@ -460,9 +497,7 @@ def _apply(entries: list, selected: list[ClipWithSegment]) -> ReviewVerdict:
     drops: list[str] = []
     fates: list[str] = []
     for entry in entries:
-        dropped, fate = _fate_of(
-            entry, selected, episodes, stars_left, plain_left, drops, max_drops
-        )
+        dropped, fate = _fate_of(entry, selected, episodes, stars_left, plain_left, drops)
         fates.append(fate)
         if dropped is not None:
             drops.append(dropped)
@@ -470,28 +505,27 @@ def _apply(entries: list, selected: list[ClipWithSegment]) -> ReviewVerdict:
 
 
 def _fate_of(
-    entry: object,
+    entry: dict,
     selected: list[ClipWithSegment],
     episodes: list[str],
     stars_left: dict[str, int],
     plain_left: dict[str, int],
     drops: list[str],
-    max_drops: int,
 ) -> tuple[str | None, str]:
-    """What becomes of one verdict entry, and the line that says so."""
-    index = entry.get("index") if isinstance(entry, dict) else None
-    reason = entry.get("reason", "no reason given") if isinstance(entry, dict) else "unreadable"
-    if not isinstance(index, int) or isinstance(index, bool):
-        return None, f"clip {index!r}: not a clip number, ignored ({reason})"
-    if not 1 <= index <= len(selected):
-        return None, f"clip {index}: no such clip in the cut, ignored ({reason})"
+    """What becomes of one cut entry, and the line that says so.
 
+    The entry is known good: an answer only reaches here once its two lists
+    account for every clip exactly once, so the index is an integer naming a
+    clip in this cut. An answer that names clip 99 is not a cut with one bad
+    line in it — it is an answer about some other set of clips, and the parser
+    refuses the whole of it.
+    """
+    index = entry["index"]
+    reason = entry.get("reason", "no reason given")
     member = selected[index - 1]
     asset_id = member.clip.asset.id
     if asset_id in drops:
-        return None, f"{asset_id}: named twice, already dropped ({reason})"
-    if len(drops) >= max_drops:
-        return None, f"{asset_id}: kept — cap of {max_drops} drop(s) this round reached ({reason})"
+        return None, f"{asset_id}: named twice, already cut ({reason})"
 
     episode = episodes[index - 1]
     if getattr(member.clip.asset, "is_favorite", False):

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -41,6 +41,8 @@ class ClipStory:
     survived: tuple[str, ...]
     dropped_at: str | None
     admitted_at: str | None
+    # Why the stage that dropped it did so, when that stage said.
+    reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -58,6 +60,10 @@ class Stage:
     kept_ids: tuple[str, ...] = ()
     lost_ids: tuple[str, ...] = ()
     gained_ids: tuple[str, ...] = ()
+    # Per-clip reasons, where the stage had one to give. `reasons` above is
+    # the stage's own narration; this is what it said about a named clip, and
+    # it is what the account can answer "why is that not in there" with.
+    notes: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -74,6 +80,10 @@ class Trace:
     # the pool passed through. Re-set by each re-selection, so the value that
     # survives is the one the verify passes left behind (#489).
     coverage: AnalysisCoverage | None = None
+    # Things a reader must not miss, printed above the funnel. A pass that
+    # could not run is the one this exists for: "0 dropped" has meant both
+    # "approved" and "never answered" for as long as the review has existed.
+    warnings: list[str] = field(default_factory=list)
 
     def record(
         self,
@@ -81,6 +91,7 @@ class Trace:
         before: Iterable,
         after: Iterable,
         reasons: list[str] | None = None,
+        notes: dict[str, str] | None = None,
     ) -> None:
         """Note that `name` turned `before` into `after`."""
         before_list, after_list = list(before), list(after)
@@ -97,6 +108,7 @@ class Trace:
                 favorites_in=sum(_is_favorite(i) for i in before_list),
                 favorites_out=sum(_is_favorite(i) for i in after_list),
                 reasons=reasons or [],
+                notes=dict(notes or {}),
                 kept_ids=tuple(sorted(after_ids)),
                 lost_ids=tuple(_asset_id(i) for i in lost),
                 gained_ids=tuple(sorted(after_ids - before_ids)),
@@ -120,11 +132,13 @@ class Trace:
         survived: list[str] = []
         dropped_at: str | None = None
         admitted_at: str | None = None
+        reason: str | None = None
         for stage in self.stages:
             if asset_id in stage.gained_ids:
                 admitted_at = stage.name
             if asset_id in stage.lost_ids:
                 dropped_at = stage.name
+                reason = stage.notes.get(asset_id)
                 survived = []
             elif asset_id in stage.kept_ids:
                 survived.append(stage.name)
@@ -136,6 +150,7 @@ class Trace:
             survived=tuple(survived),
             dropped_at=None if shipped else dropped_at,
             admitted_at=admitted_at,
+            reason=None if shipped else reason,
         )
 
     def _favourite_law_lines(self) -> list[str]:
@@ -160,6 +175,7 @@ class Trace:
             return "No selection stages were recorded.\n"
         width = max(len(s.name) for s in self.stages)
         lines = [
+            *self._warning_lines(),
             *self._coverage_lines(),
             *self._favourite_law_lines(),
             f"{'stage'.ljust(width)}  {'kept':>5} {'lost':>5}  {'favorites':>12}",
@@ -201,13 +217,20 @@ class Trace:
         for asset_id in {i for stage in self.stages for i in stage.lost_ids}:
             story = self.story_of(asset_id)
             if not story.shipped and story.dropped_at is not None:
-                by_stage.setdefault(story.dropped_at, []).append(story.facts)
+                said = f"{story.facts}  — {story.reason}" if story.reason else story.facts
+                by_stage.setdefault(story.dropped_at, []).append(said)
         if not by_stage:
             return []
         lines = ["", "and why the rest are not", "-" * 24]
         for stage in (s.name for s in self.stages):
             lines += _dropped_at(stage, sorted(by_stage.pop(stage, [])))
         return lines
+
+    def _warning_lines(self) -> list[str]:
+        """What a reader must see before anything else in the report."""
+        if not self.warnings:
+            return []
+        return [*(f"!! {warning}" for warning in self.warnings), ""]
 
     def _coverage_lines(self) -> list[str]:
         """The pool's coverage, above the funnel — it frames everything below."""
@@ -221,6 +244,7 @@ class Trace:
 
     def as_dict(self) -> dict:
         return {
+            "warnings": self.warnings.copy(),
             "coverage": (
                 None
                 if self.coverage is None
@@ -234,6 +258,7 @@ class Trace:
                     "favorites_in": s.favorites_in,
                     "favorites_out": s.favorites_out,
                     "reasons": s.reasons,
+                    "notes": s.notes,
                     "kept_ids": list(s.kept_ids),
                     "lost_ids": list(s.lost_ids),
                     "gained_ids": list(s.gained_ids),
@@ -325,11 +350,19 @@ def record(
     before: Iterable,
     after: Iterable,
     reasons: list[str] | None = None,
+    notes: dict[str, str] | None = None,
 ) -> None:
     """Record a stage when tracing is on; do nothing when it is not."""
     trace = _active.get()
     if trace is not None:
-        trace.record(name, before, after, reasons)
+        trace.record(name, before, after, reasons, notes)
+
+
+def warn(message: str) -> None:
+    """Put something above the funnel that a reader must not miss."""
+    trace = _active.get()
+    if trace is not None:
+        trace.warnings.append(message)
 
 
 def record_coverage(coverage: AnalysisCoverage) -> None:

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -439,26 +439,11 @@ class SmartPipeline:
             result = self.refiner.phase_refine(analyzed, self.tracker)
             if verify:
                 result, analyzed = self.quality.stabilize(analyzed, result)
-                # WHY a loop: one review pass drops what it can see, and the
-                # refill puts new clips in their place that nothing has looked
-                # at yet. Reviewing once leaves whatever the last refill
-                # admitted unjudged, which is how a product shot survived a
-                # cut that had already dropped two others.
-                review_changed = True
-                for _ in range(max(1, self.config.max_refinement_passes)):
-                    result, analyzed, review_changed = self.quality.review(analyzed, result)
-                    if not review_changed:
-                        break
-                    # The review's re-selection can admit new fallback clips,
-                    # exactly like a judge drop — same stabilization.
-                    result, analyzed = self.quality.stabilize(analyzed, result)
-                if review_changed:
-                    # Every pass so far dropped something and refilled, so the
-                    # last refill has never been looked at — which is how a
-                    # photo of a games console ended a December cut. Judge it
-                    # once more and simply drop what fails: a cut four seconds
-                    # short beats a cut that ends on a shelf.
-                    result, analyzed = self.quality.final_review_drop(analyzed, result)
+                # One pass, and its answer is the cut. The loop this replaces
+                # existed because the review vetoed a finished selection and
+                # the refill it triggered had never been judged; a pass that
+                # makes the cut has nothing to iterate towards.
+                result, analyzed = self.quality.cut(analyzed, result)
             trace.record_favourite_law(pool, result.selected_clips)
             self.tracker.finish()
             return result

--- a/tests/test_pipeline_efficiency.py
+++ b/tests/test_pipeline_efficiency.py
@@ -511,12 +511,13 @@ class TestNothingIsJudgedBlind:
             ),
         )
 
-    def test_the_last_review_sees_every_clip_it_is_asked_to_judge(self, tmp_path: Path) -> None:
-        """The refinement loop stops on its budget with its last refill unjudged.
+    def test_the_review_sees_every_clip_it_is_asked_to_judge(self, tmp_path: Path) -> None:
+        """A clip reaching the pass undescribed is immune to it.
 
-        Those clips arrived at the final review with a bare line — date,
-        place, score and nothing else — and survived on the very rule that
-        protects genuinely unanalysed material.
+        It arrives as a bare line — date, place, score and nothing else — and
+        survives on the very rule that protects genuinely unanalysed material.
+        The pass looks at everything first so the rule never has to protect
+        anything that ships.
         """
         from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineResult
 
@@ -545,7 +546,7 @@ class TestNothingIsJudgedBlind:
 
         # WHY: the review is an LLM call; what it is handed is the subject here.
         with patch("immich_memories.analysis.selection_review.review_selection", _capture):
-            pipeline.quality.final_review_drop([member], result)
+            pipeline.quality.cut([member], result)
 
         assert [c.clip.llm_description for c in judged] == [
             "a whiteboard covered in sticky notes"

--- a/tests/test_review_drops_are_applied.py
+++ b/tests/test_review_drops_are_applied.py
@@ -41,11 +41,19 @@ def _clip(asset_id: str, *, minutes: float = 0.0, starred: bool = False) -> Clip
     return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.5)
 
 
-def _verdict(*entries: dict) -> str:
-    return json.dumps({"drop": list(entries)})
+def _verdict(selection: list, *entries: dict) -> str:
+    """The model's answer: which clips belong, and which do not.
+
+    The keep list is derived from the entries a test names, because the parser
+    refuses any answer whose two lists do not account for every clip.
+    """
+    named = {entry["index"] for entry in entries}
+    keep = [n for n in range(1, len(selection) + 1) if n not in named]
+    return json.dumps({"keep": keep, "cut": list(entries)})
 
 
-def _review(selection, raw):
+def _review(selection, *entries: dict):
+    raw = _verdict(selection, *entries)
     # WHY: the model. Everything under test is what we do with its answer.
     with patch("immich_memories.analysis.selection_review._ask", return_value=raw):
         return review_selection(selection, LLMConfig())
@@ -60,7 +68,7 @@ class TestTheStarredBattleIsActuallyFought:
             _clip("elsewhere", minutes=6000),
         ]
 
-        verdict = _review(selection, _verdict({"index": 2, "reason": "same occasion as clip 1"}))
+        verdict = _review(selection, {"index": 2, "reason": "same occasion as clip 1"})
 
         assert verdict.drops == ["star-b"]
 
@@ -79,7 +87,7 @@ class TestTheStarredBattleIsActuallyFought:
             _clip("elsewhere", minutes=6000),
         ]
 
-        verdict = _review(selection, _verdict({"index": 2, "reason": "same occasion as clip 1"}))
+        verdict = _review(selection, {"index": 2, "reason": "same occasion as clip 1"})
 
         assert verdict.drops == []
         assert any("star-b" in fate and "kept" in fate for fate in verdict.fates)
@@ -104,10 +112,8 @@ class TestTheStarredBattleIsActuallyFought:
 
         verdict = _review(
             selection,
-            _verdict(
-                {"index": 1, "reason": "one place for the occasion"},
-                {"index": 2, "reason": "one place for the occasion"},
-            ),
+            {"index": 1, "reason": "one place for the occasion"},
+            {"index": 2, "reason": "one place for the occasion"},
         )
 
         assert verdict.drops == []
@@ -123,7 +129,7 @@ class TestTheStarredBattleIsActuallyFought:
             _clip("elsewhere", minutes=6000),
         ]
 
-        verdict = _review(selection, _verdict({"index": 1, "reason": "not worth showing"}))
+        verdict = _review(selection, {"index": 1, "reason": "not worth showing"})
 
         assert verdict.drops == []
         assert any("only-star" in fate and "kept" in fate for fate in verdict.fates)
@@ -140,10 +146,8 @@ class TestTheLedgerNamesWhatActuallyHappened:
 
         verdict = _review(
             selection,
-            _verdict(
-                {"index": 1, "reason": "vetoed one"},
-                {"index": 2, "reason": "the real drop"},
-            ),
+            {"index": 1, "reason": "vetoed one"},
+            {"index": 2, "reason": "the real drop"},
         )
 
         assert verdict.drops == ["plain"]
@@ -151,22 +155,20 @@ class TestTheLedgerNamesWhatActuallyHappened:
         assert len(applied) == 1
         assert "the real drop" in applied[0]
 
-    def test_an_out_of_range_index_is_reported(self):
+    def test_an_answer_naming_a_clip_that_is_not_there_is_refused_whole(self, caplog):
+        """Not one bad line in a good cut — an answer about some other set.
+
+        Under keep-semantics an index nothing can be placed against breaks the
+        guarantee the pass rests on: that the two lists account for every clip.
+        Carrying out the rest of it would act on part of an answer to a
+        question nobody asked.
+        """
+        import logging
+
         selection = [_clip(f"c{n}", minutes=n * 6000) for n in range(3)]
 
-        verdict = _review(selection, _verdict({"index": 99, "reason": "off the end"}))
+        with caplog.at_level(logging.WARNING, logger="immich_memories.analysis.selection_review"):
+            verdict = _review(selection, {"index": 99, "reason": "off the end"})
 
         assert verdict.drops == []
-        assert any("99" in fate for fate in verdict.fates)
-
-    def test_the_cap_says_when_it_bites(self):
-        """At most a fifth of the cut per round — silently, until now."""
-        selection = [_clip(f"c{n}", minutes=n * 6000) for n in range(5)]
-
-        verdict = _review(
-            selection,
-            _verdict(*[{"index": n, "reason": f"drop {n}"} for n in range(1, 5)]),
-        )
-
-        assert len(verdict.drops) == 1
-        assert any("cap" in fate.lower() for fate in verdict.fates)
+        assert any(record.levelno >= logging.WARNING for record in caplog.records)

--- a/tests/test_review_parsing.py
+++ b/tests/test_review_parsing.py
@@ -72,11 +72,13 @@ def test_a_verdict_buried_in_reasoning_prose_is_found() -> None:
 
 def test_a_verdict_after_prose_is_read() -> None:
     """A response that reasons aloud and then answers must be read."""
+    keep = list(range(1, 14))
     answer = (
         "Here is a thinking process:\n\n1. The format is "
-        '{"drop": [{"index": <number>, "reason": "<short reason>"}]}\n'
+        '{"keep": [<clip numbers>], "cut": [{"index": <number>, "reason": "<short reason>"}]}\n'
         "2. Clip 14 is a plain portrait.\n\n"
-        'Final answer:\n{"drop": [{"index": 14, "reason": "plain portrait"}]}'
+        f'Final answer:\n{{"keep": {keep}, '
+        '"cut": [{"index": 14, "reason": "plain portrait"}]}'
     )
 
     # WHY: the LLM server is the external boundary.
@@ -86,15 +88,29 @@ def test_a_verdict_after_prose_is_read() -> None:
     assert drops == ["asset-14"], f"the template echo beat the real verdict: {drops}"
 
 
-def test_a_real_verdict_is_read(caplog) -> None:
-    """The completed response from the probe: one drop, index 13."""
+def test_an_answer_in_the_retired_drop_shape_is_not_a_cut(caplog) -> None:
+    """A real capture from before the pass answered with the cut (#764).
+
+    Kept as a capture rather than rewritten into the new shape: the point is
+    that a well-formed answer to the OLD question is not silently read as an
+    answer to the new one. It names one clip to drop and says nothing about
+    the other thirteen, so it cannot be a cut — and a pass that guessed the
+    rest would be inventing thirteen verdicts.
+    """
+    import logging
+
     answer = (_FIXTURES / "review_reasoning_complete.txt").read_text()
+    assert '"drop"' in answer, "fixture no longer carries the retired shape"
 
     # WHY: the LLM server is the external boundary; this is its real reply.
-    with patch("immich_memories.analysis.selection_review._ask", return_value=answer):
+    with (
+        patch("immich_memories.analysis.selection_review._ask", return_value=answer),
+        caplog.at_level(logging.WARNING, logger="immich_memories.analysis.selection_review"),
+    ):
         drops = review_selection(_selection(), _config()).drops
 
-    assert drops == ["asset-13"], f"did not read the model's actual verdict: {drops}"
+    assert drops == []
+    assert any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
 def test_the_prompt_template_echo_is_not_mistaken_for_a_verdict(caplog) -> None:

--- a/tests/test_selection_review.py
+++ b/tests/test_selection_review.py
@@ -31,7 +31,7 @@ class TestReviewSelection:
         # WHY: the LLM is the external boundary; the contract is prompt in, JSON out
         with patch(
             "immich_memories.analysis.selection_review._ask",
-            return_value='{"drop": [{"index": 2, "reason": "duplicate of clip 1"}]}',
+            return_value='{"keep": [1, 3], "cut": [{"index": 2, "reason": "duplicate of 1"}]}',
         ):
             drops = review_selection(_selection(), LLMConfig()).drops
 
@@ -41,7 +41,8 @@ class TestReviewSelection:
         """Raw data to the LLM, not summaries — it finds the patterns."""
         # WHY: the LLM call is the external boundary; we inspect the prompt
         with patch(
-            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+            "immich_memories.analysis.selection_review._ask",
+            return_value='{"keep": [1, 2, 3], "cut": []}',
         ) as ask:
             review_selection(_selection(), LLMConfig())
 
@@ -64,16 +65,23 @@ class TestReviewSelection:
         ):
             assert review_selection(_selection(), LLMConfig()).drops == []
 
-    def test_the_llm_cannot_gut_the_video(self):
-        """A cap keeps an overeager model from dropping half the memory."""
+    def test_a_cut_that_keeps_nothing_is_not_an_edit(self):
+        """What used to be a 20% cap (#764).
+
+        The cap existed because the pass vetoed a finished cut and an
+        overeager model could gut it two clips at a time. The pass now MAKES
+        the cut, so a cap would be the pipeline overruling the only judgment
+        in it. The one answer still refused is the one that leaves no memory
+        at all.
+        """
         # WHY: the LLM call is the external boundary
         with patch(
             "immich_memories.analysis.selection_review._ask",
-            return_value='{"drop": [{"index": 1}, {"index": 2}, {"index": 3}]}',
+            return_value='{"keep": [], "cut": [{"index": 1}, {"index": 2}, {"index": 3}]}',
         ):
             drops = review_selection(_selection(), LLMConfig()).drops
 
-        assert len(drops) <= 1  # 20% of 3, floored, min 1
+        assert drops == []
 
 
 class TestTheClipLineCarriesRealFields:
@@ -94,7 +102,8 @@ class TestTheClipLineCarriesRealFields:
 
         # WHY: the LLM call is the external boundary; we inspect the prompt
         with patch(
-            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+            "immich_memories.analysis.selection_review._ask",
+            return_value='{"keep": [1, 2, 3], "cut": []}',
         ) as ask:
             review_selection(selection, LLMConfig())
 
@@ -103,8 +112,10 @@ class TestTheClipLineCarriesRealFields:
         assert "Jette, Belgium" in prompt
 
     def test_a_clip_without_exif_still_renders(self):
+        # WHY: the LLM call is the external boundary; we inspect the prompt
         with patch(
-            "immich_memories.analysis.selection_review._ask", return_value='{"drop": []}'
+            "immich_memories.analysis.selection_review._ask",
+            return_value='{"keep": [1, 2, 3], "cut": []}',
         ) as ask:
             review_selection(_selection(), LLMConfig())
 
@@ -123,7 +134,12 @@ class TestReviewThinksWhenTheServerCan:
         response.status_code = 200
         response.json = MagicMock(
             return_value={
-                "choices": [{"message": {"content": '{"drop": []}'}, "finish_reason": "stop"}]
+                "choices": [
+                    {
+                        "message": {"content": '{"keep": [1, 2, 3], "cut": []}'},
+                        "finish_reason": "stop",
+                    }
+                ]
             }
         )
         response.raise_for_status = lambda: None
@@ -152,7 +168,7 @@ class TestSilenceIsNotApproval:
         with (
             patch(
                 "immich_memories.analysis.selection_review._ask",
-                return_value='{"drop": []}',
+                return_value='{"keep": [1, 2, 3], "cut": []}',
             ),
             caplog.at_level(logging.INFO, logger="immich_memories.analysis.selection_review"),
         ):

--- a/tests/test_the_review_makes_the_cut.py
+++ b/tests/test_the_review_makes_the_cut.py
@@ -135,3 +135,106 @@ class TestTheCutIsTheResult:
         # this cut is one pass among four to come — condemning the material
         # here would be the hard early reject the craft warns against.
         assert [m.clip.asset.id for m in remaining] == ["c0", "c1", "c2", "c3", "c4"]
+
+
+class TestASilentPassIsNotAnApprovedCut:
+    """The pass is fail-open and it is now the ONLY quality judgment.
+
+    "0 drops" has meant both "the model read the set and approved it" and
+    "the model never answered" for as long as the review has existed, and a
+    reader could not tell them apart — the standing advice on this repo is to
+    grep the log before blaming selection. With the old loop gone a fail-open
+    run ships the whole pre-cut, and the strict partition check makes an
+    unreadable answer MORE likely, by design. So the trace has to say it, in
+    the artifact the cut is judged from rather than in another file.
+    """
+
+    def _quality(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from immich_memories.analysis.selection_quality import SelectionQuality
+        from immich_memories.config_loader import Config
+
+        # WHY MagicMock: the composed services. Every clip here is analysed
+        # and described, so the verify pass has nothing to look at.
+        return SelectionQuality(
+            config=SimpleNamespace(max_refinement_passes=3),
+            app_config=Config(content_analysis={"enabled": True}),
+            analyzer=MagicMock(),
+            refiner=MagicMock(),
+            tracker=MagicMock(),
+            client=MagicMock(),
+            provider_circuit=MagicMock(),
+        )
+
+    def _run(self, answer: str, tmp_path):
+        from immich_memories.analysis import selection_trace as trace
+        from immich_memories.analysis.smart_pipeline import PipelineResult
+
+        selection = [_clip(f"c{n}", days=n) for n in range(5)]
+        for member in selection:
+            member.analyzed = True
+        result = PipelineResult(
+            selected_clips=[m.clip for m in selection],
+            clip_segments={m.clip.asset.id: (0.0, 4.0) for m in selection},
+            errors=[],
+            stats={},
+        )
+        report_path = tmp_path / "trace.md"
+        # WHY: the model. What the trace says about its answer is the subject.
+        with (
+            trace.tracing(report_path),
+            patch("immich_memories.analysis.selection_review._ask", return_value=answer),
+        ):
+            self._quality().cut(selection, result)
+        return report_path.read_text()
+
+    def test_an_unreadable_answer_says_so_in_the_trace(self, tmp_path):
+        report = self._run("I could not decide, sorry", tmp_path)
+
+        assert "could not be read" in report
+        assert "not an approved cut" in report.lower()
+
+    def test_an_approved_cut_is_not_reported_as_a_failure(self, tmp_path):
+        report = self._run(_cut(keep=[1, 2, 3, 4, 5], cut=[]), tmp_path)
+
+        assert "not an approved cut" not in report.lower()
+
+
+class TestTheAccountSaysWhyAClipWasCut:
+    def test_a_cut_clip_carries_its_reason_into_the_account(self, tmp_path):
+        """Sam reads the account, not the log.
+
+        The reason a clip went used to live only in the fate lines beside the
+        funnel; the per-clip account named the stage and stopped there. "And
+        why the rest are not" has to answer the question it asks.
+        """
+        from immich_memories.analysis import selection_trace as trace
+        from immich_memories.analysis.smart_pipeline import PipelineResult
+
+        selection = [_clip(f"c{n}", days=n) for n in range(5)]
+        for member in selection:
+            member.analyzed = True
+        result = PipelineResult(
+            selected_clips=[m.clip for m in selection],
+            clip_segments={m.clip.asset.id: (0.0, 4.0) for m in selection},
+            errors=[],
+            stats={},
+        )
+        answer = json.dumps(
+            {
+                "keep": [1, 2, 3, 4],
+                "cut": [{"index": 5, "reason": "an empty hallway, records a place"}],
+            }
+        )
+        report_path = tmp_path / "trace.md"
+        # WHY: the model. What the trace does with its reasons is the subject.
+        with (
+            trace.tracing(report_path),
+            patch("immich_memories.analysis.selection_review._ask", return_value=answer),
+        ):
+            TestASilentPassIsNotAnApprovedCut()._quality().cut(selection, result)
+
+        rejected = report_path.read_text().split("and why the rest are not")[1]
+        assert "an empty hallway, records a place" in rejected

--- a/tests/test_the_review_makes_the_cut.py
+++ b/tests/test_the_review_makes_the_cut.py
@@ -1,0 +1,137 @@
+"""The review makes the cut instead of vetoing one (#764, slice 1).
+
+Measured on one real month: 204 candidates reached selection, arithmetic
+removed 191 of them, and the only judgment in the pipeline was then allowed to
+drop two clips out of fourteen per round. It took eight rounds of drop-and-
+refill to remove what it could see in the first one, and a clip it named three
+rounds running was capped away twice before it went.
+
+A photographer culls the pool downward; our judge vetoed the cut upward. So
+the pass now answers with the cut: which clips belong, and which do not.
+
+Keep-semantics turns silence into a kill, which is why the answer has to
+account for every clip exactly once. A truncated answer naming four clips to
+keep would otherwise cut the rest of the memory.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from immich_memories.analysis.selection_review import review_selection
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+from immich_memories.config_models_llm import LLMConfig
+
+DAY = datetime(2023, 6, 1, 12, tzinfo=UTC)
+
+
+def _clip(asset_id: str, *, days: float = 0.0, starred: bool = False) -> ClipWithSegment:
+    when = DAY + timedelta(days=days)
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=when,
+        fileModifiedAt=when,
+        updatedAt=when,
+        isFavorite=starred,
+    )
+    clip = VideoClipInfo(asset=asset, duration_seconds=4.0)
+    clip.llm_description = f"a shot called {asset_id}"
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=4.0, score=0.5)
+
+
+def _cut(keep: list[int], cut: list[int]) -> str:
+    return json.dumps({"keep": keep, "cut": [{"index": i, "reason": f"cut {i}"} for i in cut]})
+
+
+def _review(selection, raw):
+    # WHY: the model. Everything under test is what we do with its answer.
+    with patch("immich_memories.analysis.selection_review._ask", return_value=raw):
+        return review_selection(selection, LLMConfig())
+
+
+class TestTheAnswerIsTheCut:
+    def test_everything_the_model_cuts_goes_in_one_pass(self):
+        """No fifth-of-the-cut cap: eight rounds of two was the disease."""
+        selection = [_clip(f"c{n}", days=n) for n in range(10)]
+
+        verdict = _review(selection, _cut(keep=[1, 2, 3, 4, 5], cut=[6, 7, 8, 9, 10]))
+
+        assert verdict.drops == ["c5", "c6", "c7", "c8", "c9"]
+
+    def test_a_truncated_answer_cuts_nothing(self, caplog):
+        """Silence is a kill now, so an answer that stops early cannot stand.
+
+        Four clips named to keep out of ten, and the rest never reached: read
+        literally that is a six-clip cut nobody decided on. The two lists have
+        to account for every clip, which turns truncation back into what it
+        always was — an answer we could not read.
+        """
+        import logging
+
+        selection = [_clip(f"c{n}", days=n) for n in range(10)]
+
+        with caplog.at_level(logging.WARNING, logger="immich_memories.analysis.selection_review"):
+            verdict = _review(selection, '{"keep": [1, 2, 3, 4], "cut": []}')
+
+        assert verdict.drops == []
+        assert any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+class TestTheCutIsTheResult:
+    def test_what_the_review_cuts_leaves_the_selection_without_a_refill(self):
+        """One pass, and its answer stands.
+
+        The old shape dropped what it could see, re-selected to fill the gap,
+        and had to run again because the refill had never been judged. Eight
+        rounds of that on one month. The cut is now the cut: what the review
+        removes stays removed, and the memory is shorter rather than topped up
+        with whatever ranked next.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from immich_memories.analysis.selection_quality import SelectionQuality
+        from immich_memories.analysis.smart_pipeline import PipelineResult
+        from immich_memories.config_loader import Config
+
+        selection = [_clip(f"c{n}", days=n) for n in range(5)]
+        for member in selection:
+            member.analyzed = True
+        result = PipelineResult(
+            selected_clips=[m.clip for m in selection],
+            clip_segments={m.clip.asset.id: (0.0, 4.0) for m in selection},
+            errors=[],
+            stats={},
+        )
+        # WHY MagicMock: the analyzer, refiner, tracker and client are the
+        # services this orchestrator composes. Nothing here needs them —
+        # every clip is already analysed and described, so the verify pass has
+        # nothing to look at and never re-selects.
+        quality = SelectionQuality(
+            config=SimpleNamespace(max_refinement_passes=3),
+            app_config=Config(content_analysis={"enabled": True}),
+            analyzer=MagicMock(),
+            refiner=MagicMock(),
+            tracker=MagicMock(),
+            client=MagicMock(),
+            provider_circuit=MagicMock(),
+        )
+
+        # WHY: the model. What the pass does with its answer is the subject.
+        with patch(
+            "immich_memories.analysis.selection_review._ask",
+            return_value=_cut(keep=[1, 2, 3], cut=[4, 5]),
+        ):
+            trimmed, remaining = quality.cut(selection, result)
+
+        assert [c.asset.id for c in trimmed.selected_clips] == ["c0", "c1", "c2"]
+        assert set(trimmed.clip_segments) == {"c0", "c1", "c2"}
+        # The pool keeps what the cut left out. Editors re-mine dismissed
+        # material once the edit re-contextualises it, and the pass that made
+        # this cut is one pass among four to come — condemning the material
+        # here would be the hard early reject the craft warns against.
+        assert [m.clip.asset.id for m in remaining] == ["c0", "c1", "c2", "c3", "c4"]


### PR DESCRIPTION
Slice 1 of #764. **Accepted at the June gate** at this pin.

## The problem

Measured on one month: 204 candidates reached selection, arithmetic removed
191 of them, and the only judgment in the pipeline was then allowed to drop
**two clips out of fourteen per round**. It took eight rounds of drop-and-
refill to remove what the first round had already named, and a clip named
three rounds running was capped away twice before it went.

A photographer culls the pool downward. This judge vetoed the cut upward.

## What changes

The pass **makes** the cut. It is handed the selection and answers with which
clips belong and which do not, in one pass, with no cap on how many it may
remove. What it removes is not replaced — a memory four seconds short beats
one topped up with whatever ranked next, which is where a games console and a
shelf came from.

`_MAX_DROP_RATIO`, `review()`, `final_review_drop()` and the loop around them
are gone. `cut()` is the one pass.

## The part reviewers should look at hardest

Keep-semantics turns silence into a kill. So the answer must account for
**every clip exactly once** (`keep` ∪ `cut` = 1..N, disjoint). Without that, a
truncated answer naming four clips to keep would cut everything it never
reached. Failing the check is a parse failure, which the pass already knows
how to survive: it cuts nothing and says the answer was unreadable. An answer
that keeps nothing is refused the same way — a memory with nothing in it is
not an edit, whatever the model meant by it.

An index naming a clip that is not in the cut now voids the **whole** answer
rather than being skipped. It is not one bad line in a good verdict; it is an
answer about some other set of clips.

## Two decisions worth naming

- **The pool comes back whole.** Only the cut changes, and every clip left out
  of it has its reason on the record. Editors re-mine dismissed material once
  the edit re-contextualises it, and this pass is one of several to come —
  condemning the material here would be the hard early reject the craft warns
  against. Murch: avoid writing NG without saying why.
- **`cut()` is now the only quality pass, and it is fail-open.** That is why
  the second commit exists: a verdict carries *why* it does not exist, and the
  trace prints it above the funnel. `0 dropped` used to mean both "approved"
  and "never answered", which is the defect behind this repo's standing advice
  to grep the log before blaming selection. Nothing is inferred from a count
  any more.

The two commits are kept together deliberately — splitting them would merge a
known fail-open blind spot in between.

## Measured on June at this pin

- The fine cut ran, answered, and its answer stood: **13 → 11 in one pass**,
  both reasons printed inline in the funnel.
- Favourites law: **held** — first June render to say so.
- No fail-open warning fired.

Also corrects the warm-run performance page, which attributed most of a
measured 11 LLM calls to review rounds — that loop no longer exists, and the
bound it named now applies to verifying only.

Stacked on #766. Part of #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5iwe7FtKPz7hfTqYyMhBL
