### PR TITLE
feat(selection): let the story choose its moments (#764)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,6 +45,13 @@ The four core orchestrators and their composed services:
 - `ClipScaler` (clip_scaler.py): scale to target duration, deduplicate
 - `SelectionQuality` (selection_quality.py): verify, judge, and make the cut
 
+`ClipRefiner` takes one optional collaborator, `StructurePass`
+(selection_structure.py), built by `structure_pass_for()` when content analysis is
+enabled. It decides which MOMENTS the story needs before any dedup runs, and its
+answer replaces the arithmetic funnel's narrowing. When it cannot decide, or cut
+but could not rank what to give up first, the funnel narrows instead — over the
+whole pool or over what the pass kept.
+
 It also owns a `ProviderCircuit` (provider_health.py, LLM provider circuit breaker) and an
 optional `VideoDownloadCache`. The density-proportional asset budget is a plain function,
 `compute_density_budget()` (density_budget.py), called from `_phase_filter()` — not an
@@ -124,7 +131,9 @@ src/immich_memories/
 │   ├── cache_projection.py     # Project compatible cached analysis back onto in-memory clips
 │   ├── clip_analyzer.py        # ClipAnalyzer: download + analyze + score
 │   ├── clip_refiner.py         # ClipRefiner: final selection + distribution
-│   ├── arithmetic_funnel.py    # The narrowing stages that decide a cut by counting (legacy path, #764)
+│   ├── arithmetic_funnel.py    # The narrowing stages that decide a cut by counting (fallback path, #764)
+│   ├── selection_structure.py  # StructurePass: which moments does the story need? (rough cut, #764)
+│   ├── structure_answer.py     # The structure question's prompts, and the reading of its answer
 │   ├── clip_scaler.py          # ClipScaler: duration scaling + dedup
 │   ├── selection_quality.py    # SelectionQuality: verify + judge + cut
 │   ├── selection_review.py     # LLM holistic pass that MAKES the cut: which clips belong, which do not

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,6 +124,7 @@ src/immich_memories/
 │   ├── cache_projection.py     # Project compatible cached analysis back onto in-memory clips
 │   ├── clip_analyzer.py        # ClipAnalyzer: download + analyze + score
 │   ├── clip_refiner.py         # ClipRefiner: final selection + distribution
+│   ├── arithmetic_funnel.py    # The narrowing stages that decide a cut by counting (legacy path, #764)
 │   ├── clip_scaler.py          # ClipScaler: duration scaling + dedup
 │   ├── selection_quality.py    # SelectionQuality: verify + judge + cut
 │   ├── selection_review.py     # LLM holistic pass that MAKES the cut: which clips belong, which do not

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,52 +6,20 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 241,
-        "line_end": 284,
+        "line_start": 252,
+        "line_end": 295,
         "line_complexities": [
-          {
-            "line": 251,
-            "complexity": 0
-          },
-          {
-            "line": 252,
-            "complexity": 1
-          },
-          {
-            "line": 253,
-            "complexity": 0
-          },
-          {
-            "line": 256,
-            "complexity": 0
-          },
-          {
-            "line": 257,
-            "complexity": 1
-          },
-          {
-            "line": 258,
-            "complexity": 0
-          },
-          {
-            "line": 261,
-            "complexity": 0
-          },
           {
             "line": 262,
             "complexity": 0
           },
           {
+            "line": 263,
+            "complexity": 1
+          },
+          {
             "line": 264,
             "complexity": 0
-          },
-          {
-            "line": 265,
-            "complexity": 0
-          },
-          {
-            "line": 266,
-            "complexity": 1
           },
           {
             "line": 267,
@@ -59,10 +27,10 @@
           },
           {
             "line": 268,
-            "complexity": 2
+            "complexity": 1
           },
           {
-            "line": 270,
+            "line": 269,
             "complexity": 0
           },
           {
@@ -71,11 +39,7 @@
           },
           {
             "line": 273,
-            "complexity": 1
-          },
-          {
-            "line": 274,
-            "complexity": 2
+            "complexity": 0
           },
           {
             "line": 275,
@@ -83,24 +47,60 @@
           },
           {
             "line": 276,
-            "complexity": 3
+            "complexity": 0
+          },
+          {
+            "line": 277,
+            "complexity": 1
           },
           {
             "line": 278,
-            "complexity": 4
+            "complexity": 0
           },
           {
             "line": 279,
-            "complexity": 5
+            "complexity": 2
+          },
+          {
+            "line": 281,
+            "complexity": 0
+          },
+          {
+            "line": 283,
+            "complexity": 0
           },
           {
             "line": 284,
+            "complexity": 1
+          },
+          {
+            "line": 285,
+            "complexity": 2
+          },
+          {
+            "line": 286,
+            "complexity": 0
+          },
+          {
+            "line": 287,
+            "complexity": 3
+          },
+          {
+            "line": 289,
+            "complexity": 4
+          },
+          {
+            "line": 290,
+            "complexity": 5
+          },
+          {
+            "line": 295,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 91
+    "complexity": 95
   },
   {
     "path": "src/immich_memories/automation/calendar_detectors.py",

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -100,7 +100,7 @@
         ]
       }
     ],
-    "complexity": 103
+    "complexity": 104
   },
   {
     "path": "src/immich_memories/automation/calendar_detectors.py",

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,101 +6,101 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 252,
-        "line_end": 295,
+        "line_start": 292,
+        "line_end": 335,
         "line_complexities": [
           {
-            "line": 262,
+            "line": 302,
             "complexity": 0
           },
           {
-            "line": 263,
+            "line": 303,
             "complexity": 1
           },
           {
-            "line": 264,
+            "line": 304,
             "complexity": 0
           },
           {
-            "line": 267,
+            "line": 307,
             "complexity": 0
           },
           {
-            "line": 268,
+            "line": 308,
             "complexity": 1
           },
           {
-            "line": 269,
+            "line": 309,
             "complexity": 0
           },
           {
-            "line": 272,
+            "line": 312,
             "complexity": 0
           },
           {
-            "line": 273,
+            "line": 313,
             "complexity": 0
           },
           {
-            "line": 275,
+            "line": 315,
             "complexity": 0
           },
           {
-            "line": 276,
+            "line": 316,
             "complexity": 0
           },
           {
-            "line": 277,
+            "line": 317,
             "complexity": 1
           },
           {
-            "line": 278,
+            "line": 318,
             "complexity": 0
           },
           {
-            "line": 279,
+            "line": 319,
             "complexity": 2
           },
           {
-            "line": 281,
+            "line": 321,
             "complexity": 0
           },
           {
-            "line": 283,
+            "line": 323,
             "complexity": 0
           },
           {
-            "line": 284,
+            "line": 324,
             "complexity": 1
           },
           {
-            "line": 285,
+            "line": 325,
             "complexity": 2
           },
           {
-            "line": 286,
+            "line": 326,
             "complexity": 0
           },
           {
-            "line": 287,
+            "line": 327,
             "complexity": 3
           },
           {
-            "line": 289,
+            "line": 329,
             "complexity": 4
           },
           {
-            "line": 290,
+            "line": 330,
             "complexity": 5
           },
           {
-            "line": 295,
+            "line": 335,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 95
+    "complexity": 99
   },
   {
     "path": "src/immich_memories/automation/calendar_detectors.py",

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -6,101 +6,101 @@
       {
         "name": "ClipRefiner::_fill_empty_weeks",
         "complexity": 20,
-        "line_start": 266,
-        "line_end": 309,
+        "line_start": 241,
+        "line_end": 284,
         "line_complexities": [
           {
+            "line": 251,
+            "complexity": 0
+          },
+          {
+            "line": 252,
+            "complexity": 1
+          },
+          {
+            "line": 253,
+            "complexity": 0
+          },
+          {
+            "line": 256,
+            "complexity": 0
+          },
+          {
+            "line": 257,
+            "complexity": 1
+          },
+          {
+            "line": 258,
+            "complexity": 0
+          },
+          {
+            "line": 261,
+            "complexity": 0
+          },
+          {
+            "line": 262,
+            "complexity": 0
+          },
+          {
+            "line": 264,
+            "complexity": 0
+          },
+          {
+            "line": 265,
+            "complexity": 0
+          },
+          {
+            "line": 266,
+            "complexity": 1
+          },
+          {
+            "line": 267,
+            "complexity": 0
+          },
+          {
+            "line": 268,
+            "complexity": 2
+          },
+          {
+            "line": 270,
+            "complexity": 0
+          },
+          {
+            "line": 272,
+            "complexity": 0
+          },
+          {
+            "line": 273,
+            "complexity": 1
+          },
+          {
+            "line": 274,
+            "complexity": 2
+          },
+          {
+            "line": 275,
+            "complexity": 0
+          },
+          {
             "line": 276,
-            "complexity": 0
-          },
-          {
-            "line": 277,
-            "complexity": 1
-          },
-          {
-            "line": 278,
-            "complexity": 0
-          },
-          {
-            "line": 281,
-            "complexity": 0
-          },
-          {
-            "line": 282,
-            "complexity": 1
-          },
-          {
-            "line": 283,
-            "complexity": 0
-          },
-          {
-            "line": 286,
-            "complexity": 0
-          },
-          {
-            "line": 287,
-            "complexity": 0
-          },
-          {
-            "line": 289,
-            "complexity": 0
-          },
-          {
-            "line": 290,
-            "complexity": 0
-          },
-          {
-            "line": 291,
-            "complexity": 1
-          },
-          {
-            "line": 292,
-            "complexity": 0
-          },
-          {
-            "line": 293,
-            "complexity": 2
-          },
-          {
-            "line": 295,
-            "complexity": 0
-          },
-          {
-            "line": 297,
-            "complexity": 0
-          },
-          {
-            "line": 298,
-            "complexity": 1
-          },
-          {
-            "line": 299,
-            "complexity": 2
-          },
-          {
-            "line": 300,
-            "complexity": 0
-          },
-          {
-            "line": 301,
             "complexity": 3
           },
           {
-            "line": 303,
+            "line": 278,
             "complexity": 4
           },
           {
-            "line": 304,
+            "line": 279,
             "complexity": 5
           },
           {
-            "line": 309,
+            "line": 284,
             "complexity": 0
           }
         ]
       }
     ],
-    "complexity": 98
+    "complexity": 91
   },
   {
     "path": "src/immich_memories/automation/calendar_detectors.py",

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -100,7 +100,7 @@
         ]
       }
     ],
-    "complexity": 99
+    "complexity": 103
   },
   {
     "path": "src/immich_memories/automation/calendar_detectors.py",

--- a/src/immich_memories/analysis/arithmetic_funnel.py
+++ b/src/immich_memories/analysis/arithmetic_funnel.py
@@ -1,0 +1,196 @@
+"""The narrowing stages that decide a cut by counting.
+
+A per-day photo cap, a spread across dates, a fit to the runtime, a
+non-favourite ratio and a photo ratio: five stages that arrive at a cut
+arithmetically. They are the legacy path, kept as the fallback for the
+structure pass, and they go when the editing passes land (#764).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from immich_memories.analysis import selection_trace as trace
+from immich_memories.analysis.clip_distribution import (
+    _event_periods_of,
+    _partition_photos_per_day,
+    enforce_photo_cap,
+    photos_per_day_for,
+)
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.clip_scaler import ClipScaler
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment, PipelineConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ClipSelector(Protocol):
+    """What the funnel needs from the refiner that runs it.
+
+    A Protocol rather than the concrete ClipRefiner: the refiner is what
+    imports this module, and naming the two selection entry points it lends
+    keeps the dependency pointing one way.
+    """
+
+    config: PipelineConfig
+    scaler: ClipScaler
+
+    def select_clips_by_trip_segments(
+        self,
+        analyzed: list[ClipWithSegment],
+        target: int,
+    ) -> list[ClipWithSegment]: ...
+
+    def select_clips_distributed_by_date(
+        self,
+        clips: list[ClipWithSegment],
+        target_count: int,
+        event_periods: set[str] | None = ...,
+    ) -> list[ClipWithSegment]: ...
+
+
+@dataclass(frozen=True)
+class ArithmeticNarrowing:
+    """What the counting stages leave for the rest of the phase.
+
+    `analyzed` is the pool after the per-day cap — the supply the photo ratio
+    is later judged scarce against, which is not the same set the cut came
+    from. `coverage_ids` are the clips standing for a period on their own,
+    which every later stage treats as untouchable.
+    """
+
+    analyzed: list[ClipWithSegment]
+    selected: list[ClipWithSegment]
+    coverage_ids: set[str]
+
+
+def narrow_by_arithmetic(
+    selector: ClipSelector,
+    all_analyzed: list[ClipWithSegment],
+    *,
+    target_duration: float,
+    max_overrun: float,
+) -> ArithmeticNarrowing:
+    """Cap the photos per day, spread the cut across dates, fit it to runtime."""
+    config = selector.config
+    # Measured before the per-day cap flattens every day into the same
+    # narrow range (#488).
+    event_periods = _event_periods_of(all_analyzed)
+    active_days = len(
+        {c.clip.asset.file_created_at.date() for c in all_analyzed if c.clip.asset.file_created_at}
+    )
+    analyzed, _photo_overflow = _partition_photos_per_day(
+        all_analyzed,
+        photos_per_day_for(config.target_clips, active_days),
+    )
+    trace.record("per-day photo cap", all_analyzed, analyzed)
+
+    target_with_buffer = int(config.target_clips * 1.2)
+
+    if config.overnight_bases:
+        selected = selector.select_clips_by_trip_segments(analyzed, target_with_buffer)
+    else:
+        selected = selector.select_clips_distributed_by_date(
+            analyzed, target_with_buffer, event_periods
+        )
+    trace.record("distribute by date", analyzed, selected)
+
+    coverage_ids: set[str] = getattr(selector, "_coverage_ids", set())
+    before_scale = selected
+    selected = selector.scaler.scale_to_target_duration(
+        selected,
+        target_duration,
+        protected_ids=coverage_ids,
+        max_overrun_seconds=max_overrun,
+    )
+    trace.record(f"fit to {target_duration:.0f}s", before_scale, selected)
+
+    return ArithmeticNarrowing(
+        analyzed=analyzed,
+        selected=selected,
+        coverage_ids=coverage_ids,
+    )
+
+
+def _trim_non_favorites(
+    non_favorites: list[ClipWithSegment],
+    max_non_favorites: int,
+    coverage_ids: set[str],
+) -> list[ClipWithSegment]:
+    """Cut the ratio down to size without cutting what covers a period.
+
+    The scaler, the photo cap and the moment dedup all treat a coverage clip
+    as untouchable. This was the last drop site that did not: it sorted by
+    score and truncated, so the one clip standing for a whole month could be
+    cut for scoring low — which is exactly why it was added in the first
+    place, since the month had nothing better.
+    """
+    covering = [c for c in non_favorites if c.clip.asset.id in coverage_ids]
+    rest = sorted(
+        (c for c in non_favorites if c.clip.asset.id not in coverage_ids),
+        key=lambda c: c.score,
+        reverse=True,
+    )
+    room = max(0, max_non_favorites - len(covering))
+    return covering + rest[:room]
+
+
+def cap_ratios(
+    config: PipelineConfig,
+    selected: list[ClipWithSegment],
+    analyzed: list[ClipWithSegment],
+    *,
+    coverage_ids: set[str],
+    target_duration: float,
+) -> tuple[list[ClipWithSegment], bool]:
+    """Hold the cut to its non-favourite share and its photo share.
+
+    Returns the cut and whether the photo cap was bypassed for scarcity —
+    backfill has to know, because its exemption then admits photos again.
+    """
+    if config.max_non_favorite_ratio < 1.0 and config.prioritize_favorites:
+        favorites = [c for c in selected if c.clip.asset.is_favorite]
+        non_favorites = [c for c in selected if not c.clip.asset.is_favorite]
+
+        max_non_favorites = int(len(selected) * config.max_non_favorite_ratio)
+        min_non_favorites = max(0, config.target_clips - len(favorites))
+        max_non_favorites = max(max_non_favorites, min_non_favorites)
+
+        if len(non_favorites) > max_non_favorites:
+            non_favorites = _trim_non_favorites(non_favorites, max_non_favorites, coverage_ids)
+
+            logger.info(
+                f"Final selection: limiting non-favorites to {len(non_favorites)} "
+                f"({config.max_non_favorite_ratio:.0%} of {len(selected)})"
+            )
+
+            selected = favorites + non_favorites
+
+    # Enforce photo ratio cap (drop lowest-scored photos if over limit)
+    photo_cap_bypassed = False
+    if config.photo_max_ratio < 1.0:
+        from immich_memories.api.models import AssetType
+
+        # WHY: Scarcity is determined from the available supply, not an
+        # already photo-biased selection. Match unified_budget exactly:
+        # photos fill freely only when videos cannot fill half the budget.
+        available_video_duration = sum(
+            c.end_time - c.start_time for c in analyzed if c.clip.asset.type != AssetType.IMAGE
+        )
+        videos_scarce = available_video_duration < target_duration * 0.5
+        photo_cap_bypassed = videos_scarce
+        # Even when photos may ultimately fill freely, first normalize a
+        # photo-biased selection so backfill has room to use every valid
+        # video candidate. The backfill exemption then admits photos again.
+        before_cap = selected
+        selected = enforce_photo_cap(
+            selected,
+            config.photo_max_ratio,
+            protected_ids=coverage_ids,
+        )
+        trace.record("photo ratio cap", before_cap, selected)
+
+    return selected, photo_cap_bypassed

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -98,7 +98,7 @@ def _warn_if_an_absorber_will_have_to_act(
     if target_duration <= 0 or not selected:
         return
     slots = max(1, int(target_duration // MIN_CLIP_DURATION))
-    if len(selected) >= slots:
+    if len(selected) > slots:
         trace.warn(
             f"the cut hands generation {len(selected)} clips against a "
             f"{target_duration:.0f}s budget — the stride sampler will drop every "
@@ -679,22 +679,27 @@ class ClipRefiner:
             if self._structure is not None
             else None
         )
-        if structure is None:
+        if structure is not None:
+            # A condemned moment's members must never come back through the
+            # relaxation ladder, whichever stage settles the length.
+            self._refused_by_dedup |= set(structure.dropped)
+        # The story settles the length only when it said what to give up first.
+        # Otherwise the counting stages narrow what it kept — the same chain,
+        # over a smaller pool, so the dedup, the caps, backfill and the
+        # favourites law below all still run over the result.
+        by_arithmetic = structure is None or not structure.narrowed
+        if by_arithmetic:
             narrowed = narrow_by_arithmetic(
                 self,
-                all_analyzed,
+                all_analyzed if structure is None else structure.kept,
                 target_duration=target_duration,
                 max_overrun=max_overrun,
             )
             analyzed = narrowed.analyzed
             selected = narrowed.selected
             coverage_ids = narrowed.coverage_ids
-        else:
-            # The story decided this cut, so the counting stages do not run —
-            # neither the narrowing above nor the ratio caps below. A condemned
-            # moment's members join what backfill may not spend seconds on.
+        elif structure is not None:
             analyzed, selected, coverage_ids = all_analyzed, structure.kept, set()
-            self._refused_by_dedup |= set(structure.dropped)
 
         if moment_window > 0:
             before_dedup = selected
@@ -721,7 +726,7 @@ class ClipRefiner:
             self._remember_refusals(before_content, selected)
 
         photo_cap_bypassed = False
-        if structure is None:
+        if by_arithmetic:
             selected, photo_cap_bypassed = cap_ratios(
                 self.config,
                 selected,

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -752,7 +752,15 @@ class ClipRefiner:
         # neighbour from the same moment survives, each for its own good
         # reason. The rule they all answer to is applied to what they produced.
         before_law = selected
-        selected = let_the_favourite_win(selected, all_analyzed)
+        # Structure made an editorial rejection, not a mechanical drop for the
+        # law to repair. Its grouping can differ from the law's, so exclusion
+        # by id is what keeps a condemned moment condemned.
+        favourite_pool = (
+            [item for item in all_analyzed if item.clip.asset.id not in structure.dropped]
+            if structure is not None
+            else all_analyzed
+        )
+        selected = let_the_favourite_win(selected, favourite_pool)
         trace.record("the favourite wins its moment", before_law, selected)
 
         selected.sort(key=lambda c: c.clip.asset.file_created_at or datetime.min)

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -699,6 +699,9 @@ class ClipRefiner:
             selected = narrowed.selected
             coverage_ids = narrowed.coverage_ids
         elif structure is not None:
+            # `elif` only to re-narrow the type for mypy: by_arithmetic is
+            # False exactly when structure is a cut that settled its own
+            # length, so there is no third branch to reach.
             analyzed, selected, coverage_ids = all_analyzed, structure.kept, set()
 
         if moment_window > 0:

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from immich_memories.analysis.clip_scaler import ClipScaler
+    from immich_memories.analysis.selection_structure import StructurePass
     from immich_memories.analysis.smart_pipeline import (
         ClipWithSegment,
         PipelineConfig,
@@ -76,9 +77,19 @@ def _clips_per_moment(target_clips: int, moments: int) -> int:
 class ClipRefiner:
     """Selects, distributes, and refines the final clip selection."""
 
-    def __init__(self, config: PipelineConfig, scaler: ClipScaler):
+    def __init__(
+        self,
+        config: PipelineConfig,
+        scaler: ClipScaler,
+        *,
+        structure: StructurePass | None = None,
+    ):
         self.config = config
         self.scaler = scaler
+        # The editor that decides which moments the story needs (#764). Absent
+        # — no LLM configured — or unable to answer, the arithmetic funnel
+        # makes the cut instead, exactly as it always has.
+        self._structure = structure
         # What dedup has refused this run. Backfill may not spend freed seconds
         # on it, however far its relaxation ladder goes.
         self._refused_by_dedup: set[str] = set()
@@ -618,15 +629,29 @@ class ClipRefiner:
             0.0 if self.config.target_duration_seconds is not None else target_duration * 0.10
         )
 
-        narrowed = narrow_by_arithmetic(
-            self,
-            all_analyzed,
-            target_duration=target_duration,
-            max_overrun=max_overrun,
+        structure = (
+            self._structure.choose(
+                all_analyzed, target_duration=target_duration, moment_window=moment_window
+            )
+            if self._structure is not None
+            else None
         )
-        analyzed = narrowed.analyzed
-        selected = narrowed.selected
-        coverage_ids = narrowed.coverage_ids
+        if structure is None:
+            narrowed = narrow_by_arithmetic(
+                self,
+                all_analyzed,
+                target_duration=target_duration,
+                max_overrun=max_overrun,
+            )
+            analyzed = narrowed.analyzed
+            selected = narrowed.selected
+            coverage_ids = narrowed.coverage_ids
+        else:
+            # The story decided this cut, so the counting stages do not run —
+            # neither the narrowing above nor the ratio caps below. A condemned
+            # moment's members join what backfill may not spend seconds on.
+            analyzed, selected, coverage_ids = all_analyzed, structure.kept, set()
+            self._refused_by_dedup |= set(structure.dropped)
 
         if moment_window > 0:
             before_dedup = selected
@@ -652,13 +677,15 @@ class ClipRefiner:
             trace.record("same-thing dedup", before_content, selected)
             self._remember_refusals(before_content, selected)
 
-        selected, photo_cap_bypassed = cap_ratios(
-            self.config,
-            selected,
-            analyzed,
-            coverage_ids=coverage_ids,
-            target_duration=target_duration,
-        )
+        photo_cap_bypassed = False
+        if structure is None:
+            selected, photo_cap_bypassed = cap_ratios(
+                self.config,
+                selected,
+                analyzed,
+                coverage_ids=coverage_ids,
+                target_duration=target_duration,
+            )
 
         before_backfill = selected
         selected = self._backfill_to_duration(

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -709,9 +709,9 @@ class ClipRefiner:
             # How many clips one moment may keep depends on how many the cut
             # needs: thinning to one left a long memory too short to fill, and
             # backfill then restored the same clips by relaxing constraints.
-            from immich_memories.analysis.clip_scaler import group_by_moment
+            from immich_memories.analysis.clip_scaler import group_by_moment_and_place
 
-            moments = len(group_by_moment(selected, moment_window))
+            moments = len(group_by_moment_and_place(selected, moment_window))
             selected = self.scaler.deduplicate_temporal_clusters(
                 selected,
                 time_window_minutes=moment_window,

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     )
     from immich_memories.api.models import VideoClipInfo
 
+from immich_memories.analysis.arithmetic_funnel import cap_ratios, narrow_by_arithmetic
 from immich_memories.analysis.clip_backfill import (
     _build_backfill_context,
     _choose_backfill_candidate,
@@ -34,11 +35,8 @@ from immich_memories.analysis.clip_distribution import (
     _EVENT_CLIPS_PER_PERIOD,
     _event_periods_of,
     _fill_gap_periods,
-    _partition_photos_per_day,
     _period_key,
-    enforce_photo_cap,
     moment_window_for,
-    photos_per_day_for,
     span_days_of,
     spread_across_moments,
 )
@@ -73,29 +71,6 @@ def _clips_per_moment(target_clips: int, moments: int) -> int:
         return 1
     share = math.ceil(target_clips / moments)
     return max(1, min(share, int(target_clips * _MAX_SHARE_FROM_ONE_MOMENT)))
-
-
-def _trim_non_favorites(
-    non_favorites: list[ClipWithSegment],
-    max_non_favorites: int,
-    coverage_ids: set[str],
-) -> list[ClipWithSegment]:
-    """Cut the ratio down to size without cutting what covers a period.
-
-    The scaler, the photo cap and the moment dedup all treat a coverage clip
-    as untouchable. This was the last drop site that did not: it sorted by
-    score and truncated, so the one clip standing for a whole month could be
-    cut for scoring low — which is exactly why it was added in the first
-    place, since the month had nothing better.
-    """
-    covering = [c for c in non_favorites if c.clip.asset.id in coverage_ids]
-    rest = sorted(
-        (c for c in non_favorites if c.clip.asset.id not in coverage_ids),
-        key=lambda c: c.score,
-        reverse=True,
-    )
-    room = max(0, max_non_favorites - len(covering))
-    return covering + rest[:room]
 
 
 class ClipRefiner:
@@ -633,50 +608,25 @@ class ClipRefiner:
         # Prefer two photos/day during initial selection, while retaining the
         # overflow as a fallback if the diverse pool cannot fill the target.
         all_analyzed = analyzed
-        # Measured before the per-day cap flattens every day into the same
-        # narrow range (#488).
-        event_periods = _event_periods_of(all_analyzed)
-        active_days = len(
-            {
-                c.clip.asset.file_created_at.date()
-                for c in all_analyzed
-                if c.clip.asset.file_created_at
-            }
-        )
         # A moment is relative to the story: five minutes inside a month, an
         # evening inside a year.
         moment_window = moment_window_for(
             span_days_of(all_analyzed), self.config.temporal_dedup_window_minutes
         )
-        analyzed, _photo_overflow = _partition_photos_per_day(
-            all_analyzed,
-            photos_per_day_for(self.config.target_clips, active_days),
-        )
-        trace.record("per-day photo cap", all_analyzed, analyzed)
-
-        target_with_buffer = int(self.config.target_clips * 1.2)
-
-        if self.config.overnight_bases:
-            selected = self.select_clips_by_trip_segments(analyzed, target_with_buffer)
-        else:
-            selected = self.select_clips_distributed_by_date(
-                analyzed, target_with_buffer, event_periods
-            )
-        trace.record("distribute by date", analyzed, selected)
-
         target_duration = self.config.duration_target
         max_overrun = (
             0.0 if self.config.target_duration_seconds is not None else target_duration * 0.10
         )
-        coverage_ids: set[str] = getattr(self, "_coverage_ids", set())
-        before_scale = selected
-        selected = self.scaler.scale_to_target_duration(
-            selected,
-            target_duration,
-            protected_ids=coverage_ids,
-            max_overrun_seconds=max_overrun,
+
+        narrowed = narrow_by_arithmetic(
+            self,
+            all_analyzed,
+            target_duration=target_duration,
+            max_overrun=max_overrun,
         )
-        trace.record(f"fit to {target_duration:.0f}s", before_scale, selected)
+        analyzed = narrowed.analyzed
+        selected = narrowed.selected
+        coverage_ids = narrowed.coverage_ids
 
         if moment_window > 0:
             before_dedup = selected
@@ -702,47 +652,13 @@ class ClipRefiner:
             trace.record("same-thing dedup", before_content, selected)
             self._remember_refusals(before_content, selected)
 
-        if self.config.max_non_favorite_ratio < 1.0 and self.config.prioritize_favorites:
-            favorites = [c for c in selected if c.clip.asset.is_favorite]
-            non_favorites = [c for c in selected if not c.clip.asset.is_favorite]
-
-            max_non_favorites = int(len(selected) * self.config.max_non_favorite_ratio)
-            min_non_favorites = max(0, self.config.target_clips - len(favorites))
-            max_non_favorites = max(max_non_favorites, min_non_favorites)
-
-            if len(non_favorites) > max_non_favorites:
-                non_favorites = _trim_non_favorites(non_favorites, max_non_favorites, coverage_ids)
-
-                logger.info(
-                    f"Final selection: limiting non-favorites to {len(non_favorites)} "
-                    f"({self.config.max_non_favorite_ratio:.0%} of {len(selected)})"
-                )
-
-                selected = favorites + non_favorites
-
-        # Enforce photo ratio cap (drop lowest-scored photos if over limit)
-        photo_cap_bypassed = False
-        if self.config.photo_max_ratio < 1.0:
-            from immich_memories.api.models import AssetType
-
-            # WHY: Scarcity is determined from the available supply, not an
-            # already photo-biased selection. Match unified_budget exactly:
-            # photos fill freely only when videos cannot fill half the budget.
-            available_video_duration = sum(
-                c.end_time - c.start_time for c in analyzed if c.clip.asset.type != AssetType.IMAGE
-            )
-            videos_scarce = available_video_duration < target_duration * 0.5
-            photo_cap_bypassed = videos_scarce
-            # Even when photos may ultimately fill freely, first normalize a
-            # photo-biased selection so backfill has room to use every valid
-            # video candidate. The backfill exemption then admits photos again.
-            before_cap = selected
-            selected = enforce_photo_cap(
-                selected,
-                self.config.photo_max_ratio,
-                protected_ids=coverage_ids,
-            )
-            trace.record("photo ratio cap", before_cap, selected)
+        selected, photo_cap_bypassed = cap_ratios(
+            self.config,
+            selected,
+            analyzed,
+            coverage_ids=coverage_ids,
+            target_duration=target_duration,
+        )
 
         before_backfill = selected
         selected = self._backfill_to_duration(

--- a/src/immich_memories/analysis/clip_refiner.py
+++ b/src/immich_memories/analysis/clip_refiner.py
@@ -74,6 +74,46 @@ def _clips_per_moment(target_clips: int, moments: int) -> int:
     return max(1, min(share, int(target_clips * _MAX_SHARE_FROM_ONE_MOMENT)))
 
 
+def _warn_if_an_absorber_will_have_to_act(
+    selected: list[ClipWithSegment], target_duration: float
+) -> None:
+    """Say so when generation will have to fix this cut rather than render it.
+
+    Two absorbers sit below selection and neither of them says anything. The
+    stride sampler in apply_final_content_budget keeps only every nth clip once
+    the cut holds more than the budget can give a minimum-length slot; the
+    proportional trim beside it shortens every clip when the content runs long.
+    Both turn a selection problem into a render nobody can explain, so the
+    trace names the condition while the cut is still readable.
+
+    Measured against the content budget selection was given, which is the
+    closest thing available here to the one generation will plan with — the
+    title cards come out of it later, so this errs on the permissive side.
+    """
+    # One definition, imported where it is used: the sampler's floor lives with
+    # the sampler. A copy here would drift from the number actually applied.
+    from immich_memories.analysis import selection_trace as trace
+    from immich_memories.generate_clips import MIN_CLIP_DURATION
+
+    if target_duration <= 0 or not selected:
+        return
+    slots = max(1, int(target_duration // MIN_CLIP_DURATION))
+    if len(selected) >= slots:
+        trace.warn(
+            f"the cut hands generation {len(selected)} clips against a "
+            f"{target_duration:.0f}s budget — the stride sampler will drop every "
+            "other one before it renders"
+        )
+    total = sum(item.end_time - item.start_time for item in selected)
+    # A hair of tolerance: backfill fills to exactly the ceiling on the
+    # arithmetic path, and float noise there is not an overrun.
+    if total - target_duration * 1.1 > 0.05:
+        trace.warn(
+            f"the cut hands generation {total:.0f}s of content against a "
+            f"{target_duration:.0f}s budget — every clip will be trimmed to fit"
+        )
+
+
 class ClipRefiner:
     """Selects, distributes, and refines the final clip selection."""
 
@@ -631,7 +671,10 @@ class ClipRefiner:
 
         structure = (
             self._structure.choose(
-                all_analyzed, target_duration=target_duration, moment_window=moment_window
+                all_analyzed,
+                target_duration=target_duration,
+                moment_window=moment_window,
+                target_clips=self.config.target_clips,
             )
             if self._structure is not None
             else None
@@ -705,6 +748,7 @@ class ClipRefiner:
         trace.record("the favourite wins its moment", before_law, selected)
 
         selected.sort(key=lambda c: c.clip.asset.file_created_at or datetime.min)
+        _warn_if_an_absorber_will_have_to_act(selected, target_duration)
 
         clip_segments: dict[str, tuple[float, float]] = {}
         selected_clips: list[VideoClipInfo] = []

--- a/src/immich_memories/analysis/clip_scaler.py
+++ b/src/immich_memories/analysis/clip_scaler.py
@@ -115,6 +115,34 @@ def group_by_moment(
     return groups + [[c] for c in undated]
 
 
+def group_by_moment_and_place(
+    clips: list[ClipWithSegment],
+    time_window_minutes: float,
+) -> list[list[ClipWithSegment]]:
+    """Group within the bounded time window, then split parallel places.
+
+    ``group_by_moment`` supplies the span bound that stops a whole day from
+    chaining into one moment. The shared place grouper then prevents two
+    devices in different towns from being thinned as duplicates merely because
+    their clocks overlap.
+    """
+    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+
+    groups: list[list[ClipWithSegment]] = []
+    for temporal_group in group_by_moment(clips, time_window_minutes):
+        if temporal_group[0].clip.asset.file_created_at is None:
+            groups.append(temporal_group)
+            continue
+        member_by_asset = {id(member.clip.asset): member for member in temporal_group}
+        for assets in _group_by_time_and_place(
+            [member.clip.asset for member in temporal_group],
+            window_minutes=time_window_minutes,
+        ):
+            groups.append([member_by_asset[id(asset)] for asset in assets])
+    groups.sort(key=lambda group: group[0].clip.asset.file_created_at or datetime.min)
+    return groups
+
+
 def _fit_temporally_distributed(
     clips: list[ClipWithSegment], max_duration: float
 ) -> list[ClipWithSegment]:
@@ -437,7 +465,7 @@ class ClipScaler:
 
         keep = max(1, keep_per_moment)
         protected = protected_ids or set()
-        for cluster_clips in group_by_moment(clips, time_window_minutes):
+        for cluster_clips in group_by_moment_and_place(clips, time_window_minutes):
             if len(cluster_clips) <= keep:
                 result.extend(cluster_clips)
                 continue

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -29,12 +29,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from itertools import starmap
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from datetime import datetime
     from pathlib import Path
 
     from immich_memories.analysis.smart_pipeline import ClipWithSegment
@@ -110,7 +110,7 @@ def _est(moment: _Moment) -> float:
     return best.end_time - best.start_time
 
 
-def _shipped_est(kept: list[_Moment], target_clips: int) -> float:
+def _shipped_est(kept: list[_Moment], target_clips: int, *, moment_window: float) -> float:
     """What the kept moments will actually run once the cut reaches assembly.
 
     Not one representative each. This pass hands ALL members of a kept moment
@@ -127,12 +127,17 @@ def _shipped_est(kept: list[_Moment], target_clips: int) -> float:
     releasing a moment can raise the estimate rather than lower it.
     """
     from immich_memories.analysis.clip_refiner import _clips_per_moment
+    from immich_memories.analysis.clip_scaler import group_by_moment
 
-    share = _clips_per_moment(target_clips, len(kept))
+    members = [member for moment in kept for member in moment.members]
+    if moment_window <= 0:
+        return sum(member.end_time - member.start_time for member in members)
+    temporal_groups = group_by_moment(members, moment_window)
+    share = _clips_per_moment(target_clips, len(temporal_groups))
     total = 0.0
-    for moment in kept:
+    for group in temporal_groups:
         ranked = sorted(
-            moment.members,
+            group,
             key=lambda member: (member.clip.asset.is_favorite, member.score),
             reverse=True,
         )
@@ -152,31 +157,41 @@ def _ids(moment: _Moment) -> set[str]:
 
 
 def _moments_of(pool: list[ClipWithSegment], moment_window: float) -> list[_Moment]:
-    """The pool as moments, chained into episodes, in chronological order.
+    """The pool as time-and-place moments and episodes, in chronological order.
 
-    The same grouping the dedup stage collapses on, so the pass reasons in the
-    unit its decision is later carried out in. Episodes chain those moments
-    the way the review labels them: a gap wider than the episode window starts
-    a new occasion.
+    The temporal boundary stays the one the downstream dedup stage uses, then
+    the shared place rule splits parallel devices into the separate moments
+    they photographed. Episodes come from the same helper as the fine cut, so
+    both passes call the same time-and-place block one occasion.
     """
     from immich_memories.analysis.clip_scaler import group_by_moment
-    from immich_memories.analysis.moment_grouping import EPISODE_WINDOW_MINUTES
+    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+    from immich_memories.analysis.selection_review import _episode_labels
 
-    moments: list[_Moment] = []
-    episode = 0
-    previous: datetime | None = None
-    for group in group_by_moment(pool, moment_window):
-        start = _started(group[0])
-        # An undated moment can neither continue an occasion nor be continued.
-        if (
-            start is None
-            or previous is None
-            or (start - previous).total_seconds() > EPISODE_WINDOW_MINUTES * 60
+    episode_by_id = {
+        member.clip.asset.id: episode
+        for member, episode in zip(pool, _episode_labels(pool), strict=True)
+    }
+    temporal_groups = (
+        [[member] for member in sorted(pool, key=lambda item: _started(item) or datetime.min)]
+        if moment_window <= 0
+        else group_by_moment(pool, moment_window)
+    )
+    groups: list[list[ClipWithSegment]] = []
+    for temporal_group in temporal_groups:
+        if _started(temporal_group[0]) is None:
+            groups.append(temporal_group)
+            continue
+        by_id = {member.clip.asset.id: member for member in temporal_group}
+        for assets in _group_by_time_and_place(
+            [member.clip.asset for member in temporal_group],
+            window_minutes=moment_window,
         ):
-            episode += 1
-        moments.append(_Moment(tuple(group), f"E{episode}"))
-        previous = start
-    return moments
+            groups.append([by_id[asset.id] for asset in assets])
+    groups.sort(key=lambda group: _started(group[0]) or datetime.min)
+    return [
+        _Moment(tuple(group), episode_by_id.get(group[0].clip.asset.id, "E?")) for group in groups
+    ]
 
 
 def _when(moment: _Moment) -> str:
@@ -306,7 +321,12 @@ class StructurePass:
         if self._fates is not None:
             return _replay(pool, self._fates, self._fates_narrowed)
         moments = _moments_of(pool, moment_window)
-        nothing_to_decide = _nothing_to_decide(moments, target_duration, target_clips)
+        nothing_to_decide = _nothing_to_decide(
+            moments,
+            target_duration,
+            target_clips,
+            moment_window=moment_window,
+        )
         if nothing_to_decide is not None:
             # No memo: a later round may see more material than this one, and
             # a pool that fitted once is not a decision about the next pool.
@@ -320,7 +340,13 @@ class StructurePass:
             _never_ran("the answer cut all but one moment, which is not an edit")
             return None
         cut = self._carry_out(
-            pool, moments, answer, target_duration, target_clips, may_ask=not asked_twice
+            pool,
+            moments,
+            answer,
+            target_duration,
+            target_clips,
+            moment_window,
+            may_ask=not asked_twice,
         )
         self._fates, self._fates_narrowed = cut.cuts.copy(), cut.narrowed
         return cut
@@ -354,14 +380,24 @@ class StructurePass:
         answer: Answer,
         target_duration: float,
         target_clips: int,
+        moment_window: float,
         *,
         may_ask: bool,
     ) -> StructureCut:
         """Apply the rejects, and shrink to the envelope if the editor ranks."""
         kept, notes, reasons = _keep_after_the_starred_rule(moments, answer)
-        shipped = _shipped_est(list(kept.values()), target_clips)
+        shipped = _shipped_est(list(kept.values()), target_clips, moment_window=moment_window)
         if shipped <= target_duration * ENVELOPE_CEILING:
-            return _apply(pool, kept, notes, reasons, target_duration, target_clips, len(moments))
+            return _apply(
+                pool,
+                kept,
+                notes,
+                reasons,
+                target_duration,
+                target_clips,
+                moment_window,
+                len(moments),
+            )
         order = self._priority_for(kept, shipped, target_duration, reasons, may_ask)
         if order is None:
             # The judgment stands; only the length is unsettled. What the model
@@ -380,11 +416,29 @@ class StructurePass:
                 reasons,
                 target_duration,
                 target_clips,
+                moment_window,
                 len(moments),
                 narrowed=False,
             )
-        _release_to_fit(kept, order, target_duration, target_clips, notes, reasons)
-        return _apply(pool, kept, notes, reasons, target_duration, target_clips, len(moments))
+        _release_to_fit(
+            kept,
+            order,
+            target_duration,
+            target_clips,
+            moment_window,
+            notes,
+            reasons,
+        )
+        return _apply(
+            pool,
+            kept,
+            notes,
+            reasons,
+            target_duration,
+            target_clips,
+            moment_window,
+            len(moments),
+        )
 
     def _priority_for(
         self,
@@ -444,7 +498,11 @@ def _never_ran(why: str) -> None:
 
 
 def _nothing_to_decide(
-    moments: list[_Moment], target_duration: float, target_clips: int
+    moments: list[_Moment],
+    target_duration: float,
+    target_clips: int,
+    *,
+    moment_window: float,
 ) -> str | None:
     """Why this pool needs no editing, or None when it does.
 
@@ -458,7 +516,7 @@ def _nothing_to_decide(
     """
     if len(moments) < 2:
         return "one moment is not a structure to decide"
-    shipped = _shipped_est(moments, target_clips)
+    shipped = _shipped_est(moments, target_clips, moment_window=moment_window)
     if shipped <= target_duration * ENVELOPE_CEILING:
         return (
             f"the pool already fits the budget — {shipped:.0f}s as it will ship "
@@ -520,6 +578,7 @@ def _apply(
     reasons: list[str],
     target_duration: float,
     target_clips: int,
+    moment_window: float,
     of_moments: int,
     *,
     narrowed: bool = True,
@@ -529,7 +588,7 @@ def _apply(
     # Deliberately non-monotone in the number of kept moments: the share one
     # moment may ship steps up as the keep-set shrinks, so releasing a moment
     # can RAISE this estimate. A reader of the trace should not be surprised.
-    total = _shipped_est(list(kept.values()), target_clips)
+    total = _shipped_est(list(kept.values()), target_clips, moment_window=moment_window)
     reasons.insert(
         0,
         f"kept {len(kept)} of {of_moments} moment(s) — {representatives:.0f}s of "
@@ -585,6 +644,7 @@ def _release_to_fit(
     priority: tuple[int, ...],
     target_duration: float,
     target_clips: int,
+    moment_window: float,
     notes: dict[str, str],
     reasons: list[str],
 ) -> None:
@@ -606,7 +666,7 @@ def _release_to_fit(
     for index in reversed(priority):
         if len(kept) <= 1:
             return
-        if _shipped_est(list(kept.values()), target_clips) <= ceiling:
+        if _shipped_est(list(kept.values()), target_clips, moment_window=moment_window) <= ceiling:
             return
         moment = kept.get(index)
         if moment is None or _the_last_star_of_its_episode(moment, kept.values()):

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -9,18 +9,24 @@ This pass asks the question those caps were standing in for, once, at MOMENT
 granularity: which of these moments does the month's story need? Numbers still
 order things here — the table is chronological, durations are estimated, the
 keep-set is measured against the budget — but no number decides a kill. Every
-moment that goes is one the model named, or one the model itself ranked most
-expendable, released against a fixed envelope.
+moment that goes is one the model named, or one it ranked last itself: the
+keep list is written most essential first, and the envelope releases from its
+tail. Nothing here invents that order (see structure_answer.states_a_priority).
 
 Duration is a convergence bound, not an eviction rule. This is the rough cut
 and it only has to land near the content budget; the fine cut (the llm review)
-converges further downstream.
+converges further downstream. When the editor cannot say what to give up, the
+cut still stands and the counting stages narrow what it kept — see
+StructureCut.narrowed.
+
+The question itself, and the reading of its answer, live next door in
+structure_answer: the wording there is measured against real answers and fails
+differently from the editing done here.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -36,6 +42,20 @@ if TYPE_CHECKING:
 
 from immich_memories.analysis import selection_trace as trace
 from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
+from immich_memories.analysis.structure_answer import (
+    ENVELOPE_CEILING,
+    ENVELOPE_FLOOR,
+    Answer,
+    Reply,
+    answer_in,
+    defect_prompt,
+    defects_in,
+    first_prompt,
+    order_mode,
+    reorder_prompt,
+    reordering_in,
+    states_a_priority,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,110 +63,8 @@ logger = logging.getLogger(__name__)
 # against a local reasoning model, for a prompt of the same shape.
 _STRUCTURE_MAX_TOKENS = 8000
 
-# How near the content budget the rough cut has to land. Not an eviction rule:
-# the fine cut converges further, and backfill fills an under-run.
-_ENVELOPE_FLOOR = 0.9
-_ENVELOPE_CEILING = 1.1
-
 # How much of a member's description one table line carries.
 _DESCRIPTION_CHARS = 120
-
-_PROMPT = """You are structuring the rough cut of a month's memory video from
-its moments. They are listed in the order they happened, and that order is
-fixed: what you include is your only lever.
-
-Ask ONE question of every moment: **does the month's story need it?**
-
-The story needs coverage of what actually happened, not only what looks
-strongest — the punch-up is not the march. A day earns a second moment only
-when the story needs both of them. A cut made of nothing but peaks is
-shapeless: vary the tension.
-
-`starred n/m` counts the items the owner marked a favourite. Those are the
-owner's own marks and they carry the month's meaning. Cut a starred moment
-only when its occasion is already over-represented AND another starred moment
-of that occasion stays in.
-
-Moments sharing an `episode` name are ONE occasion — an afternoon somewhere, a
-party, a hike — however different their descriptions read.
-
-{moments}
-
-The content budget is {target:.0f}s. Do the arithmetic: add up the `est`
-seconds of every moment you keep, and that sum must land between {floor:.0f}s
-and {ceiling:.0f}s. Keeping more than that is not an edit, it is a list.
-
-Every moment you cut needs a one-line reason. What you leave out is mined
-again later, and a bare no is useless to whoever reads it.
-
-Also return `release_order`: every moment you kept, most expendable first —
-what falls first if the cut still has to shrink. Choose that order yourself:
-the memory plays in the order things happened, so the last moment you keep is
-the month's closer, and nothing here will guess for you.
-
-Answer with STRICT JSON only, no prose:
-{{"keep": [<moment numbers>],
- "cut": [{{"index": <moment number>, "reason": "<short reason>"}}],
- "release_order": [<every kept moment number, most expendable first>]}}
-Every moment from 1 to {count} must appear exactly once across keep and cut."""
-
-
-_REVISION_PROMPT = """You have already edited this month, and what you kept
-does not fit its runtime. Here are the same moments, in the same order and
-numbered the same way:
-
-{moments}
-
-You kept: {kept}
-Assembled, those moments run about {shipped:.0f}s. The content budget is
-{target:.0f}s, so what you keep has to land between {floor:.0f}s and
-{ceiling:.0f}s.
-
-Revise the edit. Either cut more moments until what you keep fits, or give a
-`release_order` — every moment you keep, most expendable first — and the cut
-will shrink in the order you choose.
-
-What falls first matters. The memory plays in the order things happened, so
-the last moment you keep is the month's closer: an order that releases from
-the end shortens the month instead of trimming it.
-
-Same rules as before: starred moments carry the month's meaning, moments
-sharing an `episode` are one occasion, and every moment you cut needs a
-one-line reason.
-
-Answer with STRICT JSON only, no prose:
-{{"keep": [<moment numbers>],
- "cut": [{{"index": <moment number>, "reason": "<short reason>"}}],
- "release_order": [<every kept moment number, most expendable first>]}}
-Every moment from 1 to {count} must appear exactly once across keep and cut."""
-
-
-def _first_prompt(table: str, count: int, target_duration: float) -> str:
-    return _PROMPT.format(
-        moments=table,
-        count=count,
-        target=target_duration,
-        floor=target_duration * _ENVELOPE_FLOOR,
-        ceiling=target_duration * _ENVELOPE_CEILING,
-    )
-
-
-def _revision_prompt(
-    table: str,
-    count: int,
-    kept: tuple[int, ...],
-    shipped: float,
-    target_duration: float,
-) -> str:
-    return _REVISION_PROMPT.format(
-        moments=table,
-        count=count,
-        kept=", ".join(f"M{index}" for index in kept),
-        shipped=shipped,
-        target=target_duration,
-        floor=target_duration * _ENVELOPE_FLOOR,
-        ceiling=target_duration * _ENVELOPE_CEILING,
-    )
 
 
 def _ask(
@@ -196,7 +114,10 @@ def _shipped_est(kept: list[_Moment], target_clips: int) -> float:
     structure pass replaces.
 
     The share depends on how many moments are kept, so it is recomputed as the
-    keep-set shrinks rather than fixed at the start of a walk.
+    keep-set shrinks rather than fixed at the start of a walk. That makes this
+    deliberately NON-MONOTONE in the number of kept moments: crossing the
+    keep_per_moment threshold lets each surviving moment ship more, so
+    releasing a moment can raise the estimate rather than lower it.
     """
     from immich_memories.analysis.clip_refiner import _clips_per_moment
 
@@ -301,94 +222,18 @@ def _table(moments: list[_Moment]) -> str:
 
 
 @dataclass(frozen=True)
-class _Answer:
-    """The edit the model made, once it accounts for every moment."""
-
-    keep: tuple[int, ...]
-    cut: tuple[tuple[int, str], ...]
-    # None when the model stated no usable order. There is no fallback: see
-    # _stated_release_order.
-    release_order: tuple[int, ...] | None
-
-
-def _is_a_moment_number(value: object) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def _stated_release_order(given: object, kept: list[int]) -> tuple[int, ...] | None:
-    """The editor's own order over its own keeps, or None if it stated none.
-
-    No fallback, and that is the whole point. An order we invent is a
-    mechanical kill wearing an editor's clothes: guessing "the keeps are in
-    story order, so later means looser" released M53, M52, M50 and downwards
-    on a real June and amputated the end of the month. A memory plays in the
-    order things happened, so the last moment kept IS the closer, and a rule
-    that releases from the end is a rule that shortens the month.
-
-    Read as one list rather than entry by entry: an order naming something
-    that was never kept is not an order over this cut.
-    """
-    if (
-        isinstance(given, list)
-        and all(_is_a_moment_number(n) for n in given)
-        and set(given) == set(kept)
-    ):
-        return tuple(given)
-    return None
-
-
-def _accounted_for(payload: object, count: int) -> _Answer | None:
-    """The edit, but only if the answer accounts for every moment exactly once.
-
-    Under keep-semantics silence is a kill, so a truncated answer would cut
-    every moment it never reached. Requiring the two lists to partition 1..M
-    turns truncation back into a parse failure, which this pass survives by
-    handing the cut to the arithmetic funnel. It is also the cheapest check
-    that the model answered about THESE moments.
-    """
-    if not isinstance(payload, dict):
-        return None
-    keep, cut = payload.get("keep"), payload.get("cut")
-    if not isinstance(keep, list) or not isinstance(cut, list) or not keep:
-        return None
-    kept = [n for n in keep if _is_a_moment_number(n)]
-    entries = [
-        (entry["index"], str(entry.get("reason", "no reason given")))
-        for entry in cut
-        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
-    ]
-    if len(kept) != len(keep) or len(entries) != len(cut):
-        return None
-    if sorted(kept + [index for index, _ in entries]) != list(range(1, count + 1)):
-        return None
-    return _Answer(
-        tuple(kept), tuple(entries), _stated_release_order(payload.get("release_order"), kept)
-    )
-
-
-def _answer_in(raw: str | None, count: int) -> _Answer | None:
-    """The model's edit, or None when it never made one about these moments."""
-    if not raw:
-        return None
-    from immich_memories.analysis.selection_review import _balanced_objects
-
-    for candidate in reversed(_balanced_objects(raw)):
-        try:
-            payload = json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-        answer = _accounted_for(payload, count)
-        if answer is not None:
-            return answer
-    return None
-
-
-@dataclass(frozen=True)
 class StructureCut:
-    """The clips whose moments the story kept, and why each of the rest went."""
+    """The clips whose moments the story kept, and why each of the rest went.
+
+    `narrowed` says whether the length of this cut was settled here. False is
+    the honest fallback: the story made a cut it stands behind but could not
+    say what to give up first, so the counting stages narrow what it kept
+    rather than the whole pool.
+    """
 
     kept: list[ClipWithSegment]
     cuts: dict[str, str]
+    narrowed: bool = True
 
     @property
     def dropped(self) -> frozenset[str]:
@@ -425,8 +270,10 @@ class StructurePass:
     ) -> StructureCut | None:
         """The clips whose moments the story needs, or None if it never decided.
 
-        None is the signal to fall back: the arithmetic funnel makes the cut
-        instead, and the trace says so above the funnel.
+        None is the signal to fall back entirely: the arithmetic funnel makes
+        the cut over the whole pool, and the trace says so above the funnel. A
+        cut that stands but could not be shrunk comes back with `narrowed`
+        False instead — the judgment is kept, the length is not.
         """
         if self._fates is not None:
             return _replay(pool, self._fates)
@@ -438,61 +285,121 @@ class StructurePass:
             trace.record("structure", pool, pool, [f"not asked — {nothing_to_decide}"])
             return StructureCut(kept=pool.copy(), cuts={})
         table = _table(moments)
-        answer = self._put(_first_prompt(table, len(moments), target_duration), len(moments))
+        answer, asked_twice = self._edit_of(table, moments, target_duration)
         if answer is None:
             return None
-        edit = _edit_from(moments, answer, target_duration, target_clips)
-        if edit is None:
-            edit = self._revise(table, moments, answer, target_duration, target_clips)
-        if edit is None:
-            return None
-        cut = _apply(pool, edit)
+        cut = self._carry_out(
+            pool, moments, answer, target_duration, target_clips, may_ask=not asked_twice
+        )
         self._fates = cut.cuts.copy()
         return cut
 
-    def _revise(
+    def _edit_of(
+        self, table: str, moments: list[_Moment], target_duration: float
+    ) -> tuple[Answer | None, bool]:
+        """The edit, and whether asking for it cost the run its one re-ask.
+
+        A first answer whose two lists do not account for every moment gets
+        one retry, and that retry is told exactly which numbers were wrong.
+        An answer with no edit in it at all gets nothing: there is no defect
+        to name, so there is nothing to correct.
+        """
+        count = len(moments)
+        reply = self._put(first_prompt(table, count, target_duration), count)
+        if reply.answer is not None or not reply.reached:
+            return reply.answer, False
+        if not reply.defects:
+            _never_ran("the model's answer could not be read")
+            return None, True
+        retry = self._put(defect_prompt(table, count, reply.defects), count)
+        if retry.answer is None and retry.reached:
+            _never_ran("the revised answer still did not account for every moment")
+        return retry.answer, True
+
+    def _carry_out(
         self,
-        table: str,
+        pool: list[ClipWithSegment],
         moments: list[_Moment],
-        overshot: _Answer,
+        answer: Answer,
         target_duration: float,
         target_clips: int,
-    ) -> _Edit | None:
-        """One corrective ask, then the funnel. No retry ladder.
+        *,
+        may_ask: bool,
+    ) -> StructureCut:
+        """Apply the edit, and shrink it to the envelope if the editor said how."""
+        kept, notes, reasons = _keep_after_the_starred_rule(moments, answer)
+        reasons.append(order_mode(answer.keep))
+        shipped = _shipped_est(list(kept.values()), target_clips)
+        if shipped <= target_duration * ENVELOPE_CEILING:
+            return _apply(pool, kept, notes, reasons, target_duration, target_clips, len(moments))
+        order = self._priority_for(answer.keep, kept, shipped, target_duration, reasons, may_ask)
+        if order is None:
+            # The judgment stands; only the length is unsettled. Measured four
+            # times out of four, what the model cut was sound and what it said
+            # about order was not, so the cut is kept and the counting stages
+            # are handed the remainder rather than the pool.
+            reasons.append("no priority to shrink by — the funnel narrowed what was kept")
+            trace.warn(
+                "the structure pass cut, but stated no priority — "
+                "the arithmetic funnel narrowed the remainder"
+            )
+            return _apply(
+                pool,
+                kept,
+                notes,
+                reasons,
+                target_duration,
+                target_clips,
+                len(moments),
+                narrowed=False,
+            )
+        _release_to_fit(kept, order, target_duration, target_clips, notes, reasons)
+        return _apply(pool, kept, notes, reasons, target_duration, target_clips, len(moments))
 
-        The editor kept more than the runtime holds and named no order to
-        shrink by, so it is shown its own keep list, what it will actually run
-        and the envelope, and asked to revise. A revision that still overshoots
-        with no order is refused exactly like an unreadable answer: nothing
-        here may invent the order itself.
+    def _priority_for(
+        self,
+        keep: tuple[int, ...],
+        kept: dict[int, _Moment],
+        shipped: float,
+        target_duration: float,
+        reasons: list[str],
+        may_ask: bool,
+    ) -> tuple[int, ...] | None:
+        """The order to release in, asking once if the editor stated none.
+
+        The re-ask fires on the conjunction only: an unranked keep list is
+        harmless while everything in it fits, so it costs a reasoning call
+        only when something actually has to go.
         """
-        kept, _cuts, _account = _keep_after_the_starred_rule(moments, overshot)
-        prompt = _revision_prompt(
-            table,
-            len(moments),
-            tuple(sorted(kept)),
-            _shipped_est(list(kept.values()), target_clips),
-            target_duration,
-        )
-        answer = self._put(prompt, len(moments))
-        if answer is None:
+        if states_a_priority(keep):
+            reasons.append("priority stated with its first answer")
+            return keep
+        if not may_ask:
             return None
-        edit = _edit_from(moments, answer, target_duration, target_clips, revised=True)
-        if edit is None:
-            _never_ran("the revised cut still overshot the budget and stated no release order")
-        return edit
+        echoed = tuple(kept)
+        raw = self._say(reorder_prompt(echoed, shipped, target_duration))
+        order = reordering_in(raw, echoed) if raw is not None else None
+        if order is None or not states_a_priority(order):
+            return None
+        reasons.extend(("asked once to revise", "priority stated when asked to revise"))
+        return order
 
-    def _put(self, prompt: str, count: int) -> _Answer | None:
+    def _put(self, prompt: str, count: int) -> Reply:
+        raw = self._say(prompt)
+        if raw is None:
+            return Reply(None, reached=False)
+        answer = answer_in(raw, count)
+        if answer is not None:
+            return Reply(answer)
+        return Reply(None, defects_in(raw, count))
+
+    def _say(self, prompt: str) -> str | None:
         try:
-            raw = _ask(prompt, self._llm, self._timeout, self._cache_path)
+            return _ask(prompt, self._llm, self._timeout, self._cache_path)
         except Exception as e:  # WHY broad: the pass is optional; the funnel decides instead
             stop_if_this_is_our_bug(e, "structure pass")
             _never_ran(f"the model was unavailable ({type(e).__name__})")
             return None
-        answer = _answer_in(raw, count)
-        if answer is None:
-            _never_ran("the model's answer could not be read")
-        return answer
 
 
 def _never_ran(why: str) -> None:
@@ -522,7 +429,7 @@ def _nothing_to_decide(
     if len(moments) < 2:
         return "one moment is not a structure to decide"
     shipped = _shipped_est(moments, target_clips)
-    if shipped <= target_duration * _ENVELOPE_CEILING:
+    if shipped <= target_duration * ENVELOPE_CEILING:
         return (
             f"the pool already fits the budget — {shipped:.0f}s as it will ship "
             f"against {target_duration:.0f}s"
@@ -546,16 +453,8 @@ def _the_last_star_of_its_episode(moment: _Moment, kept: Iterable[_Moment]) -> b
     )
 
 
-@dataclass(frozen=True)
-class _Edit:
-    """A carried-out edit: why each dropped clip went, and the stage's account."""
-
-    notes: dict[str, str]
-    reasons: list[str]
-
-
 def _keep_after_the_starred_rule(
-    moments: list[_Moment], answer: _Answer
+    moments: list[_Moment], answer: Answer
 ) -> tuple[dict[int, _Moment], dict[str, str], list[str]]:
     """The keep-set this answer really produces, and the account of the rest.
 
@@ -581,58 +480,43 @@ def _keep_after_the_starred_rule(
     return kept, notes, reasons
 
 
-def _edit_from(
-    moments: list[_Moment],
-    answer: _Answer,
+def _apply(
+    pool: list[ClipWithSegment],
+    kept: dict[int, _Moment],
+    notes: dict[str, str],
+    reasons: list[str],
     target_duration: float,
     target_clips: int,
+    of_moments: int,
     *,
-    revised: bool = False,
-) -> _Edit | None:
-    """Carry out the answer, or None when it overshoots with no order to shrink by.
-
-    Kept moments continue whole; cut moments go whole, minus the occasions
-    that would be left with no starred moment. None is not a refusal on its
-    own — the caller asks the editor to revise once, and refuses only if that
-    comes back the same way.
-    """
-    kept, notes, reasons = _keep_after_the_starred_rule(moments, answer)
-    if revised:
-        reasons.insert(0, "the first answer overshot the budget: asked once to revise")
-
-    if _shipped_est(list(kept.values()), target_clips) > target_duration * _ENVELOPE_CEILING:
-        if answer.release_order is None:
-            return None
-        reasons.append(
-            "released against the editor's order, stated "
-            + ("when asked to revise" if revised else "with its first answer")
-        )
-        _release_to_fit(kept, answer.release_order, target_duration, target_clips, notes, reasons)
-
+    narrowed: bool = True,
+) -> StructureCut:
+    """Put the finished edit on the record and hand back what survived it."""
     representatives = sum(_est(m) for m in kept.values())
+    # Deliberately non-monotone in the number of kept moments: the share one
+    # moment may ship steps up as the keep-set shrinks, so releasing a moment
+    # can RAISE this estimate. A reader of the trace should not be surprised.
     total = _shipped_est(list(kept.values()), target_clips)
     reasons.insert(
         0,
-        f"kept {len(kept)} of {len(moments)} moment(s) — {representatives:.0f}s of "
+        f"kept {len(kept)} of {of_moments} moment(s) — {representatives:.0f}s of "
         f"representatives, {total:.0f}s as it will ship, against a "
         f"{target_duration:.0f}s budget",
     )
-    if total > target_duration * _ENVELOPE_CEILING:
+    if narrowed and total > target_duration * ENVELOPE_CEILING:
         # The walk ran out of moments it was allowed to release. Not a refusal:
-        # what stopped it is the starred rule, which outranks the envelope.
-        reasons.append("still over the ceiling — every remaining moment is protected")
-    if total < target_duration * _ENVELOPE_FLOOR:
+        # what stopped it is the starred rule, or the last moment standing.
+        reasons.append(
+            "still over the ceiling — nothing left to release that is not "
+            "protected or the last moment standing"
+        )
+    if total < target_duration * ENVELOPE_FLOOR:
         # Nothing is forced back in: backfill exists for exactly this, and a
         # moment the story does not need is not a way to fill a runtime.
         reasons.append(f"under-run — {target_duration - total:.0f}s left for backfill to fill")
-    return _Edit(notes=notes, reasons=reasons)
-
-
-def _apply(pool: list[ClipWithSegment], edit: _Edit) -> StructureCut:
-    """Put the edit on the record and hand back what survived it."""
-    survivors = [item for item in pool if item.clip.asset.id not in edit.notes]
-    trace.record("structure", pool, survivors, edit.reasons, edit.notes)
-    return StructureCut(kept=survivors, cuts=edit.notes)
+    survivors = [item for item in pool if item.clip.asset.id not in notes]
+    trace.record("structure", pool, survivors, reasons, notes)
+    return StructureCut(kept=survivors, cuts=notes, narrowed=narrowed)
 
 
 def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
@@ -660,20 +544,30 @@ def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
 
 def _release_to_fit(
     kept: dict[int, _Moment],
-    release_order: tuple[int, ...],
+    priority: tuple[int, ...],
     target_duration: float,
     target_clips: int,
     notes: dict[str, str],
     reasons: list[str],
 ) -> None:
-    """Shrink an over-long keep-set by the model's own order of expendability.
+    """Shrink an over-long keep-set from the tail of the editor's priority.
 
     The only stage here a number can start, and it still does not choose: the
-    envelope says how much has to go, the editor said in which order.
+    envelope says how much has to go, the editor's own order says which.
+
+    A floor it never crosses: the last moment standing is never released. An
+    empty cut with every id in the refused set is unrecoverable — backfill may
+    not touch them — so a memory that cannot be shrunk any further ships long
+    and says so, and the absorber warning at the end of the phase catches it.
     """
-    ceiling = target_duration * _ENVELOPE_CEILING
-    said = f"released to fit the {target_duration:.0f}s budget (the editor's stated release order)"
-    for index in release_order:
+    ceiling = target_duration * ENVELOPE_CEILING
+    said = (
+        f"released to fit the {target_duration:.0f}s budget "
+        "(released last from the editor's priority order)"
+    )
+    for index in reversed(priority):
+        if len(kept) <= 1:
+            return
         if _shipped_est(list(kept.values()), target_clips) <= ceiling:
             return
         moment = kept.get(index)

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -127,15 +127,15 @@ def _shipped_est(kept: list[_Moment], target_clips: int, *, moment_window: float
     releasing a moment can raise the estimate rather than lower it.
     """
     from immich_memories.analysis.clip_refiner import _clips_per_moment
-    from immich_memories.analysis.clip_scaler import group_by_moment
+    from immich_memories.analysis.clip_scaler import group_by_moment_and_place
 
     members = [member for moment in kept for member in moment.members]
     if moment_window <= 0:
         return sum(member.end_time - member.start_time for member in members)
-    temporal_groups = group_by_moment(members, moment_window)
-    share = _clips_per_moment(target_clips, len(temporal_groups))
+    moments = group_by_moment_and_place(members, moment_window)
+    share = _clips_per_moment(target_clips, len(moments))
     total = 0.0
-    for group in temporal_groups:
+    for group in moments:
         ranked = sorted(
             group,
             key=lambda member: (member.clip.asset.is_favorite, member.score),
@@ -164,31 +164,18 @@ def _moments_of(pool: list[ClipWithSegment], moment_window: float) -> list[_Mome
     they photographed. Episodes come from the same helper as the fine cut, so
     both passes call the same time-and-place block one occasion.
     """
-    from immich_memories.analysis.clip_scaler import group_by_moment
-    from immich_memories.analysis.moment_grouping import _group_by_time_and_place
+    from immich_memories.analysis.clip_scaler import group_by_moment_and_place
     from immich_memories.analysis.selection_review import _episode_labels
 
     episode_by_id = {
         member.clip.asset.id: episode
         for member, episode in zip(pool, _episode_labels(pool), strict=True)
     }
-    temporal_groups = (
+    groups = (
         [[member] for member in sorted(pool, key=lambda item: _started(item) or datetime.min)]
         if moment_window <= 0
-        else group_by_moment(pool, moment_window)
+        else group_by_moment_and_place(pool, moment_window)
     )
-    groups: list[list[ClipWithSegment]] = []
-    for temporal_group in temporal_groups:
-        if _started(temporal_group[0]) is None:
-            groups.append(temporal_group)
-            continue
-        by_id = {member.clip.asset.id: member for member in temporal_group}
-        for assets in _group_by_time_and_place(
-            [member.clip.asset for member in temporal_group],
-            window_minutes=moment_window,
-        ):
-            groups.append([by_id[asset.id] for asset in assets])
-    groups.sort(key=lambda group: _started(group[0]) or datetime.min)
     return [
         _Moment(tuple(group), episode_by_id.get(group[0].clip.asset.id, "E?")) for group in groups
     ]

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -72,20 +72,81 @@ party, a hike — however different their descriptions read.
 
 {moments}
 
-The content budget is {target:.0f}s. The `est` seconds of the moments you keep
-should sum to between {floor:.0f}s and {ceiling:.0f}s.
+The content budget is {target:.0f}s. Do the arithmetic: add up the `est`
+seconds of every moment you keep, and that sum must land between {floor:.0f}s
+and {ceiling:.0f}s. Keeping more than that is not an edit, it is a list.
 
 Every moment you cut needs a one-line reason. What you leave out is mined
 again later, and a bare no is useless to whoever reads it.
 
-Also return `release_order`: the moments you kept, most expendable first. It is
-used only if the cut still has to shrink to fit.
+Also return `release_order`: every moment you kept, most expendable first —
+what falls first if the cut still has to shrink. Choose that order yourself:
+the memory plays in the order things happened, so the last moment you keep is
+the month's closer, and nothing here will guess for you.
 
 Answer with STRICT JSON only, no prose:
 {{"keep": [<moment numbers>],
  "cut": [{{"index": <moment number>, "reason": "<short reason>"}}],
- "release_order": [<kept moment numbers, most expendable first>]}}
+ "release_order": [<every kept moment number, most expendable first>]}}
 Every moment from 1 to {count} must appear exactly once across keep and cut."""
+
+
+_REVISION_PROMPT = """You have already edited this month, and what you kept
+does not fit its runtime. Here are the same moments, in the same order and
+numbered the same way:
+
+{moments}
+
+You kept: {kept}
+Assembled, those moments run about {shipped:.0f}s. The content budget is
+{target:.0f}s, so what you keep has to land between {floor:.0f}s and
+{ceiling:.0f}s.
+
+Revise the edit. Either cut more moments until what you keep fits, or give a
+`release_order` — every moment you keep, most expendable first — and the cut
+will shrink in the order you choose.
+
+What falls first matters. The memory plays in the order things happened, so
+the last moment you keep is the month's closer: an order that releases from
+the end shortens the month instead of trimming it.
+
+Same rules as before: starred moments carry the month's meaning, moments
+sharing an `episode` are one occasion, and every moment you cut needs a
+one-line reason.
+
+Answer with STRICT JSON only, no prose:
+{{"keep": [<moment numbers>],
+ "cut": [{{"index": <moment number>, "reason": "<short reason>"}}],
+ "release_order": [<every kept moment number, most expendable first>]}}
+Every moment from 1 to {count} must appear exactly once across keep and cut."""
+
+
+def _first_prompt(table: str, count: int, target_duration: float) -> str:
+    return _PROMPT.format(
+        moments=table,
+        count=count,
+        target=target_duration,
+        floor=target_duration * _ENVELOPE_FLOOR,
+        ceiling=target_duration * _ENVELOPE_CEILING,
+    )
+
+
+def _revision_prompt(
+    table: str,
+    count: int,
+    kept: tuple[int, ...],
+    shipped: float,
+    target_duration: float,
+) -> str:
+    return _REVISION_PROMPT.format(
+        moments=table,
+        count=count,
+        kept=", ".join(f"M{index}" for index in kept),
+        shipped=shipped,
+        target=target_duration,
+        floor=target_duration * _ENVELOPE_FLOOR,
+        ceiling=target_duration * _ENVELOPE_CEILING,
+    )
 
 
 def _ask(
@@ -122,6 +183,25 @@ def _est(moment: _Moment) -> float:
     """How long this moment would run — its likely representative's length."""
     best = max(moment.members, key=lambda m: m.score)
     return best.end_time - best.start_time
+
+
+def _shipped_est(kept: list[_Moment], target_clips: int) -> float:
+    """What the kept moments will actually run once the cut reaches assembly.
+
+    Not one representative each. This pass hands ALL members of a kept moment
+    on, and the same-moment dedup below it keeps up to `_clips_per_moment` of
+    them — three, on a long memory. Measured per representative, a keep-set
+    reading 1.0T left selection at two or three times that, and on this path
+    no later stage bounds it: the fit-to-runtime stage is one of the two the
+    structure pass replaces.
+
+    The share depends on how many moments are kept, so it is recomputed as the
+    keep-set shrinks rather than fixed at the start of a walk.
+    """
+    from immich_memories.analysis.clip_refiner import _clips_per_moment
+
+    share = _clips_per_moment(target_clips, len(kept))
+    return sum(_est(m) * min(len(m.members), share) for m in kept)
 
 
 def _starred(moment: _Moment) -> int:
@@ -181,14 +261,21 @@ def _place_of(moment: _Moment) -> str | None:
 
 
 def _descriptions(moment: _Moment) -> str:
-    """What the moment's two strongest members were said to show."""
+    """What the moment's two strongest DESCRIBED members were said to show.
+
+    Filtered before it is sliced. A third of a real pool has no analysis yet,
+    so taking the top two by score and then dropping the undescribed ones
+    starved the line of the only thing on it that says what the moment is OF —
+    exactly when the moment holds a described member the model could have
+    judged on.
+    """
     ranked = sorted(moment.members, key=lambda m: m.score, reverse=True)
     said = [
         str(m.clip.llm_description)[:_DESCRIPTION_CHARS]
-        for m in ranked[:2]
+        for m in ranked
         if getattr(m.clip, "llm_description", None)
     ]
-    return " / ".join(said) if said else "not described"
+    return " / ".join(said[:2]) if said else "not described"
 
 
 def _moment_line(index: int, moment: _Moment) -> str:
@@ -219,21 +306,27 @@ class _Answer:
 
     keep: tuple[int, ...]
     cut: tuple[tuple[int, str], ...]
-    release_order: tuple[int, ...]
+    # None when the model stated no usable order. There is no fallback: see
+    # _stated_release_order.
+    release_order: tuple[int, ...] | None
 
 
 def _is_a_moment_number(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _release_order(given: object, kept: list[int]) -> tuple[int, ...]:
-    """The keeps, most expendable first — the model's order, or the fallback.
+def _stated_release_order(given: object, kept: list[int]) -> tuple[int, ...] | None:
+    """The editor's own order over its own keeps, or None if it stated none.
 
-    Read as one list rather than entry by entry. An order naming something
-    that was never kept is not an order over this cut, and half of it mixed
-    with a fallback is two different rankings spliced together. The fallback
-    is the keep list reversed: the model listed its keeps in story order, so
-    the later one is the more expendable.
+    No fallback, and that is the whole point. An order we invent is a
+    mechanical kill wearing an editor's clothes: guessing "the keeps are in
+    story order, so later means looser" released M53, M52, M50 and downwards
+    on a real June and amputated the end of the month. A memory plays in the
+    order things happened, so the last moment kept IS the closer, and a rule
+    that releases from the end is a rule that shortens the month.
+
+    Read as one list rather than entry by entry: an order naming something
+    that was never kept is not an order over this cut.
     """
     if (
         isinstance(given, list)
@@ -241,7 +334,7 @@ def _release_order(given: object, kept: list[int]) -> tuple[int, ...]:
         and set(given) == set(kept)
     ):
         return tuple(given)
-    return tuple(reversed(kept))
+    return None
 
 
 def _accounted_for(payload: object, count: int) -> _Answer | None:
@@ -268,7 +361,9 @@ def _accounted_for(payload: object, count: int) -> _Answer | None:
         return None
     if sorted(kept + [index for index, _ in entries]) != list(range(1, count + 1)):
         return None
-    return _Answer(tuple(kept), tuple(entries), _release_order(payload.get("release_order"), kept))
+    return _Answer(
+        tuple(kept), tuple(entries), _stated_release_order(payload.get("release_order"), kept)
+    )
 
 
 def _answer_in(raw: str | None, count: int) -> _Answer | None:
@@ -326,6 +421,7 @@ class StructurePass:
         *,
         target_duration: float,
         moment_window: float,
+        target_clips: int,
     ) -> StructureCut | None:
         """The clips whose moments the story needs, or None if it never decided.
 
@@ -335,34 +431,65 @@ class StructurePass:
         if self._fates is not None:
             return _replay(pool, self._fates)
         moments = _moments_of(pool, moment_window)
-        nothing_to_decide = _nothing_to_decide(moments, target_duration)
+        nothing_to_decide = _nothing_to_decide(moments, target_duration, target_clips)
         if nothing_to_decide is not None:
             # No memo: a later round may see more material than this one, and
             # a pool that fitted once is not a decision about the next pool.
             trace.record("structure", pool, pool, [f"not asked — {nothing_to_decide}"])
             return StructureCut(kept=pool.copy(), cuts={})
-        answer = self._ask_about(moments, target_duration)
+        table = _table(moments)
+        answer = self._put(_first_prompt(table, len(moments), target_duration), len(moments))
         if answer is None:
             return None
-        cut = _apply(pool, moments, answer, target_duration)
+        edit = _edit_from(moments, answer, target_duration, target_clips)
+        if edit is None:
+            edit = self._revise(table, moments, answer, target_duration, target_clips)
+        if edit is None:
+            return None
+        cut = _apply(pool, edit)
         self._fates = cut.cuts.copy()
         return cut
 
-    def _ask_about(self, moments: list[_Moment], target_duration: float) -> _Answer | None:
-        prompt = _PROMPT.format(
-            moments=_table(moments),
-            count=len(moments),
-            target=target_duration,
-            floor=target_duration * _ENVELOPE_FLOOR,
-            ceiling=target_duration * _ENVELOPE_CEILING,
+    def _revise(
+        self,
+        table: str,
+        moments: list[_Moment],
+        overshot: _Answer,
+        target_duration: float,
+        target_clips: int,
+    ) -> _Edit | None:
+        """One corrective ask, then the funnel. No retry ladder.
+
+        The editor kept more than the runtime holds and named no order to
+        shrink by, so it is shown its own keep list, what it will actually run
+        and the envelope, and asked to revise. A revision that still overshoots
+        with no order is refused exactly like an unreadable answer: nothing
+        here may invent the order itself.
+        """
+        kept, _cuts, _account = _keep_after_the_starred_rule(moments, overshot)
+        prompt = _revision_prompt(
+            table,
+            len(moments),
+            tuple(sorted(kept)),
+            _shipped_est(list(kept.values()), target_clips),
+            target_duration,
         )
+        answer = self._put(prompt, len(moments))
+        if answer is None:
+            return None
+        edit = _edit_from(moments, answer, target_duration, target_clips, revised=True)
+        if edit is None:
+            _never_ran("the revised cut still overshot the budget and stated no release order")
+        return edit
+
+    def _put(self, prompt: str, count: int) -> _Answer | None:
         try:
             raw = _ask(prompt, self._llm, self._timeout, self._cache_path)
         except Exception as e:  # WHY broad: the pass is optional; the funnel decides instead
             stop_if_this_is_our_bug(e, "structure pass")
             _never_ran(f"the model was unavailable ({type(e).__name__})")
             return None
-        answer = _answer_in(raw, len(moments))
+        answer = _answer_in(raw, count)
         if answer is None:
             _never_ran("the model's answer could not be read")
         return answer
@@ -379,18 +506,27 @@ def _never_ran(why: str) -> None:
     trace.warn(f"the structure pass never ran — {why}; the arithmetic funnel decided this cut")
 
 
-def _nothing_to_decide(moments: list[_Moment], target_duration: float) -> str | None:
+def _nothing_to_decide(
+    moments: list[_Moment], target_duration: float, target_clips: int
+) -> str | None:
     """Why this pool needs no editing, or None when it does.
 
     A reasoning call is minutes of a local model's time. Spending it to hear
     that a pool which already fits its runtime should ship whole is the kind
-    of question worth not asking.
+    of question worth not asking — and skipping the counting stages for such a
+    pool is the point of this pass, not a shortcut around it.
+
+    Measured as it will ship, not per representative: the per-representative
+    number let a pool two or three times its budget call itself a fit.
     """
     if len(moments) < 2:
         return "one moment is not a structure to decide"
-    estimated = sum(_est(moment) for moment in moments)
-    if estimated <= target_duration * _ENVELOPE_CEILING:
-        return f"the pool already fits — {estimated:.0f}s against {target_duration:.0f}s"
+    shipped = _shipped_est(moments, target_clips)
+    if shipped <= target_duration * _ENVELOPE_CEILING:
+        return (
+            f"the pool already fits the budget — {shipped:.0f}s as it will ship "
+            f"against {target_duration:.0f}s"
+        )
     return None
 
 
@@ -410,13 +546,24 @@ def _the_last_star_of_its_episode(moment: _Moment, kept: Iterable[_Moment]) -> b
     )
 
 
-def _apply(
-    pool: list[ClipWithSegment],
-    moments: list[_Moment],
-    answer: _Answer,
-    target_duration: float,
-) -> StructureCut:
-    """Carry out the edit: kept moments continue, cut moments go whole."""
+@dataclass(frozen=True)
+class _Edit:
+    """A carried-out edit: why each dropped clip went, and the stage's account."""
+
+    notes: dict[str, str]
+    reasons: list[str]
+
+
+def _keep_after_the_starred_rule(
+    moments: list[_Moment], answer: _Answer
+) -> tuple[dict[int, _Moment], dict[str, str], list[str]]:
+    """The keep-set this answer really produces, and the account of the rest.
+
+    Kept separate from the envelope because it runs BEFORE it: an occasion
+    whose last starred moment was cut keeps that moment, and what it will run
+    is part of the overshoot. Told otherwise, the editor would revise against
+    a shorter month than the one it has.
+    """
     by_index = {index + 1: moment for index, moment in enumerate(moments)}
     kept = {index: by_index[index] for index in answer.keep}
     notes: dict[str, str] = {}
@@ -431,22 +578,61 @@ def _apply(
             )
             continue
         notes.update(dict.fromkeys(_ids(moment), why))
+    return kept, notes, reasons
 
-    _release_to_fit(kept, answer.release_order, target_duration, notes, reasons)
 
-    total = sum(_est(m) for m in kept.values())
+def _edit_from(
+    moments: list[_Moment],
+    answer: _Answer,
+    target_duration: float,
+    target_clips: int,
+    *,
+    revised: bool = False,
+) -> _Edit | None:
+    """Carry out the answer, or None when it overshoots with no order to shrink by.
+
+    Kept moments continue whole; cut moments go whole, minus the occasions
+    that would be left with no starred moment. None is not a refusal on its
+    own — the caller asks the editor to revise once, and refuses only if that
+    comes back the same way.
+    """
+    kept, notes, reasons = _keep_after_the_starred_rule(moments, answer)
+    if revised:
+        reasons.insert(0, "the first answer overshot the budget: asked once to revise")
+
+    if _shipped_est(list(kept.values()), target_clips) > target_duration * _ENVELOPE_CEILING:
+        if answer.release_order is None:
+            return None
+        reasons.append(
+            "released against the editor's order, stated "
+            + ("when asked to revise" if revised else "with its first answer")
+        )
+        _release_to_fit(kept, answer.release_order, target_duration, target_clips, notes, reasons)
+
+    representatives = sum(_est(m) for m in kept.values())
+    total = _shipped_est(list(kept.values()), target_clips)
     reasons.insert(
         0,
-        f"kept {len(kept)} of {len(moments)} moment(s), "
-        f"{total:.0f}s estimated against a {target_duration:.0f}s budget",
+        f"kept {len(kept)} of {len(moments)} moment(s) — {representatives:.0f}s of "
+        f"representatives, {total:.0f}s as it will ship, against a "
+        f"{target_duration:.0f}s budget",
     )
+    if total > target_duration * _ENVELOPE_CEILING:
+        # The walk ran out of moments it was allowed to release. Not a refusal:
+        # what stopped it is the starred rule, which outranks the envelope.
+        reasons.append("still over the ceiling — every remaining moment is protected")
     if total < target_duration * _ENVELOPE_FLOOR:
         # Nothing is forced back in: backfill exists for exactly this, and a
         # moment the story does not need is not a way to fill a runtime.
         reasons.append(f"under-run — {target_duration - total:.0f}s left for backfill to fill")
-    survivors = [item for item in pool if item.clip.asset.id not in notes]
-    trace.record("structure", pool, survivors, reasons, notes)
-    return StructureCut(kept=survivors, cuts=notes)
+    return _Edit(notes=notes, reasons=reasons)
+
+
+def _apply(pool: list[ClipWithSegment], edit: _Edit) -> StructureCut:
+    """Put the edit on the record and hand back what survived it."""
+    survivors = [item for item in pool if item.clip.asset.id not in edit.notes]
+    trace.record("structure", pool, survivors, edit.reasons, edit.notes)
+    return StructureCut(kept=survivors, cuts=edit.notes)
 
 
 def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
@@ -476,6 +662,7 @@ def _release_to_fit(
     kept: dict[int, _Moment],
     release_order: tuple[int, ...],
     target_duration: float,
+    target_clips: int,
     notes: dict[str, str],
     reasons: list[str],
 ) -> None:
@@ -485,9 +672,9 @@ def _release_to_fit(
     envelope says how much has to go, the editor said in which order.
     """
     ceiling = target_duration * _ENVELOPE_CEILING
-    said = f"released to fit the {target_duration:.0f}s budget (the editor's own release order)"
+    said = f"released to fit the {target_duration:.0f}s budget (the editor's stated release order)"
     for index in release_order:
-        if sum(_est(m) for m in kept.values()) <= ceiling:
+        if _shipped_est(list(kept.values()), target_clips) <= ceiling:
             return
         moment = kept.get(index)
         if moment is None or _the_last_star_of_its_episode(moment, kept.values()):

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -1,0 +1,512 @@
+"""Pass 3 — the structure pass: which moments does the story need? (#764)
+
+Selection narrowed its pool by counting: a per-day photo cap, a spread across
+dates, a fit to the runtime, two ratio caps. Five stages of arithmetic, and not
+one of them ever looked at what a moment was OF — measured on one real month,
+they deleted a moment scored 0.80 and shipped one scored 0.36.
+
+This pass asks the question those caps were standing in for, once, at MOMENT
+granularity: which of these moments does the month's story need? Numbers still
+order things here — the table is chronological, durations are estimated, the
+keep-set is measured against the budget — but no number decides a kill. Every
+moment that goes is one the model named, or one the model itself ranked most
+expendable, released against a fixed envelope.
+
+Duration is a convergence bound, not an eviction rule. This is the rough cut
+and it only has to land near the content budget; the fine cut (the llm review)
+converges further downstream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import datetime
+    from pathlib import Path
+
+    from immich_memories.analysis.smart_pipeline import ClipWithSegment
+    from immich_memories.config_loader import Config
+    from immich_memories.config_models_llm import LLMConfig
+
+from immich_memories.analysis import selection_trace as trace
+from immich_memories.analysis.llm_failures import stop_if_this_is_our_bug
+
+logger = logging.getLogger(__name__)
+
+# Room enough to answer rather than narrate — the ceiling the review measured
+# against a local reasoning model, for a prompt of the same shape.
+_STRUCTURE_MAX_TOKENS = 8000
+
+# How near the content budget the rough cut has to land. Not an eviction rule:
+# the fine cut converges further, and backfill fills an under-run.
+_ENVELOPE_FLOOR = 0.9
+_ENVELOPE_CEILING = 1.1
+
+# How much of a member's description one table line carries.
+_DESCRIPTION_CHARS = 120
+
+_PROMPT = """You are structuring the rough cut of a month's memory video from
+its moments. They are listed in the order they happened, and that order is
+fixed: what you include is your only lever.
+
+Ask ONE question of every moment: **does the month's story need it?**
+
+The story needs coverage of what actually happened, not only what looks
+strongest — the punch-up is not the march. A day earns a second moment only
+when the story needs both of them. A cut made of nothing but peaks is
+shapeless: vary the tension.
+
+`starred n/m` counts the items the owner marked a favourite. Those are the
+owner's own marks and they carry the month's meaning. Cut a starred moment
+only when its occasion is already over-represented AND another starred moment
+of that occasion stays in.
+
+Moments sharing an `episode` name are ONE occasion — an afternoon somewhere, a
+party, a hike — however different their descriptions read.
+
+{moments}
+
+The content budget is {target:.0f}s. The `est` seconds of the moments you keep
+should sum to between {floor:.0f}s and {ceiling:.0f}s.
+
+Every moment you cut needs a one-line reason. What you leave out is mined
+again later, and a bare no is useless to whoever reads it.
+
+Also return `release_order`: the moments you kept, most expendable first. It is
+used only if the cut still has to shrink to fit.
+
+Answer with STRICT JSON only, no prose:
+{{"keep": [<moment numbers>],
+ "cut": [{{"index": <moment number>, "reason": "<short reason>"}}],
+ "release_order": [<kept moment numbers, most expendable first>]}}
+Every moment from 1 to {count} must appear exactly once across keep and cut."""
+
+
+def _ask(
+    prompt: str, llm_config: LLMConfig, timeout_seconds: int, cache_path: Path | None = None
+) -> str:
+    from immich_memories.analysis.llm_query import query_llm
+
+    return asyncio.run(
+        query_llm(
+            prompt,
+            llm_config,
+            temperature=0.2,
+            max_tokens=_STRUCTURE_MAX_TOKENS,
+            timeout_seconds=timeout_seconds,
+            thinking=True,
+            cache_path=cache_path,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class _Moment:
+    """One moment of the pool, and the occasion it belongs to."""
+
+    members: tuple[ClipWithSegment, ...]
+    episode: str
+
+
+def _started(member: ClipWithSegment) -> datetime | None:
+    return getattr(member.clip.asset, "file_created_at", None)
+
+
+def _est(moment: _Moment) -> float:
+    """How long this moment would run — its likely representative's length."""
+    best = max(moment.members, key=lambda m: m.score)
+    return best.end_time - best.start_time
+
+
+def _starred(moment: _Moment) -> int:
+    return sum(1 for m in moment.members if getattr(m.clip.asset, "is_favorite", False))
+
+
+def _ids(moment: _Moment) -> set[str]:
+    return {m.clip.asset.id for m in moment.members}
+
+
+def _moments_of(pool: list[ClipWithSegment], moment_window: float) -> list[_Moment]:
+    """The pool as moments, chained into episodes, in chronological order.
+
+    The same grouping the dedup stage collapses on, so the pass reasons in the
+    unit its decision is later carried out in. Episodes chain those moments
+    the way the review labels them: a gap wider than the episode window starts
+    a new occasion.
+    """
+    from immich_memories.analysis.clip_scaler import group_by_moment
+    from immich_memories.analysis.moment_grouping import EPISODE_WINDOW_MINUTES
+
+    moments: list[_Moment] = []
+    episode = 0
+    previous: datetime | None = None
+    for group in group_by_moment(pool, moment_window):
+        start = _started(group[0])
+        # An undated moment can neither continue an occasion nor be continued.
+        if (
+            start is None
+            or previous is None
+            or (start - previous).total_seconds() > EPISODE_WINDOW_MINUTES * 60
+        ):
+            episode += 1
+        moments.append(_Moment(tuple(group), f"E{episode}"))
+        previous = start
+    return moments
+
+
+def _when(moment: _Moment) -> str:
+    start = _started(moment.members[0])
+    if start is None:
+        return "undated"
+    end = _started(moment.members[-1]) or start
+    return f"{start.date().isoformat()} {start:%H:%M}-{end:%H:%M}"
+
+
+def _place_of(moment: _Moment) -> str | None:
+    # WHY the review's helper: city, state and country, and the measurement of
+    # why a caption is too thin to reason from lives beside it.
+    from immich_memories.analysis.selection_review import _place_for_llm
+
+    for member in moment.members:
+        where = _place_for_llm(getattr(member.clip.asset, "exif_info", None))
+        if where:
+            return where
+    return None
+
+
+def _descriptions(moment: _Moment) -> str:
+    """What the moment's two strongest members were said to show."""
+    ranked = sorted(moment.members, key=lambda m: m.score, reverse=True)
+    said = [
+        str(m.clip.llm_description)[:_DESCRIPTION_CHARS]
+        for m in ranked[:2]
+        if getattr(m.clip, "llm_description", None)
+    ]
+    return " / ".join(said) if said else "not described"
+
+
+def _moment_line(index: int, moment: _Moment) -> str:
+    from immich_memories.api.models import AssetType
+
+    videos = sum(1 for m in moment.members if m.clip.asset.type != AssetType.IMAGE)
+    parts = [
+        f"M{index}: {_when(moment)}",
+        f"episode {moment.episode}",
+        f"{len(moment.members)} items ({videos} video/{len(moment.members) - videos} photos)",
+        f"starred {_starred(moment)}/{len(moment.members)}",
+        f"est {_est(moment):.0f}s",
+    ]
+    where = _place_of(moment)
+    if where:
+        parts.append(where)
+    parts.append(_descriptions(moment))
+    return " · ".join(parts)
+
+
+def _table(moments: list[_Moment]) -> str:
+    return "\n".join(_moment_line(index + 1, m) for index, m in enumerate(moments))
+
+
+@dataclass(frozen=True)
+class _Answer:
+    """The edit the model made, once it accounts for every moment."""
+
+    keep: tuple[int, ...]
+    cut: tuple[tuple[int, str], ...]
+    release_order: tuple[int, ...]
+
+
+def _is_a_moment_number(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _release_order(given: object, kept: list[int]) -> tuple[int, ...]:
+    """The keeps, most expendable first — the model's order, or the fallback.
+
+    Read as one list rather than entry by entry. An order naming something
+    that was never kept is not an order over this cut, and half of it mixed
+    with a fallback is two different rankings spliced together. The fallback
+    is the keep list reversed: the model listed its keeps in story order, so
+    the later one is the more expendable.
+    """
+    if (
+        isinstance(given, list)
+        and all(_is_a_moment_number(n) for n in given)
+        and set(given) == set(kept)
+    ):
+        return tuple(given)
+    return tuple(reversed(kept))
+
+
+def _accounted_for(payload: object, count: int) -> _Answer | None:
+    """The edit, but only if the answer accounts for every moment exactly once.
+
+    Under keep-semantics silence is a kill, so a truncated answer would cut
+    every moment it never reached. Requiring the two lists to partition 1..M
+    turns truncation back into a parse failure, which this pass survives by
+    handing the cut to the arithmetic funnel. It is also the cheapest check
+    that the model answered about THESE moments.
+    """
+    if not isinstance(payload, dict):
+        return None
+    keep, cut = payload.get("keep"), payload.get("cut")
+    if not isinstance(keep, list) or not isinstance(cut, list) or not keep:
+        return None
+    kept = [n for n in keep if _is_a_moment_number(n)]
+    entries = [
+        (entry["index"], str(entry.get("reason", "no reason given")))
+        for entry in cut
+        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
+    ]
+    if len(kept) != len(keep) or len(entries) != len(cut):
+        return None
+    if sorted(kept + [index for index, _ in entries]) != list(range(1, count + 1)):
+        return None
+    return _Answer(tuple(kept), tuple(entries), _release_order(payload.get("release_order"), kept))
+
+
+def _answer_in(raw: str | None, count: int) -> _Answer | None:
+    """The model's edit, or None when it never made one about these moments."""
+    if not raw:
+        return None
+    from immich_memories.analysis.selection_review import _balanced_objects
+
+    for candidate in reversed(_balanced_objects(raw)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        answer = _accounted_for(payload, count)
+        if answer is not None:
+            return answer
+    return None
+
+
+@dataclass(frozen=True)
+class StructureCut:
+    """The clips whose moments the story kept, and why each of the rest went."""
+
+    kept: list[ClipWithSegment]
+    cuts: dict[str, str]
+
+    @property
+    def dropped(self) -> frozenset[str]:
+        return frozenset(self.cuts)
+
+
+class StructurePass:
+    """Asks which moments a memory's story needs, and applies the answer."""
+
+    def __init__(
+        self,
+        llm_config: LLMConfig,
+        *,
+        cache_path: Path | None = None,
+        timeout_seconds: int = 45,
+    ) -> None:
+        self._llm = llm_config
+        self._cache_path = cache_path
+        self._timeout = timeout_seconds
+        # What the story decided, keyed by asset id, once it has decided. The
+        # verify/judge loop re-enters selection several times a run and the
+        # answer to "what does this month need?" does not change because a
+        # later pass dropped a clip — re-asking is whack-a-mole and ten more
+        # reasoning calls.
+        self._fates: dict[str, str] | None = None
+
+    def choose(
+        self,
+        pool: list[ClipWithSegment],
+        *,
+        target_duration: float,
+        moment_window: float,
+    ) -> StructureCut | None:
+        """The clips whose moments the story needs, or None if it never decided.
+
+        None is the signal to fall back: the arithmetic funnel makes the cut
+        instead, and the trace says so above the funnel.
+        """
+        if self._fates is not None:
+            return _replay(pool, self._fates)
+        moments = _moments_of(pool, moment_window)
+        nothing_to_decide = _nothing_to_decide(moments, target_duration)
+        if nothing_to_decide is not None:
+            # No memo: a later round may see more material than this one, and
+            # a pool that fitted once is not a decision about the next pool.
+            trace.record("structure", pool, pool, [f"not asked — {nothing_to_decide}"])
+            return StructureCut(kept=pool.copy(), cuts={})
+        answer = self._ask_about(moments, target_duration)
+        if answer is None:
+            return None
+        cut = _apply(pool, moments, answer, target_duration)
+        self._fates = cut.cuts.copy()
+        return cut
+
+    def _ask_about(self, moments: list[_Moment], target_duration: float) -> _Answer | None:
+        prompt = _PROMPT.format(
+            moments=_table(moments),
+            count=len(moments),
+            target=target_duration,
+            floor=target_duration * _ENVELOPE_FLOOR,
+            ceiling=target_duration * _ENVELOPE_CEILING,
+        )
+        try:
+            raw = _ask(prompt, self._llm, self._timeout, self._cache_path)
+        except Exception as e:  # WHY broad: the pass is optional; the funnel decides instead
+            stop_if_this_is_our_bug(e, "structure pass")
+            _never_ran(f"the model was unavailable ({type(e).__name__})")
+            return None
+        answer = _answer_in(raw, len(moments))
+        if answer is None:
+            _never_ran("the model's answer could not be read")
+        return answer
+
+
+def _never_ran(why: str) -> None:
+    """Say out loud that the funnel made this cut, not the story.
+
+    Above the funnel rather than inside it: a `structure` stage with nothing
+    dropped reads as an editor who approved the pool, which is the confusion
+    the review's own warning exists to end.
+    """
+    logger.warning("Structure pass: %s — the arithmetic funnel decided this cut", why)
+    trace.warn(f"the structure pass never ran — {why}; the arithmetic funnel decided this cut")
+
+
+def _nothing_to_decide(moments: list[_Moment], target_duration: float) -> str | None:
+    """Why this pool needs no editing, or None when it does.
+
+    A reasoning call is minutes of a local model's time. Spending it to hear
+    that a pool which already fits its runtime should ship whole is the kind
+    of question worth not asking.
+    """
+    if len(moments) < 2:
+        return "one moment is not a structure to decide"
+    estimated = sum(_est(moment) for moment in moments)
+    if estimated <= target_duration * _ENVELOPE_CEILING:
+        return f"the pool already fits — {estimated:.0f}s against {target_duration:.0f}s"
+    return None
+
+
+def _the_last_star_of_its_episode(moment: _Moment, kept: Iterable[_Moment]) -> bool:
+    """Whether losing this moment leaves its occasion with nothing starred.
+
+    The owner's marks are the month's meaning, so an occasion never gives up
+    its last one — the same battle the review fights per clip, fought here per
+    moment. Identity, not equality: the moment under judgement may itself be
+    in the keep-set, and it cannot vouch for itself.
+    """
+    if not _starred(moment):
+        return False
+    return not any(
+        other is not moment and other.episode == moment.episode and _starred(other)
+        for other in kept
+    )
+
+
+def _apply(
+    pool: list[ClipWithSegment],
+    moments: list[_Moment],
+    answer: _Answer,
+    target_duration: float,
+) -> StructureCut:
+    """Carry out the edit: kept moments continue, cut moments go whole."""
+    by_index = {index + 1: moment for index, moment in enumerate(moments)}
+    kept = {index: by_index[index] for index in answer.keep}
+    notes: dict[str, str] = {}
+    reasons: list[str] = []
+    for index, why in answer.cut:
+        moment = by_index[index]
+        if _the_last_star_of_its_episode(moment, kept.values()):
+            kept[index] = moment
+            reasons.append(
+                f"M{index} stays — starred, and {moment.episode} would keep "
+                f"no starred moment without it ({why})"
+            )
+            continue
+        notes.update(dict.fromkeys(_ids(moment), why))
+
+    _release_to_fit(kept, answer.release_order, target_duration, notes, reasons)
+
+    total = sum(_est(m) for m in kept.values())
+    reasons.insert(
+        0,
+        f"kept {len(kept)} of {len(moments)} moment(s), "
+        f"{total:.0f}s estimated against a {target_duration:.0f}s budget",
+    )
+    if total < target_duration * _ENVELOPE_FLOOR:
+        # Nothing is forced back in: backfill exists for exactly this, and a
+        # moment the story does not need is not a way to fill a runtime.
+        reasons.append(f"under-run — {target_duration - total:.0f}s left for backfill to fill")
+    survivors = [item for item in pool if item.clip.asset.id not in notes]
+    trace.record("structure", pool, survivors, reasons, notes)
+    return StructureCut(kept=survivors, cuts=notes)
+
+
+def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
+    """Apply a decision already taken to whatever pool this round supplies.
+
+    An id nobody decided about passes through: the pool only ever shrinks
+    between rounds, so this should not happen, and inventing a fate for it
+    would be the pass deciding without being asked.
+    """
+    survivors = [item for item in pool if item.clip.asset.id not in fates]
+    cuts = {
+        item.clip.asset.id: fates[item.clip.asset.id]
+        for item in pool
+        if item.clip.asset.id in fates
+    }
+    trace.record(
+        "structure",
+        pool,
+        survivors,
+        ["the structure this run already decided, unchanged and unasked"],
+        cuts,
+    )
+    return StructureCut(kept=survivors, cuts=cuts)
+
+
+def _release_to_fit(
+    kept: dict[int, _Moment],
+    release_order: tuple[int, ...],
+    target_duration: float,
+    notes: dict[str, str],
+    reasons: list[str],
+) -> None:
+    """Shrink an over-long keep-set by the model's own order of expendability.
+
+    The only stage here a number can start, and it still does not choose: the
+    envelope says how much has to go, the editor said in which order.
+    """
+    ceiling = target_duration * _ENVELOPE_CEILING
+    said = f"released to fit the {target_duration:.0f}s budget (the editor's own release order)"
+    for index in release_order:
+        if sum(_est(m) for m in kept.values()) <= ceiling:
+            return
+        moment = kept.get(index)
+        if moment is None or _the_last_star_of_its_episode(moment, kept.values()):
+            continue
+        del kept[index]
+        notes.update(dict.fromkeys(_ids(moment), said))
+        reasons.append(f"M{index} released to fit the budget")
+
+
+def structure_pass_for(app_config: Config) -> StructurePass | None:
+    """The editor for this run, or None when nothing here asks an LLM anything.
+
+    The same gate the fine cut answers to (SelectionQuality.cut): one switch
+    decides whether a run has a reader at all, and a run without one keeps the
+    arithmetic funnel it always had. Verdicts land in the same judgment cache,
+    so an identical question about an identical month is answered once.
+    """
+    if not app_config.content_analysis.enabled:
+        return None
+    from immich_memories.cache.judgment_cache import verdicts_beside
+
+    return StructurePass(app_config.llm, cache_path=verdicts_beside(app_config.cache.cache_path))

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from itertools import starmap
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -51,10 +52,8 @@ from immich_memories.analysis.structure_answer import (
     defect_prompt,
     defects_in,
     first_prompt,
-    order_mode,
     reorder_prompt,
     reordering_in,
-    states_a_priority,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,6 +69,14 @@ _DESCRIPTION_CHARS = 120
 def _ask(
     prompt: str, llm_config: LLMConfig, timeout_seconds: int, cache_path: Path | None = None
 ) -> str:
+    """One question, one answer, reasoning on and with room to give it.
+
+    Both calls carry the full token ceiling. Measured on the rank question
+    against a 22-moment table: at the wrapper's 4000-token thinking floor the
+    model spends the budget reasoning, the answer truncates, and the
+    non-thinking retry comes back in table order — a silent loss of the
+    priority the whole call exists to get.
+    """
     from immich_memories.analysis.llm_query import query_llm
 
     return asyncio.run(
@@ -217,8 +224,13 @@ def _moment_line(index: int, moment: _Moment) -> str:
     return " · ".join(parts)
 
 
-def _table(moments: list[_Moment]) -> str:
-    return "\n".join(_moment_line(index + 1, m) for index, m in enumerate(moments))
+def _table(numbered: list[tuple[int, _Moment]]) -> str:
+    """The moments as the model sees them, each under the number it is known by.
+
+    Numbered by the caller rather than by position: the rank question shows
+    only the survivors, and they must keep the numbers the first answer used.
+    """
+    return "\n".join(starmap(_moment_line, numbered))
 
 
 @dataclass(frozen=True)
@@ -259,6 +271,11 @@ class StructurePass:
         # later pass dropped a clip — re-asking is whack-a-mole and ten more
         # reasoning calls.
         self._fates: dict[str, str] | None = None
+        # And WHO settled the length. Replaying a hybrid as fully-narrowed
+        # skips the funnel on every later round — and the last round is the
+        # one that ships: measured, round one selected 2 clips for a 10s
+        # budget and round two shipped all five.
+        self._fates_narrowed: bool = True
 
     def choose(
         self,
@@ -276,7 +293,7 @@ class StructurePass:
         False instead — the judgment is kept, the length is not.
         """
         if self._fates is not None:
-            return _replay(pool, self._fates)
+            return _replay(pool, self._fates, self._fates_narrowed)
         moments = _moments_of(pool, moment_window)
         nothing_to_decide = _nothing_to_decide(moments, target_duration, target_clips)
         if nothing_to_decide is not None:
@@ -284,25 +301,28 @@ class StructurePass:
             # a pool that fitted once is not a decision about the next pool.
             trace.record("structure", pool, pool, [f"not asked — {nothing_to_decide}"])
             return StructureCut(kept=pool.copy(), cuts={})
-        table = _table(moments)
-        answer, asked_twice = self._edit_of(table, moments, target_duration)
+        table = _table(list(enumerate(moments, start=1)))
+        answer, asked_twice = self._rejects_of(table, moments, target_duration)
         if answer is None:
+            return None
+        if len(answer.survivors(len(moments))) < 2:
+            _never_ran("the answer cut all but one moment, which is not an edit")
             return None
         cut = self._carry_out(
             pool, moments, answer, target_duration, target_clips, may_ask=not asked_twice
         )
-        self._fates = cut.cuts.copy()
+        self._fates, self._fates_narrowed = cut.cuts.copy(), cut.narrowed
         return cut
 
-    def _edit_of(
+    def _rejects_of(
         self, table: str, moments: list[_Moment], target_duration: float
     ) -> tuple[Answer | None, bool]:
-        """The edit, and whether asking for it cost the run its one re-ask.
+        """What the story does not need, and whether it cost the run its re-ask.
 
-        A first answer whose two lists do not account for every moment gets
-        one retry, and that retry is told exactly which numbers were wrong.
-        An answer with no edit in it at all gets nothing: there is no defect
-        to name, so there is nothing to correct.
+        An answer whose entries name a moment outside the table, or name one
+        with no reason, gets a single retry told exactly which entries were
+        wrong. An answer with no cut list in it at all gets nothing: there is
+        no defect to name, so there is nothing to correct.
         """
         count = len(moments)
         reply = self._put(first_prompt(table, count, target_duration), count)
@@ -313,7 +333,7 @@ class StructurePass:
             return None, True
         retry = self._put(defect_prompt(table, count, reply.defects), count)
         if retry.answer is None and retry.reached:
-            _never_ran("the revised answer still did not account for every moment")
+            _never_ran("the revised answer still could not be read")
         return retry.answer, True
 
     def _carry_out(
@@ -326,19 +346,18 @@ class StructurePass:
         *,
         may_ask: bool,
     ) -> StructureCut:
-        """Apply the edit, and shrink it to the envelope if the editor said how."""
+        """Apply the rejects, and shrink to the envelope if the editor ranks."""
         kept, notes, reasons = _keep_after_the_starred_rule(moments, answer)
-        reasons.append(order_mode(answer.keep))
         shipped = _shipped_est(list(kept.values()), target_clips)
         if shipped <= target_duration * ENVELOPE_CEILING:
             return _apply(pool, kept, notes, reasons, target_duration, target_clips, len(moments))
-        order = self._priority_for(answer.keep, kept, shipped, target_duration, reasons, may_ask)
+        order = self._priority_for(kept, shipped, target_duration, reasons, may_ask)
         if order is None:
-            # The judgment stands; only the length is unsettled. Measured four
-            # times out of four, what the model cut was sound and what it said
-            # about order was not, so the cut is kept and the counting stages
-            # are handed the remainder rather than the pool.
-            reasons.append("no priority to shrink by — the funnel narrowed what was kept")
+            # The judgment stands; only the length is unsettled. What the model
+            # cut has been sound in every measured run and what it said about
+            # order has not, so the cut is kept and the counting stages are
+            # handed the remainder rather than the whole pool.
+            reasons.append("priority: unstated — the arithmetic funnel narrowed the remainder")
             trace.warn(
                 "the structure pass cut, but stated no priority — "
                 "the arithmetic funnel narrowed the remainder"
@@ -358,30 +377,30 @@ class StructurePass:
 
     def _priority_for(
         self,
-        keep: tuple[int, ...],
         kept: dict[int, _Moment],
         shipped: float,
         target_duration: float,
         reasons: list[str],
         may_ask: bool,
     ) -> tuple[int, ...] | None:
-        """The order to release in, asking once if the editor stated none.
+        """The order to release in, asked for only when something has to go.
 
-        The re-ask fires on the conjunction only: an unranked keep list is
-        harmless while everything in it fits, so it costs a reasoning call
-        only when something actually has to go.
+        The first question carries no order — it names rejects — so this is
+        where a ranking comes from at all, and it costs a reasoning call only
+        when the cut actually overshoots.
         """
-        if states_a_priority(keep):
-            reasons.append("priority stated with its first answer")
-            return keep
         if not may_ask:
+            reasons.append("no re-ask left — the first answer had already been sent back once")
             return None
         echoed = tuple(kept)
-        raw = self._say(reorder_prompt(echoed, shipped, target_duration))
-        order = reordering_in(raw, echoed) if raw is not None else None
-        if order is None or not states_a_priority(order):
+        table = _table(list(kept.items()))
+        order = reordering_in(
+            self._say(reorder_prompt(table, echoed, shipped, target_duration)), echoed
+        )
+        if order is None:
+            reasons.append("asked to revise; the answer was unusable")
             return None
-        reasons.extend(("asked once to revise", "priority stated when asked to revise"))
+        reasons.append("priority: stated on request")
         return order
 
     def _put(self, prompt: str, count: int) -> Reply:
@@ -464,7 +483,7 @@ def _keep_after_the_starred_rule(
     a shorter month than the one it has.
     """
     by_index = {index + 1: moment for index, moment in enumerate(moments)}
-    kept = {index: by_index[index] for index in answer.keep}
+    kept = {index: by_index[index] for index in answer.survivors(len(moments))}
     notes: dict[str, str] = {}
     reasons: list[str] = []
     for index, why in answer.cut:
@@ -477,7 +496,10 @@ def _keep_after_the_starred_rule(
             )
             continue
         notes.update(dict.fromkeys(_ids(moment), why))
-    return kept, notes, reasons
+    # In the order they happened: a vetoed moment is re-admitted after the
+    # survivors, and both the rank question's table and its echoed list read
+    # as a timeline.
+    return {index: kept[index] for index in sorted(kept)}, notes, reasons
 
 
 def _apply(
@@ -519,7 +541,7 @@ def _apply(
     return StructureCut(kept=survivors, cuts=notes, narrowed=narrowed)
 
 
-def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
+def _replay(pool: list[ClipWithSegment], fates: dict[str, str], narrowed: bool) -> StructureCut:
     """Apply a decision already taken to whatever pool this round supplies.
 
     An id nobody decided about passes through: the pool only ever shrinks
@@ -536,10 +558,15 @@ def _replay(pool: list[ClipWithSegment], fates: dict[str, str]) -> StructureCut:
         "structure",
         pool,
         survivors,
-        ["the structure this run already decided, unchanged and unasked"],
+        [
+            "the structure this run already decided, unchanged and unasked",
+            "the length was settled here"
+            if narrowed
+            else "priority: unstated — the arithmetic funnel narrows the remainder",
+        ],
         cuts,
     )
-    return StructureCut(kept=survivors, cuts=cuts)
+    return StructureCut(kept=survivors, cuts=cuts, narrowed=narrowed)
 
 
 def _release_to_fit(

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -129,7 +129,18 @@ def _shipped_est(kept: list[_Moment], target_clips: int) -> float:
     from immich_memories.analysis.clip_refiner import _clips_per_moment
 
     share = _clips_per_moment(target_clips, len(kept))
-    return sum(_est(m) * min(len(m.members), share) for m in kept)
+    total = 0.0
+    for moment in kept:
+        ranked = sorted(
+            moment.members,
+            key=lambda member: (member.clip.asset.is_favorite, member.score),
+            reverse=True,
+        )
+        starred = [member for member in ranked if member.clip.asset.is_favorite]
+        rest = [member for member in ranked if not member.clip.asset.is_favorite]
+        shipping = starred + rest[: max(0, share - len(starred))]
+        total += sum(member.end_time - member.start_time for member in shipping)
+    return total
 
 
 def _starred(moment: _Moment) -> int:

--- a/src/immich_memories/analysis/selection_structure.py
+++ b/src/immich_memories/analysis/selection_structure.py
@@ -9,9 +9,9 @@ This pass asks the question those caps were standing in for, once, at MOMENT
 granularity: which of these moments does the month's story need? Numbers still
 order things here — the table is chronological, durations are estimated, the
 keep-set is measured against the budget — but no number decides a kill. Every
-moment that goes is one the model named, or one it ranked last itself: the
-keep list is written most essential first, and the envelope releases from its
-tail. Nothing here invents that order (see structure_answer.states_a_priority).
+moment that goes is one the model named. If those survivors exceed the
+envelope, a separate question ranks that exact set most essential first and
+the envelope releases from its tail. Nothing here invents a fallback order.
 
 Duration is a convergence bound, not an eviction rule. This is the rough cut
 and it only has to land near the content budget; the fine cut (the llm review)

--- a/src/immich_memories/analysis/smart_pipeline.py
+++ b/src/immich_memories/analysis/smart_pipeline.py
@@ -24,6 +24,7 @@ from immich_memories.analysis.preview_builder import PreviewBuilder
 from immich_memories.analysis.progress import PipelinePhase, ProgressTracker
 from immich_memories.analysis.selection_coverage import AnalysisCoverage
 from immich_memories.analysis.selection_quality import SelectionQuality
+from immich_memories.analysis.selection_structure import structure_pass_for
 from immich_memories.analysis.source_filter import not_shot_here
 from immich_memories.analysis.thumbnail_prefetch import ThumbnailPrefetcher
 from immich_memories.config_presets import resolve_analysis_depth
@@ -236,7 +237,9 @@ class SmartPipeline:
             provider_circuit=self.provider_circuit,
         )
         self.scaler = ClipScaler()
-        self.refiner = ClipRefiner(self.config, self.scaler)
+        self.refiner = ClipRefiner(
+            self.config, self.scaler, structure=structure_pass_for(app_config)
+        )
         self.thumbnail_prefetcher = ThumbnailPrefetcher.from_client(
             client,
             thumbnail_cache,

--- a/src/immich_memories/analysis/structure_answer.py
+++ b/src/immich_memories/analysis/structure_answer.py
@@ -24,6 +24,9 @@ its moments. They are listed in the order they happened.
 
 Ask ONE question of every moment: **does the month's story need it?**
 
+Name the moments the story does NOT need, and give one line of why for each.
+Everything you do not name stays in.
+
 The story needs coverage of what actually happened, not only what looks
 strongest — the punch-up is not the march. A day earns a second moment only
 when the story needs both of them. A cut made of nothing but peaks is
@@ -39,56 +42,45 @@ party, a hike — however different their descriptions read.
 
 {moments}
 
-The content budget is {target:.0f}s. Do the arithmetic: add up the `est`
-seconds of every moment you keep, and that sum must land between {floor:.0f}s
-and {ceiling:.0f}s. Keeping more than that is not an edit, it is a list.
+The content budget is {target:.0f}s. Do the arithmetic: cut enough that the
+`est` seconds of what remains add up to between {floor:.0f}s and {ceiling:.0f}s.
+Leaving more than that in is not an edit, it is a list.
 
-WRITE THE KEEP LIST MOST ESSENTIAL FIRST. The finished memory always plays in
-the order things happened — nothing you write changes that — so the order of
-your keep list means only one thing: how essential each moment is to the
-story. Put the moment the month would be pointless without at the front, and
-the one you would give up first at the end. If the cut still has to shrink,
-the LAST entries fall first, so the end of your list is the sacrifice you are
-choosing. Choose it: the last moment left in the memory is the month's closer.
-
-Every moment you cut needs a one-line reason. What you leave out is mined
+Every moment you name needs a one-line reason. What you leave out is mined
 again later, and a bare no is useless to whoever reads it.
 
 Answer with STRICT JSON only, no prose:
-{{"keep": [<moment numbers, most essential first>],
- "cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}
-Every moment from 1 to {count} must appear exactly once across keep and cut."""
+{{"cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}
+Use moment numbers from 1 to {count} and nothing else. An empty list means the
+month needs all of it."""
 
 
-_DEFECT_PROMPT = """You have already edited this month and the answer could not
-be used: {defects}.
+_DEFECT_PROMPT = """You have already named the moments this month's story does
+not need, and some of what you named could not be used: {defects}.
 
 Here are the same moments, in the same order and numbered the same way:
 
 {moments}
 
-Edit it again. Every moment from 1 to {count} must appear exactly once — each
-number in keep or in cut, never in both, never in neither. Write the keep list
-most essential first: the memory plays in the order things happened whatever
-you write, so that order says only how essential each moment is, and if the
-cut has to shrink the last entries fall first.
+Name them again. Use moment numbers from 1 to {count} and nothing else, and
+give every one of them a one-line reason. Everything you do not name stays in.
 
 Answer with STRICT JSON only, no prose:
-{{"keep": [<moment numbers, most essential first>],
- "cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}"""
+{{"cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}"""
 
 
-_REORDER_PROMPT = """You kept these moments of the month, and they run about
-{shipped:.0f}s against a {target:.0f}s budget — more than the memory holds, so
-some of them have to go.
+_REORDER_PROMPT = """These are the moments of the month you kept. They run
+about {shipped:.0f}s against a {target:.0f}s budget — more than the memory
+holds, so some of them have to go.
+
+{moments}
 
 You kept: {kept}
 
-You listed them in table order, which says nothing about which of them the
-story needs most. Do not change what you kept and do not cut anything here.
-Give that exact list back, REORDERED most essential first: the moment the
-month would be pointless without at the front, the one you would give up
-first at the end.
+Rank them. Give that exact list back, most essential first: the moment the
+month would be pointless without at the front, the one you would give up first
+at the end. Do not add anything, do not remove anything, do not cut anything
+here — only the order changes.
 
 The memory plays in the order things happened whatever order you write, so
 this order means only how essential each moment is. The last entries fall
@@ -113,8 +105,18 @@ def defect_prompt(table: str, count: int, defects: tuple[str, ...]) -> str:
     return _DEFECT_PROMPT.format(moments=table, count=count, defects="; ".join(defects))
 
 
-def reorder_prompt(kept: tuple[int, ...], shipped: float, target_duration: float) -> str:
+def reorder_prompt(
+    table: str, kept: tuple[int, ...], shipped: float, target_duration: float
+) -> str:
+    """The rank question, showing the moments it is asking about.
+
+    The table is not decoration. Handed a bare "You kept: M1, M2, M3", the
+    model ranks opaque integers, and whatever permutation comes back would
+    then kill moments by it — an uninformed ranking is a mechanical kill
+    wearing the editor's clothes, which is the one thing this pass forbids.
+    """
     return _REORDER_PROMPT.format(
+        moments=table,
         kept=", ".join(f"M{index}" for index in kept),
         shipped=shipped,
         target=target_duration,
@@ -123,91 +125,70 @@ def reorder_prompt(kept: tuple[int, ...], shipped: float, target_duration: float
 
 @dataclass(frozen=True)
 class Answer:
-    """The edit the model made, once it accounts for every moment.
+    """The moments the model says the story does not need, and why each.
 
-    `keep` is BOTH the set of kept moments and their order of essentiality.
-    One artifact, because two was one too many: measured across four real
-    answers, a parallel `release_order` list was never once read as a ranking
-    of the keeps — every attempt ranked the cuts instead, prompt hardening and
-    a keep-list echo included.
+    Rejects only. Everything it never names is kept, so this carries no keep
+    list and no order at all — the ranking is a separate question, asked only
+    when something has to go.
     """
 
-    keep: tuple[int, ...]
     cut: tuple[tuple[int, str], ...]
+
+    def survivors(self, count: int) -> tuple[int, ...]:
+        """The moments left standing, in the order they happened."""
+        named = {index for index, _ in self.cut}
+        return tuple(index for index in range(1, count + 1) if index not in named)
 
 
 def _is_a_moment_number(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def states_a_priority(keep: tuple[int, ...]) -> bool:
-    """Whether the keep list says anything about what matters most.
-
-    Written in table order it says nothing that can be acted on. That is the
-    shape a model produces when it has not ranked at all, and a walk that
-    trusted it would release from the end of the month — which is the closer,
-    since a memory plays in the order things happened.
-
-    One moment cannot be ranked against anything, so there is nothing here to
-    ask about either.
-    """
-    return len(keep) > 1 and list(keep) != sorted(keep)
-
-
-def order_mode(keep: tuple[int, ...]) -> str:
-    """What the keep list's order is evidence of, said in the trace.
-
-    Never "the model echoed the table": ascending is indistinguishable from a
-    genuine priority that happens to run chronologically, and that coincidence
-    is likeliest in a month whose best material is late — exactly where the
-    closer matters. The line records what the evidence supports.
-    """
-    if len(keep) <= 1:
-        return "keep order: a single moment, nothing to rank"
-    if states_a_priority(keep):
-        return "keep order: expressed priority"
-    return "keep order: indistinguishable from table order"
-
-
-def _accounted_for(payload: object, count: int) -> Answer | None:
-    """The edit, but only if the answer accounts for every moment exactly once.
-
-    Under keep-semantics silence is a kill, so a truncated answer would cut
-    every moment it never reached. Requiring the two lists to partition 1..M
-    turns truncation back into a parse failure, which this pass survives by
-    handing the cut to the arithmetic funnel. It is also the cheapest check
-    that the model answered about THESE moments.
-    """
+def _entries_in(payload: object) -> list | None:
+    """The cut list, if this payload has one at all."""
     if not isinstance(payload, dict):
         return None
-    keep, cut = payload.get("keep"), payload.get("cut")
-    if not isinstance(keep, list) or not isinstance(cut, list) or not keep:
+    cut = payload.get("cut")
+    return cut if isinstance(cut, list) else None
+
+
+def _read_cut(payload: object, count: int) -> Answer | None:
+    """The rejects, but only if every entry names a moment and says why.
+
+    Deliberately NOT the strict partition the fine cut uses (see
+    selection_review._accounted_for). That check exists to stop silent
+    deletion-by-truncation, which is real under keep-semantics: an answer that
+    stops after four clips cuts everything it never reached. Reject-only gets
+    the same protection BY CONSTRUCTION, and fails in the safe direction when
+    it fails at all — a truncated answer names fewer rejects, so more content
+    survives, not less.
+
+    Keep-semantics remain right for Pass 4, where N is small and the model
+    sees the whole finished cut. At 53 moments the full partition is a cliff:
+    every measured answer went over it by dropping indices, and the retry
+    rewrote from scratch rather than patching.
+
+    One moment named twice is one decision, not a defect: the first reason
+    stands.
+    """
+    entries = _entries_in(payload)
+    if entries is None:
         return None
-    kept = [n for n in keep if _is_a_moment_number(n)]
-    entries = [
-        (entry["index"], str(entry.get("reason", "no reason given")))
-        for entry in cut
-        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
-    ]
-    if len(kept) != len(keep) or len(entries) != len(cut):
-        return None
-    if sorted(kept + [index for index, _ in entries]) != list(range(1, count + 1)):
-        return None
-    return Answer(tuple(kept), tuple(entries))
+    seen: dict[int, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not _is_a_moment_number(entry.get("index")):
+            return None
+        index, reason = entry["index"], entry.get("reason")
+        if not 1 <= index <= count or not isinstance(reason, str) or not reason.strip():
+            return None
+        seen.setdefault(index, reason.strip())
+    return Answer(tuple(seen.items()))
 
 
 def answer_in(raw: str | None, count: int) -> Answer | None:
-    """The model's edit, or None when it never made one about these moments."""
-    if not raw:
-        return None
-    from immich_memories.analysis.selection_review import _balanced_objects
-
-    for candidate in reversed(_balanced_objects(raw)):
-        try:
-            payload = json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-        answer = _accounted_for(payload, count)
+    """The model's rejects, or None when it named none we could read."""
+    for payload in _payloads_in(raw):
+        answer = _read_cut(payload, count)
         if answer is not None:
             return answer
     return None
@@ -230,56 +211,44 @@ def _payloads_in(raw: str | None) -> list[dict]:
     return found
 
 
-def _numbers_named_in(payload: dict) -> tuple[list[int], list[int]] | None:
-    """The keep and cut numbers an answer names, however badly it named them."""
-    keep, cut = payload.get("keep"), payload.get("cut")
-    if not isinstance(keep, list) or not isinstance(cut, list):
-        return None
-    kept = [n for n in keep if _is_a_moment_number(n)]
-    dropped = [
-        entry["index"]
-        for entry in cut
-        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
-    ]
-    return kept, dropped
-
-
 def defects_in(raw: str | None, count: int) -> tuple[str, ...]:
     """What was wrong with an answer we could not use, in words it can act on.
 
     A vague "that did not work, try again" is what corrupted the one revision
-    ever measured: told only that its cut ran long, the model came back with
-    one moment in both lists and three in neither. Naming the numbers is the
+    ever measured: told only that its answer was unusable, the model rewrote
+    the whole edit from scratch and came back worse. Naming the entries is the
     difference between a correction and a re-roll.
 
-    Empty means nothing nameable — prose, or no edit at all — and there is
+    Empty means nothing nameable — prose, or no cut list at all — and there is
     nothing to ask again about.
     """
     for payload in _payloads_in(raw):
-        named = _numbers_named_in(payload)
-        if named is not None:
-            return _what_is_wrong_with(named, count)
+        entries = _entries_in(payload)
+        if entries is not None:
+            return _what_is_wrong_with(entries, count)
     return ()
 
 
-def _what_is_wrong_with(named: tuple[list[int], list[int]], count: int) -> tuple[str, ...]:
-    keep, cut = named
-    both = sorted(set(keep) & set(cut))
-    everything = keep + cut
-    repeated = sorted({n for n in everything if everything.count(n) > 1})
-    missing = sorted(set(range(1, count + 1)) - set(everything))
-    outside = sorted({n for n in everything if not 1 <= n <= count})
+def _what_is_wrong_with(entries: list, count: int) -> tuple[str, ...]:
+    outside: list[int] = []
+    reasonless: list[int] = []
+    unreadable = 0
+    for entry in entries:
+        if not isinstance(entry, dict) or not _is_a_moment_number(entry.get("index")):
+            unreadable += 1
+            continue
+        index, reason = entry["index"], entry.get("reason")
+        if not 1 <= index <= count:
+            outside.append(index)
+        elif not isinstance(reason, str) or not reason.strip():
+            reasonless.append(index)
     defects = []
-    if not keep:
-        defects.append("you kept nothing, and a memory with nothing in it is not an edit")
-    if both:
-        defects.append(f"you listed {_named(both)} in both keep and cut")
-    elif repeated:
-        defects.append(f"you listed {_named(repeated)} more than once")
-    if missing:
-        defects.append(f"you omitted {_named(missing)}")
     if outside:
-        defects.append(f"you named {_named(outside)}, which is not in the table")
+        defects.append(f"you named {_named(sorted(set(outside)))}, which is not in the table")
+    if reasonless:
+        defects.append(f"you named {_named(sorted(set(reasonless)))} with no reason")
+    if unreadable:
+        defects.append(f"{unreadable} of your entries named no moment at all")
     return tuple(defects)
 
 
@@ -297,12 +266,31 @@ def reordering_in(raw: str | None, echoed: tuple[int, ...]) -> tuple[int, ...] |
     """
     for payload in _payloads_in(raw):
         order = payload.get("keep")
-        if (
-            isinstance(order, list)
-            and all(_is_a_moment_number(n) for n in order)
-            and sorted(order) == sorted(echoed)
-        ):
-            return tuple(order)
+        if not isinstance(order, list):
+            continue
+        numbers = [_moment_number(entry) for entry in order]
+        if None in numbers:
+            continue
+        ranked = [n for n in numbers if n is not None]
+        if sorted(ranked) == sorted(echoed):
+            return tuple(ranked)
+    return None
+
+
+def _moment_number(value: object) -> int | None:
+    """A moment number, whether it came back as 12 or as "M12".
+
+    Measured against the local model: asked for bare integers it sometimes
+    labels them anyway. The label is not a different answer — it is the same
+    stated order with the table's own prefix on it — so it is read rather than
+    refused. The permutation check stays strict afterwards.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().removeprefix("M").removeprefix("m")
+        if text.isdigit():
+            return int(text)
     return None
 
 

--- a/src/immich_memories/analysis/structure_answer.py
+++ b/src/immich_memories/analysis/structure_answer.py
@@ -1,0 +1,320 @@
+"""The question the structure pass asks, and how its answer is read (#764).
+
+Kept apart from the pass that acts on it because they fail differently. This
+module is the contract with the model: three prompts, one shape of answer, and
+the checks that decide whether what came back is an edit of THIS month or
+something else. Every measurement behind its wording came from real answers —
+four of them, from one June — and the wording is load-bearing in a way the
+editing logic next door is not.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+# How near the content budget the rough cut has to land. Named here because
+# the prompts state them to the model; the pass enforces them.
+ENVELOPE_FLOOR = 0.9
+ENVELOPE_CEILING = 1.1
+
+
+_PROMPT = """You are structuring the rough cut of a month's memory video from
+its moments. They are listed in the order they happened.
+
+Ask ONE question of every moment: **does the month's story need it?**
+
+The story needs coverage of what actually happened, not only what looks
+strongest — the punch-up is not the march. A day earns a second moment only
+when the story needs both of them. A cut made of nothing but peaks is
+shapeless: vary the tension.
+
+`starred n/m` counts the items the owner marked a favourite. Those are the
+owner's own marks and they carry the month's meaning. Cut a starred moment
+only when its occasion is already over-represented AND another starred moment
+of that occasion stays in.
+
+Moments sharing an `episode` name are ONE occasion — an afternoon somewhere, a
+party, a hike — however different their descriptions read.
+
+{moments}
+
+The content budget is {target:.0f}s. Do the arithmetic: add up the `est`
+seconds of every moment you keep, and that sum must land between {floor:.0f}s
+and {ceiling:.0f}s. Keeping more than that is not an edit, it is a list.
+
+WRITE THE KEEP LIST MOST ESSENTIAL FIRST. The finished memory always plays in
+the order things happened — nothing you write changes that — so the order of
+your keep list means only one thing: how essential each moment is to the
+story. Put the moment the month would be pointless without at the front, and
+the one you would give up first at the end. If the cut still has to shrink,
+the LAST entries fall first, so the end of your list is the sacrifice you are
+choosing. Choose it: the last moment left in the memory is the month's closer.
+
+Every moment you cut needs a one-line reason. What you leave out is mined
+again later, and a bare no is useless to whoever reads it.
+
+Answer with STRICT JSON only, no prose:
+{{"keep": [<moment numbers, most essential first>],
+ "cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}
+Every moment from 1 to {count} must appear exactly once across keep and cut."""
+
+
+_DEFECT_PROMPT = """You have already edited this month and the answer could not
+be used: {defects}.
+
+Here are the same moments, in the same order and numbered the same way:
+
+{moments}
+
+Edit it again. Every moment from 1 to {count} must appear exactly once — each
+number in keep or in cut, never in both, never in neither. Write the keep list
+most essential first: the memory plays in the order things happened whatever
+you write, so that order says only how essential each moment is, and if the
+cut has to shrink the last entries fall first.
+
+Answer with STRICT JSON only, no prose:
+{{"keep": [<moment numbers, most essential first>],
+ "cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}"""
+
+
+_REORDER_PROMPT = """You kept these moments of the month, and they run about
+{shipped:.0f}s against a {target:.0f}s budget — more than the memory holds, so
+some of them have to go.
+
+You kept: {kept}
+
+You listed them in table order, which says nothing about which of them the
+story needs most. Do not change what you kept and do not cut anything here.
+Give that exact list back, REORDERED most essential first: the moment the
+month would be pointless without at the front, the one you would give up
+first at the end.
+
+The memory plays in the order things happened whatever order you write, so
+this order means only how essential each moment is. The last entries fall
+first, which makes the end of your list the sacrifice you are choosing — and
+the last moment left in the memory is the month's closer.
+
+Answer with STRICT JSON only, no prose, the same numbers and no others:
+{{"keep": [<the same moment numbers, most essential first>]}}"""
+
+
+def first_prompt(table: str, count: int, target_duration: float) -> str:
+    return _PROMPT.format(
+        moments=table,
+        count=count,
+        target=target_duration,
+        floor=target_duration * ENVELOPE_FLOOR,
+        ceiling=target_duration * ENVELOPE_CEILING,
+    )
+
+
+def defect_prompt(table: str, count: int, defects: tuple[str, ...]) -> str:
+    return _DEFECT_PROMPT.format(moments=table, count=count, defects="; ".join(defects))
+
+
+def reorder_prompt(kept: tuple[int, ...], shipped: float, target_duration: float) -> str:
+    return _REORDER_PROMPT.format(
+        kept=", ".join(f"M{index}" for index in kept),
+        shipped=shipped,
+        target=target_duration,
+    )
+
+
+@dataclass(frozen=True)
+class Answer:
+    """The edit the model made, once it accounts for every moment.
+
+    `keep` is BOTH the set of kept moments and their order of essentiality.
+    One artifact, because two was one too many: measured across four real
+    answers, a parallel `release_order` list was never once read as a ranking
+    of the keeps — every attempt ranked the cuts instead, prompt hardening and
+    a keep-list echo included.
+    """
+
+    keep: tuple[int, ...]
+    cut: tuple[tuple[int, str], ...]
+
+
+def _is_a_moment_number(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def states_a_priority(keep: tuple[int, ...]) -> bool:
+    """Whether the keep list says anything about what matters most.
+
+    Written in table order it says nothing that can be acted on. That is the
+    shape a model produces when it has not ranked at all, and a walk that
+    trusted it would release from the end of the month — which is the closer,
+    since a memory plays in the order things happened.
+
+    One moment cannot be ranked against anything, so there is nothing here to
+    ask about either.
+    """
+    return len(keep) > 1 and list(keep) != sorted(keep)
+
+
+def order_mode(keep: tuple[int, ...]) -> str:
+    """What the keep list's order is evidence of, said in the trace.
+
+    Never "the model echoed the table": ascending is indistinguishable from a
+    genuine priority that happens to run chronologically, and that coincidence
+    is likeliest in a month whose best material is late — exactly where the
+    closer matters. The line records what the evidence supports.
+    """
+    if len(keep) <= 1:
+        return "keep order: a single moment, nothing to rank"
+    if states_a_priority(keep):
+        return "keep order: expressed priority"
+    return "keep order: indistinguishable from table order"
+
+
+def _accounted_for(payload: object, count: int) -> Answer | None:
+    """The edit, but only if the answer accounts for every moment exactly once.
+
+    Under keep-semantics silence is a kill, so a truncated answer would cut
+    every moment it never reached. Requiring the two lists to partition 1..M
+    turns truncation back into a parse failure, which this pass survives by
+    handing the cut to the arithmetic funnel. It is also the cheapest check
+    that the model answered about THESE moments.
+    """
+    if not isinstance(payload, dict):
+        return None
+    keep, cut = payload.get("keep"), payload.get("cut")
+    if not isinstance(keep, list) or not isinstance(cut, list) or not keep:
+        return None
+    kept = [n for n in keep if _is_a_moment_number(n)]
+    entries = [
+        (entry["index"], str(entry.get("reason", "no reason given")))
+        for entry in cut
+        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
+    ]
+    if len(kept) != len(keep) or len(entries) != len(cut):
+        return None
+    if sorted(kept + [index for index, _ in entries]) != list(range(1, count + 1)):
+        return None
+    return Answer(tuple(kept), tuple(entries))
+
+
+def answer_in(raw: str | None, count: int) -> Answer | None:
+    """The model's edit, or None when it never made one about these moments."""
+    if not raw:
+        return None
+    from immich_memories.analysis.selection_review import _balanced_objects
+
+    for candidate in reversed(_balanced_objects(raw)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        answer = _accounted_for(payload, count)
+        if answer is not None:
+            return answer
+    return None
+
+
+def _payloads_in(raw: str | None) -> list[dict]:
+    """Every JSON object in an answer, last first — the verdict follows the prose."""
+    if not raw:
+        return []
+    from immich_memories.analysis.selection_review import _balanced_objects
+
+    found = []
+    for candidate in reversed(_balanced_objects(raw)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            found.append(payload)
+    return found
+
+
+def _numbers_named_in(payload: dict) -> tuple[list[int], list[int]] | None:
+    """The keep and cut numbers an answer names, however badly it named them."""
+    keep, cut = payload.get("keep"), payload.get("cut")
+    if not isinstance(keep, list) or not isinstance(cut, list):
+        return None
+    kept = [n for n in keep if _is_a_moment_number(n)]
+    dropped = [
+        entry["index"]
+        for entry in cut
+        if isinstance(entry, dict) and _is_a_moment_number(entry.get("index"))
+    ]
+    return kept, dropped
+
+
+def defects_in(raw: str | None, count: int) -> tuple[str, ...]:
+    """What was wrong with an answer we could not use, in words it can act on.
+
+    A vague "that did not work, try again" is what corrupted the one revision
+    ever measured: told only that its cut ran long, the model came back with
+    one moment in both lists and three in neither. Naming the numbers is the
+    difference between a correction and a re-roll.
+
+    Empty means nothing nameable — prose, or no edit at all — and there is
+    nothing to ask again about.
+    """
+    for payload in _payloads_in(raw):
+        named = _numbers_named_in(payload)
+        if named is not None:
+            return _what_is_wrong_with(named, count)
+    return ()
+
+
+def _what_is_wrong_with(named: tuple[list[int], list[int]], count: int) -> tuple[str, ...]:
+    keep, cut = named
+    both = sorted(set(keep) & set(cut))
+    everything = keep + cut
+    repeated = sorted({n for n in everything if everything.count(n) > 1})
+    missing = sorted(set(range(1, count + 1)) - set(everything))
+    outside = sorted({n for n in everything if not 1 <= n <= count})
+    defects = []
+    if not keep:
+        defects.append("you kept nothing, and a memory with nothing in it is not an edit")
+    if both:
+        defects.append(f"you listed {_named(both)} in both keep and cut")
+    elif repeated:
+        defects.append(f"you listed {_named(repeated)} more than once")
+    if missing:
+        defects.append(f"you omitted {_named(missing)}")
+    if outside:
+        defects.append(f"you named {_named(outside)}, which is not in the table")
+    return tuple(defects)
+
+
+def _named(numbers: list[int]) -> str:
+    return ", ".join(f"M{n}" for n in numbers)
+
+
+def reordering_in(raw: str | None, echoed: tuple[int, ...]) -> tuple[int, ...] | None:
+    """The same keeps in a new order, or None if that is not what came back.
+
+    Nothing else in the answer is read. The re-ask regenerates no partition —
+    the first answer's judgment about what stays and what goes was reliable
+    four times out of four, and it is the revision that has never once been —
+    so anything but a permutation of what was echoed is refused.
+    """
+    for payload in _payloads_in(raw):
+        order = payload.get("keep")
+        if (
+            isinstance(order, list)
+            and all(_is_a_moment_number(n) for n in order)
+            and sorted(order) == sorted(echoed)
+        ):
+            return tuple(order)
+    return None
+
+
+@dataclass(frozen=True)
+class Reply:
+    """What came back from one ask: the edit, or what was wrong with it.
+
+    `reached` separates a model that answered badly from one that was not
+    there at all — the second has already said so above the funnel, and asking
+    it again would be asking the same silence twice.
+    """
+
+    answer: Answer | None
+    defects: tuple[str, ...] = ()
+    reached: bool = True

--- a/src/immich_memories/analysis/structure_answer.py
+++ b/src/immich_memories/analysis/structure_answer.py
@@ -45,6 +45,7 @@ party, a hike — however different their descriptions read.
 The content budget is {target:.0f}s. Do the arithmetic: cut enough that the
 `est` seconds of what remains add up to between {floor:.0f}s and {ceiling:.0f}s.
 Leaving more than that in is not an edit, it is a list.
+Leave at least two moments in the month; one moment alone is not a structure.
 
 Every moment you name needs a one-line reason. What you leave out is mined
 again later, and a bare no is useless to whoever reads it.
@@ -64,6 +65,7 @@ Here are the same moments, in the same order and numbered the same way:
 
 Name them again. Use moment numbers from 1 to {count} and nothing else, and
 give every one of them a one-line reason. Everything you do not name stays in.
+Leave at least two moments in the month; one moment alone is not a structure.
 
 Answer with STRICT JSON only, no prose:
 {{"cut": [{{"index": <moment number>, "reason": "<short reason>"}}]}}"""
@@ -195,20 +197,19 @@ def answer_in(raw: str | None, count: int) -> Answer | None:
 
 
 def _payloads_in(raw: str | None) -> list[dict]:
-    """Every JSON object in an answer, last first — the verdict follows the prose."""
+    """The final JSON object in an answer — the verdict follows the prose."""
     if not raw:
         return []
     from immich_memories.analysis.selection_review import _balanced_objects
 
-    found = []
-    for candidate in reversed(_balanced_objects(raw)):
-        try:
-            payload = json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            found.append(payload)
-    return found
+    candidates = _balanced_objects(raw)
+    if not candidates:
+        return []
+    try:
+        payload = json.loads(candidates[-1])
+    except json.JSONDecodeError:
+        return []
+    return [payload] if isinstance(payload, dict) else []
 
 
 def defects_in(raw: str | None, count: int) -> tuple[str, ...]:
@@ -290,7 +291,10 @@ def _moment_number(value: object) -> int | None:
     if isinstance(value, str):
         text = value.strip().removeprefix("M").removeprefix("m")
         if text.isdigit():
-            return int(text)
+            try:
+                return int(text)
+            except ValueError:
+                return None
     return None
 
 

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -618,7 +618,7 @@ class TestEnforcePhotoCap:
         assert len(result) == 5
 
     def test_all_photos_no_videos_returns_all(self):
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         clips = [
             _make_clip_with_segment(f"p{i}", asset_type="IMAGE", score=float(i)) for i in range(5)
@@ -627,7 +627,7 @@ class TestEnforcePhotoCap:
         assert len(result) == 5
 
     def test_photos_trimmed_to_cap(self):
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         videos = [_make_clip_with_segment(f"v{i}") for i in range(4)]
         photos = [
@@ -645,7 +645,7 @@ class TestEnforcePhotoCap:
         assert photo_ids == {"p5"}  # score=5.0
 
     def test_photos_within_cap_unchanged(self):
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         videos = [_make_clip_with_segment(f"v{i}") for i in range(8)]
         photos = [_make_clip_with_segment(f"p{i}", asset_type="IMAGE") for i in range(2)]

--- a/tests/test_clip_refiner.py
+++ b/tests/test_clip_refiner.py
@@ -289,7 +289,7 @@ class TestPhotoCapScarcity:
     """Photo cap should respect video scarcity — let photos fill when needed."""
 
     def test_cap_enforced_when_videos_plentiful(self):
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         base = datetime(2021, 7, 22, tzinfo=UTC)
         clips = [
@@ -307,7 +307,7 @@ class TestPhotoCapScarcity:
 
     def test_no_videos_all_photos_kept(self):
         """All photos, no videos — nothing to cap against."""
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         base = datetime(2021, 7, 22, tzinfo=UTC)
         clips = [
@@ -319,7 +319,7 @@ class TestPhotoCapScarcity:
 
     def test_cap_is_calculated_against_final_not_prefilter_total(self):
         """One video at a 50% cap can retain one photo, regardless of input size."""
-        from immich_memories.analysis.clip_refiner import enforce_photo_cap
+        from immich_memories.analysis.clip_distribution import enforce_photo_cap
 
         base = datetime(2021, 7, 22, tzinfo=UTC)
         clips = [_make_clip("video", base, asset_type=AssetType.VIDEO, score=0.5)] + [
@@ -672,7 +672,7 @@ class TestTheRatioTrimHonoursCoverage:
     """
 
     def test_a_coverage_clip_survives_the_non_favorite_trim(self) -> None:
-        from immich_memories.analysis.clip_refiner import _trim_non_favorites
+        from immich_memories.analysis.arithmetic_funnel import _trim_non_favorites
 
         covering = _make_clip("covers-a-month", datetime(2026, 3, 2, 12, tzinfo=UTC))
         covering.score = 0.1

--- a/tests/test_same_moment.py
+++ b/tests/test_same_moment.py
@@ -15,6 +15,7 @@ import pytest
 
 from immich_memories.analysis.clip_scaler import ClipScaler, group_by_moment, is_same_moment
 from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import ExifInfo
 from tests.conftest import make_clip
 
 
@@ -46,6 +47,21 @@ def test_shots_further_apart_than_the_window_are_separate_moments() -> None:
     )
 
     assert len(kept) == 2
+
+
+def test_parallel_places_are_not_temporal_duplicates() -> None:
+    """A nearby timestamp cannot erase a different place's moment."""
+    brussels = _at(15, 54, score=0.9)
+    spa = _at(15, 56, score=0.8)
+    brussels.clip.asset.exif_info = ExifInfo(latitude=50.8466, longitude=4.3528)
+    spa.clip.asset.exif_info = ExifInfo(latitude=50.4922, longitude=5.8645)
+
+    kept = ClipScaler().deduplicate_temporal_clusters([brussels, spa], time_window_minutes=5.0)
+
+    assert {clip.clip.asset.id for clip in kept} == {
+        brussels.clip.asset.id,
+        spa.clip.asset.id,
+    }
 
 
 def test_a_held_shutter_stays_one_moment_however_long_it_runs() -> None:

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -8,6 +8,10 @@ them deleting a 0.80 and shipping a 0.36.
 This pass asks one question at moment granularity instead, and these tests pin
 what may and may not decide a kill. Numbers order the table and measure the
 envelope; the model decides what goes.
+
+The question is asked REJECT-ONLY — name what the story does not need — so an
+answer that stops early cuts less rather than more. Everything the model never
+mentions is kept.
 """
 
 from __future__ import annotations
@@ -24,6 +28,17 @@ from immich_memories.config_models_llm import LLMConfig
 
 JUNE = datetime(2023, 6, 1, 12, tzinfo=UTC)
 MOMENT_WINDOW = 10.0
+
+SUBJECTS = (
+    "a harbour",
+    "a kitchen",
+    "a mountain",
+    "a bicycle",
+    "a birthday",
+    "a rainstorm",
+    "a garden",
+    "a concert",
+)
 
 
 def _clip(
@@ -64,14 +79,14 @@ def _pool(
     ]
 
 
-def _answer(keep: list[int], cut: list[int]) -> str:
-    """An edit whose keep list is written most-essential-first."""
-    return json.dumps(
-        {
-            "keep": keep,
-            "cut": [{"index": i, "reason": f"M{i} is not needed"} for i in cut],
-        }
-    )
+def _answer(cut: list[int]) -> str:
+    """A reject-only answer: every moment it does not name is kept."""
+    return json.dumps({"cut": [{"index": i, "reason": f"M{i} is not needed"} for i in cut]})
+
+
+def _priority(order: list[int]) -> str:
+    """The surviving moments handed back, most essential first."""
+    return json.dumps({"keep": order})
 
 
 def _choose(
@@ -81,22 +96,56 @@ def _choose(
     target: float = 10.0,
     target_clips: int = 2,
 ):
+    return _choose_answers(pool, [raw], target=target, target_clips=target_clips)[0]
+
+
+def _choose_answers(
+    pool: list[ClipWithSegment],
+    raws: list[str],
+    *,
+    target: float = 10.0,
+    target_clips: int = 2,
+):
     pass_ = StructurePass(LLMConfig())
-    # WHY: the model. Everything under test is what we do with its answer.
-    with patch("immich_memories.analysis.selection_structure._ask", return_value=raw):
-        return pass_.choose(
+    # Under test is how often we go back to it, and what we do with the answer.
+    # WHY: the model.
+    with patch("immich_memories.analysis.selection_structure._ask", side_effect=raws * 4) as asked:
+        cut = pass_.choose(
             pool,
             target_duration=target,
             moment_window=MOMENT_WINDOW,
             target_clips=target_clips,
         )
+    return cut, asked
+
+
+def _choose_exactly(
+    pool: list[ClipWithSegment],
+    raws: list[str],
+    *,
+    target: float = 10.0,
+    target_clips: int = 2,
+):
+    """Like _choose_answers, but a call past the end of `raws` is an error."""
+    pass_ = StructurePass(LLMConfig())
+    # A third call raises StopIteration, which is the assertion: this pass
+    # never asks more than twice.
+    # WHY: the model.
+    with patch("immich_memories.analysis.selection_structure._ask", side_effect=raws) as asked:
+        cut = pass_.choose(
+            pool,
+            target_duration=target,
+            moment_window=MOMENT_WINDOW,
+            target_clips=target_clips,
+        )
+    return cut, asked
 
 
 class TestTheStoryChoosesItsMoments:
     def test_a_cut_moment_takes_all_of_its_members_with_it(self):
         pool = _pool(moments=4)
 
-        cut = _choose(pool, _answer(keep=[1, 2], cut=[3, 4]))
+        cut = _choose(pool, _answer(cut=[3, 4]))
 
         assert [c.clip.asset.id for c in cut.kept] == ["m1c0", "m1c1", "m2c0", "m2c1"]
         assert cut.dropped == frozenset({"m3c0", "m3c1", "m4c0", "m4c1"})
@@ -106,7 +155,7 @@ class TestTheStoryChoosesItsMoments:
         pool = _pool(moments=4)
 
         with selection_trace.tracing() as recorded:
-            _choose(pool, _answer(keep=[1, 2], cut=[3, 4]))
+            _choose(pool, _answer(cut=[3, 4]))
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert stage.notes["m3c0"] == "M3 is not needed"
@@ -114,18 +163,151 @@ class TestTheStoryChoosesItsMoments:
         assert stage.notes["m4c0"] == "M4 is not needed"
 
 
+class TestSilenceKeeps:
+    """Reject-only, so a truncated answer costs coverage, never content.
+
+    Keep-semantics made silence a kill: an answer that stopped after four
+    moments cut the rest of the month. The strict partition existed to catch
+    that. Naming only rejects gets the same protection by construction, and
+    fails in the safe direction when it fails at all.
+    """
+
+    def test_an_answer_that_stops_early_keeps_everything_it_never_reached(self):
+        pool = _pool(moments=5)
+        stopped_early = json.dumps({"cut": [{"index": 5, "reason": "a quiet day"}]})
+
+        cut = _choose(pool, stopped_early, target=20.0)
+
+        assert cut.dropped == frozenset({"m5c0", "m5c1"})
+
+    def test_an_empty_cut_list_is_an_answer_rather_than_a_refusal(self):
+        """ "The month needs all of it" is a legitimate edit, and readable."""
+        pool = _pool(moments=5)
+
+        cut, _asked = _choose_exactly(
+            pool, [_answer(cut=[]), _priority([1, 2, 3, 4, 5])], target=20.0
+        )
+
+        assert cut is not None and cut.narrowed
+
+    def test_the_same_moment_named_twice_is_one_decision(self):
+        pool = _pool(moments=5)
+        twice = json.dumps(
+            {"cut": [{"index": 5, "reason": "quiet"}, {"index": 5, "reason": "quiet again"}]}
+        )
+
+        cut = _choose(pool, twice, target=20.0)
+
+        assert cut.dropped == frozenset({"m5c0", "m5c1"})
+
+    def test_cutting_all_but_one_moment_is_not_an_edit(self):
+        pool = _pool(moments=5)
+
+        cut, _asked = _choose_answers(pool, [_answer(cut=[2, 3, 4, 5])])
+
+        assert cut is None
+
+
+class TestAnUnusableAnswerHandsTheCutBack:
+    def test_an_index_that_is_not_in_the_table_is_refused_after_one_retry(self):
+        pool = _pool(moments=4)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        with selection_trace.tracing() as recorded:
+            cut, asked = _choose_exactly(pool, [nonsense, nonsense])
+
+        assert cut is None
+        assert asked.call_count == 2
+        assert any("the structure pass never ran" in w for w in recorded.warnings)
+
+    def test_an_entry_with_no_reason_is_refused_after_one_retry(self):
+        pool = _pool(moments=4)
+        bare = json.dumps({"cut": [{"index": 3}]})
+
+        cut, asked = _choose_exactly(pool, [bare, bare])
+
+        assert cut is None
+        assert asked.call_count == 2
+
+    def test_a_retry_that_fixes_the_entry_is_carried_out(self):
+        pool = _pool(moments=4)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        cut, asked = _choose_exactly(pool, [nonsense, _answer(cut=[3, 4])])
+
+        assert asked.call_count == 2
+        assert cut.dropped == frozenset({"m3c0", "m3c1", "m4c0", "m4c1"})
+
+    def test_the_funnel_makes_the_cut_when_the_pass_refuses(self):
+        pool = _pool(moments=4)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, [nonsense, nonsense])
+
+        names = [stage.name for stage in recorded.stages]
+        assert "structure" not in names
+        assert "per-day photo cap" in names
+
+    def test_a_decided_structure_replaces_the_counting_stages(self):
+        pool = _pool(moments=4)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, _answer(cut=[3, 4]))
+
+        names = [stage.name for stage in recorded.stages]
+        assert "structure" in names
+        assert "per-day photo cap" not in names
+        assert "distribute by date" not in names
+        assert "photo ratio cap" not in names
+
+
+class TestTheReAskNamesTheDefect:
+    """Vague revision requests are what corrupted the one revision measured.
+
+    Told only that its answer did not work, the model rewrote from scratch and
+    came back worse. Naming the entries is the difference between a correction
+    and a re-roll.
+    """
+
+    def test_an_index_outside_the_table_is_named_back_to_the_model(self):
+        pool = _pool(moments=4)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        _cut, asked = _choose_exactly(pool, [nonsense, _answer(cut=[3])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "M99, which is not in the table" in revision
+
+    def test_an_entry_with_no_reason_is_named_back_to_the_model(self):
+        pool = _pool(moments=4)
+        bare = json.dumps({"cut": [{"index": 3}, {"index": 4, "reason": "fine"}]})
+
+        _cut, asked = _choose_exactly(pool, [bare, _answer(cut=[3])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "M3 with no reason" in revision
+
+    def test_an_answer_with_nothing_nameable_wrong_is_not_re_asked(self):
+        """Prose with no edit in it is not a defect anyone can correct."""
+        pool = _pool(moments=4)
+
+        cut, asked = _choose_exactly(pool, ["I would keep most of these, honestly."])
+
+        assert cut is None
+        assert asked.call_count == 1
+
+
 class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
     """A number may order the release; it may never pick the victim."""
 
-    def test_an_over_budget_keep_set_releases_what_the_model_ranked_expendable(self):
+    def test_an_over_budget_cut_releases_what_the_model_ranked_expendable(self):
         # The releases score high and the survivors score low: a shrink by
         # score would keep the exact opposite pair.
         pool = _pool(moments=5, scores={1: 0.9, 3: 0.9, 5: 0.9, 2: 0.1, 4: 0.1})
 
-        cut = _choose(
-            pool,
-            _answer(keep=[2, 4, 1, 5, 3], cut=[]),
-            target=10.0,
+        cut, _asked = _choose_exactly(
+            pool, [_answer(cut=[]), _priority([2, 4, 1, 5, 3])], target=10.0
         )
 
         assert {c.clip.asset.id for c in cut.kept} == {"m2c0", "m2c1", "m4c0", "m4c1"}
@@ -134,74 +316,162 @@ class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
         pool = _pool(moments=5)
 
         with selection_trace.tracing() as recorded:
-            _choose(
-                pool,
-                _answer(keep=[2, 4, 1, 5, 3], cut=[]),
-                target=10.0,
-            )
+            _choose_exactly(pool, [_answer(cut=[]), _priority([2, 4, 1, 5, 3])], target=10.0)
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert stage.notes["m3c0"] == (
             "released to fit the 10s budget (released last from the editor's priority order)"
         )
 
-    def test_an_answer_inside_the_envelope_releases_nothing(self):
+    def test_a_cut_inside_the_envelope_is_never_asked_to_rank(self):
         pool = _pool(moments=5)
 
-        cut = _choose(pool, _answer(keep=[1, 2], cut=[3, 4, 5]), target=10.0)
+        cut, asked = _choose_exactly(pool, [_answer(cut=[3, 4, 5])], target=10.0)
 
+        assert asked.call_count == 1
         assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
 
 
-def _episode_pool(starred: set[str]) -> list[ClipWithSegment]:
-    """Two moments half an hour apart — one occasion — then two lone days."""
-    return [
-        _clip("e1a", days=1, minutes=0, starred="e1a" in starred),
-        _clip("e1b", days=1, minutes=2, starred="e1b" in starred),
-        _clip("e1late", days=1, minutes=30, starred="e1late" in starred),
-        _clip("day2", days=2, starred="day2" in starred),
-        _clip("day3", days=3, starred="day3" in starred),
-    ]
+class TestTheReorderQuestionShowsTheMoments:
+    """Ranking opaque integers is not an editorial act.
+
+    Handed "You kept: M1, M2, M3" and nothing else, the model has no basis to
+    rank anything — and whatever permutation comes back would kill moments by
+    it. The question shows the moments it is asking about.
+    """
+
+    def test_the_reorder_prompt_carries_the_surviving_moments(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_exactly(
+            pool, [_answer(cut=[4, 5]), _priority([1, 2, 3])], target=10.0
+        )
+
+        reorder = asked.call_args_list[1].args[0]
+        assert "M1: 2023-06-02" in reorder
+        assert "a shot called m1c0" in reorder
+
+    def test_the_reorder_prompt_leaves_out_what_was_already_cut(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_exactly(
+            pool, [_answer(cut=[4, 5]), _priority([1, 2, 3])], target=10.0
+        )
+
+        reorder = asked.call_args_list[1].args[0]
+        assert "M4:" not in reorder
+        assert "a shot called m4c0" not in reorder
+
+    def test_a_moment_the_starred_rule_kept_is_shown_and_listed(self):
+        """The veto happens before the overshoot is measured, so it counts."""
+        pool = [
+            _clip("plain1", days=1, shows=SUBJECTS[0]),
+            _clip("star2", days=2, starred=True, shows=SUBJECTS[1]),
+            _clip("plain3", days=3, shows=SUBJECTS[2]),
+        ]
+
+        _cut, asked = _choose_exactly(pool, [_answer(cut=[2]), _priority([1, 2, 3])], target=5.0)
+
+        reorder = asked.call_args_list[1].args[0]
+        assert "You kept: M1, M2, M3" in reorder
+        assert "M2: 2023-06-03" in reorder
 
 
 class TestTheOwnersMarksSurviveTheirOccasion:
     """A star loses its place only to another star of the same occasion."""
 
-    def test_cutting_an_occasions_only_starred_moment_is_vetoed(self):
-        pool = _episode_pool(starred={"e1late"})
+    def _episode_pool(self, starred: set[str]) -> list[ClipWithSegment]:
+        """Two moments half an hour apart — one occasion — then two lone days."""
+        return [
+            _clip("e1a", days=1, minutes=0, starred="e1a" in starred),
+            _clip("e1b", days=1, minutes=2, starred="e1b" in starred),
+            _clip("e1late", days=1, minutes=30, starred="e1late" in starred),
+            _clip("day2", days=2, starred="day2" in starred),
+            _clip("day3", days=3, starred="day3" in starred),
+        ]
 
-        cut = _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+    def test_cutting_an_occasions_only_starred_moment_is_vetoed(self):
+        pool = self._episode_pool(starred={"e1late"})
+
+        cut = _choose(pool, _answer(cut=[2, 4]), target=15.0)
 
         assert "e1late" in {c.clip.asset.id for c in cut.kept}
         assert cut.dropped == frozenset({"day3"})
 
     def test_the_veto_is_on_the_record(self):
-        pool = _episode_pool(starred={"e1late"})
+        pool = self._episode_pool(starred={"e1late"})
 
         with selection_trace.tracing() as recorded:
-            _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+            _choose(pool, _answer(cut=[2, 4]), target=15.0)
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert any("E1" in reason and "M2" in reason for reason in stage.reasons)
 
     def test_a_star_may_lose_to_a_star_of_the_same_occasion(self):
-        pool = _episode_pool(starred={"e1a", "e1late"})
+        pool = self._episode_pool(starred={"e1a", "e1late"})
 
-        cut = _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+        cut = _choose(pool, _answer(cut=[2, 4]), target=15.0)
 
         assert "e1late" in cut.dropped
 
     def test_the_envelope_walk_will_not_release_an_occasions_last_star(self):
-        pool = _episode_pool(starred={"e1late"})
+        pool = self._episode_pool(starred={"e1late"})
 
-        cut = _choose(
-            pool,
-            _answer(keep=[1, 3, 4, 2], cut=[]),
-            target=10.0,
-        )
+        cut, _asked = _choose_exactly(pool, [_answer(cut=[]), _priority([1, 3, 4, 2])], target=10.0)
 
         assert "e1late" in {c.clip.asset.id for c in cut.kept}
         assert cut.dropped == frozenset({"day2", "day3"})
+
+
+class TestTheEnvelopeMeasuresWhatWillShip:
+    """A moment hands on ALL its members; dedup keeps up to three of them.
+
+    Measured on one representative each, a keep-set that reads 1.0T can leave
+    selection at two or three times that, and on the structure path nothing
+    downstream bounds it.
+    """
+
+    def test_a_pool_that_fits_per_representative_but_not_as_it_ships_is_asked_about(self):
+        pool = _pool(moments=2, per_moment=3)
+
+        _cut, asked = _choose_answers(pool, [_answer(cut=[])], target=12.0, target_clips=8)
+
+        assert asked.call_count >= 1
+
+    def test_the_walk_releases_on_what_will_ship_not_on_one_clip_a_moment(self):
+        pool = _pool(moments=4, per_moment=3)
+
+        cut, _asked = _choose_exactly(
+            pool,
+            [_answer(cut=[]), _priority([1, 2, 3, 4])],
+            target=20.0,
+            target_clips=8,
+        )
+
+        assert {c.clip.asset.id for c in cut.kept} == {
+            "m1c0",
+            "m1c1",
+            "m1c2",
+            "m2c0",
+            "m2c1",
+            "m2c2",
+        }
+
+    def test_the_stage_states_both_numbers(self):
+        pool = _pool(moments=4, per_moment=3)
+
+        with selection_trace.tracing() as recorded:
+            _choose_exactly(
+                pool,
+                [_answer(cut=[]), _priority([1, 2, 3, 4])],
+                target=20.0,
+                target_clips=8,
+            )
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        summary = stage.reasons[0]
+        assert "10s of representatives" in summary
+        assert "20s as it will ship" in summary
 
 
 def _wired(*, target_clips: int = 2, dedup_window: float = MOMENT_WINDOW):
@@ -225,108 +495,32 @@ def _wired(*, target_clips: int = 2, dedup_window: float = MOMENT_WINDOW):
     return refiner, tracker
 
 
-def _refine(pool: list[ClipWithSegment], raw: str, *, target_clips: int = 2):
+def _refine(pool: list[ClipWithSegment], raws: str | list[str], *, target_clips: int = 2):
     """Run the refinement phase with the structure pass wired in."""
     refiner, tracker = _wired(target_clips=target_clips)
+    answers = [raws] if isinstance(raws, str) else raws
     # WHY: the model. Everything under test is what the pipeline does with it.
-    with patch("immich_memories.analysis.selection_structure._ask", return_value=raw):
+    with patch("immich_memories.analysis.selection_structure._ask", side_effect=answers * 4):
         return refiner.phase_refine(pool, tracker)
 
 
-class TestAnUnreadableAnswerHandsTheCutBack:
-    def test_an_answer_that_leaves_moments_unaccounted_for_is_refused_wholesale(self):
-        """Silence is a kill under keep-semantics, so a partial answer is none."""
-        pool = _pool(moments=4)
-
-        with selection_trace.tracing() as recorded:
-            _refine(pool, '{"keep": [1], "cut": []}')
-
-        assert not any(stage.name == "structure" for stage in recorded.stages)
-        assert any(stage.name == "per-day photo cap" for stage in recorded.stages)
-
-    def test_the_trace_says_the_funnel_made_this_cut(self):
-        pool = _pool(moments=4)
-
-        with selection_trace.tracing() as recorded:
-            _refine(pool, '{"keep": [1], "cut": []}')
-
-        assert "!! the structure pass never ran" in recorded.report()
-
-    def test_a_decided_structure_replaces_the_counting_stages(self):
-        pool = _pool(moments=4)
-
-        with selection_trace.tracing() as recorded:
-            _refine(pool, _answer(keep=[1, 2], cut=[3, 4]))
-
-        names = [stage.name for stage in recorded.stages]
-        assert "structure" in names
-        assert "per-day photo cap" not in names
-        assert "distribute by date" not in names
-        assert "photo ratio cap" not in names
-
-
-class TestTheQuestionIsAskedOnce:
-    """The verify/judge loop re-enters selection; the story does not change."""
-
-    def test_a_second_refinement_asks_nothing_and_applies_the_same_fates(self):
-        pool = _pool(moments=4)
-        refiner, tracker = _wired()
-
-        # WHY: the model. What is under test is that it is consulted once.
-        with patch(
-            "immich_memories.analysis.selection_structure._ask",
-            return_value=_answer(keep=[1, 2], cut=[3, 4]),
-        ) as asked:
-            refiner.phase_refine(pool, tracker)
-            thinner = [c for c in pool if c.clip.asset.id != "m1c1"]
-            second = refiner.phase_refine(thinner, tracker)
-
-        assert asked.call_count == 1
-        shipped = {c.asset.id for c in second.selected_clips}
-        assert shipped and not shipped & {"m3c0", "m3c1", "m4c0", "m4c1"}
-
-
-class TestACondemnedMomentStaysCondemned:
-    def test_backfill_will_not_spend_freed_seconds_on_a_cut_moment(self):
-        """The relaxation ladder reaches far. It may not reach in here.
-
-        The kept moments are two seconds each and the cut ones five, so the
-        cut finishes well short of its runtime and backfill goes looking —
-        which is exactly the state that used to rebuild what a stage refused.
-        """
-        short = [_clip(f"keep{i}", days=1 + i, seconds=2.0) for i in range(4)]
-        long = [_clip(f"gone{i}", days=5 + i, seconds=5.0) for i in range(4)]
-        refiner, tracker = _wired(target_clips=4, dedup_window=0.0)
-
-        # WHY: the model. What is under test is what backfill does afterwards.
-        with patch(
-            "immich_memories.analysis.selection_structure._ask",
-            return_value=_answer(keep=[1, 2, 3, 4], cut=[5, 6, 7, 8]),
-        ):
-            result = refiner.phase_refine([*short, *long], tracker)
-
-        shipped = {c.asset.id for c in result.selected_clips}
-        assert shipped == {"keep0", "keep1", "keep2", "keep3"}
-
-
-def _choose_without_asking(pool: list[ClipWithSegment], *, target: float, target_clips: int = 2):
-    pass_ = StructurePass(LLMConfig())
-    # WHY: the model — and here the point is that it is never reached.
-    with patch("immich_memories.analysis.selection_structure._ask") as asked:
-        cut = pass_.choose(
-            pool,
-            target_duration=target,
-            moment_window=MOMENT_WINDOW,
-            target_clips=target_clips,
-        )
-    return cut, asked
-
-
 class TestNothingToStructure:
+    def _choose_without_asking(self, pool: list[ClipWithSegment], *, target: float):
+        pass_ = StructurePass(LLMConfig())
+        # WHY: the model — and here the point is that it is never reached.
+        with patch("immich_memories.analysis.selection_structure._ask") as asked:
+            cut = pass_.choose(
+                pool,
+                target_duration=target,
+                moment_window=MOMENT_WINDOW,
+                target_clips=2,
+            )
+        return cut, asked
+
     def test_a_single_moment_is_not_a_structure_to_decide(self):
         pool = _pool(moments=1, per_moment=3)
 
-        cut, asked = _choose_without_asking(pool, target=10.0)
+        cut, asked = self._choose_without_asking(pool, target=10.0)
 
         assert asked.call_count == 0
         assert cut.kept == pool
@@ -335,7 +529,7 @@ class TestNothingToStructure:
     def test_a_pool_that_already_fits_the_budget_is_left_alone(self):
         pool = _pool(moments=2)
 
-        cut, asked = _choose_without_asking(pool, target=20.0)
+        cut, asked = self._choose_without_asking(pool, target=20.0)
 
         assert asked.call_count == 0
         assert cut.kept == pool
@@ -344,7 +538,7 @@ class TestNothingToStructure:
         pool = _pool(moments=2)
 
         with selection_trace.tracing() as recorded:
-            _choose_without_asking(pool, target=20.0)
+            self._choose_without_asking(pool, target=20.0)
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert stage.dropped == 0
@@ -358,7 +552,7 @@ class TestNothingToStructure:
         # WHY: the model. The first call must not reach it, the second must.
         with patch(
             "immich_memories.analysis.selection_structure._ask",
-            return_value=_answer(keep=[1, 2], cut=[3, 4]),
+            return_value=_answer(cut=[3, 4]),
         ) as asked:
             pass_.choose(pool, target_duration=20.0, moment_window=MOMENT_WINDOW, target_clips=2)
             pass_.choose(
@@ -366,117 +560,6 @@ class TestNothingToStructure:
             )
 
         assert asked.call_count == 1
-
-
-class TestWhoGetsAnEditor:
-    """The same gate the fine cut answers to — one LLM switch, both passes."""
-
-    def test_a_run_that_reads_no_content_gets_none(self):
-        from immich_memories.analysis.selection_structure import structure_pass_for
-        from immich_memories.config_loader import Config
-
-        assert structure_pass_for(Config()) is None
-
-    def test_a_content_analysis_run_gets_one(self):
-        from immich_memories.analysis.selection_structure import structure_pass_for
-        from immich_memories.config_loader import Config
-
-        editor = structure_pass_for(Config(content_analysis={"enabled": True}))
-
-        assert isinstance(editor, StructurePass)
-
-
-class TestWhatOneLineTellsTheModel:
-    """Description is the only thing in the table saying what a moment is OF."""
-
-    def _line(self, members: list[ClipWithSegment]) -> str:
-        from immich_memories.analysis.selection_structure import _moments_of, _table
-
-        return _table(_moments_of(members, MOMENT_WINDOW))
-
-    def test_a_described_moment_says_what_it_shows(self):
-        line = self._line([_clip("seen", minutes=0), _clip("also", minutes=1)])
-
-        assert "a shot called seen" in line
-
-    def test_descriptions_come_from_the_described_members_not_the_top_two(self):
-        """Slicing before filtering starved the prompt of the only content it had."""
-        blind = [_clip("blind1", minutes=0, score=0.9), _clip("blind2", minutes=1, score=0.8)]
-        for member in blind:
-            member.clip.llm_description = None
-
-        line = self._line([*blind, _clip("seen", minutes=2, score=0.1)])
-
-        assert "a shot called seen" in line
-
-    def test_the_line_counts_the_owners_marks(self):
-        line = self._line(
-            [
-                _clip("star", minutes=0, starred=True),
-                _clip("plain1", minutes=1),
-                _clip("plain2", minutes=2),
-            ]
-        )
-
-        assert "starred 1/3" in line
-
-    def test_the_line_estimates_from_the_top_scored_member(self):
-        line = self._line(
-            [_clip("long", minutes=0, score=0.9, seconds=9.0), _clip("short", minutes=1, score=0.1)]
-        )
-
-        assert "est 9s" in line
-
-
-class TestTheEnvelopeMeasuresWhatWillShip:
-    """A moment hands on ALL its members; dedup keeps up to three of them.
-
-    Measured on one representative each, a keep-set that reads 1.0T can leave
-    selection at two or three times that, and on the structure path nothing
-    downstream bounds it.
-    """
-
-    def test_a_pool_that_fits_per_representative_but_not_as_it_ships_is_asked_about(self):
-        pool = _pool(moments=2, per_moment=3)
-
-        _cut, asked = _choose_without_asking(pool, target=12.0, target_clips=8)
-
-        assert asked.call_count == 1
-
-    def test_the_walk_releases_on_what_will_ship_not_on_one_clip_a_moment(self):
-        pool = _pool(moments=4, per_moment=3)
-
-        cut = _choose(
-            pool,
-            _answer(keep=[2, 1, 3, 4], cut=[]),
-            target=20.0,
-            target_clips=8,
-        )
-
-        assert {c.clip.asset.id for c in cut.kept} == {
-            "m1c0",
-            "m1c1",
-            "m1c2",
-            "m2c0",
-            "m2c1",
-            "m2c2",
-        }
-
-    def test_the_stage_states_both_numbers(self):
-        pool = _pool(moments=4, per_moment=3)
-
-        with selection_trace.tracing() as recorded:
-            _choose(
-                pool,
-                _answer(keep=[2, 1, 3, 4], cut=[]),
-                target=20.0,
-                target_clips=8,
-            )
-
-        stage = next(s for s in recorded.stages if s.name == "structure")
-        summary = stage.reasons[0]
-        assert "10s of representatives" in summary
-        assert "20s as it will ship" in summary
 
 
 class TestAPoolThatFitsIsStillADecision:
@@ -519,211 +602,258 @@ class TestAPoolThatFitsIsStillADecision:
         assert "same-moment dedup" in [stage.name for stage in recorded.stages]
 
 
-def _choose_answers(
-    pool: list[ClipWithSegment],
-    raws: list[str],
-    *,
-    target: float = 10.0,
-    target_clips: int = 2,
-):
-    pass_ = StructurePass(LLMConfig())
-    # WHY: the model. Under test is how often we go back to it.
-    with patch("immich_memories.analysis.selection_structure._ask", side_effect=raws) as asked:
-        cut = pass_.choose(
-            pool,
-            target_duration=target,
-            moment_window=MOMENT_WINDOW,
-            target_clips=target_clips,
-        )
-    return cut, asked
+class TestAValidJudgmentIsNeverThrownAway:
+    """A failed rank must not cost the cut the model got right.
 
-
-# Kept every moment, in table order: an answer that states no priority at all.
-NO_PRIORITY = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
-# A priority order, and over budget: M3 falls first, then M5, then M1.
-PRIORITY = json.dumps({"keep": [2, 4, 1, 5, 3], "cut": []})
-
-
-class TestOneCorrectiveReask:
-    """The keep list IS the priority order — there is no second artifact.
-
-    Four real answers measured on one June: the model never once read
-    `release_order` as a ranking of what it KEPT. Every attempt ranked what it
-    had cut, prompt hardening and a keep-list echo included. A parallel list
-    with its own semantics was one concept too many, so the order it already
-    writes carries the meaning instead.
+    The first answer's judgment about what stays and what goes has been sound
+    in every measured run; it is the second call that has never once been. So
+    a failed rank leaves the cuts standing and hands the length — only the
+    length — to the counting stages.
     """
 
-    def test_a_keep_list_in_table_order_over_budget_is_asked_again(self):
+    def test_an_unusable_ranking_keeps_the_first_cut(self):
         pool = _pool(moments=5)
 
-        _cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
+        cut, asked = _choose_exactly(pool, [_answer(cut=[5]), "no idea"])
 
         assert asked.call_count == 2
+        assert cut is not None
+        assert cut.dropped == frozenset({"m5c0", "m5c1"})
+        assert not cut.narrowed
 
-    def test_a_keep_list_in_table_order_that_fits_is_never_asked_again(self):
-        """The conjunction, not the tell: an unranked list nothing has to leave
-        costs no reasoning call at all."""
+    def test_a_ranking_that_is_not_the_same_moments_is_refused(self):
+        """The rank question regenerates no cut: only the order may change."""
         pool = _pool(moments=5)
 
-        _cut, asked = _choose_answers(pool, [_answer(keep=[1, 2], cut=[3, 4, 5])])
-
-        assert asked.call_count == 1
-
-    def test_the_revision_may_reorder_its_own_keeps_instead_of_cutting_more(self):
-        pool = _pool(moments=5)
-
-        cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
-
-        assert asked.call_count == 2
-        assert {c.clip.asset.id for c in cut.kept} == {"m2c0", "m2c1", "m4c0", "m4c1"}
-
-    def test_the_re_ask_asks_for_a_reordering_of_the_list_it_echoes(self):
-        pool = _pool(moments=5)
-
-        _cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[1, 2], cut=[3, 4, 5])])
-
-        revision = asked.call_args_list[1].args[0]
-        assert "You kept: M1, M2, M3, M4, M5" in revision
-        assert "most essential first" in revision
-
-    def test_a_stated_priority_is_carried_out_without_a_second_ask(self):
-        pool = _pool(moments=5)
-
-        _cut, asked = _choose_answers(pool, [PRIORITY])
-
-        assert asked.call_count == 1
-
-    def test_a_reordering_that_is_not_the_same_moments_is_refused(self):
-        """The re-ask regenerates no partition: only the order may change."""
-        pool = _pool(moments=5)
-        not_the_same_list = json.dumps({"keep": [2, 1]})
-
-        cut, asked = _choose_answers(pool, [NO_PRIORITY, not_the_same_list])
+        cut, asked = _choose_exactly(pool, [_answer(cut=[]), _priority([2, 1])])
 
         assert asked.call_count == 2
         assert cut is not None and not cut.narrowed
-
-
-class TestAValidJudgmentIsNeverThrownAway:
-    """A failed re-ask must not cost the cut the model got right.
-
-    Four real answers: the FIRST ask produced a valid partition every time,
-    and the revision corrupted it every time. So a revision that fails leaves
-    the first answer's cuts standing and hands the length — only the length —
-    to the counting stages.
-    """
-
-    def test_a_revision_that_still_states_no_priority_keeps_the_first_cut(self):
-        pool = _pool(moments=5)
-
-        cut, asked = _choose_answers(pool, [NO_PRIORITY, NO_PRIORITY])
-
-        assert asked.call_count == 2
-        assert cut is not None
-        assert cut.dropped == frozenset()
-        assert not cut.narrowed
-
-    def test_an_unreadable_revision_keeps_the_first_cut(self):
-        pool = _pool(moments=5)
-        kept_three = json.dumps(
-            {"keep": [1, 2, 3], "cut": [{"index": 4, "reason": "x"}, {"index": 5, "reason": "x"}]}
-        )
-
-        cut, asked = _choose_answers(pool, [kept_three, "no idea"])
-
-        assert asked.call_count == 2
-        assert cut is not None
-        assert cut.dropped == frozenset({"m4c0", "m4c1", "m5c0", "m5c1"})
-        assert not cut.narrowed
 
     def test_the_trace_says_the_funnel_narrowed_the_remainder(self):
         pool = _pool(moments=5)
 
         with selection_trace.tracing() as recorded:
-            _choose_answers(pool, [NO_PRIORITY, NO_PRIORITY])
+            _choose_exactly(pool, [_answer(cut=[]), "no idea"])
 
         assert any("the structure pass cut, but stated no priority" in w for w in recorded.warnings)
 
+    def test_a_failed_re_ask_is_visible_in_the_stage(self):
+        """Forensics must tell a failed re-ask from one that never happened."""
+        pool = _pool(moments=5)
 
-class TestTheReAskNamesTheDefect:
-    """Vague revision requests are what corrupted the one revision measured.
+        with selection_trace.tracing() as recorded:
+            _choose_exactly(pool, [_answer(cut=[]), "no idea"])
 
-    Told only that its cut was too long, the model came back with M53 in both
-    lists and three moments in neither. Naming the numbers is the difference
-    between a correction and a re-roll.
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert any("asked to revise; the answer was unusable" in r for r in stage.reasons)
+
+    def test_a_re_ask_spent_on_a_defective_answer_says_it_had_none_left(self):
+        pool = _pool(moments=5)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        with selection_trace.tracing() as recorded:
+            cut, asked = _choose_exactly(pool, [nonsense, _answer(cut=[])])
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert asked.call_count == 2
+        assert not cut.narrowed
+        assert any("no re-ask left" in reason for reason in stage.reasons)
+
+
+class TestTheTraceSaysWhereThePriorityCameFrom:
+    def _reasons(self, raws: list[str], *, target: float = 10.0) -> list[str]:
+        with selection_trace.tracing() as recorded:
+            _choose_exactly(_pool(moments=5), raws, target=target)
+        return next(s for s in recorded.stages if s.name == "structure").reasons
+
+    def test_a_ranked_answer_is_recorded_as_stated_on_request(self):
+        reasons = self._reasons([_answer(cut=[]), _priority([2, 4, 1, 5, 3])])
+
+        assert "priority: stated on request" in reasons
+
+    def test_an_unranked_answer_names_the_funnel_that_took_over(self):
+        reasons = self._reasons([_answer(cut=[]), "no idea"])
+
+        assert "priority: unstated — the arithmetic funnel narrowed the remainder" in reasons
+
+
+class TestTheQuestionIsAskedOnce:
+    """The verify/judge loop re-enters selection; the story does not change."""
+
+    def test_a_second_refinement_asks_nothing_and_applies_the_same_fates(self):
+        pool = _pool(moments=4)
+        refiner, tracker = _wired()
+
+        # WHY: the model. What is under test is that it is consulted once.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(cut=[3, 4]),
+        ) as asked:
+            refiner.phase_refine(pool, tracker)
+            thinner = [c for c in pool if c.clip.asset.id != "m1c1"]
+            second = refiner.phase_refine(thinner, tracker)
+
+        assert asked.call_count == 1
+        shipped = {c.asset.id for c in second.selected_clips}
+        assert shipped and not shipped & {"m3c0", "m3c1", "m4c0", "m4c1"}
+
+    def test_a_replayed_hybrid_still_hands_the_length_to_the_funnel(self):
+        """The memo carries WHO settles the length, not just what was cut.
+
+        Replaying a hybrid as fully-narrowed skips the funnel on every later
+        round — and the LAST round is the one that ships. Measured: round one
+        selected 2 clips for a 10s budget, round two shipped all five.
+        """
+        pool = _pool(moments=5)
+        refiner, tracker = _wired()
+
+        # The first round goes hybrid (its rank is unusable); the second must
+        # not quietly promote that to a settled length.
+        # WHY: the model.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            side_effect=[_answer(cut=[]), "no idea"],
+        ):
+            refiner.phase_refine(pool, tracker)
+            with selection_trace.tracing() as recorded:
+                refiner.phase_refine(pool, tracker)
+
+        names = [stage.name for stage in recorded.stages]
+        assert "per-day photo cap" in names
+        assert "photo ratio cap" in names
+
+
+class TestACondemnedMomentStaysCondemned:
+    def test_backfill_will_not_spend_freed_seconds_on_a_cut_moment(self):
+        """The relaxation ladder reaches far. It may not reach in here.
+
+        The kept moments are two seconds each and the cut ones five, so the
+        cut finishes well short of its runtime and backfill goes looking —
+        which is exactly the state that used to rebuild what a stage refused.
+        """
+        short = [_clip(f"keep{i}", days=1 + i, seconds=2.0) for i in range(4)]
+        long = [_clip(f"gone{i}", days=5 + i, seconds=5.0) for i in range(4)]
+        refiner, tracker = _wired(target_clips=4, dedup_window=0.0)
+
+        # WHY: the model. What is under test is what backfill does afterwards.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(cut=[5, 6, 7, 8]),
+        ):
+            result = refiner.phase_refine([*short, *long], tracker)
+
+        shipped = {c.asset.id for c in result.selected_clips}
+        assert shipped == {"keep0", "keep1", "keep2", "keep3"}
+
+
+class TestTheHybridRunsTheWholeChain:
+    """The funnel narrows the remainder — through the normal chain, not beside it.
+
+    fit-to-Ns protects coverage ids, not stars, so the favourites law at the
+    end of the phase is the safety net for any arithmetic narrowing. A hybrid
+    that skipped it could drop a starred moment through the honest-fallback
+    door.
     """
 
-    def test_a_moment_in_both_lists_is_named_back_to_the_model(self):
-        pool = _pool(moments=5)
-        corrupt = json.dumps(
-            {"keep": [1, 2, 3], "cut": [{"index": 3, "reason": "x"}, {"index": 4, "reason": "x"}]}
+    def _pool(self) -> list[ClipWithSegment]:
+        return [
+            _clip(f"day{day}", days=day, shows=subject)
+            for day, subject in enumerate(SUBJECTS[:4], start=1)
+        ]
+
+    def _stages(self):
+        with selection_trace.tracing() as recorded:
+            _refine(self._pool(), [_answer(cut=[4]), "no idea"])
+        return recorded, [stage.name for stage in recorded.stages]
+
+    def test_the_counting_stages_run_after_the_structure_stage(self):
+        _recorded, names = self._stages()
+
+        assert names.index("structure") < names.index("per-day photo cap")
+        assert "distribute by date" in names
+
+    def test_the_favourites_law_still_closes_the_phase(self):
+        _recorded, names = self._stages()
+
+        assert names[-1] == "the favourite wins its moment"
+        assert names.index("per-day photo cap") < names.index("the favourite wins its moment")
+
+    def test_what_the_story_cut_stays_cut(self):
+        recorded, _names = self._stages()
+
+        assert "day4" not in recorded.stages[-1].kept_ids
+
+    def test_the_warning_names_the_hybrid(self):
+        recorded, _names = self._stages()
+
+        assert any("the arithmetic funnel narrowed the remainder" in w for w in recorded.warnings)
+
+
+class TestTheWalkHasAFloor:
+    def _pool(self) -> list[ClipWithSegment]:
+        return [
+            _clip("huge1", days=1, seconds=50.0, shows=SUBJECTS[0]),
+            _clip("huge2", days=2, seconds=50.0, shows=SUBJECTS[1]),
+        ]
+
+    def test_the_last_moment_standing_is_never_released(self):
+        """An empty cut with every id refused is unrecoverable: backfill may
+        not touch what a stage condemned."""
+        cut, _asked = _choose_exactly(
+            self._pool(), [_answer(cut=[]), _priority([2, 1])], target=10.0
         )
 
-        _cut, asked = _choose_answers(pool, [corrupt, _answer(keep=[1, 2], cut=[3, 4, 5])])
+        assert len(cut.kept) == 1
 
-        revision = asked.call_args_list[1].args[0]
-        assert "you listed M3 in both keep and cut" in revision
-
-    def test_omitted_moments_are_named_back_to_the_model(self):
-        pool = _pool(moments=5)
-        corrupt = json.dumps({"keep": [1, 2], "cut": [{"index": 4, "reason": "x"}]})
-
-        _cut, asked = _choose_answers(pool, [corrupt, _answer(keep=[1, 2], cut=[3, 4, 5])])
-
-        revision = asked.call_args_list[1].args[0]
-        assert "you omitted M3, M5" in revision
-
-    def test_a_corrupt_first_answer_that_stays_corrupt_hands_the_cut_back(self):
-        pool = _pool(moments=5)
-        corrupt = json.dumps({"keep": [1, 2], "cut": [{"index": 4, "reason": "x"}]})
-
-        cut, asked = _choose_answers(pool, [corrupt, corrupt])
-
-        assert cut is None
-        assert asked.call_count == 2
-
-    def test_an_answer_with_nothing_nameable_wrong_is_not_re_asked(self):
-        """Prose with no edit in it is not a defect anyone can correct."""
-        pool = _pool(moments=5)
-
-        cut, asked = _choose_answers(pool, ["I would keep most of these, honestly."])
-
-        assert cut is None
-        assert asked.call_count == 1
-
-
-class TestTheTraceTellsTheTruthAboutTheOrder:
-    def test_a_walk_on_a_first_answer_says_where_the_priority_came_from(self):
-        pool = _pool(moments=5)
-
+    def test_the_stage_says_it_could_not_shrink_any_further(self):
         with selection_trace.tracing() as recorded:
-            _choose_answers(pool, [PRIORITY])
+            _choose_exactly(self._pool(), [_answer(cut=[]), _priority([2, 1])], target=10.0)
 
         stage = next(s for s in recorded.stages if s.name == "structure")
-        assert any("priority stated with its first answer" in r for r in stage.reasons)
-
-    def test_a_walk_after_a_revision_says_so_and_says_the_re_ask_fired(self):
-        pool = _pool(moments=5)
-
-        with selection_trace.tracing() as recorded:
-            _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
-
-        stage = next(s for s in recorded.stages if s.name == "structure")
-        assert any("priority stated when asked to revise" in r for r in stage.reasons)
-        assert any("asked once to revise" in r for r in stage.reasons)
+        assert any("last moment standing" in reason for reason in stage.reasons)
 
 
-SUBJECTS = (
-    "a harbour",
-    "a kitchen",
-    "a mountain",
-    "a bicycle",
-    "a birthday",
-    "a rainstorm",
-    "a garden",
-    "a concert",
-)
+class TestWhatOneLineTellsTheModel:
+    """Description is the only thing in the table saying what a moment is OF."""
+
+    def _line(self, members: list[ClipWithSegment]) -> str:
+        from immich_memories.analysis.selection_structure import _moments_of, _table
+
+        return _table(list(enumerate(_moments_of(members, MOMENT_WINDOW), start=1)))
+
+    def test_a_described_moment_says_what_it_shows(self):
+        line = self._line([_clip("seen", minutes=0), _clip("also", minutes=1)])
+
+        assert "a shot called seen" in line
+
+    def test_descriptions_come_from_the_described_members_not_the_top_two(self):
+        """Slicing before filtering starved the prompt of the only content it had."""
+        blind = [_clip("blind1", minutes=0, score=0.9), _clip("blind2", minutes=1, score=0.8)]
+        for member in blind:
+            member.clip.llm_description = None
+
+        line = self._line([*blind, _clip("seen", minutes=2, score=0.1)])
+
+        assert "a shot called seen" in line
+
+    def test_the_line_counts_the_owners_marks(self):
+        line = self._line(
+            [
+                _clip("star", minutes=0, starred=True),
+                _clip("plain1", minutes=1),
+                _clip("plain2", minutes=2),
+            ]
+        )
+
+        assert "starred 1/3" in line
+
+    def test_the_line_estimates_from_the_top_scored_member(self):
+        line = self._line(
+            [_clip("long", minutes=0, score=0.9, seconds=9.0), _clip("short", minutes=1, score=0.1)]
+        )
+
+        assert "est 9s" in line
 
 
 class TestTheAbsorbersDownstreamAreNotSilent:
@@ -754,7 +884,7 @@ class TestTheAbsorbersDownstreamAreNotSilent:
         ]
 
         with selection_trace.tracing() as recorded:
-            _refine(pool, _answer(keep=[2, 1, 3], cut=[]))
+            _refine(pool, [_answer(cut=[]), _priority([2, 1, 3])])
 
         assert any("trimmed to fit" in warning for warning in recorded.warnings)
 
@@ -765,6 +895,20 @@ class TestTheAbsorbersDownstreamAreNotSilent:
             _refine(pool, "", target_clips=4)
 
         assert recorded.warnings == []
+
+
+class TestTheSamplerWarningMatchesTheSampler:
+    def test_exactly_as_many_clips_as_slots_is_not_a_warning(self):
+        """The sampler acts above the count, not at it: `len(clips) <= max` returns."""
+        pool = [
+            _clip(f"tiny{day}", days=day, seconds=1.0, shows=subject)
+            for day, subject in enumerate(SUBJECTS[:6], start=1)
+        ]
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "")
+
+        assert not any("stride sampler" in warning for warning in recorded.warnings)
 
 
 class TestAModelThatCannotAnswer:
@@ -808,133 +952,19 @@ class TestAModelThatCannotAnswer:
             pass_.choose(pool, target_duration=10.0, moment_window=MOMENT_WINDOW, target_clips=2)
 
 
-class TestTheRevisionAsksAboutWhatWillActuallyShip:
-    def test_a_moment_the_starred_rule_kept_is_in_the_keep_list_it_is_shown(self):
-        """The veto happens before the overshoot is measured, so it counts.
+class TestWhoGetsAnEditor:
+    """The same gate the fine cut answers to — one LLM switch, both passes."""
 
-        Told it kept M1 and M3 when the starred rule also put M2 back, the
-        editor would revise against a shorter month than the one it has.
-        """
-        pool = [
-            _clip("plain1", days=1, shows=SUBJECTS[0]),
-            _clip("star2", days=2, starred=True, shows=SUBJECTS[1]),
-            _clip("plain3", days=3, shows=SUBJECTS[2]),
-        ]
-        first = json.dumps({"keep": [1, 3], "cut": [{"index": 2, "reason": "quiet day"}]})
+    def test_a_run_that_reads_no_content_gets_none(self):
+        from immich_memories.analysis.selection_structure import structure_pass_for
+        from immich_memories.config_loader import Config
 
-        _cut, asked = _choose_answers(pool, [first, _answer(keep=[1], cut=[2, 3])], target=5.0)
+        assert structure_pass_for(Config()) is None
 
-        revision = asked.call_args_list[1].args[0]
-        assert "You kept: M1, M3, M2" in revision
+    def test_a_content_analysis_run_gets_one(self):
+        from immich_memories.analysis.selection_structure import structure_pass_for
+        from immich_memories.config_loader import Config
 
+        editor = structure_pass_for(Config(content_analysis={"enabled": True}))
 
-class TestTheTraceSaysWhatTheKeepOrderIsEvidenceOf:
-    """The next smoke render must answer "does this model rank at all?".
-
-    Never "the model echoed the table": a priority that happens to run
-    chronologically is indistinguishable from no priority at all, and that
-    coincidence is likeliest in a month whose best material is late — exactly
-    where the closer matters.
-    """
-
-    def _reasons(self, raws: list[str], *, target: float = 10.0) -> list[str]:
-        with selection_trace.tracing() as recorded:
-            _choose_answers(_pool(moments=5), raws, target=target)
-        return next(s for s in recorded.stages if s.name == "structure").reasons
-
-    def test_a_ranked_keep_list_is_recorded_as_an_expressed_priority(self):
-        assert "keep order: expressed priority" in self._reasons([PRIORITY])
-
-    def test_an_ascending_keep_list_is_recorded_as_indistinguishable(self):
-        reasons = self._reasons([NO_PRIORITY, NO_PRIORITY])
-
-        assert "keep order: indistinguishable from table order" in reasons
-        assert not any("echo" in reason for reason in reasons)
-
-    def test_a_single_kept_moment_says_there_was_nothing_to_rank(self):
-        reasons = self._reasons([_answer(keep=[1], cut=[2, 3, 4, 5])])
-
-        assert "keep order: a single moment, nothing to rank" in reasons
-
-
-class TestTheHybridRunsTheWholeChain:
-    """The funnel narrows the remainder — through the normal chain, not beside it.
-
-    fit-to-Ns protects coverage ids, not stars, so the favourites law at the
-    end of the phase is the safety net for any arithmetic narrowing. A hybrid
-    that skipped it could drop a starred moment through the honest-fallback
-    door.
-    """
-
-    def _stages(self, pool: list[ClipWithSegment]):
-        with selection_trace.tracing() as recorded:
-            _refine(pool, json.dumps({"keep": [1, 2, 3], "cut": [{"index": 4, "reason": "no"}]}))
-        return recorded, [stage.name for stage in recorded.stages]
-
-    def _pool(self) -> list[ClipWithSegment]:
-        return [
-            _clip(f"day{day}", days=day, shows=subject)
-            for day, subject in enumerate(SUBJECTS[:4], start=1)
-        ]
-
-    def test_the_counting_stages_run_after_the_structure_stage(self):
-        _recorded, names = self._stages(self._pool())
-
-        assert names.index("structure") < names.index("per-day photo cap")
-        assert "distribute by date" in names
-
-    def test_the_favourites_law_still_closes_the_phase(self):
-        _recorded, names = self._stages(self._pool())
-
-        assert names[-1] == "the favourite wins its moment"
-        assert names.index("per-day photo cap") < names.index("the favourite wins its moment")
-
-    def test_what_the_story_cut_stays_cut(self):
-        recorded, _names = self._stages(self._pool())
-
-        assert "day4" not in recorded.stages[-1].kept_ids
-
-    def test_the_warning_names_the_hybrid(self):
-        recorded, _names = self._stages(self._pool())
-
-        assert any("the arithmetic funnel narrowed the remainder" in w for w in recorded.warnings)
-
-
-class TestTheWalkHasAFloor:
-    def test_the_last_moment_standing_is_never_released(self):
-        """An empty cut with every id refused is unrecoverable: backfill may
-        not touch what a stage condemned."""
-        pool = [
-            _clip("huge1", days=1, seconds=50.0, shows=SUBJECTS[0]),
-            _clip("huge2", days=2, seconds=50.0, shows=SUBJECTS[1]),
-        ]
-
-        cut = _choose(pool, _answer(keep=[2, 1], cut=[]), target=10.0)
-
-        assert len(cut.kept) == 1
-
-    def test_the_stage_says_it_could_not_shrink_any_further(self):
-        pool = [
-            _clip("huge1", days=1, seconds=50.0, shows=SUBJECTS[0]),
-            _clip("huge2", days=2, seconds=50.0, shows=SUBJECTS[1]),
-        ]
-
-        with selection_trace.tracing() as recorded:
-            _choose(pool, _answer(keep=[2, 1], cut=[]), target=10.0)
-
-        stage = next(s for s in recorded.stages if s.name == "structure")
-        assert any("last moment standing" in reason for reason in stage.reasons)
-
-
-class TestTheSamplerWarningMatchesTheSampler:
-    def test_exactly_as_many_clips_as_slots_is_not_a_warning(self):
-        """The sampler acts above the count, not at it: `len(clips) <= max` returns."""
-        pool = [
-            _clip(f"tiny{day}", days=day, seconds=1.0, shows=subject)
-            for day, subject in enumerate(SUBJECTS[:6], start=1)
-        ]
-
-        with selection_trace.tracing() as recorded:
-            _refine(pool, "")
-
-        assert not any("stride sampler" in warning for warning in recorded.warnings)
+        assert isinstance(editor, StructurePass)

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -194,6 +194,22 @@ class TestStructureUsesTheSharedMomentMap:
         ]
         assert [moment.episode for moment in moments] == ["E1", "E2"]
 
+    def test_parallel_places_are_counted_in_the_shipping_envelope(self):
+        brussels = (50.8466, 4.3528)
+        spa = (50.4922, 5.8645)
+        pool = [_clip(f"brussels-{index}", minutes=index, where=brussels) for index in range(3)] + [
+            _clip("spa", minutes=1, where=spa)
+        ]
+
+        _cut, asked = _choose_exactly(
+            pool,
+            [_answer(cut=[]), _priority([1, 2])],
+            target=15.0,
+            target_clips=12,
+        )
+
+        assert asked.call_count == 2
+
 
 class TestSilenceKeeps:
     """Reject-only, so a truncated answer costs coverage, never content.

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -64,13 +64,14 @@ def _pool(
     ]
 
 
-def _answer(keep: list[int], cut: list[int], release_order: list[int] | None = None) -> str:
-    payload = {
-        "keep": keep,
-        "cut": [{"index": i, "reason": f"M{i} is not needed"} for i in cut],
-        "release_order": keep[::-1] if release_order is None else release_order,
-    }
-    return json.dumps(payload)
+def _answer(keep: list[int], cut: list[int]) -> str:
+    """An edit whose keep list is written most-essential-first."""
+    return json.dumps(
+        {
+            "keep": keep,
+            "cut": [{"index": i, "reason": f"M{i} is not needed"} for i in cut],
+        }
+    )
 
 
 def _choose(
@@ -123,7 +124,7 @@ class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
 
         cut = _choose(
             pool,
-            _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 1, 5, 4, 2]),
+            _answer(keep=[2, 4, 1, 5, 3], cut=[]),
             target=10.0,
         )
 
@@ -135,13 +136,13 @@ class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
         with selection_trace.tracing() as recorded:
             _choose(
                 pool,
-                _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 1, 5, 4, 2]),
+                _answer(keep=[2, 4, 1, 5, 3], cut=[]),
                 target=10.0,
             )
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert stage.notes["m3c0"] == (
-            "released to fit the 10s budget (the editor's stated release order)"
+            "released to fit the 10s budget (released last from the editor's priority order)"
         )
 
     def test_an_answer_inside_the_envelope_releases_nothing(self):
@@ -195,7 +196,7 @@ class TestTheOwnersMarksSurviveTheirOccasion:
 
         cut = _choose(
             pool,
-            _answer(keep=[1, 2, 3, 4], cut=[], release_order=[2, 4, 3, 1]),
+            _answer(keep=[1, 3, 4, 2], cut=[]),
             target=10.0,
         )
 
@@ -447,7 +448,7 @@ class TestTheEnvelopeMeasuresWhatWillShip:
 
         cut = _choose(
             pool,
-            _answer(keep=[1, 2, 3, 4], cut=[], release_order=[4, 3, 2, 1]),
+            _answer(keep=[2, 1, 3, 4], cut=[]),
             target=20.0,
             target_clips=8,
         )
@@ -467,7 +468,7 @@ class TestTheEnvelopeMeasuresWhatWillShip:
         with selection_trace.tracing() as recorded:
             _choose(
                 pool,
-                _answer(keep=[1, 2, 3, 4], cut=[], release_order=[4, 3, 2, 1]),
+                _answer(keep=[2, 1, 3, 4], cut=[]),
                 target=20.0,
                 target_clips=8,
             )
@@ -537,85 +538,180 @@ def _choose_answers(
     return cut, asked
 
 
-KEPT_EVERYTHING = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
+# Kept every moment, in table order: an answer that states no priority at all.
+NO_PRIORITY = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
+# A priority order, and over budget: M3 falls first, then M5, then M1.
+PRIORITY = json.dumps({"keep": [2, 4, 1, 5, 3], "cut": []})
 
 
 class TestOneCorrectiveReask:
-    """An order we invent is a mechanical kill wearing an editor's clothes.
+    """The keep list IS the priority order — there is no second artifact.
 
-    The reversed-keep guess released M53, M52, M50 … strictly downwards on a
-    real June: it amputated the end of the month. The memory plays in the
-    order things happened, so the last moment kept IS the closer. When the
-    editor states no order, we ask it once — and refuse rather than guess.
+    Four real answers measured on one June: the model never once read
+    `release_order` as a ranking of what it KEPT. Every attempt ranked what it
+    had cut, prompt hardening and a keep-list echo included. A parallel list
+    with its own semantics was one concept too many, so the order it already
+    writes carries the meaning instead.
     """
 
-    def test_an_overshoot_with_no_stated_order_is_asked_about_once_more(self):
+    def test_a_keep_list_in_table_order_over_budget_is_asked_again(self):
         pool = _pool(moments=5)
 
-        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, _answer(keep=[1, 2], cut=[3, 4, 5])])
+        _cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
 
         assert asked.call_count == 2
-        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
 
-    def test_the_revision_may_state_the_order_instead_of_cutting_more(self):
+    def test_a_keep_list_in_table_order_that_fits_is_never_asked_again(self):
+        """The conjunction, not the tell: an unranked list nothing has to leave
+        costs no reasoning call at all."""
         pool = _pool(moments=5)
-        revised = _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])
 
-        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, revised])
+        _cut, asked = _choose_answers(pool, [_answer(keep=[1, 2], cut=[3, 4, 5])])
+
+        assert asked.call_count == 1
+
+    def test_the_revision_may_reorder_its_own_keeps_instead_of_cutting_more(self):
+        pool = _pool(moments=5)
+
+        cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
 
         assert asked.call_count == 2
-        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+        assert {c.clip.asset.id for c in cut.kept} == {"m2c0", "m2c1", "m4c0", "m4c1"}
 
-    def test_a_revision_that_still_overshoots_hands_the_cut_back(self):
+    def test_the_re_ask_asks_for_a_reordering_of_the_list_it_echoes(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_answers(pool, [NO_PRIORITY, _answer(keep=[1, 2], cut=[3, 4, 5])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "You kept: M1, M2, M3, M4, M5" in revision
+        assert "most essential first" in revision
+
+    def test_a_stated_priority_is_carried_out_without_a_second_ask(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_answers(pool, [PRIORITY])
+
+        assert asked.call_count == 1
+
+    def test_a_reordering_that_is_not_the_same_moments_is_refused(self):
+        """The re-ask regenerates no partition: only the order may change."""
+        pool = _pool(moments=5)
+        not_the_same_list = json.dumps({"keep": [2, 1]})
+
+        cut, asked = _choose_answers(pool, [NO_PRIORITY, not_the_same_list])
+
+        assert asked.call_count == 2
+        assert cut is not None and not cut.narrowed
+
+
+class TestAValidJudgmentIsNeverThrownAway:
+    """A failed re-ask must not cost the cut the model got right.
+
+    Four real answers: the FIRST ask produced a valid partition every time,
+    and the revision corrupted it every time. So a revision that fails leaves
+    the first answer's cuts standing and hands the length — only the length —
+    to the counting stages.
+    """
+
+    def test_a_revision_that_still_states_no_priority_keeps_the_first_cut(self):
+        pool = _pool(moments=5)
+
+        cut, asked = _choose_answers(pool, [NO_PRIORITY, NO_PRIORITY])
+
+        assert asked.call_count == 2
+        assert cut is not None
+        assert cut.dropped == frozenset()
+        assert not cut.narrowed
+
+    def test_an_unreadable_revision_keeps_the_first_cut(self):
+        pool = _pool(moments=5)
+        kept_three = json.dumps(
+            {"keep": [1, 2, 3], "cut": [{"index": 4, "reason": "x"}, {"index": 5, "reason": "x"}]}
+        )
+
+        cut, asked = _choose_answers(pool, [kept_three, "no idea"])
+
+        assert asked.call_count == 2
+        assert cut is not None
+        assert cut.dropped == frozenset({"m4c0", "m4c1", "m5c0", "m5c1"})
+        assert not cut.narrowed
+
+    def test_the_trace_says_the_funnel_narrowed_the_remainder(self):
         pool = _pool(moments=5)
 
         with selection_trace.tracing() as recorded:
-            cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, KEPT_EVERYTHING])
+            _choose_answers(pool, [NO_PRIORITY, NO_PRIORITY])
 
-        assert cut is None
-        assert asked.call_count == 2
-        assert any("the structure pass never ran" in w for w in recorded.warnings)
+        assert any("the structure pass cut, but stated no priority" in w for w in recorded.warnings)
 
-    def test_an_unreadable_revision_hands_the_cut_back(self):
+
+class TestTheReAskNamesTheDefect:
+    """Vague revision requests are what corrupted the one revision measured.
+
+    Told only that its cut was too long, the model came back with M53 in both
+    lists and three moments in neither. Naming the numbers is the difference
+    between a correction and a re-roll.
+    """
+
+    def test_a_moment_in_both_lists_is_named_back_to_the_model(self):
         pool = _pool(moments=5)
-
-        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, "no idea"])
-
-        assert cut is None
-        assert asked.call_count == 2
-
-    def test_a_stated_order_is_carried_out_without_a_second_ask(self):
-        pool = _pool(moments=5)
-
-        _cut, asked = _choose_answers(
-            pool, [_answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])]
+        corrupt = json.dumps(
+            {"keep": [1, 2, 3], "cut": [{"index": 3, "reason": "x"}, {"index": 4, "reason": "x"}]}
         )
 
+        _cut, asked = _choose_answers(pool, [corrupt, _answer(keep=[1, 2], cut=[3, 4, 5])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "you listed M3 in both keep and cut" in revision
+
+    def test_omitted_moments_are_named_back_to_the_model(self):
+        pool = _pool(moments=5)
+        corrupt = json.dumps({"keep": [1, 2], "cut": [{"index": 4, "reason": "x"}]})
+
+        _cut, asked = _choose_answers(pool, [corrupt, _answer(keep=[1, 2], cut=[3, 4, 5])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "you omitted M3, M5" in revision
+
+    def test_a_corrupt_first_answer_that_stays_corrupt_hands_the_cut_back(self):
+        pool = _pool(moments=5)
+        corrupt = json.dumps({"keep": [1, 2], "cut": [{"index": 4, "reason": "x"}]})
+
+        cut, asked = _choose_answers(pool, [corrupt, corrupt])
+
+        assert cut is None
+        assert asked.call_count == 2
+
+    def test_an_answer_with_nothing_nameable_wrong_is_not_re_asked(self):
+        """Prose with no edit in it is not a defect anyone can correct."""
+        pool = _pool(moments=5)
+
+        cut, asked = _choose_answers(pool, ["I would keep most of these, honestly."])
+
+        assert cut is None
         assert asked.call_count == 1
 
 
 class TestTheTraceTellsTheTruthAboutTheOrder:
-    def test_a_walk_on_a_first_answer_says_where_the_order_came_from(self):
+    def test_a_walk_on_a_first_answer_says_where_the_priority_came_from(self):
         pool = _pool(moments=5)
 
         with selection_trace.tracing() as recorded:
-            _choose_answers(
-                pool, [_answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])]
-            )
+            _choose_answers(pool, [PRIORITY])
 
         stage = next(s for s in recorded.stages if s.name == "structure")
-        assert any("stated with its first answer" in reason for reason in stage.reasons)
+        assert any("priority stated with its first answer" in r for r in stage.reasons)
 
     def test_a_walk_after_a_revision_says_so_and_says_the_re_ask_fired(self):
         pool = _pool(moments=5)
-        revised = _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])
 
         with selection_trace.tracing() as recorded:
-            _choose_answers(pool, [KEPT_EVERYTHING, revised])
+            _choose_answers(pool, [NO_PRIORITY, _answer(keep=[2, 4, 1, 5, 3], cut=[])])
 
         stage = next(s for s in recorded.stages if s.name == "structure")
-        assert any("stated when asked to revise" in reason for reason in stage.reasons)
-        assert any("asked once to revise" in reason for reason in stage.reasons)
+        assert any("priority stated when asked to revise" in r for r in stage.reasons)
+        assert any("asked once to revise" in r for r in stage.reasons)
 
 
 SUBJECTS = (
@@ -658,7 +754,7 @@ class TestTheAbsorbersDownstreamAreNotSilent:
         ]
 
         with selection_trace.tracing() as recorded:
-            _refine(pool, _answer(keep=[1, 2, 3], cut=[], release_order=[3, 2, 1]))
+            _refine(pool, _answer(keep=[2, 1, 3], cut=[]))
 
         assert any("trimmed to fit" in warning for warning in recorded.warnings)
 
@@ -729,4 +825,116 @@ class TestTheRevisionAsksAboutWhatWillActuallyShip:
         _cut, asked = _choose_answers(pool, [first, _answer(keep=[1], cut=[2, 3])], target=5.0)
 
         revision = asked.call_args_list[1].args[0]
-        assert "You kept: M1, M2, M3" in revision
+        assert "You kept: M1, M3, M2" in revision
+
+
+class TestTheTraceSaysWhatTheKeepOrderIsEvidenceOf:
+    """The next smoke render must answer "does this model rank at all?".
+
+    Never "the model echoed the table": a priority that happens to run
+    chronologically is indistinguishable from no priority at all, and that
+    coincidence is likeliest in a month whose best material is late — exactly
+    where the closer matters.
+    """
+
+    def _reasons(self, raws: list[str], *, target: float = 10.0) -> list[str]:
+        with selection_trace.tracing() as recorded:
+            _choose_answers(_pool(moments=5), raws, target=target)
+        return next(s for s in recorded.stages if s.name == "structure").reasons
+
+    def test_a_ranked_keep_list_is_recorded_as_an_expressed_priority(self):
+        assert "keep order: expressed priority" in self._reasons([PRIORITY])
+
+    def test_an_ascending_keep_list_is_recorded_as_indistinguishable(self):
+        reasons = self._reasons([NO_PRIORITY, NO_PRIORITY])
+
+        assert "keep order: indistinguishable from table order" in reasons
+        assert not any("echo" in reason for reason in reasons)
+
+    def test_a_single_kept_moment_says_there_was_nothing_to_rank(self):
+        reasons = self._reasons([_answer(keep=[1], cut=[2, 3, 4, 5])])
+
+        assert "keep order: a single moment, nothing to rank" in reasons
+
+
+class TestTheHybridRunsTheWholeChain:
+    """The funnel narrows the remainder — through the normal chain, not beside it.
+
+    fit-to-Ns protects coverage ids, not stars, so the favourites law at the
+    end of the phase is the safety net for any arithmetic narrowing. A hybrid
+    that skipped it could drop a starred moment through the honest-fallback
+    door.
+    """
+
+    def _stages(self, pool: list[ClipWithSegment]):
+        with selection_trace.tracing() as recorded:
+            _refine(pool, json.dumps({"keep": [1, 2, 3], "cut": [{"index": 4, "reason": "no"}]}))
+        return recorded, [stage.name for stage in recorded.stages]
+
+    def _pool(self) -> list[ClipWithSegment]:
+        return [
+            _clip(f"day{day}", days=day, shows=subject)
+            for day, subject in enumerate(SUBJECTS[:4], start=1)
+        ]
+
+    def test_the_counting_stages_run_after_the_structure_stage(self):
+        _recorded, names = self._stages(self._pool())
+
+        assert names.index("structure") < names.index("per-day photo cap")
+        assert "distribute by date" in names
+
+    def test_the_favourites_law_still_closes_the_phase(self):
+        _recorded, names = self._stages(self._pool())
+
+        assert names[-1] == "the favourite wins its moment"
+        assert names.index("per-day photo cap") < names.index("the favourite wins its moment")
+
+    def test_what_the_story_cut_stays_cut(self):
+        recorded, _names = self._stages(self._pool())
+
+        assert "day4" not in recorded.stages[-1].kept_ids
+
+    def test_the_warning_names_the_hybrid(self):
+        recorded, _names = self._stages(self._pool())
+
+        assert any("the arithmetic funnel narrowed the remainder" in w for w in recorded.warnings)
+
+
+class TestTheWalkHasAFloor:
+    def test_the_last_moment_standing_is_never_released(self):
+        """An empty cut with every id refused is unrecoverable: backfill may
+        not touch what a stage condemned."""
+        pool = [
+            _clip("huge1", days=1, seconds=50.0, shows=SUBJECTS[0]),
+            _clip("huge2", days=2, seconds=50.0, shows=SUBJECTS[1]),
+        ]
+
+        cut = _choose(pool, _answer(keep=[2, 1], cut=[]), target=10.0)
+
+        assert len(cut.kept) == 1
+
+    def test_the_stage_says_it_could_not_shrink_any_further(self):
+        pool = [
+            _clip("huge1", days=1, seconds=50.0, shows=SUBJECTS[0]),
+            _clip("huge2", days=2, seconds=50.0, shows=SUBJECTS[1]),
+        ]
+
+        with selection_trace.tracing() as recorded:
+            _choose(pool, _answer(keep=[2, 1], cut=[]), target=10.0)
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert any("last moment standing" in reason for reason in stage.reasons)
+
+
+class TestTheSamplerWarningMatchesTheSampler:
+    def test_exactly_as_many_clips_as_slots_is_not_a_warning(self):
+        """The sampler acts above the count, not at it: `len(clips) <= max` returns."""
+        pool = [
+            _clip(f"tiny{day}", days=day, seconds=1.0, shows=subject)
+            for day, subject in enumerate(SUBJECTS[:6], start=1)
+        ]
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "")
+
+        assert not any("stride sampler" in warning for warning in recorded.warnings)

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -34,6 +34,7 @@ def _clip(
     starred: bool = False,
     score: float = 0.5,
     seconds: float = 5.0,
+    shows: str | None = None,
 ) -> ClipWithSegment:
     when = JUNE + timedelta(days=days, minutes=minutes)
     asset = Asset(
@@ -45,7 +46,7 @@ def _clip(
         isFavorite=starred,
     )
     clip = VideoClipInfo(asset=asset, duration_seconds=seconds)
-    clip.llm_description = f"a shot called {asset_id}"
+    clip.llm_description = shows or f"a shot called {asset_id}"
     return ClipWithSegment(clip=clip, start_time=0.0, end_time=seconds, score=score)
 
 
@@ -72,11 +73,22 @@ def _answer(keep: list[int], cut: list[int], release_order: list[int] | None = N
     return json.dumps(payload)
 
 
-def _choose(pool: list[ClipWithSegment], raw: str, *, target: float = 10.0):
+def _choose(
+    pool: list[ClipWithSegment],
+    raw: str,
+    *,
+    target: float = 10.0,
+    target_clips: int = 2,
+):
     pass_ = StructurePass(LLMConfig())
     # WHY: the model. Everything under test is what we do with its answer.
     with patch("immich_memories.analysis.selection_structure._ask", return_value=raw):
-        return pass_.choose(pool, target_duration=target, moment_window=MOMENT_WINDOW)
+        return pass_.choose(
+            pool,
+            target_duration=target,
+            moment_window=MOMENT_WINDOW,
+            target_clips=target_clips,
+        )
 
 
 class TestTheStoryChoosesItsMoments:
@@ -129,29 +141,8 @@ class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
 
         stage = next(s for s in recorded.stages if s.name == "structure")
         assert stage.notes["m3c0"] == (
-            "released to fit the 10s budget (the editor's own release order)"
+            "released to fit the 10s budget (the editor's stated release order)"
         )
-
-    def test_no_release_order_falls_back_to_the_keep_list_reversed(self):
-        """The model listed its keeps in story order, so later is looser."""
-        pool = _pool(moments=5)
-        answered = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
-
-        cut = _choose(pool, answered, target=10.0)
-
-        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
-
-    def test_a_release_order_that_names_something_uncut_is_not_an_order(self):
-        """Half a ranking spliced onto a fallback is two rankings, not one."""
-        pool = _pool(moments=5)
-
-        cut = _choose(
-            pool,
-            _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 9]),
-            target=10.0,
-        )
-
-        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
 
     def test_an_answer_inside_the_envelope_releases_nothing(self):
         pool = _pool(moments=5)
@@ -317,11 +308,16 @@ class TestACondemnedMomentStaysCondemned:
         assert shipped == {"keep0", "keep1", "keep2", "keep3"}
 
 
-def _choose_without_asking(pool: list[ClipWithSegment], *, target: float):
+def _choose_without_asking(pool: list[ClipWithSegment], *, target: float, target_clips: int = 2):
     pass_ = StructurePass(LLMConfig())
     # WHY: the model — and here the point is that it is never reached.
     with patch("immich_memories.analysis.selection_structure._ask") as asked:
-        cut = pass_.choose(pool, target_duration=target, moment_window=MOMENT_WINDOW)
+        cut = pass_.choose(
+            pool,
+            target_duration=target,
+            moment_window=MOMENT_WINDOW,
+            target_clips=target_clips,
+        )
     return cut, asked
 
 
@@ -363,8 +359,10 @@ class TestNothingToStructure:
             "immich_memories.analysis.selection_structure._ask",
             return_value=_answer(keep=[1, 2], cut=[3, 4]),
         ) as asked:
-            pass_.choose(pool, target_duration=20.0, moment_window=MOMENT_WINDOW)
-            pass_.choose(_pool(moments=4), target_duration=10.0, moment_window=MOMENT_WINDOW)
+            pass_.choose(pool, target_duration=20.0, moment_window=MOMENT_WINDOW, target_clips=2)
+            pass_.choose(
+                _pool(moments=4), target_duration=10.0, moment_window=MOMENT_WINDOW, target_clips=2
+            )
 
         assert asked.call_count == 1
 
@@ -385,3 +383,350 @@ class TestWhoGetsAnEditor:
         editor = structure_pass_for(Config(content_analysis={"enabled": True}))
 
         assert isinstance(editor, StructurePass)
+
+
+class TestWhatOneLineTellsTheModel:
+    """Description is the only thing in the table saying what a moment is OF."""
+
+    def _line(self, members: list[ClipWithSegment]) -> str:
+        from immich_memories.analysis.selection_structure import _moments_of, _table
+
+        return _table(_moments_of(members, MOMENT_WINDOW))
+
+    def test_a_described_moment_says_what_it_shows(self):
+        line = self._line([_clip("seen", minutes=0), _clip("also", minutes=1)])
+
+        assert "a shot called seen" in line
+
+    def test_descriptions_come_from_the_described_members_not_the_top_two(self):
+        """Slicing before filtering starved the prompt of the only content it had."""
+        blind = [_clip("blind1", minutes=0, score=0.9), _clip("blind2", minutes=1, score=0.8)]
+        for member in blind:
+            member.clip.llm_description = None
+
+        line = self._line([*blind, _clip("seen", minutes=2, score=0.1)])
+
+        assert "a shot called seen" in line
+
+    def test_the_line_counts_the_owners_marks(self):
+        line = self._line(
+            [
+                _clip("star", minutes=0, starred=True),
+                _clip("plain1", minutes=1),
+                _clip("plain2", minutes=2),
+            ]
+        )
+
+        assert "starred 1/3" in line
+
+    def test_the_line_estimates_from_the_top_scored_member(self):
+        line = self._line(
+            [_clip("long", minutes=0, score=0.9, seconds=9.0), _clip("short", minutes=1, score=0.1)]
+        )
+
+        assert "est 9s" in line
+
+
+class TestTheEnvelopeMeasuresWhatWillShip:
+    """A moment hands on ALL its members; dedup keeps up to three of them.
+
+    Measured on one representative each, a keep-set that reads 1.0T can leave
+    selection at two or three times that, and on the structure path nothing
+    downstream bounds it.
+    """
+
+    def test_a_pool_that_fits_per_representative_but_not_as_it_ships_is_asked_about(self):
+        pool = _pool(moments=2, per_moment=3)
+
+        _cut, asked = _choose_without_asking(pool, target=12.0, target_clips=8)
+
+        assert asked.call_count == 1
+
+    def test_the_walk_releases_on_what_will_ship_not_on_one_clip_a_moment(self):
+        pool = _pool(moments=4, per_moment=3)
+
+        cut = _choose(
+            pool,
+            _answer(keep=[1, 2, 3, 4], cut=[], release_order=[4, 3, 2, 1]),
+            target=20.0,
+            target_clips=8,
+        )
+
+        assert {c.clip.asset.id for c in cut.kept} == {
+            "m1c0",
+            "m1c1",
+            "m1c2",
+            "m2c0",
+            "m2c1",
+            "m2c2",
+        }
+
+    def test_the_stage_states_both_numbers(self):
+        pool = _pool(moments=4, per_moment=3)
+
+        with selection_trace.tracing() as recorded:
+            _choose(
+                pool,
+                _answer(keep=[1, 2, 3, 4], cut=[], release_order=[4, 3, 2, 1]),
+                target=20.0,
+                target_clips=8,
+            )
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        summary = stage.reasons[0]
+        assert "10s of representatives" in summary
+        assert "20s as it will ship" in summary
+
+
+class TestAPoolThatFitsIsStillADecision:
+    """Skipping the caps on a genuinely fitting pool IS the design.
+
+    The counting stages exist to force a pool down to a runtime. A pool that
+    already fits one has nothing for them to do, and running them anyway is
+    how a month with fourteen moments shipped four. Dedup and the fine cut
+    still run underneath.
+    """
+
+    def test_the_counting_stages_are_skipped_for_a_pool_that_already_fits(self):
+        pool = _pool(moments=2)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "", target_clips=4)
+
+        names = [stage.name for stage in recorded.stages]
+        assert "structure" in names
+        assert "per-day photo cap" not in names
+        assert "distribute by date" not in names
+        assert "photo ratio cap" not in names
+
+    def test_the_stage_says_the_pool_already_fits_the_budget(self):
+        pool = _pool(moments=2)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "", target_clips=4)
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert stage.dropped == 0
+        assert any("already fits the budget" in reason for reason in stage.reasons)
+
+    def test_the_dedup_stages_still_run_underneath(self):
+        pool = _pool(moments=2)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "", target_clips=4)
+
+        assert "same-moment dedup" in [stage.name for stage in recorded.stages]
+
+
+def _choose_answers(
+    pool: list[ClipWithSegment],
+    raws: list[str],
+    *,
+    target: float = 10.0,
+    target_clips: int = 2,
+):
+    pass_ = StructurePass(LLMConfig())
+    # WHY: the model. Under test is how often we go back to it.
+    with patch("immich_memories.analysis.selection_structure._ask", side_effect=raws) as asked:
+        cut = pass_.choose(
+            pool,
+            target_duration=target,
+            moment_window=MOMENT_WINDOW,
+            target_clips=target_clips,
+        )
+    return cut, asked
+
+
+KEPT_EVERYTHING = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
+
+
+class TestOneCorrectiveReask:
+    """An order we invent is a mechanical kill wearing an editor's clothes.
+
+    The reversed-keep guess released M53, M52, M50 … strictly downwards on a
+    real June: it amputated the end of the month. The memory plays in the
+    order things happened, so the last moment kept IS the closer. When the
+    editor states no order, we ask it once — and refuse rather than guess.
+    """
+
+    def test_an_overshoot_with_no_stated_order_is_asked_about_once_more(self):
+        pool = _pool(moments=5)
+
+        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, _answer(keep=[1, 2], cut=[3, 4, 5])])
+
+        assert asked.call_count == 2
+        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+
+    def test_the_revision_may_state_the_order_instead_of_cutting_more(self):
+        pool = _pool(moments=5)
+        revised = _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])
+
+        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, revised])
+
+        assert asked.call_count == 2
+        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+
+    def test_a_revision_that_still_overshoots_hands_the_cut_back(self):
+        pool = _pool(moments=5)
+
+        with selection_trace.tracing() as recorded:
+            cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, KEPT_EVERYTHING])
+
+        assert cut is None
+        assert asked.call_count == 2
+        assert any("the structure pass never ran" in w for w in recorded.warnings)
+
+    def test_an_unreadable_revision_hands_the_cut_back(self):
+        pool = _pool(moments=5)
+
+        cut, asked = _choose_answers(pool, [KEPT_EVERYTHING, "no idea"])
+
+        assert cut is None
+        assert asked.call_count == 2
+
+    def test_a_stated_order_is_carried_out_without_a_second_ask(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_answers(
+            pool, [_answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])]
+        )
+
+        assert asked.call_count == 1
+
+
+class TestTheTraceTellsTheTruthAboutTheOrder:
+    def test_a_walk_on_a_first_answer_says_where_the_order_came_from(self):
+        pool = _pool(moments=5)
+
+        with selection_trace.tracing() as recorded:
+            _choose_answers(
+                pool, [_answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])]
+            )
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert any("stated with its first answer" in reason for reason in stage.reasons)
+
+    def test_a_walk_after_a_revision_says_so_and_says_the_re_ask_fired(self):
+        pool = _pool(moments=5)
+        revised = _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[5, 4, 3, 2, 1])
+
+        with selection_trace.tracing() as recorded:
+            _choose_answers(pool, [KEPT_EVERYTHING, revised])
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert any("stated when asked to revise" in reason for reason in stage.reasons)
+        assert any("asked once to revise" in reason for reason in stage.reasons)
+
+
+SUBJECTS = (
+    "a harbour",
+    "a kitchen",
+    "a mountain",
+    "a bicycle",
+    "a birthday",
+    "a rainstorm",
+    "a garden",
+    "a concert",
+)
+
+
+class TestTheAbsorbersDownstreamAreNotSilent:
+    """Generation can fix a cut it should have been handed whole.
+
+    Two absorbers sit below selection and neither says anything: the stride
+    sampler drops every other clip when the cut holds more than the budget can
+    give a minimum-length slot, and the proportional trim shortens every clip
+    when the content runs long. Both are selection problems paid for at render
+    time, so the trace names them while the cut is still readable.
+    """
+
+    def test_too_many_clips_for_the_budget_says_the_sampler_will_act(self):
+        pool = [
+            _clip(f"tiny{day}", days=day, seconds=1.0, shows=subject)
+            for day, subject in enumerate(SUBJECTS, start=1)
+        ]
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "")
+
+        assert any("stride sampler" in warning for warning in recorded.warnings)
+
+    def test_content_beyond_the_envelope_says_every_clip_will_be_trimmed(self):
+        pool = [
+            _clip(f"star{day}", days=day, starred=True, shows=subject)
+            for day, subject in enumerate(SUBJECTS[:3], start=1)
+        ]
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, _answer(keep=[1, 2, 3], cut=[], release_order=[3, 2, 1]))
+
+        assert any("trimmed to fit" in warning for warning in recorded.warnings)
+
+    def test_a_cut_that_fits_says_nothing(self):
+        pool = _pool(moments=2)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, "", target_clips=4)
+
+        assert recorded.warnings == []
+
+
+class TestAModelThatCannotAnswer:
+    """The branch most likely to fire in production: nothing is listening."""
+
+    def test_an_unreachable_model_hands_the_cut_to_the_funnel(self):
+        pool = _pool(moments=4)
+        pass_ = StructurePass(LLMConfig())
+
+        # A local LLM on a laptop that went to sleep is a server that is gone.
+        # WHY: the model.
+        with (
+            patch(
+                "immich_memories.analysis.selection_structure._ask",
+                side_effect=TimeoutError("no server"),
+            ),
+            selection_trace.tracing() as recorded,
+        ):
+            cut = pass_.choose(
+                pool, target_duration=10.0, moment_window=MOMENT_WINDOW, target_clips=2
+            )
+
+        assert cut is None
+        assert any("the model was unavailable (TimeoutError)" in w for w in recorded.warnings)
+
+    def test_a_bug_in_our_own_code_is_not_treated_as_an_absent_model(self):
+        """A TypeError in the ask is our mistake, and it stops the run."""
+        import pytest
+
+        pool = _pool(moments=4)
+        pass_ = StructurePass(LLMConfig())
+
+        # WHY: the model. The bug being simulated is on our side of the call.
+        with (
+            patch(
+                "immich_memories.analysis.selection_structure._ask",
+                side_effect=TypeError("unexpected keyword argument"),
+            ),
+            pytest.raises(TypeError),
+        ):
+            pass_.choose(pool, target_duration=10.0, moment_window=MOMENT_WINDOW, target_clips=2)
+
+
+class TestTheRevisionAsksAboutWhatWillActuallyShip:
+    def test_a_moment_the_starred_rule_kept_is_in_the_keep_list_it_is_shown(self):
+        """The veto happens before the overshoot is measured, so it counts.
+
+        Told it kept M1 and M3 when the starred rule also put M2 back, the
+        editor would revise against a shorter month than the one it has.
+        """
+        pool = [
+            _clip("plain1", days=1, shows=SUBJECTS[0]),
+            _clip("star2", days=2, starred=True, shows=SUBJECTS[1]),
+            _clip("plain3", days=3, shows=SUBJECTS[2]),
+        ]
+        first = json.dumps({"keep": [1, 3], "cut": [{"index": 2, "reason": "quiet day"}]})
+
+        _cut, asked = _choose_answers(pool, [first, _answer(keep=[1], cut=[2, 3])], target=5.0)
+
+        revision = asked.call_args_list[1].args[0]
+        assert "You kept: M1, M2, M3" in revision

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -1,0 +1,387 @@
+"""Pass 3 — which moments does the story need? (#764, slice 2)
+
+Selection narrowed 204 candidates to 13 by counting: a per-day photo cap, a
+spread across dates, a fit to the runtime, two ratio caps. Not one of those
+stages ever looked at what a moment was OF, and the measured funnel showed
+them deleting a 0.80 and shipping a 0.36.
+
+This pass asks one question at moment granularity instead, and these tests pin
+what may and may not decide a kill. Numbers order the table and measure the
+envelope; the model decides what goes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from immich_memories.analysis import selection_trace
+from immich_memories.analysis.selection_structure import StructurePass
+from immich_memories.analysis.smart_pipeline import ClipWithSegment
+from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+from immich_memories.config_models_llm import LLMConfig
+
+JUNE = datetime(2023, 6, 1, 12, tzinfo=UTC)
+MOMENT_WINDOW = 10.0
+
+
+def _clip(
+    asset_id: str,
+    *,
+    days: float = 0.0,
+    minutes: float = 0.0,
+    starred: bool = False,
+    score: float = 0.5,
+    seconds: float = 5.0,
+) -> ClipWithSegment:
+    when = JUNE + timedelta(days=days, minutes=minutes)
+    asset = Asset(
+        id=asset_id,
+        type=AssetType.VIDEO,
+        fileCreatedAt=when,
+        fileModifiedAt=when,
+        updatedAt=when,
+        isFavorite=starred,
+    )
+    clip = VideoClipInfo(asset=asset, duration_seconds=seconds)
+    clip.llm_description = f"a shot called {asset_id}"
+    return ClipWithSegment(clip=clip, start_time=0.0, end_time=seconds, score=score)
+
+
+def _pool(
+    moments: int,
+    per_moment: int = 2,
+    scores: dict[int, float] | None = None,
+) -> list[ClipWithSegment]:
+    """`moments` days, each holding `per_moment` clips two minutes apart."""
+    by_day = scores or {}
+    return [
+        _clip(f"m{day}c{index}", days=day, minutes=2 * index, score=by_day.get(day, 0.5))
+        for day in range(1, moments + 1)
+        for index in range(per_moment)
+    ]
+
+
+def _answer(keep: list[int], cut: list[int], release_order: list[int] | None = None) -> str:
+    payload = {
+        "keep": keep,
+        "cut": [{"index": i, "reason": f"M{i} is not needed"} for i in cut],
+        "release_order": keep[::-1] if release_order is None else release_order,
+    }
+    return json.dumps(payload)
+
+
+def _choose(pool: list[ClipWithSegment], raw: str, *, target: float = 10.0):
+    pass_ = StructurePass(LLMConfig())
+    # WHY: the model. Everything under test is what we do with its answer.
+    with patch("immich_memories.analysis.selection_structure._ask", return_value=raw):
+        return pass_.choose(pool, target_duration=target, moment_window=MOMENT_WINDOW)
+
+
+class TestTheStoryChoosesItsMoments:
+    def test_a_cut_moment_takes_all_of_its_members_with_it(self):
+        pool = _pool(moments=4)
+
+        cut = _choose(pool, _answer(keep=[1, 2], cut=[3, 4]))
+
+        assert [c.clip.asset.id for c in cut.kept] == ["m1c0", "m1c1", "m2c0", "m2c1"]
+        assert cut.dropped == frozenset({"m3c0", "m3c1", "m4c0", "m4c1"})
+
+    def test_every_member_of_a_cut_moment_carries_the_moment_reason(self):
+        """The account answers "why is that not in there" for free from notes."""
+        pool = _pool(moments=4)
+
+        with selection_trace.tracing() as recorded:
+            _choose(pool, _answer(keep=[1, 2], cut=[3, 4]))
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert stage.notes["m3c0"] == "M3 is not needed"
+        assert stage.notes["m3c1"] == "M3 is not needed"
+        assert stage.notes["m4c0"] == "M4 is not needed"
+
+
+class TestTheEnvelopeShrinksByTheEditorsOwnOrder:
+    """A number may order the release; it may never pick the victim."""
+
+    def test_an_over_budget_keep_set_releases_what_the_model_ranked_expendable(self):
+        # The releases score high and the survivors score low: a shrink by
+        # score would keep the exact opposite pair.
+        pool = _pool(moments=5, scores={1: 0.9, 3: 0.9, 5: 0.9, 2: 0.1, 4: 0.1})
+
+        cut = _choose(
+            pool,
+            _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 1, 5, 4, 2]),
+            target=10.0,
+        )
+
+        assert {c.clip.asset.id for c in cut.kept} == {"m2c0", "m2c1", "m4c0", "m4c1"}
+
+    def test_a_released_moment_says_which_budget_took_it(self):
+        pool = _pool(moments=5)
+
+        with selection_trace.tracing() as recorded:
+            _choose(
+                pool,
+                _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 1, 5, 4, 2]),
+                target=10.0,
+            )
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert stage.notes["m3c0"] == (
+            "released to fit the 10s budget (the editor's own release order)"
+        )
+
+    def test_no_release_order_falls_back_to_the_keep_list_reversed(self):
+        """The model listed its keeps in story order, so later is looser."""
+        pool = _pool(moments=5)
+        answered = json.dumps({"keep": [1, 2, 3, 4, 5], "cut": []})
+
+        cut = _choose(pool, answered, target=10.0)
+
+        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+
+    def test_a_release_order_that_names_something_uncut_is_not_an_order(self):
+        """Half a ranking spliced onto a fallback is two rankings, not one."""
+        pool = _pool(moments=5)
+
+        cut = _choose(
+            pool,
+            _answer(keep=[1, 2, 3, 4, 5], cut=[], release_order=[3, 9]),
+            target=10.0,
+        )
+
+        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+
+    def test_an_answer_inside_the_envelope_releases_nothing(self):
+        pool = _pool(moments=5)
+
+        cut = _choose(pool, _answer(keep=[1, 2], cut=[3, 4, 5]), target=10.0)
+
+        assert {c.clip.asset.id for c in cut.kept} == {"m1c0", "m1c1", "m2c0", "m2c1"}
+
+
+def _episode_pool(starred: set[str]) -> list[ClipWithSegment]:
+    """Two moments half an hour apart — one occasion — then two lone days."""
+    return [
+        _clip("e1a", days=1, minutes=0, starred="e1a" in starred),
+        _clip("e1b", days=1, minutes=2, starred="e1b" in starred),
+        _clip("e1late", days=1, minutes=30, starred="e1late" in starred),
+        _clip("day2", days=2, starred="day2" in starred),
+        _clip("day3", days=3, starred="day3" in starred),
+    ]
+
+
+class TestTheOwnersMarksSurviveTheirOccasion:
+    """A star loses its place only to another star of the same occasion."""
+
+    def test_cutting_an_occasions_only_starred_moment_is_vetoed(self):
+        pool = _episode_pool(starred={"e1late"})
+
+        cut = _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+
+        assert "e1late" in {c.clip.asset.id for c in cut.kept}
+        assert cut.dropped == frozenset({"day3"})
+
+    def test_the_veto_is_on_the_record(self):
+        pool = _episode_pool(starred={"e1late"})
+
+        with selection_trace.tracing() as recorded:
+            _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert any("E1" in reason and "M2" in reason for reason in stage.reasons)
+
+    def test_a_star_may_lose_to_a_star_of_the_same_occasion(self):
+        pool = _episode_pool(starred={"e1a", "e1late"})
+
+        cut = _choose(pool, _answer(keep=[1, 3], cut=[2, 4]), target=15.0)
+
+        assert "e1late" in cut.dropped
+
+    def test_the_envelope_walk_will_not_release_an_occasions_last_star(self):
+        pool = _episode_pool(starred={"e1late"})
+
+        cut = _choose(
+            pool,
+            _answer(keep=[1, 2, 3, 4], cut=[], release_order=[2, 4, 3, 1]),
+            target=10.0,
+        )
+
+        assert "e1late" in {c.clip.asset.id for c in cut.kept}
+        assert cut.dropped == frozenset({"day2", "day3"})
+
+
+def _wired(*, target_clips: int = 2, dedup_window: float = MOMENT_WINDOW):
+    """A refiner with the structure pass injected, and its progress tracker."""
+    from unittest.mock import MagicMock
+
+    from immich_memories.analysis.clip_refiner import ClipRefiner
+    from immich_memories.analysis.clip_scaler import ClipScaler
+    from immich_memories.analysis.smart_pipeline import PipelineConfig
+
+    # WHY: ProgressTracker is the terminal/UI progress boundary; refinement
+    # only reports into it and reads back the error list it collected.
+    tracker = MagicMock()
+    tracker.progress = MagicMock()
+    tracker.progress.errors = []
+    refiner = ClipRefiner(
+        PipelineConfig(target_clips=target_clips, temporal_dedup_window_minutes=dedup_window),
+        ClipScaler(),
+        structure=StructurePass(LLMConfig()),
+    )
+    return refiner, tracker
+
+
+def _refine(pool: list[ClipWithSegment], raw: str, *, target_clips: int = 2):
+    """Run the refinement phase with the structure pass wired in."""
+    refiner, tracker = _wired(target_clips=target_clips)
+    # WHY: the model. Everything under test is what the pipeline does with it.
+    with patch("immich_memories.analysis.selection_structure._ask", return_value=raw):
+        return refiner.phase_refine(pool, tracker)
+
+
+class TestAnUnreadableAnswerHandsTheCutBack:
+    def test_an_answer_that_leaves_moments_unaccounted_for_is_refused_wholesale(self):
+        """Silence is a kill under keep-semantics, so a partial answer is none."""
+        pool = _pool(moments=4)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, '{"keep": [1], "cut": []}')
+
+        assert not any(stage.name == "structure" for stage in recorded.stages)
+        assert any(stage.name == "per-day photo cap" for stage in recorded.stages)
+
+    def test_the_trace_says_the_funnel_made_this_cut(self):
+        pool = _pool(moments=4)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, '{"keep": [1], "cut": []}')
+
+        assert "!! the structure pass never ran" in recorded.report()
+
+    def test_a_decided_structure_replaces_the_counting_stages(self):
+        pool = _pool(moments=4)
+
+        with selection_trace.tracing() as recorded:
+            _refine(pool, _answer(keep=[1, 2], cut=[3, 4]))
+
+        names = [stage.name for stage in recorded.stages]
+        assert "structure" in names
+        assert "per-day photo cap" not in names
+        assert "distribute by date" not in names
+        assert "photo ratio cap" not in names
+
+
+class TestTheQuestionIsAskedOnce:
+    """The verify/judge loop re-enters selection; the story does not change."""
+
+    def test_a_second_refinement_asks_nothing_and_applies_the_same_fates(self):
+        pool = _pool(moments=4)
+        refiner, tracker = _wired()
+
+        # WHY: the model. What is under test is that it is consulted once.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(keep=[1, 2], cut=[3, 4]),
+        ) as asked:
+            refiner.phase_refine(pool, tracker)
+            thinner = [c for c in pool if c.clip.asset.id != "m1c1"]
+            second = refiner.phase_refine(thinner, tracker)
+
+        assert asked.call_count == 1
+        shipped = {c.asset.id for c in second.selected_clips}
+        assert shipped and not shipped & {"m3c0", "m3c1", "m4c0", "m4c1"}
+
+
+class TestACondemnedMomentStaysCondemned:
+    def test_backfill_will_not_spend_freed_seconds_on_a_cut_moment(self):
+        """The relaxation ladder reaches far. It may not reach in here.
+
+        The kept moments are two seconds each and the cut ones five, so the
+        cut finishes well short of its runtime and backfill goes looking —
+        which is exactly the state that used to rebuild what a stage refused.
+        """
+        short = [_clip(f"keep{i}", days=1 + i, seconds=2.0) for i in range(4)]
+        long = [_clip(f"gone{i}", days=5 + i, seconds=5.0) for i in range(4)]
+        refiner, tracker = _wired(target_clips=4, dedup_window=0.0)
+
+        # WHY: the model. What is under test is what backfill does afterwards.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(keep=[1, 2, 3, 4], cut=[5, 6, 7, 8]),
+        ):
+            result = refiner.phase_refine([*short, *long], tracker)
+
+        shipped = {c.asset.id for c in result.selected_clips}
+        assert shipped == {"keep0", "keep1", "keep2", "keep3"}
+
+
+def _choose_without_asking(pool: list[ClipWithSegment], *, target: float):
+    pass_ = StructurePass(LLMConfig())
+    # WHY: the model — and here the point is that it is never reached.
+    with patch("immich_memories.analysis.selection_structure._ask") as asked:
+        cut = pass_.choose(pool, target_duration=target, moment_window=MOMENT_WINDOW)
+    return cut, asked
+
+
+class TestNothingToStructure:
+    def test_a_single_moment_is_not_a_structure_to_decide(self):
+        pool = _pool(moments=1, per_moment=3)
+
+        cut, asked = _choose_without_asking(pool, target=10.0)
+
+        assert asked.call_count == 0
+        assert cut.kept == pool
+        assert cut.dropped == frozenset()
+
+    def test_a_pool_that_already_fits_the_budget_is_left_alone(self):
+        pool = _pool(moments=2)
+
+        cut, asked = _choose_without_asking(pool, target=20.0)
+
+        assert asked.call_count == 0
+        assert cut.kept == pool
+
+    def test_the_trace_says_why_it_was_not_asked(self):
+        pool = _pool(moments=2)
+
+        with selection_trace.tracing() as recorded:
+            _choose_without_asking(pool, target=20.0)
+
+        stage = next(s for s in recorded.stages if s.name == "structure")
+        assert stage.dropped == 0
+        assert any("already fits" in reason for reason in stage.reasons)
+
+    def test_a_pass_through_leaves_the_question_open_for_the_next_round(self):
+        """No memo: a later round with more material may still need asking."""
+        pool = _pool(moments=2)
+        pass_ = StructurePass(LLMConfig())
+
+        # WHY: the model. The first call must not reach it, the second must.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(keep=[1, 2], cut=[3, 4]),
+        ) as asked:
+            pass_.choose(pool, target_duration=20.0, moment_window=MOMENT_WINDOW)
+            pass_.choose(_pool(moments=4), target_duration=10.0, moment_window=MOMENT_WINDOW)
+
+        assert asked.call_count == 1
+
+
+class TestWhoGetsAnEditor:
+    """The same gate the fine cut answers to — one LLM switch, both passes."""
+
+    def test_a_run_that_reads_no_content_gets_none(self):
+        from immich_memories.analysis.selection_structure import structure_pass_for
+        from immich_memories.config_loader import Config
+
+        assert structure_pass_for(Config()) is None
+
+    def test_a_content_analysis_run_gets_one(self):
+        from immich_memories.analysis.selection_structure import structure_pass_for
+        from immich_memories.config_loader import Config
+
+        editor = structure_pass_for(Config(content_analysis={"enabled": True}))
+
+        assert isinstance(editor, StructurePass)

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 from immich_memories.analysis import selection_trace
 from immich_memories.analysis.selection_structure import StructurePass
 from immich_memories.analysis.smart_pipeline import ClipWithSegment
-from immich_memories.api.models import Asset, AssetType, VideoClipInfo
+from immich_memories.api.models import Asset, AssetType, ExifInfo, VideoClipInfo
 from immich_memories.config_models_llm import LLMConfig
 
 JUNE = datetime(2023, 6, 1, 12, tzinfo=UTC)
@@ -50,6 +50,7 @@ def _clip(
     score: float = 0.5,
     seconds: float = 5.0,
     shows: str | None = None,
+    where: tuple[float, float] | None = None,
 ) -> ClipWithSegment:
     when = JUNE + timedelta(days=days, minutes=minutes)
     asset = Asset(
@@ -59,6 +60,7 @@ def _clip(
         fileModifiedAt=when,
         updatedAt=when,
         isFavorite=starred,
+        exifInfo=ExifInfo(latitude=where[0], longitude=where[1]) if where else None,
     )
     clip = VideoClipInfo(asset=asset, duration_seconds=seconds)
     clip.llm_description = shows or f"a shot called {asset_id}"
@@ -95,8 +97,15 @@ def _choose(
     *,
     target: float = 10.0,
     target_clips: int = 2,
+    moment_window: float = MOMENT_WINDOW,
 ):
-    return _choose_answers(pool, [raw], target=target, target_clips=target_clips)[0]
+    return _choose_answers(
+        pool,
+        [raw],
+        target=target,
+        target_clips=target_clips,
+        moment_window=moment_window,
+    )[0]
 
 
 def _choose_answers(
@@ -105,6 +114,7 @@ def _choose_answers(
     *,
     target: float = 10.0,
     target_clips: int = 2,
+    moment_window: float = MOMENT_WINDOW,
 ):
     pass_ = StructurePass(LLMConfig())
     # Under test is how often we go back to it, and what we do with the answer.
@@ -113,7 +123,7 @@ def _choose_answers(
         cut = pass_.choose(
             pool,
             target_duration=target,
-            moment_window=MOMENT_WINDOW,
+            moment_window=moment_window,
             target_clips=target_clips,
         )
     return cut, asked
@@ -125,6 +135,7 @@ def _choose_exactly(
     *,
     target: float = 10.0,
     target_clips: int = 2,
+    moment_window: float = MOMENT_WINDOW,
 ):
     """Like _choose_answers, but a call past the end of `raws` is an error."""
     pass_ = StructurePass(LLMConfig())
@@ -135,7 +146,7 @@ def _choose_exactly(
         cut = pass_.choose(
             pool,
             target_duration=target,
-            moment_window=MOMENT_WINDOW,
+            moment_window=moment_window,
             target_clips=target_clips,
         )
     return cut, asked
@@ -161,6 +172,27 @@ class TestTheStoryChoosesItsMoments:
         assert stage.notes["m3c0"] == "M3 is not needed"
         assert stage.notes["m3c1"] == "M3 is not needed"
         assert stage.notes["m4c0"] == "M4 is not needed"
+
+
+class TestStructureUsesTheSharedMomentMap:
+    def test_parallel_places_are_separate_moments_and_occasions(self):
+        from immich_memories.analysis.selection_structure import _moments_of
+
+        brussels = (50.8466, 4.3528)
+        spa = (50.4922, 5.8645)
+        pool = [
+            _clip("brussels-a", minutes=0, where=brussels),
+            _clip("brussels-b", minutes=1, where=brussels),
+            _clip("spa", minutes=1, where=spa),
+        ]
+
+        moments = _moments_of(pool, MOMENT_WINDOW)
+
+        assert [[member.clip.asset.id for member in moment.members] for moment in moments] == [
+            ["brussels-a", "brussels-b"],
+            ["spa"],
+        ]
+        assert [moment.episode for moment in moments] == ["E1", "E2"]
 
 
 class TestSilenceKeeps:
@@ -478,6 +510,20 @@ class TestTheEnvelopeMeasuresWhatWillShip:
         _cut, asked = _choose_answers(pool, [_answer(cut=[])], target=10.0, target_clips=2)
 
         assert asked.call_count >= 1
+
+    def test_disabling_the_moment_cap_counts_and_can_release_every_clip(self):
+        pool = [_clip(f"m{day}c{index}", days=day) for day in range(1, 3) for index in range(4)]
+
+        cut, asked = _choose_exactly(
+            pool,
+            [_answer(cut=[]), _priority(list(range(1, 9)))],
+            target=10.0,
+            target_clips=2,
+            moment_window=0.0,
+        )
+
+        assert asked.call_count == 2
+        assert sum(member.end_time - member.start_time for member in cut.kept) == 10.0
 
     def test_the_walk_releases_on_what_will_ship_not_on_one_clip_a_moment(self):
         pool = _pool(moments=4, per_moment=3)

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -468,6 +468,17 @@ class TestTheEnvelopeMeasuresWhatWillShip:
 
         assert asked.call_count >= 1
 
+    def test_favourites_exempt_from_the_moment_cap_are_part_of_the_estimate(self):
+        pool = [
+            _clip("m1-star-a", days=1, starred=True, seconds=8.0),
+            _clip("m1-star-b", days=1, minutes=2, starred=True, seconds=8.0),
+            _clip("m2", days=2, seconds=1.0),
+        ]
+
+        _cut, asked = _choose_answers(pool, [_answer(cut=[])], target=10.0, target_clips=2)
+
+        assert asked.call_count >= 1
+
     def test_the_walk_releases_on_what_will_ship_not_on_one_clip_a_moment(self):
         pool = _pool(moments=4, per_moment=3)
 

--- a/tests/test_selection_structure.py
+++ b/tests/test_selection_structure.py
@@ -207,6 +207,14 @@ class TestSilenceKeeps:
 
         assert cut is None
 
+    def test_the_question_says_that_at_least_two_moments_must_survive(self):
+        pool = _pool(moments=5)
+
+        _cut, asked = _choose_answers(pool, [_answer(cut=[2, 3, 4, 5])])
+
+        prompt = asked.call_args_list[0].args[0]
+        assert "Leave at least two moments in the month" in prompt
+
 
 class TestAnUnusableAnswerHandsTheCutBack:
     def test_an_index_that_is_not_in_the_table_is_refused_after_one_retry(self):
@@ -234,6 +242,19 @@ class TestAnUnusableAnswerHandsTheCutBack:
         nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
 
         cut, asked = _choose_exactly(pool, [nonsense, _answer(cut=[3, 4])])
+
+        assert asked.call_count == 2
+        assert cut.dropped == frozenset({"m3c0", "m3c1", "m4c0", "m4c1"})
+
+    def test_a_malformed_final_object_is_retried_instead_of_using_an_earlier_draft(self):
+        pool = _pool(moments=4)
+        draft = _answer(cut=[4])
+        malformed_final = json.dumps({"cut": [{"index": "four", "reason": "quiet"}]})
+
+        cut, asked = _choose_exactly(
+            pool,
+            [f"{draft}\n{malformed_final}", _answer(cut=[3, 4])],
+        )
 
         assert asked.call_count == 2
         assert cut.dropped == frozenset({"m3c0", "m3c1", "m4c0", "m4c1"})
@@ -287,6 +308,15 @@ class TestTheReAskNamesTheDefect:
 
         revision = asked.call_args_list[1].args[0]
         assert "M3 with no reason" in revision
+
+    def test_the_revision_also_requires_two_surviving_moments(self):
+        pool = _pool(moments=5)
+        nonsense = json.dumps({"cut": [{"index": 99, "reason": "no such moment"}]})
+
+        _cut, asked = _choose_exactly(pool, [nonsense, _answer(cut=[3, 4, 5])])
+
+        revision = asked.call_args_list[1].args[0]
+        assert "Leave at least two moments in the month" in revision
 
     def test_an_answer_with_nothing_nameable_wrong_is_not_re_asked(self):
         """Prose with no edit in it is not a defect anyone can correct."""
@@ -630,6 +660,18 @@ class TestAValidJudgmentIsNeverThrownAway:
         assert asked.call_count == 2
         assert cut is not None and not cut.narrowed
 
+    def test_a_malformed_moment_label_keeps_the_first_cut(self):
+        """A bad rank is an unusable answer, not an exception from selection."""
+        pool = _pool(moments=5)
+        malformed_rank = json.dumps({"keep": ["M²", "M1", "M2", "M3"]})
+
+        cut, asked = _choose_exactly(pool, [_answer(cut=[5]), malformed_rank])
+
+        assert asked.call_count == 2
+        assert cut is not None
+        assert cut.dropped == frozenset({"m5c0", "m5c1"})
+        assert not cut.narrowed
+
     def test_the_trace_says_the_funnel_narrowed_the_remainder(self):
         pool = _pool(moments=5)
 
@@ -721,7 +763,10 @@ class TestTheQuestionIsAskedOnce:
 
         names = [stage.name for stage in recorded.stages]
         assert "per-day photo cap" in names
+        assert "distribute by date" in names
+        assert any(name.startswith("fit to ") for name in names)
         assert "photo ratio cap" in names
+        assert names[-1] == "the favourite wins its moment"
 
 
 class TestACondemnedMomentStaysCondemned:
@@ -745,6 +790,26 @@ class TestACondemnedMomentStaysCondemned:
 
         shipped = {c.asset.id for c in result.selected_clips}
         assert shipped == {"keep0", "keep1", "keep2", "keep3"}
+
+    def test_the_favourites_law_cannot_resurrect_a_structure_cut(self):
+        """The law repairs mechanical drops; it does not overrule the editor."""
+        pool = [
+            _clip("plain", minutes=0),
+            _clip("cut-star", minutes=6, starred=True),
+            _clip("kept-star", minutes=30, starred=True),
+        ]
+        refiner, tracker = _wired(dedup_window=5.0)
+
+        # WHY: the model. It cuts the middle moment while another starred
+        # moment keeps the occasion represented.
+        with patch(
+            "immich_memories.analysis.selection_structure._ask",
+            return_value=_answer(cut=[2]),
+        ):
+            result = refiner.phase_refine(pool, tracker)
+
+        shipped = {c.asset.id for c in result.selected_clips}
+        assert shipped == {"plain", "kept-star"}
 
 
 class TestTheHybridRunsTheWholeChain:


### PR DESCRIPTION
## Description

Adds Pass 3, the Structure pass: it asks which moments the month's story needs
before arithmetic spends the runtime.

- Extracts the old arithmetic funnel behind one narrow boundary, unchanged, so
  later slices can delete it as a unit.
- Presents chronological, time-and-place moments to the editor and accepts only
  named rejects with a reason.
- Uses the model's own priority order when the rough cut exceeds the duration
  envelope. It never invents a fallback order.
- Preserves a valid editorial cut when ranking fails, then lets the old funnel
  narrow only the survivors and emits a loud trace warning.
- Makes the duration estimate match what temporal dedup will actually ship,
  including favourites, disabled dedup, and parallel places.
- Replays Structure decisions through judge retries without resurrecting a
  condemned moment.

The first commit is a behavior-preserving extraction and was verified
independently. The remaining commits are the Structure pass and review fixes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🏗️ CI/Build changes

## Related Issues

Part of #764. Slices 3–5 remain; this PR must not close the umbrella issue.

## Checklist

- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] I have run `make check` locally and all checks pass
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

Private contact sheets stay local. The owner judged the earlier Slice 2 sheet
"very good"; two final correctness fixes changed the exact-head composition,
so that verdict is not being carried forward silently.

## Additional Notes

- `make ci`: 6,069 passed, 9 skipped; all static, security, architecture, docs,
  and self-critique gates passed.
- Independent final review: no Critical or Important findings after the
  time/place fix.
- Current exact-head June trace has no `!!`, but its subjective gate is pending.
  A generic anti-repetition prompt A/B passed a five-show counterexample and
  failed the real month, so none of that wording is in this PR.
- Pass 3 remains thesis-less until Pass 0 exists, as recorded in #764.
