### PR TITLE
refactor(selection): replace the editor through visual passes (#764)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ on:
       - "tests/performance/test_benchmark_contract.py"
       - "Makefile"
   pull_request:
-    branches: [main]
+    branches: [main, feature/764-editorial-selection]
     paths:
       - "src/immich_memories/processing/**"
       - "src/immich_memories/analysis/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feature/764-editorial-selection]
   workflow_call:  # Called from release.yml on push to main (provides Codecov baseline)
 
 permissions:
@@ -233,12 +233,15 @@ jobs:
       # only those: an unrelated PR runs none of them.
       - name: Integration coverage for changed paths
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        env:
+          DIFF_BASE: origin/${{ github.base_ref }}
         run: make integration-coverage-for-diff
 
       - name: Diff coverage (≥80% on changed lines)
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_BASE: origin/${{ github.base_ref }}
         run: |
           make diff-cover-ci
 
@@ -247,7 +250,7 @@ jobs:
           for f in tests/*-coverage.xml; do
             [ -f "$f" ] && COVERAGE_FILES="$COVERAGE_FILES $f"
           done
-          uvx diff-cover $COVERAGE_FILES --compare-branch=origin/main --format markdown:diff-cover-report.md || true
+          uvx diff-cover $COVERAGE_FILES --compare-branch=$DIFF_BASE --format markdown:diff-cover-report.md || true
           if [ -s diff-cover-report.md ]; then
             {
               echo "## Diff Coverage Report"

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ special-days*.json
 
 # people graph: the names of everyone in a real library, never repo data
 people*.yaml
+
+# graphify knowledge-graph cache (local tooling output)
+graphify-out/

--- a/Makefile
+++ b/Makefile
@@ -406,8 +406,16 @@ bandit-ci:
 	sys.exit(len(high))"
 
 # Commit message lint (Commitizen conventional commits)
+# An empty range is a pass, not a failure: a run that happens after its commits
+# have merged has nothing left to check, and `cz check` exits 3 on "No commit
+# found with range". That made every post-merge re-run unpassable.
 commitlint:
-	uvx --from commitizen cz check --rev-range $${COMMIT_RANGE:-HEAD~1..HEAD}
+	@range="$${COMMIT_RANGE:-HEAD~1..HEAD}"; \
+	if [ -z "$$(git rev-list "$$range" 2>/dev/null)" ]; then \
+		echo "commitlint: no commits in $$range - nothing to check"; \
+	else \
+		uvx --from commitizen cz check --rev-range "$$range"; \
+	fi
 
 # Cognitive complexity (complements cyclomatic complexity)
 # On failure the FAILED list is only the grandfathered backlog — the actual
@@ -445,8 +453,12 @@ refurb:
 # Semgrep SAST (cross-file security analysis)
 # Excludes sqlalchemy-execute-raw-query: our SQL uses ?-parameterized values,
 # column names are hardcoded in code. Semgrep can't distinguish f-string placeholders from injection.
+# Pinned to 3.12 on purpose. semgrep publishes no cp313 manylinux wheel, so on
+# a Linux runner using 3.13 uv builds it from the sdist -- which carries no
+# semgrep-core binary, and the scan dies with "Failed to find semgrep-core".
+# The interpreter running semgrep is unrelated to the project's own.
 semgrep:
-	uvx semgrep scan --config auto --config p/python --error --severity ERROR \
+	uvx --python 3.12 semgrep scan --config auto --config p/python --error --severity ERROR \
 		--exclude-rule python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query \
 		src/
 

--- a/Makefile
+++ b/Makefile
@@ -460,10 +460,14 @@ dep-check:
 arch-check:
 	uv run lint-imports
 
+# Diff base for local runs and pull-request CI. CI overrides this with the
+# actual pull request base branch; local runs safely default to main.
+DIFF_BASE ?= origin/main
+
 # Diff coverage (for PRs: new code must be ≥95% covered)
 diff-cover:
 	uv run pytest --cov=src/immich_memories --cov-branch --cov-report=xml -q
-	uvx diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+	uvx diff-cover coverage.xml --compare-branch=$(DIFF_BASE) --fail-under=80
 
 # Dependency vulnerability audit
 # Fails closed: a truncated export or a crashed pip-audit must not read as a clean audit.
@@ -490,7 +494,7 @@ diff-cover-local:  ## Check diff-cover locally before pushing (runs tests + merg
 	for f in tests/*-coverage.xml; do \
 		if [ -f "$$f" ]; then COVERAGE_FILES="$$COVERAGE_FILES $$f"; fi; \
 	done; \
-	uvx diff-cover $$COVERAGE_FILES --compare-branch=origin/main --fail-under=80 \
+	uvx diff-cover $$COVERAGE_FILES --compare-branch=$(DIFF_BASE) --fail-under=80 \
 	|| (echo "" && echo "⚠️  Diff coverage below 80% on changed lines." && \
 		echo "" && \
 		echo "   CI runs the FFmpeg-only integration suites that cover your changed" && \
@@ -506,7 +510,7 @@ diff-cover-local:  ## Check diff-cover locally before pushing (runs tests + merg
 		exit 1)
 
 integration-coverage-for-diff:  ## Run only the FFmpeg-only integration suites the diff touches (used by CI before diff-cover)
-	@CHANGED=$$(git diff --name-only origin/main...HEAD -- 'src/immich_memories/**/*.py' 2>/dev/null); \
+	@CHANGED=$$(git diff --name-only $(DIFF_BASE)...HEAD -- 'src/immich_memories/**/*.py' 2>/dev/null); \
 	SUITES=""; \
 	case "$$CHANGED" in *src/immich_memories/titles/*) SUITES="$$SUITES titles";; esac; \
 	case "$$CHANGED" in *src/immich_memories/processing/*) SUITES="$$SUITES processing assembly";; esac; \
@@ -529,7 +533,7 @@ integration-coverage-for-diff:  ## Run only the FFmpeg-only integration suites t
 # tests/*-coverage.xml is gitignored and can never arrive from a contributor's
 # machine, which is why CI produces it rather than asking them to commit it.
 diff-cover-ci:
-	@SRC_CHANGED=$$(git diff --numstat origin/main...HEAD -- '*.py' 2>/dev/null | grep '^' | grep -v 'tests/' | awk '{s+=$$1+$$2} END {print s+0}'); \
+	@SRC_CHANGED=$$(git diff --numstat $(DIFF_BASE)...HEAD -- '*.py' 2>/dev/null | grep '^' | grep -v 'tests/' | awk '{s+=$$1+$$2} END {print s+0}'); \
 	echo "Changed source lines (excl tests): $${SRC_CHANGED}"; \
 	if [ "$${SRC_CHANGED}" -gt 1000 ]; then \
 		echo "WARN: Skipping diff-cover: $${SRC_CHANGED} lines changed (>1000). Large refactor."; \
@@ -545,7 +549,7 @@ diff-cover-ci:
 		if [ "$$COVERAGE_FILES" != "coverage.xml" ]; then \
 			echo "Merging local integration coverage with CI coverage"; \
 		fi; \
-		uvx diff-cover $$COVERAGE_FILES --compare-branch=origin/main --fail-under=80 --exclude "**/analysis/apple_vision*.py"; \
+		uvx diff-cover $$COVERAGE_FILES --compare-branch=$(DIFF_BASE) --fail-under=80 --exclude "**/analysis/apple_vision*.py"; \
 	fi
 
 # Build check (twine)

--- a/docs/designs/2026-08-25-contact-sheet-editing-process.md
+++ b/docs/designs/2026-08-25-contact-sheet-editing-process.md
@@ -1,8 +1,8 @@
 ---
 date: 2026-08-25
-status: proposed for owner review
+status: owner approved
 issue: 764
-draft_pr: 768
+rejected_experiment_pr: 768
 decision: contact sheets are the working surface of every editorial pass
 ---
 
@@ -38,9 +38,9 @@ This keeps the editing process described in the craft research: binary passes, a
 selects before assembly, a revisable thesis, explicit sacrifices, and a fine cut that judges the
 whole. It changes the implementation order and contracts, not the underlying editorial method.
 
-Draft PR #768 stays open but blocked while this foundation is built. Its June sheet is a migration
-gate, not an accepted selection. We do not tune the current Structure prompt until it happens to
-pass one month.
+PR #768 is retained as rejected experimental evidence. Its June sheet is a migration gate, not an
+accepted selection, and its branch is not the base for this replacement. We do not tune the current
+Structure prompt until it happens to pass one month.
 
 ## Why the current draft regressed
 
@@ -465,7 +465,14 @@ feature.
 ## Migration plan and slice gates
 
 Build replacements in dependency order. Update issue #764 as the design of record; do not open a
-competing architecture issue. Keep PR #768 draft until Pass 3 runs on the real upstream contracts.
+competing architecture issue. Keep PR #768 available as rejected evidence while Pass 3 is rebuilt
+on the real upstream contracts.
+
+The replacement uses a two-level branch model. `feature/764-editorial-selection` is a long-lived
+integration trunk created from `origin/main`. Every implementation slice branches from and opens a
+pull request back into that integration trunk. Published integration history is merged forward from
+`main`, never rebased underneath active slice branches. The existing selector remains untouched on
+`main` until a final, owner-approved cutover pull request merges the complete integration trunk.
 
 ### Slice A: Pass 0 visual insight
 
@@ -513,9 +520,9 @@ competing architecture issue. Keep PR #768 draft until Pass 3 runs on the real u
   pass the real gates.
 - Update public documentation and configuration migration notes.
 
-Stacked builds remain allowed. Each slice blocks its own merge until the owner accepts its contact
-sheet. Deletions remain last so a rejected experimental pass does not leave the product without a
-working fallback.
+Stacked builds remain allowed inside the feature trunk. Each slice blocks its merge into the
+feature trunk until the owner accepts its contact sheet. Deletions remain last so a rejected
+experimental pass does not leave the product without a working fallback.
 
 ## Test strategy
 
@@ -581,5 +588,6 @@ Each slice also runs the full repository gate and critique process. The final mi
 - Refusal and truncation cannot cause unnamed losses.
 - The JSON trace accounts for every candidate; Markdown truncation is explicitly display-only.
 - CLI, UI, automation, and dry-run execute the same source and editorial contracts.
-- June is at least as strong as the accepted pre-regression sheet before #768 can leave draft.
-- The owner approves this architecture before an implementation plan or production-code change.
+- June is at least as strong as the accepted pre-regression sheet before the replacement Structure
+  slice can merge into the feature trunk.
+- The owner approved this architecture before implementation planning and production-code changes.

--- a/docs/designs/2026-08-25-contact-sheet-editing-process.md
+++ b/docs/designs/2026-08-25-contact-sheet-editing-process.md
@@ -188,8 +188,10 @@ and measured visual judgement quality.
   sheets. Do not ask a model to describe the same pixels again for each pass.
 - Pack as many complete episode or moment groups as remain legible on one sheet. One Pass 2 request
   returns decisions for many visually separated moment battles.
-- Attach multiple sheet pages to one request when the configured provider supports it and a probe
-  proves that numbering and decision accuracy remain reliable.
+- Attach multiple sheet pages to one request only when that pass's versioned wire contract supports
+  it and a probe proves numbering and decision accuracy remain reliable. `episode-scan-v3` is
+  deliberately stricter: exactly one page per request with unique pack-local tile numbers. A
+  multi-page episode scan requires a schema/prompt/pass version bump.
 - Combine independent questions over the exact same visual evidence. The episode scan may return
   the Pass 0 `EpisodeReading` plus separately namespaced Pass 1 record marks and clear-unusable
   rejects in one response. This is safe because Cull is deliberately independent of the thesis.
@@ -263,6 +265,18 @@ weakness relative to another frame, and relevance to the thesis are not Cull rea
 subject quotas do not run. Screenshots, documents, and near-duplicates wait for their visible
 function or comparison to be understood. Ambiguous material survives. A parser failure,
 truncation, refusal, or missing model answer kills nothing and adds a loud `!!` warning.
+
+Cull also protects the exact starred candidate so that Pass 2, not Pass 1, applies favourite law.
+That protection does not spread to every member of a Live Photo stitch or burst. A non-favourite
+sibling may still be rejected for a valid visual defect, and no still-versus-motion choice happens
+in Cull.
+
+Source preparation preserves a complete Live Photo burst as a frozen rendering family rather than
+electing the enriched `VideoClipInfo` carrier. Its versioned ID hashes one chronologically ordered,
+aligned manifest of admitted still IDs, video IDs, trim points, and shutter timestamps. Every
+admitted member carries the same family reference. Owner-excluded components are filtered out;
+incomplete, contradictory, or cross-moment declarations produce `!!` and no family instead of an
+invented union. This is option identity, not a render decision and not group-wide favourite state.
 
 If Cull rejects more than 75% of an otherwise source-eligible corpus, emit `!! possible over-cull`.
 This is a diagnostic, not a quota: the system never restores items by score to satisfy a ratio.
@@ -378,12 +392,17 @@ the editorial membership, the run warns and the gate is invalid.
 
 ## Rendering comes last
 
-The editorial system selects visuals and their intended durations before deciding how to render
-them. A Live Photo remains one visual with a still or motion rendering option. It is not a second
-editorial candidate simply because it has a video component.
+The editorial system selects visuals and mode-neutral duration bounds before deciding how to render
+them. A selected Live Photo carries its source-owned rendering-family reference; it does not become
+a second editorial candidate merely because motion is available. Pre-render stages must not store
+one duration that silently assumes the motion option.
 
-The renderer may trim, animate, or choose the Live Photo motion component inside the selected
-visual's contract. It may not change the membership of the cut.
+After Fine Cut, the renderer chooses still or stitched motion from the preserved ordered manifest
+and emits the selected asset identity either way. It may trim or animate inside that contract, but
+may not change membership. The aligned arrays are never independently sorted or zipped, and the
+legacy `_motion_by_carrier` shortcut must not decide availability. A later atlas revision must show
+still plus local motion evidence in one tile/call; until those pixels exist, no pass may claim that
+motion itself was visually judged.
 
 ## Banking and cache identity
 

--- a/docs/implementation-plans/2026-08-25-contact-sheet-editing-process.md
+++ b/docs/implementation-plans/2026-08-25-contact-sheet-editing-process.md
@@ -29,6 +29,16 @@ Click, GitHub Actions.
   before every commit.
 - Do not tune product rules to June. June, April, and August are private acceptance corpora; the
   synthetic suite must prove the same decision shapes under unrelated topics and label swaps.
+- **Separate provenance from evidence.** "Only explicit source scope removes before Pass 0" means
+  no *judgement* may pre-cull. It never meant the corpus is unfiltered. Whether a file came off
+  this library's camera, and whether it is the motion half of a photograph, are facts about the
+  file, not opinions about its quality — they belong to scope and they run before Pass 0. Both
+  were lost by reading this constraint the other way; 52% of one acceptance month is material the
+  owner never photographed.
+- **Consult `2026-08-25-existing-selection-rules.md` before building any pool, group, or corpus.**
+  It lists what the current selector already gets right, which of those rules are carried, and
+  which are still AT RISK. A rule with four legacy callers and none of them yours is a rule you
+  have lost. Adding a second door to a one-door rule removes the guarantee.
 - Contact sheets are the model input, not merely a diagnostic. Hash, write, attach, cache, and trace
   the same encoded JPEG bytes.
 - A video filmstrip is composed locally inside one tile. It costs no additional model request.
@@ -36,6 +46,22 @@ Click, GitHub Actions.
   bank answers, and fuse only independent namespaces over identical evidence.
 - Start at one sheet per request. Increase that limit only after a provider probe proves tile
   conservation and decision quality. Never infer image limits from a provider name.
+- **Show the response shape; never describe it.** Every prompt embeds a complete example envelope
+  built from the same wire keys its parser demands, and a test parses that very example. A prose
+  schema and a strict parser drift silently, and fixtures written from the parser can never catch
+  it: on the first real gate this voided three of four namespaces.
+- **Everything in an example is instruction, values and whitespace included.** Show placeholders,
+  not plausible literals — shown "ticket", the model labelled a pregnancy test a ticket; shown a
+  populated cull entry, it copied that defect onto seven unrelated visuals. Decision arrays are
+  shown EMPTY, which also states the honest default.
+- **Ask the small local model for less.** Measured three times: each added paragraph made the
+  answer worse — more rejects carrying one identical label, then a defect/evidence pair that was
+  not even legal. Prefer deleting a sentence to adding one, and never restate in prose what the
+  parser already enforces; a closed vocabulary cannot express "repetitive", so forbidding it only
+  spends attention.
+- **Bounded model prose is fitted, not fatal.** A reason that runs long is trimmed to its bound and
+  its decision survives. The same images produced 91/84/76-character reasons on one run and
+  103/105/104 on the next, so a hard bound makes every pass a coin flip that fails open and unseen.
 - Reject-only actions fail open. Refusal, truncation, unknown IDs, incomplete partitions, or request
   failure cannot create an unnamed loss. Any mechanical preview carries `!!` and is invalid for an
   owner verdict.
@@ -72,6 +98,13 @@ origin/main
   lines when cohesion permits. Do not use `Fixes #764` until the final cutover PR.
 - A slice merges into the feature trunk only after focused tests, `make critique`, `make ci`, its
   warning-free trace, and the owner-visible contact-sheet gate described below.
+- A slice that builds a pool, a group, or a corpus additionally answers the standing check in
+  `2026-08-25-existing-selection-rules.md`: name every rule the legacy path applies at that stage
+  and say, per rule, whether it is carried, superseded, or deliberately dropped. Green CI is not
+  evidence here — both lost rules passed full CI and an independent review.
+- Every gate runs on a corpus that is the owner's own material. A judgement measured on the wrong
+  corpus tells you nothing: four rounds of prompt tuning were spent on behaviour that turned out to
+  be caused by forwarded images in the pool.
 - The final feature-trunk → `main` PR contains no new editorial behavior. It only syncs `main`,
   resolves integration drift, reruns all gates, and records the final owner verdict.
 
@@ -500,6 +533,15 @@ def test_only_source_scope_and_owner_exclusions_apply_before_pass_zero() -> None
   adapter for raw `Asset`/`VideoClipInfo`. Eligibility is date/library scope, supported media, and
   explicit hard owner exclusions only.
 
+- [x] RED/GREEN: provenance is part of scope, not evidence. A Live Photo's motion component and
+  anything `not_shot_here()` rejects are excluded before Pass 0, each recorded with a named reason
+  so the account still answers for the whole fetch. `SourceScope` carries the filename patterns and
+  the stills-need-a-camera flag; a star still overrides both. Landed `b8ecc10` + this branch.
+
+- [ ] RED/GREEN: decide, do not default, whether `with_burst_neighbours()` and
+  `expand_to_neighbors()` are still needed. The editorial path fetches a date range rather than a
+  person, so they may be genuinely unnecessary — record which, and why, in the rules inventory.
+
 - [ ] RED/GREEN: expose pure chronological `build_episode_groups()` and `build_moment_groups()`
   over already-eligible candidates. Stable group IDs derive from ordered asset IDs and grouping
   version. Move no winners here.
@@ -610,6 +652,16 @@ def test_record_mark_wins_a_namespace_collision_without_discarding_siblings() ->
   Cull may reject only clearly unusable non-record items. Subject labels, repetition, relative
   weakness, and thesis relevance are invalid Cull reasons.
 
+- [ ] RED/GREEN: freeze `episode-scan-v3` at one physical page per request with unique pack-local
+  tile aliases. Scopes exactly partition that page. A future multi-page request bumps the pass,
+  prompt, and schema instead of reinterpreting v3 aliases.
+
+- [ ] RED/GREEN: normalize duplicate snapshots with favourite OR semantics. Preserve a complete,
+  aligned, source-owned `LivePhotoRenderingFamily` with a versioned manifest hash and propagate its
+  reference to every admitted member. Owner exclusions trim aligned entries. Incomplete,
+  contradictory, or cross-moment manifests warn and create no family; never elect a carrier or a
+  render mode here.
+
 - [ ] RED/GREEN: refusal, timeout, invalid IDs, and truncated JSON reject nothing. Valid sibling
   namespaces remain banked. More than 75% rejection adds `!! possible over-cull` but does not
   restore by score.
@@ -652,6 +704,21 @@ git commit -m "feat(selection): cull visibly and preserve record shots (#764)"
 asset appears; the pregnancy test is marked as a record shot; refusal/truncation rejects nothing;
 the trace reports episode-scan packs rather than one request per asset.
 
+Measured on the first real run, and required of any re-run:
+
+- The sheet contains no material the owner did not photograph. Before provenance was restored the
+  same day yielded 15 candidates of which 6 were forwarded, and the record lane marked tweet
+  screenshots and an advert — record marks shield from Cull, so the lane was protecting the junk.
+  With provenance applied the same day yields 9, and the marks are the medical result and the
+  handwritten notes.
+- A record shot is proof of something that happened to these people. Legible text is never enough
+  on its own, and the scene has to be one they were in.
+- Cull returns an empty array unless the pixels are unusable. Confabulated defects are the failure
+  to watch for: three invented rejects on the first run, then seven carrying one identical copied
+  label. The asymmetry is the reason to keep — a wrong keep is fixed by a later pass a person can
+  check, a wrong cull is permanent and invisible.
+- Zero `!!` in the trace. Two of the first three runs looked clean by their decision counts alone.
+
 ---
 
 ## Task 7: Select Representatives with Visual Moment Battles
@@ -681,6 +748,14 @@ def test_one_favourite_wins_its_moment_and_record_shot_stays_separate() -> None:
 
 - [ ] GREEN: a single favorite auto-wins. If several favorites collide, build a battle containing
   only those favorites. Favorites outside the winning occasion are not globally immune.
+
+- [ ] RED/GREEN: treat one `rendering_family_id` as one still-or-motion option inside its moment.
+  Select exactly one asset for that family/moment and preserve its family reference. A lone exact
+  favourite wins; multiple favourites in the family battle only one another. If RECORD and
+  favourite annotations land on different family members, they must not silently become two final
+  outputs: preserve RECORD as a sidecar and resolve one editorial representative explicitly.
+- [ ] RED/GREEN: a selected non-favourite member retains the same family option on merit. Family
+  membership never makes its siblings Cull-immune and never depends on the legacy enriched carrier.
 
 - [ ] RED/GREEN: for ordinary groups, pack many complete separated battles per request. The answer
   is exactly one `MomentSelect` (`selected` or `no_peak`) per group plus at most one reason-specific
@@ -729,6 +804,10 @@ git commit -m "feat(selection): choose peaks with visual moment battles (#764)"
 
 ## Task 8: Move Expensive Analysis behind Selects
 
+- [ ] RED/GREEN: carry `looks_like_a_photograph()`. Anything with a still goes to the photo scorer,
+  Live Photo or not. Sent to the video analyser a burst carrier "fails in milliseconds, is marked
+  attempted, and is never looked at again" — and ships undescribed.
+
 **Files:**
 
 - Modify: `src/immich_memories/analysis/smart_pipeline.py:269-390`
@@ -776,6 +855,16 @@ representatives only—not the final narrative cut yet.
 ---
 
 ## Task 9: Rewrite Structure as a Visual Reject-Only Rough Cut
+
+- [ ] RED/GREEN: **temporal coverage.** At least one visual per period across the whole range, with
+  the granularity the current selector uses: daily up to a month, weekly to three months, monthly
+  to a year, quarterly beyond. The plan did not mention this rule at all before the rules
+  inventory; Structure is where a period can vanish silently.
+
+- [ ] RED/GREEN: **proportion.** No single moment may supply more than a quarter of the cut. Selects
+  kills duplicate frames by construction, which covers redundancy but not proportion: nothing else
+  stops a memory spending itself on one very good afternoon. `ceil()` alone is the measured wrong
+  answer — it "handed every memory two per moment".
 
 **Branch:** `refactor/764-structure-projection`
 
@@ -888,6 +977,13 @@ may survive if its three contributions earn the time. No topic count is asserted
 
 ## Task 11: Judge the Whole Cut and Perform One Bounded Repair
 
+- [ ] RED/GREEN: **a period's last voice survives Fine Cut unless it is unusable.** Carry
+  `spare_last_voices()` as a CORRECTION applied after the verdict, never as an exemption granted
+  before it — "exempting has to guess in advance which clips carry a period, and both ways of
+  guessing are wrong." Unusable stays dropped however alone it is; merely weak does not. Every
+  drop site in the cut must treat a period's only visual as untouchable, which is the lesson
+  `_trim_non_favorites` records as the last site that did not.
+
 **Branch:** `feat/764-fine-cut`
 
 **Files:**
@@ -972,7 +1068,7 @@ git commit -m "feat(selection): judge the complete visual cut (#764)"
 - Add: `tests/integration/assembly/test_editorial_membership.py`
 
 - [ ] RED: select photo/video/Live Photo visuals in a known order and assert render planning chooses
-  a mode without changing membership.
+  a mode from the selected asset's immutable `LivePhotoRenderingFamily` without changing membership.
 
 ```python
 def test_render_plan_preserves_ordered_editorial_membership() -> None:
@@ -981,8 +1077,15 @@ def test_render_plan_preserves_ordered_editorial_membership() -> None:
     assert tuple(item.asset_id for item in plan) == ("photo", "live", "video")
 ```
 
-- [ ] GREEN: resolve still versus motion only after Fine Cut. A Live Photo remains one selected
-  visual with render options, not two editorial candidates.
+- [ ] GREEN: resolve still versus stitched motion only after Fine Cut from the preserved ordered,
+  aligned family manifest. Emit the selected asset identity for either mode, remove legacy
+  `_motion_by_carrier`, and never independently align sorted still/video/trim/shutter arrays.
+- [ ] RED/GREEN: pre-render stages carry per-mode duration options or explicit mode-neutral bounds;
+  a single intended duration must not secretly choose motion. Validate the final chosen mode's
+  duration contract during render planning.
+- [ ] RED/GREEN: the visual atlas eventually places a Live Photo still and bounded local motion
+  evidence in the same tile and existing request. It adds no LLM call and never claims motion was
+  judged when motion pixels were unavailable.
 
 - [ ] RED/GREEN: remove membership changes from `_sample_for_minimum_duration()`. Budget adjustment
   may trim intended segments proportionally within their contracts; it cannot add, drop, reorder,

--- a/docs/implementation-plans/2026-08-25-contact-sheet-editing-process.md
+++ b/docs/implementation-plans/2026-08-25-contact-sheet-editing-process.md
@@ -1,0 +1,1235 @@
+# Contact-Sheet Editing Process Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current score-, quota-, and absorber-driven selector with a visual editing
+process that sees the complete eligible corpus, banks every decision, minimizes model calls, and
+produces one conserved chronological cut across every public surface.
+
+**Architecture:** A long-lived feature trunk holds the replacement while `main` continues to ship
+the current selector. Inside that trunk, one core flow owns source eligibility, a reusable visual
+atlas, Insight, Cull/record shots, Selects, Structure, projection, Fine Cut, intended duration, and
+the trace. Every decision-bearing pass receives the exact contact-sheet JPEG bytes recorded in its
+provenance. Rendering consumes the final ordered membership and may not change it.
+
+**Tech Stack:** Python 3.12/3.13, frozen Pydantic models, Pillow, FFmpeg/ffprobe, provider-neutral
+multimodal LLM requests, SQLite-backed judgement cache, pytest through Makefile targets, NiceGUI,
+Click, GitHub Actions.
+
+**Spec:** `docs/designs/2026-08-25-contact-sheet-editing-process.md`
+
+## Global Constraints
+
+- Run `make dev` before any other Make target in a fresh worktree.
+- Use one RED → GREEN → REFACTOR cycle at a time. Tests exercise public behavior; no more than
+  three mocked boundaries per test, and every mock carries a `# WHY:` comment.
+- Run focused tests with `make test-one T="..."`, then `make test`, `make critique`, and `make ci`
+  before every commit.
+- Do not tune product rules to June. June, April, and August are private acceptance corpora; the
+  synthetic suite must prove the same decision shapes under unrelated topics and label swaps.
+- Contact sheets are the model input, not merely a diagnostic. Hash, write, attach, cache, and trace
+  the same encoded JPEG bytes.
+- A video filmstrip is composed locally inside one tile. It costs no additional model request.
+- A logical pass is not necessarily a model request. Reuse one visual atlas, pack complete groups,
+  bank answers, and fuse only independent namespaces over identical evidence.
+- Start at one sheet per request. Increase that limit only after a provider probe proves tile
+  conservation and decision quality. Never infer image limits from a provider name.
+- Reject-only actions fail open. Refusal, truncation, unknown IDs, incomplete partitions, or request
+  failure cannot create an unnamed loss. Any mechanical preview carries `!!` and is invalid for an
+  owner verdict.
+- Preserve chronology in every contract. Sets may be used for validation, never as the stored order.
+- Keep all private contact sheets, traces, and media outside Git and GitHub.
+- Rewrite the existing Structure modules in place. PR #768 is evidence only; do not cherry-pick its
+  implementation wholesale.
+- Do not remove legacy machinery until the replacement owns the same public surface and all real
+  gates pass.
+
+## Branch and PR Strategy
+
+```text
+origin/main
+  └─ feature/764-editorial-selection          # long-lived replacement trunk
+       ├─ ci/764-feature-trunk
+       ├─ feat/764-visual-foundation
+       ├─ feat/764-insight-cull
+       ├─ feat/764-selects
+       ├─ refactor/764-structure-projection
+       ├─ feat/764-fine-cut
+       └─ refactor/764-editorial-cutover
+```
+
+- Bootstrap `feature/764-editorial-selection` from current `origin/main` with only the approved
+  design, this plan, and CI support for feature-trunk PRs. Open an umbrella draft PR from the feature
+  trunk to `main`; it stays unmergeable until final owner acceptance.
+- Every production slice branches from the latest feature trunk and targets its PR back to
+  `feature/764-editorial-selection`. Use squash merge for slice PRs.
+- Short-lived slice branches rebase on the current feature trunk before their final gate. The
+  published feature trunk itself merges `origin/main` forward and is never rebased beneath active
+  slices.
+- Each slice PR uses a conventional title, includes `Refs #764`, and stays below roughly 300 changed
+  lines when cohesion permits. Do not use `Fixes #764` until the final cutover PR.
+- A slice merges into the feature trunk only after focused tests, `make critique`, `make ci`, its
+  warning-free trace, and the owner-visible contact-sheet gate described below.
+- The final feature-trunk → `main` PR contains no new editorial behavior. It only syncs `main`,
+  resolves integration drift, reruns all gates, and records the final owner verdict.
+
+## Shared Public Contracts
+
+Create immutable records in `src/immich_memories/analysis/editorial_contracts.py`. Add records only
+when their first consumer lands; the complete target contract is:
+
+```python
+@dataclass(frozen=True)
+class DecisionProvenance:
+    pass_name: str
+    pass_version: str
+    schema_version: str
+    model_identity: str
+    input_ids: tuple[str, ...]
+    sheet_hashes: tuple[str, ...]
+    request_key: str
+    cache_hit: bool
+
+@dataclass(frozen=True)
+class InsightEvidence:
+    observation: str
+    episode_ids: tuple[str, ...]
+    asset_ids: tuple[str, ...]
+
+@dataclass(frozen=True)
+class PeriodInsight:
+    thesis: str | None
+    evidence: tuple[InsightEvidence, ...]
+    tensions: tuple[str, ...]
+    recurring_threads: tuple[str, ...]
+    unavailable_reason: str | None
+    revision: int
+    provenance: DecisionProvenance
+
+@dataclass(frozen=True)
+class EditorialCandidate:
+    asset_id: str
+    taken_at: datetime
+    media_kind: Literal["photo", "video", "live_photo"]
+    favourite: bool
+    source: Asset
+    proposed_segment: tuple[float, float] | None
+    shippable_duration: float
+    grounded_annotations: tuple[str, ...]
+
+@dataclass(frozen=True)
+class SelectedVisual:
+    asset_id: str
+    moment_id: str
+    episode_id: str
+    intended_segment: tuple[float, float] | None
+    intended_duration: float
+    render_options: tuple[Literal["still", "motion"], ...]
+
+@dataclass(frozen=True)
+class EditorialSelectionResult:
+    selected: tuple[SelectedVisual, ...]
+    insight: PeriodInsight | None
+    trace: Trace
+    warnings: tuple[str, ...]
+    conservation: ConservationCheck
+```
+
+The only final public orchestration API is:
+
+```python
+def prepare_editorial_source(
+    request: EditorialSelectionRequest,
+    dependencies: EditorialDependencies,
+) -> PreparedEditorialSource: ...
+
+def select_editorial_cut(
+    prepared: PreparedEditorialSource,
+    dependencies: EditorialDependencies,
+) -> EditorialSelectionResult: ...
+
+def run_editorial_selection(
+    request: EditorialSelectionRequest,
+    dependencies: EditorialDependencies,
+) -> EditorialSelectionResult:
+    return select_editorial_cut(prepare_editorial_source(request, dependencies), dependencies)
+```
+
+The split form exists only so UI owner exclusions can be recorded between retrieval and Pass 0. It
+is still one flow: the UI cannot select, score, suppress, or rebuild membership itself.
+
+---
+
+## Task 0: Bootstrap CI for the Feature Trunk
+
+**Branch:** `ci/764-feature-trunk`, based on `feature/764-editorial-selection`
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml:4-5, 229-263`
+- Modify: `.github/workflows/benchmark.yml:31-43`
+- Modify: `Makefile:464-548`
+
+- [ ] Run `make dev`, then capture the current failure mode without changing files:
+
+```bash
+make dev
+make -n integration-coverage-for-diff DIFF_BASE=origin/feature/764-editorial-selection
+```
+
+Expected before implementation: the printed Git diff still contains `origin/main`.
+
+- [ ] Make the diff base injectable once, with `main` as the safe default:
+
+```make
+DIFF_BASE ?= origin/main
+
+diff-cover:
+	uv run pytest --cov=src/immich_memories --cov-branch --cov-report=xml -q
+	uvx diff-cover coverage.xml --compare-branch=$(DIFF_BASE) --fail-under=80
+```
+
+Use `$(DIFF_BASE)` in `diff-cover-local`, `integration-coverage-for-diff`, and `diff-cover-ci`,
+including line-count and changed-path Git diffs.
+
+- [ ] Allow CI and benchmark pull-request workflows to run when the PR base is the feature trunk:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, feature/764-editorial-selection]
+```
+
+- [ ] Pass the actual PR base to every diff-aware target and report command:
+
+```yaml
+env:
+  DIFF_BASE: origin/${{ github.base_ref }}
+run: |
+  make integration-coverage-for-diff
+  make diff-cover-ci
+```
+
+- [ ] Verify the resolved commands, then the repository gate:
+
+```bash
+make -n integration-coverage-for-diff DIFF_BASE=origin/feature/764-editorial-selection
+make ci
+```
+
+Expected: no hard-coded `origin/main` appears in the diff commands when `DIFF_BASE` is supplied;
+all CI checks pass.
+
+- [ ] Commit and merge this bootstrap into the feature trunk:
+
+```bash
+git add Makefile .github/workflows/ci.yml .github/workflows/benchmark.yml
+git commit -m "ci(selection): support feature-trunk pull requests (#764)"
+```
+
+**Gate:** Open a deliberately empty test PR against the feature trunk or inspect this PR's
+`pull_request` run. Quality, test matrix, commitlint, and diff coverage must all start and compare
+against `origin/feature/764-editorial-selection`.
+
+---
+
+## Task 1: Establish Contracts, Chronological Trace, and Conservation
+
+**Branch:** `feat/764-visual-foundation`
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/editorial_contracts.py`
+- Modify: `src/immich_memories/analysis/selection_trace.py:34-116, 172-269`
+- Create: `tests/test_editorial_contracts.py`
+- Create: `tests/test_editorial_trace.py`
+- Modify: `tests/test_selection_accountability.py`
+
+- [ ] RED: add one public behavior test proving chronological IDs survive and every input has one
+  fate:
+
+```python
+def test_editorial_pass_keeps_chronology_and_conserves_every_input() -> None:
+    trace = Trace()
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=("late", "early", "middle"),
+            kept_ids=("late", "middle"),
+            rejected=(TraceDecision("early", "unusable exposure"),),
+            unresolved=(),
+            duration_before=12.0,
+            duration_after=8.0,
+            provenance=_provenance(("late", "early", "middle")),
+        )
+    )
+
+    payload = trace.as_dict()
+    assert payload["editorial_passes"][0]["kept_ids"] == ["late", "middle"]
+    assert payload["editorial_passes"][0]["conservation"]["valid"] is True
+```
+
+Run `make test-one T="tests/test_editorial_trace.py"`; expect failure because the editorial trace
+API does not exist.
+
+- [ ] GREEN: add frozen tuple-based `DecisionProvenance`, `TraceDecision`, `PassTrace`,
+  `RequestTrace`, and `ConservationCheck`. Extend the existing `Trace`; do not create a second
+  ledger. Preserve the legacy `record()` adapter for the old selector until Task 14.
+
+- [ ] RED/GREEN: add a test where one input is both kept and rejected and one disappears. The pass
+  must produce `valid=False`, list duplicate and missing IDs, and add a `!! conservation failure`
+  warning.
+
+- [ ] RED/GREEN: assert Markdown emits exactly `showing 12 of N; full list in JSON` when decisions
+  are abbreviated, while JSON remains complete.
+
+- [ ] REFACTOR: keep serialization in `selection_trace.py`; keep immutable cross-pass values in
+  `editorial_contracts.py`. Avoid a registry or generic event bus.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_editorial_contracts.py tests/test_editorial_trace.py tests/test_selection_accountability.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/editorial_contracts.py src/immich_memories/analysis/selection_trace.py tests/test_editorial_contracts.py tests/test_editorial_trace.py tests/test_selection_accountability.py
+git commit -m "feat(selection): account for every editorial decision (#764)"
+```
+
+---
+
+## Task 2: Build One Reusable Visual Atlas
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/visual_atlas.py`
+- Create: `src/immich_memories/analysis/contact_sheets.py`
+- Modify: `src/immich_memories/processing/frame_sampling.py:29-136`
+- Modify: `src/immich_memories/analysis/moment_reading.py:35-178, 293-359`
+- Modify: `src/immich_memories/analysis/thumbnail_prefetch.py:38-128`
+- Create: `tests/test_visual_atlas.py`
+- Create: `tests/test_contact_sheets.py`
+- Modify: `tests/test_frame_extraction.py`
+- Modify: `tests/test_moment_reading.py`
+
+- [ ] RED: create generated red/green/blue frames and assert a video becomes one chronological
+  filmstrip tile, with no requester involved:
+
+```python
+def test_video_tile_is_one_locally_composed_chronological_filmstrip(tmp_path: Path) -> None:
+    source = fake_video_source(tmp_path, colors=("red", "green", "blue"))
+    atlas = build_visual_atlas((source,), frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for(source.asset.id)
+    assert tile.kind == "filmstrip"
+    assert tile.frame_count == 3
+    assert tile.sha256 == sha256(tile.jpeg_bytes).hexdigest()
+```
+
+Run `make test-one T="tests/test_visual_atlas.py"`; expect import failure.
+
+- [ ] GREEN: add `AtlasSource`, `AtlasTile`, and `VisualAtlas`. Photos use cached/server preview
+  JPEGs. Videos and Live Photo motion options call a new cached segment-aware sampler:
+
+```python
+def sample_segment_frames(
+    video: Path,
+    *,
+    start_time: float,
+    end_time: float,
+    count: int,
+    width: int,
+    cache_dir: Path | None,
+) -> tuple[Path, ...]: ...
+```
+
+Its cache identity includes source path metadata, segment bounds, count, width, and a render
+version. Move useful `.part`, zero-byte, and short-video fallback behavior from
+`scripts/contact_sheet.py:118-182` into this core seam; the core must not import the script.
+
+- [ ] RED/GREEN: prove a changed segment or render version invalidates cached filmstrip frames.
+
+- [ ] RED: assert one encoded page's bytes are identical across hash, disk, request attachment,
+  and trace:
+
+```python
+page = build_contact_sheets(tiles, scope_id="episode-1", output_dir=tmp_path)[0]
+assert page.path.read_bytes() == page.jpeg_bytes
+assert sha256(page.jpeg_bytes).hexdigest() == page.sha256
+assert page.tile_refs == tuple(TileRef(i + 1, tile.entity_id) for i, tile in enumerate(tiles))
+```
+
+- [ ] GREEN: generalize `sheet_layout`, `sheets_of`, and `tile_sheet` from
+  `moment_reading.py`. `ContactSheetPage` holds `sheet_id`, path, exact JPEG bytes, SHA-256, ordered
+  `TileRef`s, and layout version. Keep the current 120-tile/2100px safety bounds and global tile
+  numbering.
+
+- [ ] REFACTOR: adapt `moment_reading.py` to the shared sheet builder without changing its legacy
+  behavior. This proves reuse before the new editor depends on it.
+
+- [ ] Run focused tests and FFmpeg coverage:
+
+```bash
+make test-one T="tests/test_visual_atlas.py tests/test_contact_sheets.py tests/test_frame_extraction.py tests/test_moment_reading.py"
+make test-integration-processing
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/visual_atlas.py src/immich_memories/analysis/contact_sheets.py src/immich_memories/processing/frame_sampling.py src/immich_memories/analysis/moment_reading.py src/immich_memories/analysis/thumbnail_prefetch.py tests/test_visual_atlas.py tests/test_contact_sheets.py tests/test_frame_extraction.py tests/test_moment_reading.py
+git commit -m "feat(selection): build a reusable visual atlas (#764)"
+```
+
+---
+
+## Task 3: Pack, Attach, Cache, and Trace Visual Requests
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/visual_request_planner.py`
+- Create: `src/immich_memories/analysis/editorial_gateway.py`
+- Modify: `src/immich_memories/analysis/llm_query.py:138-193, 228-445`
+- Modify: `src/immich_memories/cache/judgment_cache.py:40-110`
+- Modify: `src/immich_memories/analysis/selection_trace.py`
+- Create: `tests/test_visual_request_planner.py`
+- Create: `tests/test_editorial_gateway.py`
+- Modify: `tests/test_llm_query.py`
+- Modify: `tests/test_judgment_cache.py`
+
+- [ ] RED: prove planning conserves complete groups and defaults to one sheet per request:
+
+```python
+def test_request_plan_conserves_groups_without_guessing_provider_limits() -> None:
+    plans = plan_visual_requests(groups=(group("a"), group("b")), limits=VisionRequestLimits())
+    assert tuple(group_id for plan in plans for group_id in plan.group_ids) == ("a", "b")
+    assert all(len(plan.pages) == 1 for plan in plans)
+```
+
+- [ ] GREEN: add pure `VisionRequestLimits`, `SheetGroup`, `VisualRequestPlan`, and
+  `plan_visual_requests()`. Oversized groups get explicit numbered continuations; a group is never
+  silently split across unrelated requests.
+
+- [ ] RED/GREEN: pass a page into `EditorialGateway.ask()` and decode the outgoing request payload.
+  Assert its image SHA-256 equals the page and request-trace hashes exactly.
+
+- [ ] GREEN: define one provider-neutral seam:
+
+```python
+class EditorialGateway(Protocol):
+    def ask(self, request: VisualEditorialRequest) -> BankedVisualAnswer: ...
+```
+
+`VisualEditorialRequest` contains pass/prompt/schema versions, ordered IDs, exact pages, grounded
+annotations, upstream decision versions, and request limits. It returns raw complete text plus
+provenance; pass-specific parsers own semantics.
+
+- [ ] RED/GREEN: add `VisualJudgmentIdentity` and `VisualJudgmentCache` without changing the legacy
+  text-cache meaning. Independently test invalidation for pixels, page order, annotations, model,
+  prompt/schema/render/layout version, and upstream insight version. Exclude API keys.
+
+- [ ] RED/GREEN: make request trace record planned calls, actual calls, cache hits, attached pages,
+  tile count, provider/model identity, and every retry. A cache hit records original provenance and
+  current reuse.
+
+- [ ] Probe before increasing call packing. Against generated sheets and the configured model,
+  compare `image_detail=low` with `auto`/`high`, then one versus multiple pages per request. Require
+  exact tile accounting and equivalent decisions. Record the result outside Git. Keep production
+  defaults at one JPEG if the probe is inconclusive.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_visual_request_planner.py tests/test_editorial_gateway.py tests/test_llm_query.py tests/test_judgment_cache.py tests/test_editorial_trace.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/visual_request_planner.py src/immich_memories/analysis/editorial_gateway.py src/immich_memories/analysis/llm_query.py src/immich_memories/cache/judgment_cache.py src/immich_memories/analysis/selection_trace.py tests/test_visual_request_planner.py tests/test_editorial_gateway.py tests/test_llm_query.py tests/test_judgment_cache.py tests/test_editorial_trace.py
+git commit -m "feat(selection): bank visual editorial requests (#764)"
+```
+
+**Slice gate:** The attached provider payload, saved sheet, and trace hash are byte-identical. The
+trace reports the measured request count and no tile disappears under packing.
+
+---
+
+## Task 4: Prepare the Complete Source-Eligible Corpus
+
+**Branch:** `feat/764-insight-cull`
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/selection_flow.py`
+- Modify: `src/immich_memories/analysis/source_filter.py:68-113`
+- Modify: `src/immich_memories/analysis/moment_grouping.py:66-138`
+- Modify: `src/immich_memories/analysis/source_quality.py`
+- Create: `tests/test_selection_source.py`
+- Modify: `tests/test_moment_grouping.py`
+- Modify: `tests/test_pool_stages_are_on_the_record.py`
+
+- [ ] RED: feed a pregnancy-test image, a screenshot, a short clip, and an owner-excluded asset
+  through `prepare_editorial_source()`. Assert only the explicit owner exclusion leaves before
+  Pass 0; the other signals are annotations:
+
+```python
+def test_only_source_scope_and_owner_exclusions_apply_before_pass_zero() -> None:
+    prepared = prepare_editorial_source(request_with_four_assets(), fake_dependencies())
+    assert prepared.candidate_ids == ("pregnancy-test", "screenshot", "short-clip")
+    assert prepared.excluded_ids == ("owner-excluded",)
+    assert prepared.trace.story_of("pregnancy-test").first_pass == "pass-0"
+```
+
+- [ ] GREEN: implement `SourceScope`, `EditorialSelectionRequest`, `EditorialDependencies`,
+  `PreparedEditorialSource`, `prepare_editorial_source()`, and a normalized `EditorialCandidate`
+  adapter for raw `Asset`/`VideoClipInfo`. Eligibility is date/library scope, supported media, and
+  explicit hard owner exclusions only.
+
+- [ ] RED/GREEN: expose pure chronological `build_episode_groups()` and `build_moment_groups()`
+  over already-eligible candidates. Stable group IDs derive from ordered asset IDs and grouping
+  version. Move no winners here.
+
+- [ ] GREEN: retain re-encode, resolution, duration, blur, burst, inferred subject, and similarity
+  findings as grounded evidence. Do not call legacy subject quota, thumbnail winner, burst winner,
+  photo-vs-motion suppression, or density shortlist in the new flow.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selection_source.py tests/test_moment_grouping.py tests/test_pool_stages_are_on_the_record.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/selection_flow.py src/immich_memories/analysis/source_filter.py src/immich_memories/analysis/moment_grouping.py src/immich_memories/analysis/source_quality.py tests/test_selection_source.py tests/test_moment_grouping.py tests/test_pool_stages_are_on_the_record.py
+git commit -m "feat(selection): start from the complete eligible corpus (#764)"
+```
+
+---
+
+## Task 5: Read Episodes and Form a Provisional Period Insight
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/period_insight_answer.py`
+- Create: `src/immich_memories/analysis/period_insight.py`
+- Create: `tests/test_period_insight_answer.py`
+- Create: `tests/test_period_insight.py`
+- Create: `tests/test_period_insight_generalisation.py`
+
+- [ ] RED: assert strict parsing accepts the final complete balanced object, maps displayed numbers
+  to stable IDs, and rejects an auto-closed truncated object.
+
+```python
+def test_truncated_episode_answer_cannot_select_representatives() -> None:
+    raw = '{"episode_id":"day-1","representative_tiles":[1,2]'
+    assert read_episode_answer(raw, episode_id="day-1", tile_map={1: "a", 2: "b"}) is None
+```
+
+- [ ] GREEN: implement strict `read_episode_answer()` and `read_period_answer()`. Do not reuse
+  `_parse_json_object_text()` from `llm_response_parser.py` because it repairs truncation.
+
+- [ ] RED/GREEN: build chronological episode sheets from every prepared candidate, request short
+  `EpisodeReading`s and reasoned representative IDs, then build the period sheet from every episode
+  reading and its representatives. A representative decision makes the period wall legible; it
+  does not cull the episode.
+
+- [ ] RED/GREEN: if any required visual evidence is unreadable, return `PeriodInsight(thesis=None,
+  unavailable_reason=...)`, retain all assets for Cull, and add `!!`. Never invent representative
+  IDs mechanically and present them as editorial.
+
+- [ ] RED/GREEN: the generalisation matrix swaps cycling/live-show labels while preserving pixels
+  and evidence. The shape of the insight evidence must remain stable; tests must not assert exact
+  prose.
+
+- [ ] Add Pass 0 to `selection_flow.py`, bank its answer, and record actual call count. At this
+  point the new flow is observation-only and has no public caller.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_period_insight_answer.py tests/test_period_insight.py tests/test_period_insight_generalisation.py tests/test_editorial_trace.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/period_insight_answer.py src/immich_memories/analysis/period_insight.py src/immich_memories/analysis/selection_flow.py tests/test_period_insight_answer.py tests/test_period_insight.py tests/test_period_insight_generalisation.py
+git commit -m "feat(selection): read the period before making cuts (#764)"
+```
+
+---
+
+## Task 6: Fuse Cull and the Record-Shot Lane into Episode Scans
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/cull_answer.py`
+- Create: `src/immich_memories/analysis/selection_cull.py`
+- Modify: `src/immich_memories/analysis/period_insight.py`
+- Modify: `src/immich_memories/analysis/subject_policy.py:28-177, 215-274`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Create: `tests/test_cull_answer.py`
+- Create: `tests/test_selection_cull.py`
+- Modify: `tests/test_subject_policy.py`
+
+- [ ] RED: one episode response contains independent `episode_reading`, `record_shots`, and
+  `cull_rejects` namespaces. A record/reject collision invalidates only the rejection:
+
+```python
+def test_record_mark_wins_a_namespace_collision_without_discarding_siblings() -> None:
+    answer = read_episode_scan_answer(raw_collision(), tile_map={1: "test", 2: "blur"})
+    assert answer.record_shots[0].asset_id == "test"
+    assert answer.cull_rejects == (CullDecision("blur", "unusable motion blur"),)
+    assert answer.warnings == ("!! cull reject conflicted with record-shot mark: test",)
+```
+
+- [ ] GREEN: version the episode-scan schema and request identity. Ask record-shot function first;
+  Cull may reject only clearly unusable non-record items. Subject labels, repetition, relative
+  weakness, and thesis relevance are invalid Cull reasons.
+
+- [ ] RED/GREEN: refusal, timeout, invalid IDs, and truncated JSON reject nothing. Valid sibling
+  namespaces remain banked. More than 75% rejection adds `!! possible over-cull` but does not
+  restore by score.
+
+- [ ] RED/GREEN: convert `classify_subject()` to evidence-only use in the new path. Screenshots,
+  documents, and the pregnancy-test fixture reach the visual request. Legacy quota functions stay
+  callable only for the old selector until Task 13.
+
+- [ ] Add `run_cull()`:
+
+```python
+def run_cull(
+    episodes: Sequence[EpisodeSheet],
+    *,
+    requester: EditorialGateway,
+    trace: Trace,
+) -> CullPassResult: ...
+```
+
+Return chronological survivors, independent `RecordShotMark`s, decisions, warnings, and
+provenance. Add it after Pass 0 in `selection_flow.py`.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_cull_answer.py tests/test_selection_cull.py tests/test_subject_policy.py tests/test_selection_source.py tests/test_editorial_trace.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/cull_answer.py src/immich_memories/analysis/selection_cull.py src/immich_memories/analysis/period_insight.py src/immich_memories/analysis/subject_policy.py src/immich_memories/analysis/selection_flow.py tests/test_cull_answer.py tests/test_selection_cull.py tests/test_subject_policy.py
+git commit -m "feat(selection): cull visibly and preserve record shots (#764)"
+```
+
+**Slice gate:** The private Pass 0/1 sheet is judgeable and chronological; every source-eligible
+asset appears; the pregnancy test is marked as a record shot; refusal/truncation rejects nothing;
+the trace reports episode-scan packs rather than one request per asset.
+
+---
+
+## Task 7: Select Representatives with Visual Moment Battles
+
+**Branch:** `feat/764-selects`
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/selects_answer.py`
+- Create: `src/immich_memories/analysis/selection_selects.py`
+- Modify: `src/immich_memories/analysis/moment_grouping.py`
+- Modify: `src/immich_memories/analysis/favourite_law.py`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Create: `tests/test_selects_answer.py`
+- Create: `tests/test_selection_selects.py`
+- Modify: `tests/test_favourite_law.py`
+- Modify: `tests/test_same_moment.py`
+
+- [ ] RED: prove favorite construction semantics:
+
+```python
+def test_one_favourite_wins_its_moment_and_record_shot_stays_separate() -> None:
+    result = run_selects((group("plain", "star", "record"),), record_shots=(mark("record"),), requester=never_called(), trace=Trace())
+    assert result.selects[0].selected_asset_id == "star"
+    assert result.record_shots[0].asset_id == "record"
+```
+
+- [ ] GREEN: a single favorite auto-wins. If several favorites collide, build a battle containing
+  only those favorites. Favorites outside the winning occasion are not globally immune.
+
+- [ ] RED/GREEN: for ordinary groups, pack many complete separated battles per request. The answer
+  is exactly one `MomentSelect` (`selected` or `no_peak`) per group plus at most one reason-specific
+  alternate. Unknown, duplicate, cross-group, or incomplete decisions leave that group unresolved
+  and add `!!`; scalar score never selects a fallback.
+
+- [ ] RED/GREEN: five repeated events in cycling and live-music fixtures produce decisions from
+  visible contribution, not a fixed count. Swapping topic labels preserves the decision shape.
+
+- [ ] Add:
+
+```python
+def run_selects(
+    groups: Sequence[MomentGroup],
+    *,
+    record_shots: Sequence[RecordShotMark],
+    requester: EditorialGateway,
+    trace: Trace,
+) -> SelectsPassResult: ...
+```
+
+Every selected representative exposes its actual shippable duration. Record shots stay in a
+sidecar lane and are added to the workprint without competing for the aesthetic slot.
+
+- [ ] Stop membership-changing dedup, burst winners, photo-vs-motion suppression, and post-select
+  scalar dedup in the new flow. Keep their similarity calculations as grounded annotations and
+  leave old functions present for the legacy selector until Task 14.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selects_answer.py tests/test_selection_selects.py tests/test_favourite_law.py tests/test_same_moment.py tests/test_content_dedup.py tests/test_photo_burst_dedup.py tests/test_moment_suppression.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/selects_answer.py src/immich_memories/analysis/selection_selects.py src/immich_memories/analysis/moment_grouping.py src/immich_memories/analysis/favourite_law.py src/immich_memories/analysis/selection_flow.py tests/test_selects_answer.py tests/test_selection_selects.py tests/test_favourite_law.py tests/test_same_moment.py
+git commit -m "feat(selection): choose peaks with visual moment battles (#764)"
+```
+
+---
+
+## Task 8: Move Expensive Analysis behind Selects
+
+**Files:**
+
+- Modify: `src/immich_memories/analysis/smart_pipeline.py:269-390`
+- Modify: `src/immich_memories/photos/photo_pipeline.py:63-138, 648-721`
+- Modify: `src/immich_memories/analysis/llm_response_parser.py:227-284`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Create: `tests/test_selected_visual_analysis.py`
+- Modify: `tests/test_pipeline_integration.py`
+
+- [ ] RED: script a corpus of 20 assets resolving to four representatives and one alternate. Assert
+  content/deep analysis runs only for those five visuals after Pass 2, while every source asset was
+  visible in Pass 0/1.
+
+- [ ] GREEN: add `analyze_selected_visuals()` after Selects. Materialize selected video segments,
+  compute actual shippable durations, and attach objective motion/audio/content evidence to the
+  selected visual contracts. Do not call `_enhance_with_llm()` once per discarded photo.
+
+- [ ] RED/GREEN: when selected media cannot be analyzed or rendered into its promised segment,
+  leave the editorial result unresolved with `!!`; do not silently substitute the next score.
+
+- [ ] REFACTOR: use the atlas's frame sampler instead of the uncached
+  `ContentAnalyzer.extract_frames()` path where the evidence is identical.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selected_visual_analysis.py tests/test_pipeline_integration.py tests/test_frame_extraction.py"
+make test-integration-processing
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/smart_pipeline.py src/immich_memories/photos/photo_pipeline.py src/immich_memories/analysis/llm_response_parser.py src/immich_memories/analysis/selection_flow.py tests/test_selected_visual_analysis.py tests/test_pipeline_integration.py
+git commit -m "refactor(selection): analyze the visuals that reach the cut (#764)"
+```
+
+**Slice gate:** The Pass 2 sheet exposes complete moment battles, correct favorite behavior, the
+pregnancy-test sidecar, bounded alternates, actual durations, and measured request counts. Judge
+representatives only—not the final narrative cut yet.
+
+---
+
+## Task 9: Rewrite Structure as a Visual Reject-Only Rough Cut
+
+**Branch:** `refactor/764-structure-projection`
+
+**Files:**
+
+- Rewrite: `src/immich_memories/analysis/selection_structure.py:69-663`
+- Rewrite: `src/immich_memories/analysis/structure_answer.py:157-298`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Rewrite/adapt: `tests/test_selection_structure.py`
+- Modify: `tests/test_structure_answer.py`
+
+- [ ] RED: feed a fully fitting workprint and assert Structure still receives its exact sheet.
+  Unnamed moments survive; only complete named rejects act.
+
+```python
+def test_structure_runs_when_cut_already_fits_and_only_named_rejects_act() -> None:
+    result = run_structure(workprint("a", "b", "c", seconds=40), insight=insight(), target_duration=60, requester=scripted_reject("b"), trace=Trace())
+    assert result.kept_ids == ("a", "c")
+    assert result.rejected == (StructureDecision("b", "duplicates the same contribution"),)
+```
+
+- [ ] GREEN: replace `_ask()` text tables with a chronological selected workprint sheet containing
+  record shots, Pass 2 reasons, actual durations, and current insight. Remove the already-fits
+  bypass, global rank, `_shipped_est`, per-moment cap, and release-to-fit logic.
+
+- [ ] RED/GREEN: if the initial valid rough cut is above 110%, ask for the smallest additional
+  named sacrifice set. Apply a complete set atomically. A failed/incomplete continuation leaves
+  the valid overlong cut unchanged and adds `!! unresolved envelope`.
+
+- [ ] RED/GREEN: rejecting the last surviving visual of an episode or the last record/favorite
+  representative requires an explicit protected-occasion reason. Visual weakness, repetition, and
+  duration alone are invalid protected-occasion reasons.
+
+- [ ] RED/GREEN: assert chronology is stored, even when sacrifice importance order is deliberately
+  non-chronological. There is no runtime prefix/tail interpretation.
+
+- [ ] Keep only the safe #768 ideas with fresh tests: balanced complete-object parsing,
+  reject-only application, chronological IDs, reason ledger, and no invented fallback order.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selection_structure.py tests/test_structure_answer.py tests/test_editorial_trace.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/selection_structure.py src/immich_memories/analysis/structure_answer.py src/immich_memories/analysis/selection_flow.py tests/test_selection_structure.py tests/test_structure_answer.py
+git commit -m "refactor(selection): make structure a visual rough cut (#764)"
+```
+
+---
+
+## Task 10: Project and Revise the Insight Once
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/projection_answer.py`
+- Create: `src/immich_memories/analysis/selection_projection.py`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Create: `tests/test_selection_projection.py`
+
+- [ ] RED: a revised insight replays Structure exactly once over the complete original Pass 2
+  workprint, including an item rejected by the first Structure answer.
+
+```python
+def test_revised_insight_replays_structure_once_over_complete_workprint() -> None:
+    result = select_with_script(first_reject="b", projection="revise", replay_keep="b")
+    assert result.structure_calls == 2
+    assert result.structure_inputs[1] == ("a", "b", "c")
+    assert result.selected_ids == ("a", "b", "c")
+```
+
+- [ ] GREEN: implement `project_insight()` returning confirm, revise, or discard with evidence. If
+  no provisional thesis exists, skip the model call and record the skip.
+
+- [ ] RED/GREEN: enforce a single revision and a single replay. A second revision request is
+  invalid and fail-open. Cache identity includes prior insight, complete workprint, Structure
+  decisions, and sheet hashes.
+
+- [ ] RED/GREEN: bank before/after evidence in the same trace. First Structure decisions are
+  evidence, never vetoes during replay.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selection_projection.py tests/test_selection_structure.py tests/test_editorial_trace.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/projection_answer.py src/immich_memories/analysis/selection_projection.py src/immich_memories/analysis/selection_flow.py tests/test_selection_projection.py
+git commit -m "feat(selection): revise the thesis once against the cut (#764)"
+```
+
+**Slice gate:** Only now judge the June Structure cut. It must receive the pregnancy-test record
+shot, actual Pass 2 representatives, favorites, durations, and insight. Two professional races may
+not both survive merely for being separate events; the Brussels Tour setup/action/payoff sequence
+may survive if its three contributions earn the time. No topic count is asserted.
+
+---
+
+## Task 11: Judge the Whole Cut and Perform One Bounded Repair
+
+**Branch:** `feat/764-fine-cut`
+
+**Files:**
+
+- Create: `src/immich_memories/analysis/fine_cut_answer.py`
+- Create: `src/immich_memories/analysis/selection_fine_cut.py`
+- Modify: `src/immich_memories/analysis/selection_flow.py`
+- Create: `tests/test_fine_cut_answer.py`
+- Create: `tests/test_selection_fine_cut.py`
+- Adapt: `tests/test_selection_review.py`
+- Adapt: `tests/test_review_parsing.py`
+- Adapt: `tests/test_review_drops_are_applied.py`
+
+- [ ] RED: Fine Cut sees one complete chronological cut sheet, current insight, Structure reasons,
+  record-shot marks, and one banked alternate per eligible moment. It returns a strict partition.
+
+- [ ] GREEN: implement:
+
+```python
+def run_fine_cut(
+    structure: StructurePassResult,
+    *,
+    insight: PeriodInsight | None,
+    alternates: Mapping[str, tuple[str, ...]],
+    record_shots: Sequence[RecordShotMark],
+    requester: EditorialGateway,
+    trace: Trace,
+) -> FineCutResult: ...
+```
+
+Retain the useful strict partition and fail-open parser semantics from `selection_review.py`, but
+replace its text-only question and post-hoc favorite vetoes.
+
+- [ ] RED/GREEN: a reject reason such as “missing establishing context” may inspect one banked
+  alternate from the same moment. The replacement gets one visual judgment. A rejected moment or
+  occasion cannot return through a sibling; reopening requires the already-bounded projection
+  replay.
+
+- [ ] RED/GREEN: a shorter strong cut remains short. Fine Cut cannot call backfill, score-ranked
+  replenish, stabilise, numeric judge, or an open-ended repair loop.
+
+- [ ] RED/GREEN: failure, refusal, or truncation rejects nothing further and adds `!!`; complete
+  named rejects before a truncated tail may act only when the complete partition contract still
+  validates.
+
+- [ ] Probe the combined Projection + provisional Fine Cut request against separate calls over the
+  same sheet. Enable fusion only if conservation and decisions match. If projection revises,
+  discard the provisional Fine Cut response, replay Structure, and run Fine Cut once on the changed
+  workprint. Record planned and actual call counts.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_fine_cut_answer.py tests/test_selection_fine_cut.py tests/test_selection_review.py tests/test_review_parsing.py tests/test_review_drops_are_applied.py tests/test_the_review_makes_the_cut.py"
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/fine_cut_answer.py src/immich_memories/analysis/selection_fine_cut.py src/immich_memories/analysis/selection_flow.py tests/test_fine_cut_answer.py tests/test_selection_fine_cut.py tests/test_selection_review.py tests/test_review_parsing.py tests/test_review_drops_are_applied.py
+git commit -m "feat(selection): judge the complete visual cut (#764)"
+```
+
+---
+
+## Task 12: Make Rendering a Conserved Implementation Detail
+
+**Files:**
+
+- Modify: `src/immich_memories/analysis/motion_rendering.py:20-76`
+- Modify: `src/immich_memories/analysis/live_photo_pipeline.py:28-120`
+- Modify: `src/immich_memories/generate_clips.py:96-184`
+- Modify: `src/immich_memories/generate_timeline.py:78-129`
+- Modify: `src/immich_memories/generate.py`
+- Create: `tests/test_render_membership.py`
+- Modify: `tests/test_rendering_last.py`
+- Modify: `tests/test_motion_rendering.py`
+- Modify: `tests/test_timeline_budget.py`
+- Add: `tests/integration/assembly/test_editorial_membership.py`
+
+- [ ] RED: select photo/video/Live Photo visuals in a known order and assert render planning chooses
+  a mode without changing membership.
+
+```python
+def test_render_plan_preserves_ordered_editorial_membership() -> None:
+    selected = (visual("photo"), visual("live", modes=("still", "motion")), visual("video"))
+    plan = plan_renderings(selected)
+    assert tuple(item.asset_id for item in plan) == ("photo", "live", "video")
+```
+
+- [ ] GREEN: resolve still versus motion only after Fine Cut. A Live Photo remains one selected
+  visual with render options, not two editorial candidates.
+
+- [ ] RED/GREEN: remove membership changes from `_sample_for_minimum_duration()`. Budget adjustment
+  may trim intended segments proportionally within their contracts; it cannot add, drop, reorder,
+  or substitute visuals.
+
+- [ ] RED/GREEN: make extraction failure fatal to the run. After extraction and after assembly,
+  compare ordered selected IDs with ordered produced IDs. Missing, extra, or reordered IDs create a
+  conservation failure and abort; never ship a partial output.
+
+- [ ] Add a real FFmpeg `testsrc` integration proving ordered membership and an injected extraction
+  failure proving no partial output is accepted.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_render_membership.py tests/test_rendering_last.py tests/test_motion_rendering.py tests/test_timeline_budget.py"
+make test-integration-assembly
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/analysis/motion_rendering.py src/immich_memories/analysis/live_photo_pipeline.py src/immich_memories/generate_clips.py src/immich_memories/generate_timeline.py src/immich_memories/generate.py tests/test_render_membership.py tests/test_rendering_last.py tests/test_motion_rendering.py tests/test_timeline_budget.py tests/integration/assembly/test_editorial_membership.py
+git commit -m "fix(selection): preserve the cut through rendering (#764)"
+```
+
+**Slice gate:** Review the complete June, April, and August cuts. Each is chronological,
+warning-free, conserved, and near its requested duration without filler. June includes the
+pregnancy test, excludes the generic selfie unless it earns a role, and resolves repeated races
+from their contribution—not a cycling cap.
+
+---
+
+## Task 13: Converge CLI, UI, Automation, Dry-Run, and Contact Sheets
+
+**Branch:** `refactor/764-editorial-cutover`
+
+**Files:**
+
+- Modify: `src/immich_memories/cli/_pipeline_runner.py:134-178, 263-313, 316-568`
+- Modify: `src/immich_memories/cli/_candidate_pool.py:27-215`
+- Modify: `src/immich_memories/cli/generate.py:243-289, 370-602`
+- Modify: `src/immich_memories/cli/_album_generation.py:30-148`
+- Modify: `src/immich_memories/cli/_trip_generation.py:147-317`
+- Modify: `src/immich_memories/ui/pages/step2_loading.py:41-234`
+- Modify: `src/immich_memories/ui/pages/clip_pipeline.py:183-370`
+- Modify: `src/immich_memories/ui/state.py:65-113, 279-281`
+- Modify: `src/immich_memories/ui/pages/step3_options.py`
+- Modify: `src/immich_memories/ui/pages/step4_export.py`
+- Modify: `src/immich_memories/ui/pages/_step4_generate.py`
+- Modify: `src/immich_memories/automation/runner.py:503-580`
+- Modify: `scripts/contact_sheet.py:35-72, 197-303`
+- Create: `tests/test_selection_surface_parity.py`
+- Modify: `tests/test_no_render.py`
+- Modify: `tests/test_clip_pipeline_ui.py`
+- Modify: `tests/test_auto_runner.py`
+- Modify: `tests/test_contact_sheet.py`
+
+- [ ] RED: dependency-inject one scripted gateway and run CLI, UI adapter, automation, dry-run, and
+  no-render over the same fake source. Assert exact equality of source IDs, owner exclusions, pass
+  order, ordered final IDs, intended segments/durations, warnings, request count, and trace
+  fingerprint.
+
+- [ ] GREEN: make all surfaces call only `prepare_editorial_source()` and
+  `select_editorial_cut()`. Source scopes cover date range, album, and trip. The core imports no UI
+  or CLI package, preserving `pyproject.toml` import-linter contracts.
+
+- [ ] RED/GREEN: UI Step 2 checkboxes become explicit owner exclusions before Pass 0. Persist the
+  typed `EditorialSelectionResult` in UI state. Steps 3 and 4 consume its unified ordered visual
+  list directly; never reconstruct selected photos against a video-only source list.
+
+- [ ] RED/GREEN: automation dry-run invokes the real CLI with rendering, upload, delivery, and
+  notifications disabled. It reports success only after selection succeeds.
+
+- [ ] RED/GREEN: `--dry-run` and `--no-render` share full editorial semantics. Keep `--no-render`
+  as a compatibility alias if needed. If a cheap inventory-only operation remains useful, give it
+  a different explicit name; it is never gate evidence.
+
+- [ ] Replace `scripts/contact_sheet.py` private SmartPipeline monkeypatching with the public
+  no-render outcome and trace. Preserve the private-media warning and sweep output layout.
+
+- [ ] Run:
+
+```bash
+make test-one T="tests/test_selection_surface_parity.py tests/test_no_render.py tests/test_clip_pipeline_ui.py tests/test_auto_runner.py tests/test_contact_sheet.py tests/test_surface_parity.py"
+make test-integration-pipeline
+make test-integration-cli
+make e2e
+make test
+make critique
+make ci
+```
+
+- [ ] Commit:
+
+```bash
+git add src/immich_memories/cli src/immich_memories/ui src/immich_memories/automation/runner.py scripts/contact_sheet.py tests/test_selection_surface_parity.py tests/test_no_render.py tests/test_clip_pipeline_ui.py tests/test_auto_runner.py tests/test_contact_sheet.py tests/test_surface_parity.py
+git commit -m "refactor(selection): route every surface through one editor (#764)"
+```
+
+---
+
+## Task 14: Delete Superseded Selectors and Migrate Configuration
+
+**Files:**
+
+- Delete after replacement tests pass: `src/immich_memories/analysis/arithmetic_funnel.py`
+- Delete after replacement tests pass: `src/immich_memories/analysis/selection_review.py`
+- Delete or reduce: `src/immich_memories/analysis/selection_quality.py`
+- Delete or reduce: `src/immich_memories/analysis/clip_backfill.py`
+- Delete or reduce: `src/immich_memories/analysis/clip_refiner.py`
+- Delete or reduce: `src/immich_memories/analysis/photo_look.py`
+- Modify: `src/immich_memories/analysis/smart_pipeline.py`
+- Modify: `src/immich_memories/analysis/subject_policy.py`
+- Modify: `src/immich_memories/config_models_analysis.py`
+- Modify: `src/immich_memories/config_models_render.py`
+- Modify: `src/immich_memories/config_loader.py:73-121`
+- Modify: `src/immich_memories/config_presets.py`
+- Modify: `ARCHITECTURE.md`
+- Modify: `docs-site/docs/create/pipeline/pipeline-overview.md`
+- Modify: `docs-site/docs/create/pipeline/clip-selection-scoring.md`
+- Modify: `docs-site/docs/create/pipeline/photo-support.md`
+- Modify: `docs-site/docs/create/cli/generate.md`
+- Modify: relevant pages under `docs-site/docs/create/web-ui/`
+- Modify: `docs-site/docs/reference/config-reference.md`
+
+- [ ] RED: replace obsolete behavior tests with assertions that the new public flow cannot import
+  or call arithmetic rank, quota, backfill, numeric judge, text Structure/Review, photo cap, or
+  timeline membership sampling.
+
+- [ ] GREEN: delete each legacy membership changer only after its replacement coverage is green:
+
+  - arithmetic funnel after Structure convergence and honest unresolved-envelope behavior;
+  - subject quotas after Cull evidence and cross-surface parity;
+  - `let_the_favourite_win()` after construction-time favorite tests;
+  - membership-changing dedup after visual Selects/Fine Cut reasons and conservation;
+  - backfill after shorter-strong-cut and bounded-alternate tests;
+  - numeric judge/stabilize/photo look after Fine Cut owns final visible rejection;
+  - legacy trace adapters after every public path emits complete editorial pass/request records.
+
+  Keep source similarity evidence, Live Photo component normalization, and non-membership segment
+  trimming.
+
+- [ ] RED/GREEN: removed nested Pydantic fields currently disappear silently. Emit explicit removed
+  field warnings before deleting them; do not add compatibility aliases or reinterpret old ratios
+  as new editorial policy.
+
+- [ ] Update CLI/config generated references, pipeline docs, UI docs, and `ARCHITECTURE.md`. Explain
+  the pass order, minimum-call packing, dry-run semantics, cache invalidation, owner exclusions,
+  and the fact that shorter strong cuts beat filler.
+
+- [ ] Run:
+
+```bash
+make docs-cli
+make docs-cli-check
+make docs-config-check
+make docs-build
+make docs-check
+make test-integration-processing
+make test-integration-pipeline
+make test-integration-cli
+make e2e
+make test
+make critique
+make ci
+```
+
+- [ ] Commit deletion and docs as separate reviewable commits, each after `make ci`:
+
+```bash
+git commit -m "refactor(selection): remove superseded membership paths (#764)"
+git commit -m "docs(selection): document the contact-sheet editor (#764)"
+```
+
+---
+
+## Task 15: Final Acceptance and Cutover
+
+**Branch:** `feature/764-editorial-selection`, after all slice PRs are squash-merged
+
+- [ ] Merge current `origin/main` into the feature trunk. Resolve conflicts by preserving the new
+  single-flow contracts; never resurrect a legacy membership stage merely to make a test pass.
+
+- [ ] Run synthetic acceptance tests covering:
+
+  - 1, 2, and 3 useful repetitions under short, medium, and long envelopes;
+  - five repetitions in an unrelated domain;
+  - topic-label swaps preserving decision shape;
+  - low-aesthetic record shot survival and composition;
+  - favorite auto-win and protected-occasion omission;
+  - refusal/truncation fail-open behavior;
+  - one projection replay maximum;
+  - complete chronological pass/request trace and conservation;
+  - exact CLI/UI/automation/dry-run parity;
+  - real FFmpeg membership/order conservation and fatal extraction failure.
+
+- [ ] Run a fresh private output directory for the feature-trunk SHA:
+
+```bash
+make dev
+make contact-sheets SPEC=/absolute/private/764-gates.json OUT=/absolute/private/cutover-<sha>
+```
+
+The private spec contains June plus accepted April and August controls. Never commit or attach the
+media, sheets, or traces.
+
+- [ ] Owner acceptance requires all three sheets to be chronological, judgeable, warning-free,
+  conserved, and near target without filler. June additionally checks the observed regressions:
+  pregnancy-test record shot present, generic selfie absent unless it earns a role, kitten selfie
+  allowed if useful, repeated professional races resolved by contribution, and Brussels Tour
+  setup/action/payoff allowed to survive when earned.
+
+- [ ] Run final repository gates:
+
+```bash
+make test-integration
+make test-integration-cli
+make e2e
+make docs-check
+make critique
+make ci
+make launch-check
+```
+
+- [ ] Update the umbrella draft PR body with per-slice PRs, measured cached/uncached model call
+  counts, synthetic results, private owner verdicts without private media, configuration removals,
+  and rollback instructions. Change it from draft only after owner approval.
+
+- [ ] Merge the final `feature/764-editorial-selection` → `main` PR. This is the only PR that closes
+  #764. Keep the previous selector available in Git history; do not add a hidden runtime fallback
+  that can silently masquerade as the new editor.
+
+## Final Self-Review Checklist
+
+- [ ] No `TODO`, `TBD`, placeholder parser, provider-name limit guess, or topic-specific quota is in
+  production code.
+- [ ] Every pass consumes exact pixels and carries input IDs, sheet hashes, schema/model versions,
+  cache identity, duration, decisions, and conservation in one trace.
+- [ ] The normal uncached call budget is episode-scan packs + one period synthesis + packed Selects
+  + one Structure + one Projection/Fine request, with extra calls only for proven continuations,
+  one revision replay, or a failed combined-call probe.
+- [ ] No per-asset or per-moment LLM loop exists where a packed sheet can preserve judgment quality.
+- [ ] No scalar score, quota, deduper, backfill, reviewer, or renderer changes final membership.
+- [ ] The feature trunk is the base of every production slice; `main` changes only at final cutover.
+- [ ] `make ci`, `make critique`, required integration suites, docs gates, and owner contact-sheet
+  gates all pass at the exact final SHA.

--- a/docs/implementation-plans/2026-08-25-existing-selection-rules.md
+++ b/docs/implementation-plans/2026-08-25-existing-selection-rules.md
@@ -1,0 +1,199 @@
+# What the Current Selector Knows
+
+> Companion to `2026-08-25-contact-sheet-editing-process.md`. That plan replaces the
+> selector. This page is the list of what the selector already gets right, so the
+> replacement is measured against it instead of rediscovering it by accident.
+
+## Why this page exists
+
+Three rules were lost in the first six tasks of the replacement, and every one of
+them was found only because a real library happened to expose it — never by a test,
+a review, or a reading of the code:
+
+- `drop_live_photo_components` — one month admitted 729 candidates for 543
+  photographs. Restored in `b8ecc10`.
+- `not_shot_here` / `from_the_camera_roll` — **52% of one month and 54% of another**
+  is material that never came off this library's camera. A period read from the
+  unfiltered corpus produced a thesis about a festival the owner never attended.
+- `SubjectCategory.SCREEN` / `_is_never_worth_padding` — the replacement's Cull
+  vocabulary was entirely technical, so a photograph of a TV showing a stock
+  wallpaper was inexpressible and survived untouched while Cull reported zero
+  rejects. Restored as `photograph_of_a_screen` in `c67d098`.
+
+None was a judgement call anyone made. They happened because the replacement builds
+its pool, its groups and its vocabulary from scratch, and **a rule that lives in a
+module the new path does not import is indistinguishable from a rule that does not
+exist.**
+
+`moment_grouping.moments_to_read` had already recorded this exact failure and its
+fix — *"a wedding, a fresh tattoo and a grid comparing chihuahuas to muffins"* read
+as remarkable days, solved by putting the filter at **the one door** into
+grouping-for-reading. The replacement added a second door
+(`group_by_time_and_place`, "without applying the legacy source filter") and the
+guarantee was gone. **A one-door rule is only a rule while there is one door.**
+
+## Status key
+
+| | |
+|---|---|
+| **CARRIED** | the replacement already implements it |
+| **RESTORED** | was lost, fixed, commit named |
+| **AT RISK** | not implemented, and *not mentioned anywhere in the plan* |
+| **SUPERSEDED** | deliberately replaced; what replaces it is named |
+
+---
+
+## A. Provenance and population — facts about the file, before any judgement
+
+These decide what the corpus *is*. None of them is a quality opinion, so none of
+them belongs to a pass. They run before Pass 0 or they do not run.
+
+| Rule | Where | Status |
+|---|---|---|
+| A Live Photo's motion component is not a second visual | `live_photo_pipeline.drop_live_photo_components` | **RESTORED** `b8ecc10` |
+| Material that never came off this camera is not source | `source_filter.not_shot_here` | **RESTORED** (this branch) |
+| A star overrides provenance | inside `not_shot_here` | **CARRIED** — the star settles it, as it settles every hard gate |
+| Untagged frames of a fetched burst come too | `live_photo_pipeline.with_burst_neighbours` | **AT RISK** |
+| Untagged Live Photos beside tagged ones come too | `live_photo_pipeline.expand_to_neighbors` | **AT RISK** |
+| An image with a still goes to the photo scorer, not the video one | `selection_quality.looks_like_a_photograph` | **AT RISK** — Task 8 |
+| A photograph of a screen is a thing, not a moment | `subject_policy.SubjectCategory.SCREEN`, `clip_backfill._is_never_worth_padding` | **RESTORED** `c67d098` |
+
+**On the two burst/neighbour rules:** both exist because a moment is not one
+asset. If frames 1, 2, 3 are one moment and only 2 is tagged, 1 and 3 belong to
+that moment too. The editorial path fetches a date range rather than a person, so
+these may be genuinely unnecessary — **but that has to be decided, not defaulted.**
+
+**On `looks_like_a_photograph`:** its docstring records the cost of getting it
+wrong — a burst carrier sent to the video analyser "fails in milliseconds, is
+marked attempted, and is never looked at again… it ships undescribed."
+
+---
+
+## B. Protection — what must never be dropped
+
+| Rule | Where | Status |
+|---|---|---|
+| Favourites are exempt from the quality gate | `selection_quality.judge_offenders` | **CARRIED** — `_protect_favourites` |
+| A period's last voice is kept unless it is *unusable* | `selection_quality.spare_last_voices` | **AT RISK** — zero mentions in the plan |
+| A coverage clip is untouchable at every drop site | `clip_refiner._trim_non_favorites` | **AT RISK** |
+
+**`spare_last_voices` is the most valuable rule on this page and the plan does not
+mention it.** Its docstring is the argument:
+
+> The judge removes offenders from the pool for good, so read as "this clip is bad"
+> its verdict costs a month whose only clip scored low. Read as "we can do better
+> than this clip" it costs nothing, because when there is nothing better the clip
+> stays.
+>
+> Unusable is different from weak, and the distinction is what makes this safe: a
+> shot of the ground or a pocket is not worth a month, and stays dropped however
+> alone it is.
+>
+> **A correction, not an exemption.** Exempting has to guess in advance which clips
+> carry a period, and both ways of guessing are wrong.
+
+That "correction, not exemption" shape matters: it is applied *after* the judgement,
+so the gate never has to be switched off. `_trim_non_favorites` records the same
+lesson from the other side — it was "the last drop site that did not" treat a
+coverage clip as untouchable, so the one clip standing for a whole month could be
+cut for scoring low, "which is exactly why it was added in the first place."
+
+**Where this lands in the replacement:** Fine Cut (Task 11) is the pass that removes
+things last, so the correction belongs there. Structure (Task 9) is where a moment
+can vanish entirely.
+
+---
+
+## C. Structure and coverage
+
+| Rule | Where | Status |
+|---|---|---|
+| At least one clip per period, across the whole range | `clip_refiner._ensure_temporal_coverage` | **AT RISK** — zero mentions in the plan |
+| Granularity adapts: daily ≤1 month, weekly ≤3 months, monthly ≤1 year, quarterly beyond | same | **AT RISK** |
+| No moment gives more than a quarter of the cut | `clip_refiner._clips_per_moment` | **AT RISK** |
+| An occasion already in the cut covers a candidate | `clip_backfill._is_same_occasion` | **PARTIAL** — Selects kills redundancy by construction; the *window* rule is not carried |
+
+**On `_clips_per_moment`:** the quarter cap is what "keeps a deduplicated slot from
+being refilled by its own duplicate." Its docstring also records a measured failure
+of the obvious implementation — `ceil()` alone "handed every memory two per moment:
+a real December shipped an eight-clip month with the same group photo twice."
+
+The replacement's answer is that Selects picks one frame per moment, so redundancy
+dies by construction. **That covers the duplicate case but not the proportion
+case:** nothing stops Structure spending a whole memory on one very good afternoon.
+Chronology is preserved, but the shape is not.
+
+---
+
+## D. Superseded by design — with the reasoning worth keeping
+
+These the plan deletes deliberately (Task 14). Listed so the *judgement* inside them
+is not thrown out with the mechanism.
+
+| Rule | Replaced by | Reasoning to preserve |
+|---|---|---|
+| `apply_subject_quotas` — keep people, ration animals and objects | Cull evidence + Selects | *"a new car is a memory and a lawnmower is not, and the only thing separating them is whether the clip is actually any good"* |
+| `quota_for` — quotas as a share of finished length | duration as a convergence bound | a ten-minute video should not get a sixty-second video's allowance |
+| `arithmetic_funnel`, numeric rank | the five passes | numbers may order, never decide |
+| `clip_backfill` | shorter strong cuts beat filler | but see `_is_never_worth_padding` below |
+| `selection_review` | Fine Cut (Task 11) | one question the judge answers |
+
+**Cull is two questions, not one.** Measured on a real month: *"remove the junk, remove
+the failed pictures, protect the favourites."* The replacement implemented only the
+second. A vocabulary of ways pixels can fail cannot reject a sharp, well-exposed
+photograph of a bank contract, and the record lane was actively shielding it.
+
+The junk half is decidable by looking, with no comparison and no score: **the photo
+was taken as a note rather than as a memory.** A screen, a document, an object shot
+to record what it is. Encoded as `photograph_of_a_screen`,
+`paperwork_not_a_moment`, `reference_shot_not_a_moment` — and those three
+**override a record mark**, because a mark argues about how a picture LOOKS and has
+no standing over what it IS. A mark on something Cull removed goes with it.
+
+What Cull must NOT do is choose between similar frames. A real month held ~170
+near-duplicates in runs of 8 to 35; that is Selects' and Structure's work, and
+letting Cull near it is how it becomes a taste pass.
+
+**Junk is not the same as defective.** The replacement's Cull vocabulary described
+only ways pixels can fail — obstruction, motion blur, exposure, corruption. A TV
+wallpaper is sharp, exposed and uncorrupted, so every one of them is false of it and
+the pass had no way to say what was wrong. The old selector was blunt about this:
+*"there is no gap worth a photograph of a monitor."* The lesson generalises past
+screens: **a closed vocabulary decides what a pass is able to notice**, so a gap in
+it reads as silence rather than as an error.
+
+**`_is_never_worth_padding` carries a rule that must survive its module:** an
+*unlabelled* clip is kept, because "a third of a real pool has no analysis yet and
+reading that silence as junk would empty the quiet months." Absence of evidence is
+not evidence of junk. The replacement inherits this risk directly — anything the
+model cannot read must fail toward keeping.
+
+---
+
+## E. Evidence signals the judge is entitled to
+
+Not membership rules; inputs a pass may weigh. Losing them costs judgement quality
+rather than correctness.
+
+| Signal | Where | Status |
+|---|---|---|
+| Front camera / selfie, from the EXIF lens name | `selection_review._front_camera` | **AT RISK** |
+| Subject class from Immich face tags + model label | `subject_policy.classify_subject` | **CARRIED** as evidence-only |
+| Place as city/state/country, not a caption | `selection_review._place_for_llm` | **CARRIED** — Task 5 grounding |
+| Which moment a clip belongs to | `selection_review._clips_block` | **CARRIED** |
+
+---
+
+## The standing check
+
+Before any slice merges into the feature trunk:
+
+1. **Does this slice build a pool, a group, or a corpus from scratch?** If so, name
+   every rule the legacy path applies at that stage and say, per rule, whether it is
+   carried, superseded, or deliberately dropped.
+2. **Did it add a second door to a one-door rule?** Grep the legacy caller list of
+   any helper it replaces. A rule with four callers and none of them yours is a rule
+   you have lost.
+3. **Does the gate corpus look like the owner's life?** A judgement measured on the
+   wrong corpus tells you nothing. Half of one month was other people's material,
+   and four rounds of prompt tuning were spent on what that corpus caused.

--- a/docs/implementation-plans/2026-08-26-editing-process-as-built.md
+++ b/docs/implementation-plans/2026-08-26-editing-process-as-built.md
@@ -1,0 +1,262 @@
+# The Editing Process, As Built
+
+> **Living record, updated while building.** Not a plan — a description of what the
+> code actually does and what it actually costs, measured on the real library.
+> `2026-08-25-contact-sheet-editing-process.md` is the plan; this is the outcome.
+> Written so the user-facing documentation can be assembled from it at the end.
+
+Every measurement below comes from real library months, never synthetic fixtures.
+
+---
+
+## 1. Cost and latency
+
+### Model calls per memory
+
+| stage | calls | notes |
+|---|---|---|
+| Source preparation | **0** | metadata only — no model, no downloads |
+| Pass 0 — episode scan | **one per pack** | one call per contact sheet |
+| Pass 0 — period synthesis | **1** | one wall over the episode representatives |
+| Pass 1 — Cull | **0** | reparses Pass 0's banked answer as a second namespace |
+
+Measured on two real months of very different shape:
+
+| month | fetched | candidates | episodes | packs | **total calls** |
+|---|---|---|---|---|---|
+| a sparse month | 729 | 261 | 58 | 3 | **4** |
+| a dense month | 2016 | 1468 | 101 | 15 | **16** |
+
+Cost scales with contact sheets, not with assets: a corpus 5.6× larger costs 4×
+the calls. A pack is tile-capped at ~120, so a dense month's packs hold 4–14
+episodes while a sparse, scattered month packed as many as 36 into one.
+
+**Cull is free.** It is a logical pass, not a request: Pass 0 and Pass 1 ride in one
+fused envelope over identical evidence. This is the single most important cost
+property of the design and it must survive every later change.
+
+### What drives the pack count
+
+A pack is one contact sheet, and the packer fills it until the largest *valid*
+response would no longer fit the output budget (`fused_episode_response_fits`).
+Raising tiles-per-pack lowers the call count and has a hard quality limit — see §3.
+**A pack holds at most 14 episodes** (`MAX_EPISODES_PER_PACK`). The output budget
+bounds how much a pack can SAY, never how much it can be asked about. Measured at
+temperature 0: a 36-episode pack returned a complete, valid answer with every Cull
+list empty — no refusal, no truncation, no warning, indistinguishable from a month
+with no junk in it. Capping it took the same month from 0 culls to 19.
+
+Episode count per pack matters less than first measured. Probed across packs of 1,
+4, 6, 7, 8, 9, 11 and 14 episodes at ~110 tiles each, three repeats: **23 of 24 runs
+parsed and every one carried `cull_rejects`.** There is no cliff. (An earlier probe
+that appeared to show one at 8 episodes was starving the model on the dataclass
+default of 500 output tokens instead of production's 4000.)
+
+The observed failure is at the extreme: one 36-episode pack returned a complete,
+valid answer with `cull_rejects` simply absent, and one 14-episode run ran away to
+15,586 characters. Both are tail behaviour, not a threshold.
+
+### Measured wall-clock
+
+| run | scope | calls | time |
+|---|---|---|---|
+| one day | 9 candidates, 1 pack | 2 | ~12 s |
+| sparse month | 261 candidates, 3 packs | 4 | **49 s** |
+| dense month | 1468 candidates, 15 packs | 16 | **189 s (3.2 min)** |
+
+**~12 s per call**, flat across pack sizes. A month is a few minutes, and the
+cost is dominated by the number of sheets, not by their contents.
+
+Thumbnails are fetched once per asset and reused across passes; the atlas is built
+once and every pass is handed the same encoded JPEG bytes.
+
+### Cacheability
+
+Answers are banked against `VisualJudgmentIdentity`: the exact sheet bytes plus the
+exact question. Measured on the sparse month:
+
+| | cold bank | warm bank |
+|---|---|---|
+| wall time | 49 s | **10 s** |
+| cache hits | 0 of 3 | **3 of 3** |
+| model calls | 3 | **0** |
+
+Three tiers, in order of how much they cost:
+
+1. **An unchanged month re-runs free.** Pack identities are byte-identical across
+   runs, so every call is a hit and the decisions replay exactly.
+2. **One asset changed re-asks about one pack.** Removing a real candidate mid-month
+   left 2 of 3 pack identities intact — packs break on episode boundaries, so a
+   change stays local instead of cascading down the month.
+3. **Any change to the question re-asks the whole library.** Model, prompt version,
+   pass version, schema version, render version, layout version, image detail,
+   thinking, and the request limits are all in the key. The v3 → v4 bump stranded
+   every banked answer.
+
+The coarseness is inherent: a holistic pass judges in context, so the unit of cache
+has to be the sheet, not the asset. The practical consequence is that **prompt tuning
+is expensive once a library is banked** — settle a contract on small probes before a
+full-library bank exists.
+
+### Requirements this sets
+
+- **Cost must scale with contact sheets, never with assets.** 4 calls for a sparse
+  month and 16 for one 5.6× larger is the shape to preserve; anything that adds a
+  call per asset, per moment, or per episode is out.
+- **A pass that needs its own request must justify it against a fused namespace.**
+  Fusion is only valid over identical evidence with independent namespaces.
+- **No pass may re-download or re-encode pixels.** One atlas, hashed, reused.
+
+---
+
+## 2. The process, end to end
+
+### Source preparation — no model
+
+Runs before any pass and removes only **facts about the file**, never judgements.
+Every exclusion is recorded with a named reason, so the account still answers for
+the whole fetch.
+
+| removed | why | sparse month |
+|---|---|---|
+| Live Photo motion components | the video half is part of a photograph, not a second visual | **186** |
+| not shot on this camera | forwarded and downloaded material is not theirs to remember | **282** |
+| out of date/library scope | not asked for | — |
+| owner exclusions | the owner said no | — |
+
+**729 fetched → 261 candidates.** A star overrides provenance, as it overrides every
+other hard gate.
+
+Candidates are then grouped, chronologically and by place, into **episodes** (58)
+and **moments** (81). Groups conserve every candidate exactly once.
+
+### Pass 0 — Insight
+
+Reads each episode pack and returns, per episode, a `visual_summary` and
+`representative_tiles`. Those representatives are composed into one **period wall**,
+which is read once more to form the month's thesis.
+
+Observation only: Pass 0 changes no membership.
+
+### Pass 1 — Cull
+
+**Removes the junk, removes the failed pictures, protects the favourites.** It never
+chooses between similar frames — a month held near-duplicate runs of 8 to 35, and
+deciding among those belongs to Selects and Structure.
+
+Asked inside **each episode's own scope**, two lists per episode:
+
+| bucket | means | acted on |
+|---|---|---|
+| `notes` | taken as a note rather than as a memory — a screen, a document, an object photographed to record what it is | removed |
+| `failed` | the picture did not come out — obstructed, smeared, unreadable | removed |
+| `ordinary` | nothing wrong with it, just unremarkable or one of several alike | **read, validated, discarded** |
+
+`ordinary` exists so that `notes` does not become a dumping ground. Without it the
+model had only two ways to express a verdict, and "this frame is unremarkable"
+landed in `notes`: measured at temperature 0 on one real pack, `notes` held 19
+tiles of which nine were fields and cycling paths. With the third list it held four
+— a document and three shots of a television — and `ordinary` absorbed 24
+landscapes. It is optional on the wire: an answer that omits it has still answered.
+
+Protections and fail-safes:
+
+- a **favourite** named by Cull is kept, with a warning;
+- **unavailable pixels** cannot actuate a decision;
+- refusal, timeout, truncation, or a tile this pack never showed **rejects nothing**
+  and raises a loud `!!`;
+- a tile filed under the wrong episode is still applied and warned — bookkeeping
+  must not void a pack of correct judgements, which it did on a real month;
+- more than 75% rejected raises `!! possible over-cull` — a diagnostic, never a quota;
+- any `!!` marks the review sheet **invalid for an owner verdict**.
+
+### The review sheet
+
+Every pass renders an owner-judgeable contact sheet: each candidate in chronological
+order, banded with its fate and its reason, favourites badged, warnings in a red
+banner across the top. **A sheet carrying `!!` is not judgeable** and no verdict may
+be taken from it.
+
+---
+
+## 3. Constraints learned by measurement
+
+These are not preferences. Each cost a real failure.
+
+**Scope decides reliability.** A flat question over a 57-tile pack parsed 1 run in 3
+and gave 55 of 57 tiles the same label. The identical question asked per episode
+parsed 3 in 3 with identical output. A small model cannot search a large flat set; it
+answers reliably inside a named small scope. This caps how large a pack can usefully
+get, independently of the token budget.
+
+**Show the shape, never describe it.** Prompts embed a complete example envelope
+built from the same keys the parser demands, and a test parses that very example.
+Prose schemas drift from strict parsers silently, and fixtures written from the
+parser cannot catch it.
+
+**Everything in an example is instruction** — values and whitespace included. Shown
+`"ticket"`, the model labelled a pregnancy test a ticket. Shown a populated reject,
+it copied that defect onto seven unrelated visuals. Decision lists are shown empty.
+
+**Ask for less.** Three measured rounds: each added paragraph made the answer worse.
+Never restate in prose what the parser already enforces.
+
+**Bounded prose is fitted, not fatal.** A reason running past its bound is trimmed;
+the decision it explains survives.
+
+**Decide greedily, always.** Every call in the project was sampling at the
+transport default of 0.3, because nothing ever passed a temperature. That, not the
+prompt and not the model, was the instability: four repeats of one real pack gave
+2107, 1917, 2253 and 2448 characters, and the fourth named all 105 tiles in the
+pack. At 0.0 all four were byte-identical. The default is now 0.0 everywhere.
+
+This is what makes the rest measurable. Before it, comparing two prompts was
+comparing two samples, and a banked answer was not what re-asking would return.
+
+**Some assets have no preview at all.** A dense month raised 23
+`!! Pass 0 visual unavailable` warnings where the preview endpoint answered 404.
+Those visuals cannot be judged and correctly actuate nothing.
+
+**Failing open is only safe if it is loud.** Every fail-open path writes `!!`, and
+the sheet says INVALID. Two of three early runs looked clean by their decision counts
+alone.
+
+---
+
+## 4. Where Cull stands, measured
+
+Both months at temperature 0, with the cap:
+
+| month | packs | calls | readings | culled |
+|---|---|---|---|---|
+| sparse | 5 | 5 | 58/58 | 19 (7.3%) |
+| dense | 15 | 15 | 88/101 | 64 (4.4%) |
+
+**Precision is now the point, and it is good.** The sparse month's culls are two
+photographed documents, four shots of a television, and three objects held up to
+the camera. No landscape, no path, no portrait — every false positive from the
+two-bucket version is gone.
+
+**Recall is deliberately behind it.** A watch face, two bike computers, a washing
+machine and a rim label survive in packs that answered; they went to `ordinary`.
+That is the right direction to fail: a wrong cull is permanent and invisible, a
+wrong keep is fixed by a later pass a person can check.
+
+**The open reliability gap is whole packs, not whole months.** Two of the sparse
+month's five packs returned an answer whose Cull namespace did not parse, so their
+decisions were discarded and the sheet is marked invalid. Fail-open works; the
+frequency does not.
+
+## 5. Open, not yet built
+
+Passes 2–4 (Selects, Structure, Fine Cut) and the surface convergence. The
+near-duplicate reduction — the largest single quality lever on the sheet — lives
+there, not in Cull.
+
+Rules still owed, from `2026-08-25-existing-selection-rules.md`: a period's last
+voice, temporal coverage with adaptive granularity, and the quarter-of-the-cut
+proportion cap.
+
+Known open behaviour: the period thesis is all-or-nothing on episode readings, so 14
+unreadable episodes out of 101 cost the thesis for the other 87. That is the same
+asymmetry corrected everywhere else in this pass and has not been corrected here.

--- a/docs/superpowers/specs/2026-08-25-contact-sheet-editing-process-design.md
+++ b/docs/superpowers/specs/2026-08-25-contact-sheet-editing-process-design.md
@@ -1,0 +1,585 @@
+---
+date: 2026-08-25
+status: proposed for owner review
+issue: 764
+draft_pr: 768
+decision: contact sheets are the working surface of every editorial pass
+---
+
+# Contact-Sheet Editing Process Design
+
+## Decision
+
+Rebuild smart selection in the order a human editor needs information:
+
+```text
+source eligibility
+    ↓
+Pass 0: Insight
+    ↓
+Pass 1: Cull + record-shot lane
+    ↓
+Pass 2: Selects
+    ↓
+Pass 3: Structure
+    ↓
+projection checkpoint
+    ↓
+Pass 4: Fine cut
+    ↓
+rendering
+```
+
+Every editorial pass works from pixels on a purpose-built contact sheet. Text is grounded
+annotation, not a substitute for seeing the material. Each pass banks its decision and reasons so
+later passes can use them without inventing the missing context again.
+
+This keeps the editing process described in the craft research: binary passes, a wall of material,
+selects before assembly, a revisable thesis, explicit sacrifices, and a fine cut that judges the
+whole. It changes the implementation order and contracts, not the underlying editorial method.
+
+Draft PR #768 stays open but blocked while this foundation is built. Its June sheet is a migration
+gate, not an accepted selection. We do not tune the current Structure prompt until it happens to
+pass one month.
+
+## Why the current draft regressed
+
+The accepted Slice 2 gate at `80e3037` had 11 clips in 61 seconds. It was too cycling-heavy, but it
+kept the Brussels Tour setup, live action, and medal as a readable personal sequence. The current
+draft at `9ee0f61` has 8 clips in 47 seconds. It keeps a dull selfie, keeps both professional races,
+and reduces the owner's Brussels Tour to the medal. That is worse.
+
+The regression starts at `27618ef`. The latest commit did not cause it; its PNG and trace are
+byte-identical. The actual failure is the contract around Structure:
+
+- Structure sees time, place, counts, favourite count, a duration estimate, and two score-selected
+  descriptions truncated to 120 characters.
+- It does not see the pixels, the period insight, the relationship between frames, record-shot
+  status, or the previous pass's editorial reasoning.
+- A global priority order is later converted into a mechanical tail release. In June that killed
+  18 of 42 moments without another visual judgement.
+- Structure intent does not survive downstream. The fine cut can treat the Brussels Tour action as
+  redundant with the medal because it never receives “effort before payoff.”
+- A separate numeric judge can remove an asset without adding that loss to the editorial trace.
+
+Prompting harder cannot restore evidence that the model never receives. The fix is to make each
+pass see the right sheet and hand its decision to the next one.
+
+## Goals
+
+1. Emulate a recognisable human editing process instead of producing a score-ranked slideshow.
+2. Make pixels the primary evidence at every editorial decision.
+3. Preserve record shots and favourites without turning either into an unconditional topic quota.
+4. Let repetition and variety emerge from visual roles in this particular period.
+5. Keep every rejection attributable to one pass, one explicit decision, and one reason.
+6. Make the duration envelope an editorial constraint, never an excuse for a mechanical tail cut.
+7. Give the owner a judgeable contact sheet after every migration slice.
+8. Use one selection flow from CLI, UI, automation, and dry-run.
+9. Extract as many decisions as safely possible from each visual request and avoid per-item calls.
+
+## Non-goals
+
+- No cycling, concert, pet, selfie, person, or location quotas.
+- No fixed “two events per topic” rule.
+- No CLIP database or semantic retrieval system.
+- No new scalar quality score pretending to be an editor.
+- No reordering the final chronology.
+- No deletion of source media.
+- No upload of private contact sheets, descriptions, names, or locations to public issues or PRs.
+- No wholesale removal of the old safety net before its replacement passes the real-library gates.
+
+## The editorial object model
+
+The passes exchange explicit editorial records. These names describe contracts, not a required
+module layout.
+
+```text
+PeriodInsight
+  thesis: str | None
+  evidence: list[InsightEvidence]
+  tensions: list[str]
+  recurring_threads: list[str]
+  unavailable_reason: str | None
+  revision: int
+
+EpisodeReading
+  episode_id: str
+  visual_summary: str
+  representative_asset_ids: list[str]
+
+CullDecision
+  asset_id: str
+  decision: reject | survive
+  reason: str
+
+RecordShotMark
+  asset_id: str
+  function: str
+  evidence: str
+
+MomentGroup
+  moment_id: str
+  episode_id: str
+  candidate_asset_ids: list[str]
+
+MomentSelect
+  moment_id: str
+  episode_id: str
+  status: selected | no_peak | unresolved
+  representative_asset_id: str | None
+  alternate_asset_ids: list[str]
+  record_asset_ids: list[str]
+  selection_reason: str
+  unresolved_reason: str | None
+  shippable_duration: float
+
+StructureDecision
+  moment_id: str
+  decision: keep | reject | unresolved
+  reason: str
+  intended_contribution: str | None
+```
+
+The thesis is prose, provisional, and allowed to be absent. Narrative contributions are model
+observations for this run, not an enum of approved story roles. Otherwise “five live shows” soon
+becomes another hard-coded diversity problem with fancier labels.
+
+Every record is immutable and carries the exact input asset IDs, pass version, model identity,
+contact-sheet identity, and decision provenance. Later passes add records rather than mutating an
+earlier pass's reading. They may challenge an interpretation when the complete cut contradicts it.
+
+## Contact sheets are the working surface
+
+The repository already has the useful machinery in `moment_reading.py`: `tile_sheet`, `sheets_of`,
+wide layouts, numbering, thumbnail caching, and time/place grouping. Keep and generalise it.
+Current measurements show 215 photos can be represented in 14 model calls in roughly 22 seconds.
+The existing ceiling of 120 tiles and 2100 pixels keeps sheets readable and requests bounded.
+
+Each sheet must:
+
+- show large enough pixels to judge gesture, action, expression, composition, and duplication;
+- preserve chronological numbering even when split across pages;
+- map every tile number to one stable asset or moment ID;
+- include only grounded metadata available from the library or earlier passes;
+- carry a hash in the trace so the decision can be reproduced;
+- be stored locally and never attached to a public GitHub conversation.
+
+“The model sees the sheet” has a literal meaning: the exact sheet image bytes are attached to the
+model request. Saving a PNG, mentioning its path, or tracing its hash while sending only text fails
+the pass contract. Request-level tests compare the attached image hashes with the traced hashes.
+
+A photograph contributes one tile. When motion matters, a video contributes one locally composed
+tile containing a small chronological filmstrip from its proposed segment plus grounded duration
+and audio annotations. The filmstrip changes pixels inside the tile; it does not add a model call.
+A pass without temporal evidence may judge visual membership, but it cannot claim to have judged
+motion, audio, or pacing.
+
+## Minimum-call request planning
+
+Passes are logical decision and trace boundaries; they are not synonymous with model calls. A
+single packed request may produce separately validated outputs for independent passes, while a
+single difficult pass may need a bounded continuation.
+
+The unit of work is a packed sheet request, never one asset or one moment. The request planner
+minimises calls subject to three hard limits: provider payload limits, conservation of every tile,
+and measured visual judgement quality.
+
+- Build thumbnails and video filmstrips locally once, then reuse that visual atlas in derived
+  sheets. Do not ask a model to describe the same pixels again for each pass.
+- Pack as many complete episode or moment groups as remain legible on one sheet. One Pass 2 request
+  returns decisions for many visually separated moment battles.
+- Attach multiple sheet pages to one request when the configured provider supports it and a probe
+  proves that numbering and decision accuracy remain reliable.
+- Combine independent questions over the exact same visual evidence. The episode scan may return
+  the Pass 0 `EpisodeReading` plus separately namespaced Pass 1 record marks and clear-unusable
+  rejects in one response. This is safe because Cull is deliberately independent of the thesis.
+- Parse and validate those namespaces independently. Record IDs and model Cull-reject IDs must be
+  disjoint. If an asset appears in both, its rejection is invalid and fail-open while the record
+  mark remains. Failure in one namespace never discards a valid sibling namespace.
+- Do not combine dependent questions when the earlier answer changes the later question's sheet.
+  Period insight must exist before Structure, and the structured cut must exist before projection.
+- Projection and Fine Cut may share one ordered response over the same rough-cut sheet. If
+  projection revises the insight, discard the provisional Fine Cut answer, replay Structure once,
+  and judge the changed sheet. This optimisation ships only if a probe matches the separate-call
+  control.
+- Make continuation calls conditional. Structure asks for more sacrifices only when the named cut
+  is genuinely over budget. Projection replays Structure only when the insight materially changes.
+- Cache complete namespaced outputs by visual evidence and schema version. A later pass consumes
+  the banked result; it does not re-query it for convenience.
+
+The trace records planned calls, actual calls, cache hits, attached sheet count, and tile count per
+request. Any batching change is probed against conservation and decision-quality fixtures before
+build. “One enormous call” is not an optimisation if the model starts skipping tiles.
+
+The normal uncached budget is therefore expressed as:
+
+```text
+episode scan packs (Pass 0 readings + independent Pass 1 decisions)
++ 1 period insight synthesis
++ packed Pass 2 battle requests
++ 1 Structure request
++ 1 combined projection + Fine Cut request
++ conditional Structure continuation, replay, and post-replay Fine Cut only when required
+```
+
+Each implementation slice reports this call count on the synthetic and June gates. A change that
+adds calls must show a visual-decision failure that the extra request fixes.
+
+Grounded annotations may include timestamp, place, favourite or record status, tagged people,
+actual duration, audio/activity findings, episode reading, and provisional insight. Generated
+descriptions can support the pixels. They cannot replace them.
+
+### Pass 0 sheet: see the period
+
+Pass 0 uses a hierarchical wall because one unreadably dense month sheet is not useful:
+
+1. Build chronological sheets for each episode or day cluster from the full source-eligible corpus,
+   before editorial subject filtering.
+2. Ask for a short `EpisodeReading` and representative tile IDs grounded in what is visible.
+3. Build a period sheet from those episode readings and representative tiles.
+4. Ask what this period appears to be about, what repeats, and where the contrasts are.
+
+The representative tiles are an explicit, reasoned model decision over the complete episode sheet,
+never a score pick. They make the period sheet legible; they do not cull the episode. The period
+request receives every episode reading and its selected tiles, while the trace proves page and
+episode conservation. Every source asset still reaches Pass 1.
+
+The output is a provisional `PeriodInsight`, not a command to force every frame into a theme. If
+the model cannot form a credible thesis, `thesis` is `None`. The later passes make an honest
+highlight cut and the trace says that insight was unavailable. They do not invent a story.
+
+### Pass 1 sheet: cull only clear failures
+
+Pass 1 sees the complete chronological episode sheet. Its response may share the earlier episode
+scan request, but its schema and trace remain a separate pass contract. Record-shot detection runs
+first as a separate lane over that same sheet. A pregnancy test, finish-line proof, score board,
+ticket, sign, document, or other evidentiary frame may be visually weak and still carry the story.
+Pass 1 names that function before an aesthetic comparison can erase it. Record shots are seeded
+into Structure and Fine Cut so the edit composes around them.
+
+Cull then asks only: “Which non-record items are clearly unusable?” It is a reject-only pass. Blur,
+accidental captures, and unusable exposure can leave here. Subject class, ordinary repetition,
+weakness relative to another frame, and relevance to the thesis are not Cull reasons. Legacy
+subject quotas do not run. Screenshots, documents, and near-duplicates wait for their visible
+function or comparison to be understood. Ambiguous material survives. A parser failure,
+truncation, refusal, or missing model answer kills nothing and adds a loud `!!` warning.
+
+If Cull rejects more than 75% of an otherwise source-eligible corpus, emit `!! possible over-cull`.
+This is a diagnostic, not a quota: the system never restores items by score to satisfy a ratio.
+
+A record shot remains in the candidate cut whenever its occasion remains. Rejecting the last record
+shot or starred representative of an occasion requires an explicit protected-occasion decision
+explaining why the occasion itself is outside this edit. Visual quality, repetition, and duration
+alone are invalid reasons.
+
+Subject policy belongs at this boundary and must run identically in every public entry point. This
+means inferred subject categories become evidence for record handling and later decisions, not the
+legacy class-based quotas. Explicit hard owner exclusions are source scope and apply before Pass 0.
+This is why the pregnancy test cannot appear in a Structure-only sheet today: it has already died
+upstream under the old policy.
+
+### Pass 2 sheet: choose the peak frame in each moment
+
+Pass 2 uses packed battle sheets containing as many complete, visually separated `MomentGroup`s as
+remain judgeable. It compares neighbours directly and returns one namespaced decision per group in
+the request. Its question is: “Does this moment reach a peak; if so, which visual expresses it, and
+what useful alternate remains?”
+
+A favourite wins its moment automatically. If several favourites collide, only those favourites
+compete in the visual battle. This is battle semantics, not global immunity: the whole occasion can
+still be omitted by Structure through the protected-occasion decision. “Favourites intact” means
+each starred occasion that ships uses a starred representative; it does not mean every starred
+asset must ship.
+
+Without a favourite, the model may choose one representative and bank bounded alternates for a
+specific reason such as a better establishing view. It may instead return `no_peak` with a reason;
+a situation is not forced to produce a keeper merely because its answer parsed. Scalar score does
+not silently choose the winner. The chosen representative contributes its actual shippable
+duration to later planning.
+
+Record shots remain a sidecar lane and do not compete for the aesthetic representative slot. This
+prevents a visually strong favourite from hiding the evidentiary frame in the same moment.
+
+An unreadable answer leaves the moment unresolved. A mechanical preview frame may be used to keep
+a diagnostic render running, but it is marked non-editorial, cannot be banked as a valid select,
+and puts `!!` on the gate sheet.
+
+### Pass 3 sheet: make the rough cut
+
+Pass 3 sees a chronological work-print sheet with one selected representative per moment, visible
+record shots, the provisional insight, and the prior passes' short reasons. Its question is:
+“Which moments does this particular story need?”
+
+Structure's actuating answer is reject-only. Every valid rejection names one moment and a reason;
+unnamed moments survive. Kept contributions are useful non-actuating annotations and may remain
+unresolved without deleting anything. A rejected moment explains why that moment's contribution is
+unnecessary. If it removes the final surviving moment from an episode, the reason must additionally
+justify losing the whole occasion. Chronology is fixed, but importance need not be confused with
+chronology.
+
+Structure runs even when all moments already fit. Fitting the envelope does not make a cut
+coherent.
+
+If the first rough cut is over budget, the model sees the surviving work print again and is asked
+to name the smallest additional sacrifice set, with a reason for every member. The set applies
+atomically. It returns no rank, and runtime never takes a prefix or tail based on duration. Only IDs
+explicitly named by the model may leave. There is no global rank followed by a tail release, no
+invented fallback ordering, no per-moment cap, and no `_shipped_est` adjustment based on
+hypothetical future deduplication.
+
+The rough cut should normally land within 10% of the content target. If the model stops before the
+envelope is met or a sacrifice continuation fails, no additional editorial membership changes. The
+valid overlong cut returns with `!! unresolved envelope`. A mechanically narrowed preview may be
+generated as a separate diagnostic artifact, but it cannot replace or mutate the
+`StructureDecision` and is never valid gate evidence. A failed request never destroys an otherwise
+valid cut, but the owner is not shown a warning-free fake.
+
+This is where repetition resolves emergently. If a month contains five live shows, two may survive
+because one establishes a friend's first original song and another closes on a festival crowd. If
+three shows make three distinct contributions, three can survive. If they all do the same job, one
+may be enough. The same logic applies to professional races: two separate races are not useful
+merely because they are separate events if both provide the same “cycling happened” beat.
+
+### Projection checkpoint: test the thesis against the cut
+
+After the first structured cut, project the provisional insight against the surviving work-print,
+the banked insight evidence, and the rejected-moment ledger. The model may confirm it, revise it
+once, or discard it. If no provisional insight exists, skip this question. A revised insight
+triggers at most one Structure replay over the complete Pass 2 work-print, including moments the
+first Structure answer rejected. Earlier Structure decisions are evidence, not vetoes.
+
+This bounded checkpoint models a normal editorial fact: the assembly teaches the editor what the
+film is about. It avoids both extremes—locking an early thesis forever or looping until the model
+manufactures a justification for every choice.
+
+The revision and the before/after evidence are banked in the trace. When the combined-request probe
+passes, this checkpoint and the provisional Fine Cut share one ordered response over the same
+sheet. Any revision invalidates that provisional fine answer.
+
+### Pass 4 sheet: judge the complete cut
+
+Pass 4 sees the complete chronological candidate cut as a contact sheet, not isolated clips. It
+also receives the current insight and each Structure keep reason. Its question is: “Does every
+visual belong, and does the set have enough air and progression?”
+
+It partitions the cut into keep and reject with a reason for every rejection. It may disagree with
+Structure after seeing the whole. It cannot replenish the timeline with score-ranked material or
+run an open-ended stabilisation loop.
+
+Fine Cut may inspect one banked alternate from the same moment only when it rejects the current
+representative for a reason another representative could answer. The reason must name the hole,
+and the replacement gets one visual judgement. If the moment or occasion itself was rejected, no
+sibling may return. Reopening an occasion requires the single bounded Projection/Structure replay.
+This is bounded repair, not a second selection system.
+
+Fine Cut aims for the requested duration within a few percent when the material supports it. A
+shorter strong cut beats filler. If a downstream duration absorber, deduper, or score judge changes
+the editorial membership, the run warns and the gate is invalid.
+
+## Rendering comes last
+
+The editorial system selects visuals and their intended durations before deciding how to render
+them. A Live Photo remains one visual with a still or motion rendering option. It is not a second
+editorial candidate simply because it has a video component.
+
+The renderer may trim, animate, or choose the Live Photo motion component inside the selected
+visual's contract. It may not change the membership of the cut.
+
+## Banking and cache identity
+
+Editorial calls are expensive enough to cache and important enough not to reuse against the wrong
+pixels. The existing judgement cache keys text prompts but does not fully identify visual inputs.
+Image-bearing decisions use a stronger key containing:
+
+- pass name and prompt/schema version;
+- model and thinking configuration;
+- exact ordered asset or moment IDs;
+- source-analysis and thumbnail-render versions;
+- contact-sheet layout version and sheet content hash;
+- grounded annotations supplied to the model;
+- upstream insight and decision versions relevant to this pass.
+
+Any change to the visual evidence invalidates the decision. Cache files remain safe to delete. A
+cache hit records the original decision provenance and the current reuse in the trace.
+
+Banked insight and decisions can support generation, titles, and later local discovery, but private
+content stays in the user's local state. Public test fixtures use synthetic descriptions and
+generated or licensed pixels.
+
+## Failure semantics
+
+Rejection is fail-open throughout the pipeline:
+
+- A failed cull rejects nothing.
+- A failed Selects answer chooses no editorial winner.
+- A failed Structure continuation keeps the valid cut and marks the envelope unresolved.
+- A failed Fine Cut rejects nothing further.
+- Truncated output can only act on complete, explicitly named decisions.
+
+Fallbacks used to produce a diagnostic preview are labelled mechanical and add `!!`. They are not
+valid gate evidence. The standing rule remains: never record an owner verdict on a sheet whose
+trace carries `!!`.
+
+Optional model failure may still produce an honest legacy highlight video during migration, but
+the run must say which path was used. Once the replacement is complete, the product fallback is a
+deterministic highlight cut with no claimed thesis—not a hidden score-based imitation of the visual
+editor. This fallback is a separate output contract; it never mutates or masquerades as the failed
+editorial decision.
+
+## One trace, no missing bodies
+
+The JSON trace is the complete record. For every pass it contains:
+
+- input and output IDs in chronological order;
+- contact-sheet reference and hash;
+- prompt/schema/model/cache provenance;
+- insight used at that point;
+- all keep, reject, unresolved, and replacement reasons;
+- actual duration before and after;
+- warnings and any mechanical fallback;
+- a conservation check proving every input has one fate.
+
+Markdown may stay readable by showing a sample, but it must say `showing 12 of N; full list in
+JSON`. Display truncation must never look like missing selection accounting.
+
+No numeric judge or downstream filter may remove an asset without adding a named trace decision.
+
+## One public selection path
+
+CLI generation, UI generation, automation, dry-run, and tests call one shared selection flow. The
+flow owns, in order:
+
+1. source eligibility: date range, library scope, supported media type, and explicit hard owner
+   exclusions only;
+2. contact-sheet construction;
+3. Pass 0, then Pass 1 including subject policy, then Passes 2–4 and their handoffs;
+4. final editorial membership and duration;
+5. the complete trace.
+
+Entry points may select configuration and presentation. They may not skip source eligibility or
+editorial passes. Technical quality, re-encode findings, and inferred subject evidence are supplied
+to Cull; no separate source-quality stage removes an editorial candidate before Pass 0. This closes
+the current gap where the CLI and UI can feed different material to the same named selection
+feature.
+
+## Migration plan and slice gates
+
+Build replacements in dependency order. Update issue #764 as the design of record; do not open a
+competing architecture issue. Keep PR #768 draft until Pass 3 runs on the real upstream contracts.
+
+### Slice A: Pass 0 visual insight
+
+- Generalise the existing contact-sheet builder.
+- Add hierarchical episode and period sheets.
+- Add the packed request planner, `PeriodInsight`, visual cache identity, trace support, and honest
+  no-insight behaviour.
+- Gate on a judgeable period wall and banked result, not final clip selection.
+
+### Slice B: Pass 1 cull and record-shot lane
+
+- Run subject policy and visual reject-only cull from the full episode sheets.
+- Detect and preserve record-shot function.
+- Prove parser refusal and truncation reject nothing.
+- The pregnancy test becomes judgeable here, not in Structure.
+
+### Slice C: Pass 2 selects
+
+- Build packed visual battle sheets with complete, separated moment groups.
+- Implement favourite auto-win and bounded alternates.
+- Remove score as the silent representative chooser.
+- Gate on whether each retained moment has the right peak frame.
+
+### Slice D: rework Pass 3 Structure
+
+- Replace the text table with the chronological selected work print.
+- Consume Pass 0–2 records and actual shippable durations.
+- Add the bounded projection checkpoint.
+- Remove global rank/tail release, `_shipped_est`, per-moment caps, and already-fits bypass.
+- Preserve the safe parts of #768: reject-only parsing, truncation-safe action, chronological IDs,
+  reason ledger, and refusal to invent a fallback order.
+
+### Slice E: Pass 4 visual fine cut
+
+- Show the whole candidate cut with Structure intent.
+- Replace score deduplication and stabilise/replenish loops with one visual partition and bounded
+  reason-led re-mining.
+- Prove downstream rendering cannot change membership silently.
+
+### Slice F: delete superseded paths
+
+- Route CLI, UI, automation, and dry-run through the same orchestration.
+- Delete the old arithmetic funnel, duplicate subject-policy path, legacy caps, text-only Structure
+  table, silent numeric judge, and downstream membership absorbers only after their replacements
+  pass the real gates.
+- Update public documentation and configuration migration notes.
+
+Stacked builds remain allowed. Each slice blocks its own merge until the owner accepts its contact
+sheet. Deletions remain last so a rejected experimental pass does not leave the product without a
+working fallback.
+
+## Test strategy
+
+Implementation uses vertical red-green-refactor slices through public interfaces.
+
+### Contract and unit tests
+
+- stable chronological tile numbering across multiple sheets;
+- cache invalidation when pixels, order, annotations, model, or pass version changes;
+- minimum-call packing without skipped tiles or cross-group decisions;
+- video filmstrips are locally composed tiles and do not add requests;
+- complete parsers and reject-only fail-open behaviour under refusal and truncation;
+- explicit handoffs for insight, record shots, representatives, Structure intent, and revisions;
+- favourite wins its moment while the occasion remains rejectable with a reason;
+- no unnamed rejection during envelope convergence;
+- projection can revise once and cannot loop;
+- conservation accounting for every pass;
+- identical source policy and pass order through CLI, UI, automation, and dry-run.
+
+### Synthetic generalisation controls
+
+The tests must punish hard-coded topic rules:
+
+- A matrix of periods contains repeated topics under different duration envelopes and with one,
+  two, and three genuinely distinct contributions. Decisions follow the visible contributions and
+  insight, not topic labels or a fixed survivor count.
+- Five repeated activities from another domain use different evidence and can reach a different
+  answer.
+- Swapping topic labels while preserving evidence preserves the decision shape.
+- A record shot with low aesthetic quality survives the cull and is composed into the story.
+
+### Real-library migration gates
+
+Use local, private contact sheets for June plus the previously accepted April and August controls.
+Never attach them to GitHub.
+
+The June gate is successful when:
+
+- the result is chronological and warning-free;
+- every rejected asset has a visible fate in the JSON trace;
+- the generic selfie does not survive merely because it scored well;
+- the kitten selfie may survive if it earns a role;
+- two professional races do not both survive when they perform the same job;
+- the Brussels Tour can retain setup, live effort, and payoff when that progression earns the time;
+- the pregnancy test ships through the record-shot lane; this is a private regression fixture, not
+  a product-level object quota;
+- all shipped favourite occasions use a favourite representative;
+- the duration lands near target without filler or a mechanical tail cut.
+
+These are observations from this month, not product rules. A different period is allowed to reach a
+different answer for visible reasons.
+
+Each slice also runs the full repository gate and critique process. The final migration requires
+`make ci`, `make critique`, warning-free traces, and owner acceptance of the contact sheets.
+
+## Acceptance criteria
+
+- Every editorial pass judges pixels on a purpose-built contact sheet.
+- The runtime order is Insight → Cull/record → Selects → Structure → projection → Fine Cut.
+- Later passes receive the decisions and reasons that earlier passes learned.
+- No scalar score, rank tail, cap, deduper, or renderer silently changes editorial membership.
+- Repetition resolves from the material's contribution to this cut, not a topic quota.
+- Refusal and truncation cannot cause unnamed losses.
+- The JSON trace accounts for every candidate; Markdown truncation is explicitly display-only.
+- CLI, UI, automation, and dry-run execute the same source and editorial contracts.
+- June is at least as strong as the accepted pre-regression sheet before #768 can leave draft.
+- The owner approves this architecture before an implementation plan or production-code change.

--- a/src/immich_memories/analysis/contact_sheets.py
+++ b/src/immich_memories/analysis/contact_sheets.py
@@ -90,6 +90,7 @@ def build_contact_sheets(
     output_dir: Path,
     *,
     per_sheet: int = MAX_SHEET_TILES,
+    page_sizes: tuple[int, ...] | None = None,
 ) -> tuple[ContactSheetPage, ...]:
     """Encode each page once, write those exact bytes, and retain its stable mapping."""
     if not 1 <= per_sheet <= MAX_SHEET_TILES:
@@ -100,13 +101,23 @@ def build_contact_sheets(
         raise ValueError("contact sheet tiles need non-empty entity IDs")
     if len(set(entity_ids)) != len(entity_ids):
         raise ValueError("contact sheet tiles must have unique entity IDs")
+    if page_sizes is not None and (
+        any(size < 1 or size > MAX_SHEET_TILES for size in page_sizes)
+        or sum(page_sizes) != len(entries)
+    ):
+        raise ValueError("contact sheet page sizes must exactly partition the tiles")
     try:
         output_dir.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         raise ValueError(f"cannot create contact sheet directory: {output_dir}") from exc
 
     pages: list[ContactSheetPage] = []
-    for page_index, numbered in enumerate(sheets_of(entries, per_sheet), start=1):
+    numbered_pages = (
+        sheets_of(entries, per_sheet)
+        if page_sizes is None
+        else _pages_with_sizes(entries, page_sizes)
+    )
+    for page_index, numbered in enumerate(numbered_pages, start=1):
         frames = [
             (number, _image_for(tile, tile_size=sheet_layout(len(numbered))[1]))
             for number, tile in numbered
@@ -128,6 +139,17 @@ def build_contact_sheets(
             )
         )
     return tuple(pages)
+
+
+def _pages_with_sizes(items: list[T], page_sizes: tuple[int, ...]) -> list[list[tuple[int, T]]]:
+    pages: list[list[tuple[int, T]]] = []
+    offset = 0
+    for size in page_sizes:
+        pages.append(
+            [(offset + index + 1, item) for index, item in enumerate(items[offset : offset + size])]
+        )
+        offset += size
+    return pages
 
 
 def _image_for(tile: Any, *, tile_size: int):

--- a/src/immich_memories/analysis/contact_sheets.py
+++ b/src/immich_memories/analysis/contact_sheets.py
@@ -1,0 +1,158 @@
+"""One encoded, numbered contact-sheet format for every editorial pass."""
+
+from __future__ import annotations
+
+import io
+import math
+from contextlib import suppress
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, TypeVar
+
+MAX_SHEET_TILES = 120
+MAX_SHEET_PX = 2100
+LAYOUT_VERSION = "1"
+_TARGET_ASPECT = 1.6
+_MAX_TILE = 400
+_MIN_TILE = 120
+_SHEET_BACKGROUND = (18, 18, 18)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class TileRef:
+    """The stable entity represented by one global tile number."""
+
+    number: int
+    entity_id: str
+
+
+@dataclass(frozen=True)
+class ContactSheetPage:
+    """The exact JPEG evidence that is both stored and attached to a request."""
+
+    sheet_id: str
+    path: Path
+    jpeg_bytes: bytes
+    sha256: str
+    tile_refs: tuple[TileRef, ...]
+    layout_version: str
+
+
+def sheet_layout(count: int) -> tuple[int, int]:
+    """Return the wide grid dimensions for one page of visual evidence."""
+    columns = max(1, round(math.sqrt(count * _TARGET_ASPECT)))
+    tile = min(_MAX_TILE, MAX_SHEET_PX // columns)
+    rows = -(-count // columns)
+    if rows * tile > MAX_SHEET_PX * 1.2:
+        tile = int(MAX_SHEET_PX * 1.2) // rows
+    return columns, max(_MIN_TILE, tile)
+
+
+def sheets_of(items: list[T], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, T]]]:
+    """Split items into bounded pages while keeping tile numbers global."""
+    return [
+        [
+            (offset + number + 1, item)
+            for number, item in enumerate(items[offset : offset + per_sheet])
+        ]
+        for offset in range(0, len(items), per_sheet)
+    ]
+
+
+def tile_sheet(frames: list[tuple[int, Any | None]]):
+    """Lay images in a numbered wide grid without dropping unavailable entries."""
+    from PIL import Image, ImageDraw
+
+    if not frames:
+        return None
+    columns, tile = sheet_layout(len(frames))
+    rows = -(-len(frames) // columns)
+    sheet = Image.new("RGB", (columns * tile, rows * tile), _SHEET_BACKGROUND)
+    draw = ImageDraw.Draw(sheet)
+    label = max(16, tile // 11)
+    for position, (number, frame) in enumerate(frames):
+        left = (position % columns) * tile
+        top = (position // columns) * tile
+        if frame is not None:
+            thumbnail = frame.copy()
+            thumbnail.thumbnail((tile - 6, tile - 6))
+            sheet.paste(thumbnail, (left + 3, top + 3))
+        _draw_number(draw, left, top, label, number)
+    return sheet
+
+
+def build_contact_sheets(
+    tiles: tuple[Any, ...] | list[Any],
+    scope_id: str,
+    output_dir: Path,
+    *,
+    per_sheet: int = MAX_SHEET_TILES,
+) -> tuple[ContactSheetPage, ...]:
+    """Encode each page once, write those exact bytes, and retain its stable mapping."""
+    if not 1 <= per_sheet <= MAX_SHEET_TILES:
+        raise ValueError(f"per_sheet must be between 1 and {MAX_SHEET_TILES}")
+    entries = list(tiles)
+    entity_ids = [getattr(tile, "entity_id", None) for tile in entries]
+    if any(not isinstance(entity_id, str) or not entity_id for entity_id in entity_ids):
+        raise ValueError("contact sheet tiles need non-empty entity IDs")
+    if len(set(entity_ids)) != len(entity_ids):
+        raise ValueError("contact sheet tiles must have unique entity IDs")
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(f"cannot create contact sheet directory: {output_dir}") from exc
+
+    pages: list[ContactSheetPage] = []
+    for page_index, numbered in enumerate(sheets_of(entries, per_sheet), start=1):
+        frames = [
+            (number, _image_for(tile, tile_size=sheet_layout(len(numbered))[1]))
+            for number, tile in numbered
+        ]
+        sheet = tile_sheet(frames)
+        assert sheet is not None
+        jpeg_bytes = _encode_jpeg(sheet)
+        sheet_id = f"{scope_id}-{page_index:03d}"
+        path = output_dir / f"{sheet_id}.jpg"
+        path.write_bytes(jpeg_bytes)
+        pages.append(
+            ContactSheetPage(
+                sheet_id=sheet_id,
+                path=path,
+                jpeg_bytes=jpeg_bytes,
+                sha256=sha256(jpeg_bytes).hexdigest(),
+                tile_refs=tuple(TileRef(number, tile.entity_id) for number, tile in numbered),
+                layout_version=LAYOUT_VERSION,
+            )
+        )
+    return tuple(pages)
+
+
+def _image_for(tile: Any, *, tile_size: int):
+    from PIL import Image, ImageDraw
+
+    data = getattr(tile, "jpeg_bytes", None)
+    if isinstance(data, bytes):
+        with suppress(OSError), Image.open(io.BytesIO(data)) as decoded:
+            return decoded.convert("RGB")
+    image = Image.new("RGB", (tile_size - 6, tile_size - 6), (35, 35, 35))
+    reason = getattr(tile, "unavailable_reason", None) or "unavailable"
+    ImageDraw.Draw(image).text((8, 8), reason, fill=(220, 220, 220))
+    return image
+
+
+def _encode_jpeg(sheet: Any) -> bytes:
+    buffer = io.BytesIO()
+    sheet.save(buffer, "JPEG", quality=85)
+    return buffer.getvalue()
+
+
+def _draw_number(draw: Any, left: int, top: int, label: int, number: int) -> None:
+    text = str(number)
+    draw.rectangle(
+        [left + 3, top + 3, left + 3 + label * (0.6 * len(text) + 0.8), top + 3 + label],
+        fill=(0, 0, 0),
+    )
+    draw.text((left + 7, top + 5), text, fill=(255, 255, 255))

--- a/src/immich_memories/analysis/cull_answer.py
+++ b/src/immich_memories/analysis/cull_answer.py
@@ -1,0 +1,261 @@
+"""Strict parsing for the two Cull buckets, asked inside each episode's scope.
+
+Cull removes the junk and the failed pictures, and protects the favourites. It
+never chooses between similar frames: a real month held runs of eight to
+thirty-five near-duplicates, and deciding between those is a later pass's work.
+
+The per-episode shape is not presentation. Probed on one real 57-tile pack,
+three repeats each: a flat answer over the whole pack parsed once in three and
+gave fifty-five of fifty-seven tiles the same label, while the same question
+asked inside each episode's own scope parsed three times in three and returned
+identical tiles every run. A small model cannot search a large flat set; it
+answers reliably inside a named small scope.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TypeGuard
+
+from immich_memories.analysis.period_insight_answer import (
+    EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+    EPISODE_SCAN_SCHEMA_VERSION,
+    EPISODE_VISUAL_SUMMARY_MAX_CHARS,
+)
+from immich_memories.analysis.strict_json import final_json_object
+
+# Two buckets, because a vocabulary of named defects was measured collapsing:
+# shown one populated example the model copied its defect onto seven unrelated
+# visuals, and asked to choose among four families it produced a pair that was
+# not even legal. The bucket carries the reason; the model only sorts.
+CULL_BUCKET_REASONS = {
+    "notes": "taken as a note rather than as a moment",
+    "failed": "the picture did not come out",
+}
+CULL_BUCKETS = tuple(CULL_BUCKET_REASONS)
+# Read, validated, and thrown away. Without somewhere to put "merely
+# unremarkable" the model puts it in notes: measured at temperature 0 on one
+# real pack, notes held 19 tiles of which nine were fields and cycling paths.
+# Given this third list it held four -- a photographed document and three shots
+# of a television -- and nothing else. Choosing between similar frames is a
+# later pass's work, so what lands here is not Cull's to act on.
+DISCARDED_BUCKETS = ("ordinary",)
+CULL_SCOPE_WIRE_KEYS = ("episode", *CULL_BUCKETS)
+_RESPONSE_PLANNING_CHARS_PER_TOKEN = 3
+
+
+@dataclass(frozen=True)
+class CullDecision:
+    """One visual Cull removed, and which of its two questions removed it."""
+
+    asset_id: str
+    bucket: str
+    reason: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        reason = CULL_BUCKET_REASONS.get(self.bucket)
+        if not self.asset_id.strip() or reason is None:
+            raise ValueError("Cull decision needs a stable asset and a known bucket")
+        object.__setattr__(self, "reason", reason)
+
+
+@dataclass(frozen=True)
+class ParsedCullNamespaces:
+    """Validated Pass 1 decisions from one banked scan."""
+
+    cull_rejects: tuple[CullDecision, ...]
+    warnings: tuple[str, ...]
+    cull_valid: bool
+
+
+def fused_episode_response_fits(
+    displayed_by_episode: tuple[tuple[int, ...], ...],
+    *,
+    max_output_tokens: int,
+) -> bool:
+    """Whether the largest valid fused response still fits its output envelope."""
+    readings = tuple(
+        {
+            "episode": episode_alias,
+            "page": 1,
+            "visual_summary": "s" * EPISODE_VISUAL_SUMMARY_MAX_CHARS,
+            "representative_tiles": displayed,
+            "representative_reason": "r" * EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+        }
+        for episode_alias, displayed in enumerate(displayed_by_episode, start=1)
+    )
+    # Worst case is every tile named once: a tile cannot sit in both buckets.
+    rejects = tuple(
+        {"episode": episode_alias, "notes": list(displayed), "failed": []}
+        for episode_alias, displayed in enumerate(displayed_by_episode, start=1)
+    )
+    envelope = json.dumps(
+        {
+            "schema_version": EPISODE_SCAN_SCHEMA_VERSION,
+            "pack": 1,
+            "episode_readings": readings,
+            "cull_rejects": rejects,
+        },
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return len(envelope) <= max_output_tokens * _RESPONSE_PLANNING_CHARS_PER_TOKEN
+
+
+def read_cull_namespaces(
+    raw: str,
+    *,
+    pack_alias: int,
+    tile_map: Mapping[int, str],
+    episode_tiles: Mapping[int, tuple[int, ...]],
+    unavailable_asset_ids: frozenset[str] = frozenset(),
+) -> ParsedCullNamespaces | None:
+    """Read Pass 1 without repairing a malformed outer response."""
+    payload = final_json_object(raw)
+    if (
+        payload is None
+        or payload.get("schema_version") != EPISODE_SCAN_SCHEMA_VERSION
+        or not _is_integer_alias(payload.get("pack"))
+        or payload.get("pack") != pack_alias
+    ):
+        return None
+    read = _read_scoped_rejects(payload.get("cull_rejects"), tile_map, episode_tiles)
+    if read is None:
+        return ParsedCullNamespaces(cull_rejects=(), warnings=(), cull_valid=False)
+    rejects, misfiled = read
+    kept, warnings = _discard_unavailable_decisions(rejects, unavailable_asset_ids)
+    return ParsedCullNamespaces(cull_rejects=kept, warnings=misfiled + warnings, cull_valid=True)
+
+
+def _read_scoped_rejects(
+    value: object,
+    tile_map: Mapping[int, str],
+    episode_tiles: Mapping[int, tuple[int, ...]],
+) -> tuple[tuple[CullDecision, ...], tuple[str, ...]] | None:
+    if not isinstance(value, list):
+        return None
+    seen_episodes: set[int] = set()
+    verdicts: dict[str, set[str]] = {}
+    misfiled: list[str] = []
+    for entry in value:
+        read = _one_episode_entry(entry, tile_map, episode_tiles, seen_episodes, verdicts)
+        if read is None:
+            return None
+        misfiled.extend(read)
+    return _resolve_verdicts(verdicts, tuple(misfiled))
+
+
+def _resolve_verdicts(
+    verdicts: dict[str, set[str]], misfiled: tuple[str, ...]
+) -> tuple[tuple[CullDecision, ...], tuple[str, ...]]:
+    """One decision per asset, resolving a disagreement toward keeping it.
+
+    Naming the same tile twice with the same verdict agrees with itself and is
+    one decision. Naming it with two different verdicts is a contradiction, and
+    a contradiction about whether to remove something resolves the only safe
+    way: the asset stays, and the trace says why.
+    """
+    decisions: list[CullDecision] = []
+    warnings = list(misfiled)
+    for asset_id, buckets in verdicts.items():
+        if len(buckets) > 1:
+            warnings.append(f"!! Cull gave contradictory verdicts for {asset_id}")
+            continue
+        decisions.append(CullDecision(asset_id, next(iter(buckets))))
+    return tuple(decisions), tuple(warnings)
+
+
+def _one_episode_entry(
+    entry: object,
+    tile_map: Mapping[int, str],
+    episode_tiles: Mapping[int, tuple[int, ...]],
+    seen_episodes: set[int],
+    verdicts: dict[str, set[str]],
+) -> tuple[str, ...] | None:
+    """This episode's misfiling notes, or None when the answer left the sheet."""
+    episode = _entry_episode(entry, episode_tiles, seen_episodes)
+    if episode is None:
+        return None
+    scope = frozenset(episode_tiles[episode])
+    misfiled: list[str] = []
+    assert isinstance(entry, dict)
+    for bucket in DISCARDED_BUCKETS:
+        named = entry.get(bucket)
+        # The partition binds the lists that REMOVE things. A discarded list
+        # cannot contradict anything that matters, so it is checked only for
+        # naming tiles this sheet really shows: a real month sent episode 1's
+        # ordinary list naming every tile and each later episode naming its own
+        # again, and holding that to the partition voided two packs of five.
+        if named is not None and _tiles_in(named, tile_map) is None:
+            return None
+    for bucket in CULL_BUCKETS:
+        tiles = _tiles_in(entry.get(bucket), tile_map)
+        if tiles is None:
+            return None
+        # Which episode a tile was filed under is bookkeeping; the judgement is
+        # about pixels this sheet really shows.
+        misfiled.extend(
+            f"!! Cull filed tile {tile} under episode {episode}"
+            for tile in tiles
+            if tile not in scope
+        )
+        for tile in tiles:
+            verdicts.setdefault(tile_map[tile], set()).add(bucket)
+    return tuple(misfiled)
+
+
+def _entry_episode(
+    entry: object,
+    episode_tiles: Mapping[int, tuple[int, ...]],
+    seen_episodes: set[int],
+) -> int | None:
+    """The episode this entry answers for, or None if it is not a usable entry."""
+    if not isinstance(entry, dict):
+        return None
+    # The discarded lists are optional: an answer that omits one has still
+    # answered, and voiding it over a key nothing acts on would be absurd.
+    if set(entry) - set(DISCARDED_BUCKETS) != set(CULL_SCOPE_WIRE_KEYS):
+        return None
+    episode = entry.get("episode")
+    if not _is_integer_alias(episode) or episode not in episode_tiles:
+        return None
+    if episode in seen_episodes:
+        return None
+    seen_episodes.add(episode)
+    return episode
+
+
+def _tiles_in(
+    value: object,
+    tile_map: Mapping[int, str],
+) -> tuple[int, ...] | None:
+    """Tiles named for one bucket, or None when the answer left the sheet."""
+    if not isinstance(value, list):
+        return None
+    tiles: list[int] = []
+    for tile in value:
+        # A tile this pack never showed means the answer stopped tracking which
+        # sheet it was reading, and nothing in it can be trusted.
+        if not _is_integer_alias(tile) or tile not in tile_map:
+            return None
+        tiles.append(tile)
+    return tuple(tiles)
+
+
+def _discard_unavailable_decisions(
+    rejects: tuple[CullDecision, ...],
+    unavailable_asset_ids: frozenset[str],
+) -> tuple[tuple[CullDecision, ...], tuple[str, ...]]:
+    """A decision about pixels nobody could see is not a decision."""
+    unavailable = tuple(
+        decision.asset_id for decision in rejects if decision.asset_id in unavailable_asset_ids
+    )
+    kept = tuple(decision for decision in rejects if decision.asset_id not in unavailable_asset_ids)
+    warnings = tuple(f"!! unavailable Cull decision: {asset_id}" for asset_id in unavailable)
+    return kept, warnings
+
+
+def _is_integer_alias(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)

--- a/src/immich_memories/analysis/editorial_contracts.py
+++ b/src/immich_memories/analysis/editorial_contracts.py
@@ -1,0 +1,79 @@
+"""Immutable records exchanged between editorial selection passes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DecisionProvenance:
+    """Evidence that lets a decision be reproduced from its original request."""
+
+    pass_name: str
+    pass_version: str
+    schema_version: str
+    model_identity: str
+    input_ids: tuple[str, ...]
+    sheet_hashes: tuple[str, ...]
+    request_key: str
+    cache_hit: bool
+
+
+@dataclass(frozen=True)
+class TraceDecision:
+    """One asset's named editorial fate."""
+
+    asset_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ConservationCheck:
+    """Whether an editorial pass gave every input exactly one fate."""
+
+    valid: bool
+    missing_ids: tuple[str, ...]
+    duplicate_ids: tuple[str, ...]
+    unexpected_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PassTrace:
+    """The immutable record of one editorial pass."""
+
+    name: str
+    input_ids: tuple[str, ...]
+    kept_ids: tuple[str, ...]
+    rejected: tuple[TraceDecision, ...]
+    unresolved: tuple[TraceDecision, ...]
+    duration_before: float
+    duration_after: float
+    provenance: DecisionProvenance
+    request_traces: tuple[RequestTrace, ...] = ()
+    conservation: ConservationCheck | None = None
+
+
+@dataclass(frozen=True)
+class RequestTrace:
+    """The request provenance associated with one editorial pass."""
+
+    provenance: DecisionProvenance
+    attached_sheet_hashes: tuple[str, ...]
+    planned_calls: int = 1
+    actual_calls: int = 0
+    cache_hit: bool = False
+    tile_count: int = 0
+    provider: str = ""
+    model: str = ""
+    attempts: tuple[RequestAttemptTrace, ...] = ()
+    original_provenance: DecisionProvenance | None = None
+
+
+@dataclass(frozen=True)
+class RequestAttemptTrace:
+    """One wire attempt, including failures and request dialect adjustments."""
+
+    attempt: int
+    outcome: str
+    status_code: int | None = None
+    adaptation: str | None = None

--- a/src/immich_memories/analysis/editorial_contracts.py
+++ b/src/immich_memories/analysis/editorial_contracts.py
@@ -2,7 +2,186 @@
 
 from __future__ import annotations
 
+import json
+import math
 from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from immich_memories.api.models import Asset
+
+LIVE_PHOTO_RENDERING_FAMILY_VERSION = "live-photo-rendering-family-v1"
+
+
+@dataclass(frozen=True)
+class EditorialCandidate:
+    """One source-eligible visual before any editorial decision has happened."""
+
+    asset_id: str
+    taken_at: datetime
+    media_kind: Literal["photo", "video", "live_photo"]
+    live_photo_stitch_member_ids: tuple[str, ...]
+    rendering_family_id: str | None
+    favourite: bool
+    source: Asset
+    proposed_segment: tuple[float, float] | None
+    shippable_duration: float
+    grounded_annotations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LivePhotoRenderingFamily:
+    """Source-owned aligned options for one later still-or-motion rendering choice."""
+
+    family_id: str
+    still_ids: tuple[str, ...]
+    video_ids: tuple[str, ...]
+    trim_points: tuple[tuple[float, float], ...]
+    shutter_timestamps: tuple[float, ...]
+    motion_duration_seconds: float | None = None
+    minimum_motion_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        _validate_rendering_family_ids(self)
+        _validate_rendering_family_timing(self)
+        _validate_rendering_family_durations(self)
+        expected = live_photo_rendering_family_id(
+            self.still_ids,
+            self.video_ids,
+            self.trim_points,
+            self.shutter_timestamps,
+            motion_duration_seconds=self.motion_duration_seconds,
+            minimum_motion_seconds=self.minimum_motion_seconds,
+        )
+        if self.family_id != expected:
+            raise ValueError("Live Photo rendering family ID must hash its canonical manifest")
+
+
+def _validate_rendering_family_ids(family: LivePhotoRenderingFamily) -> None:
+    size = len(family.still_ids)
+    aligned_sizes = (
+        len(family.video_ids),
+        len(family.trim_points),
+        len(family.shutter_timestamps),
+    )
+    unique = len(set(family.still_ids)) == size == len(set(family.video_ids))
+    nonblank = all(value.strip() for value in (*family.still_ids, *family.video_ids))
+    if size == 0 or any(item != size for item in aligned_sizes) or not unique or not nonblank:
+        raise ValueError("Live Photo rendering family needs unique aligned source IDs")
+
+
+def _validate_rendering_family_timing(family: LivePhotoRenderingFamily) -> None:
+    trims_are_safe = all(
+        _is_finite_number(start) and _is_finite_number(end) and start >= 0 and end > start
+        for start, end in family.trim_points
+    )
+    shutters_are_safe = all(_is_finite_number(value) for value in family.shutter_timestamps)
+    if not trims_are_safe or not shutters_are_safe:
+        raise ValueError("Live Photo rendering family needs safe aligned timing")
+    order = tuple(zip(family.shutter_timestamps, family.still_ids, strict=True))
+    if order != tuple(sorted(order)):
+        raise ValueError("Live Photo rendering family entries must be chronological")
+
+
+def _validate_rendering_family_durations(family: LivePhotoRenderingFamily) -> None:
+    durations = (family.motion_duration_seconds, family.minimum_motion_seconds)
+    paired = (durations[0] is None) == (durations[1] is None)
+    safe = all(value is None or (_is_finite_number(value) and value > 0) for value in durations)
+    if not paired or not safe:
+        raise ValueError("Live Photo rendering duration and minimum must be safe and paired")
+
+
+def _is_finite_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def live_photo_rendering_family_id(
+    still_ids: tuple[str, ...],
+    video_ids: tuple[str, ...],
+    trim_points: tuple[tuple[float, float], ...],
+    shutter_timestamps: tuple[float, ...],
+    *,
+    motion_duration_seconds: float | None,
+    minimum_motion_seconds: float | None,
+) -> str:
+    """Hash the versioned aligned rendering manifest without choosing a render mode."""
+    manifest = {
+        "version": LIVE_PHOTO_RENDERING_FAMILY_VERSION,
+        "entries": [
+            {
+                "still_id": still_id,
+                "video_id": video_id,
+                "trim_point": [start, end],
+                "shutter_timestamp": timestamp,
+            }
+            for still_id, video_id, (start, end), timestamp in zip(
+                still_ids,
+                video_ids,
+                trim_points,
+                shutter_timestamps,
+                strict=True,
+            )
+        ],
+        "motion_duration_seconds": motion_duration_seconds,
+        "minimum_motion_seconds": minimum_motion_seconds,
+    }
+    digest = sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    ).hexdigest()
+    return f"{LIVE_PHOTO_RENDERING_FAMILY_VERSION}-{digest}"
+
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    """Precomputed source measurements supplied without running new analysis."""
+
+    blur: float | None = None
+    exposure: float | None = None
+    similarity: str | None = None
+
+
+@dataclass(frozen=True)
+class InsightEvidence:
+    """One period observation grounded in the episodes and pixels that support it."""
+
+    observation: str
+    episode_ids: tuple[str, ...]
+    asset_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.observation.strip():
+            raise ValueError("insight evidence observation cannot be blank")
+        if not self.episode_ids or any(not episode_id.strip() for episode_id in self.episode_ids):
+            raise ValueError("insight evidence needs nonblank episode IDs")
+        if not self.asset_ids or any(not asset_id.strip() for asset_id in self.asset_ids):
+            raise ValueError("insight evidence needs nonblank asset IDs")
+
+
+@dataclass(frozen=True)
+class PeriodInsight:
+    """The provisional reading of one complete period wall."""
+
+    thesis: str | None
+    evidence: tuple[InsightEvidence, ...]
+    tensions: tuple[str, ...]
+    recurring_threads: tuple[str, ...]
+    unavailable_reason: str | None
+    revision: int
+    provenance: DecisionProvenance
+
+    def __post_init__(self) -> None:
+        if self.revision < 0:
+            raise ValueError("period insight revision cannot be negative")
+        if (self.thesis is None) == (self.unavailable_reason is None):
+            raise ValueError("period insight needs exactly one thesis or unavailable reason")
+        if self.thesis is not None and (not self.thesis.strip() or not self.evidence):
+            raise ValueError("period insight thesis needs visual evidence")
+        if self.unavailable_reason is not None and not self.unavailable_reason.strip():
+            raise ValueError("period insight unavailable reason cannot be blank")
+        if any(not item.episode_ids or not item.asset_ids for item in self.evidence):
+            raise ValueError("period insight evidence must identify episodes and assets")
 
 
 @dataclass(frozen=True)

--- a/src/immich_memories/analysis/editorial_gateway.py
+++ b/src/immich_memories/analysis/editorial_gateway.py
@@ -30,6 +30,15 @@ __all__ = [
 ]
 
 
+# Every pass behind this gateway DECIDES something, so it is asked greedily
+# rather than sampled. Measured on one real pack, four repeats each: at the
+# transport default of 0.3 no two answers matched and one named all 105 tiles
+# in the pack; at 0 all four responses were byte-identical. Sampling also makes
+# a banked answer a lie -- the cache would return something re-asking would not
+# have produced.
+EDITORIAL_TEMPERATURE = 0.0
+
+
 @dataclass(frozen=True)
 class VisualEditorialRequest:
     """All non-semantic evidence and versioning supplied to one visual pass."""
@@ -59,6 +68,7 @@ class BankedVisualAnswer:
     raw_text: str
     provenance: DecisionProvenance
     original_provenance: DecisionProvenance
+    request_trace: RequestTrace
 
 
 class EditorialGateway(Protocol):
@@ -94,7 +104,11 @@ class VisualEditorialGateway:
             render_version=request.render_version,
             layout_versions=tuple(page.layout_version for page in request.pages),
             upstream_material=request.upstream_material,
-            request_limits=(f"max_pages={request.limits.max_pages_per_request}",),
+            request_limits=(
+                f"max_pages={request.limits.max_pages_per_request}",
+                f"max_output_tokens={request.limits.max_output_tokens}",
+                f"timeout_seconds={request.limits.timeout_seconds}",
+            ),
             continuation_identity=(request.continuation_number, request.continuation_count),
             endpoint=self.llm_config.base_url.rstrip("/"),
         )
@@ -106,14 +120,14 @@ class VisualEditorialGateway:
             provenance = _provenance(
                 request, page_hashes, request_key, cache_hit=True, model=self.llm_config.model
             )
-            self._record(
+            request_trace = self._record(
                 provenance,
                 request.pages,
                 page_hashes,
                 cache_hit=True,
                 original_provenance=original,
             )
-            return BankedVisualAnswer(raw_text, provenance, original)
+            return BankedVisualAnswer(raw_text, provenance, original, request_trace)
 
         provenance = _provenance(
             request, page_hashes, request_key, cache_hit=False, model=self.llm_config.model
@@ -133,19 +147,22 @@ class VisualEditorialGateway:
         try:
             raw_text = _run_sync(
                 query_llm(
-                    request.prompt,
+                    _provider_prompt(request),
                     self.llm_config,
+                    temperature=EDITORIAL_TEMPERATURE,
                     thinking=request.thinking,
                     images=tuple(page.jpeg_bytes for page in request.pages),
                     image_detail=request.image_detail,
                     transport_observer=record_attempt,
                     require_complete=True,
+                    max_tokens=request.limits.max_output_tokens,
+                    timeout_seconds=request.limits.timeout_seconds,
                 )
             )
             if not raw_text.strip():
                 raise ValueError("visual editorial answer must be nonblank")
-        except Exception:
-            self._record(
+        except Exception as exc:
+            failed_trace = self._record(
                 provenance,
                 request.pages,
                 page_hashes,
@@ -153,9 +170,10 @@ class VisualEditorialGateway:
                 actual_calls=len(attempts),
                 attempts=tuple(attempts),
             )
+            setattr(exc, "request_trace", failed_trace)  # noqa: B010 - preserve original exception
             raise
         self.cache.remember(request_key, raw_text, _provenance_json(provenance))
-        self._record(
+        request_trace = self._record(
             provenance,
             request.pages,
             page_hashes,
@@ -163,7 +181,7 @@ class VisualEditorialGateway:
             actual_calls=len(attempts),
             attempts=tuple(attempts),
         )
-        return BankedVisualAnswer(raw_text, provenance, provenance)
+        return BankedVisualAnswer(raw_text, provenance, provenance, request_trace)
 
     def _record(
         self,
@@ -175,20 +193,20 @@ class VisualEditorialGateway:
         actual_calls: int = 0,
         original_provenance: DecisionProvenance | None = None,
         attempts: tuple[RequestAttemptTrace, ...] = (),
-    ) -> None:
-        self.trace.record_request(
-            RequestTrace(
-                provenance=provenance,
-                attached_sheet_hashes=page_hashes,
-                actual_calls=actual_calls,
-                cache_hit=cache_hit,
-                tile_count=sum(len(page.tile_refs) for page in pages),
-                provider=self.llm_config.provider,
-                model=self.llm_config.model,
-                attempts=attempts,
-                original_provenance=original_provenance,
-            )
+    ) -> RequestTrace:
+        request_trace = RequestTrace(
+            provenance=provenance,
+            attached_sheet_hashes=page_hashes,
+            actual_calls=actual_calls,
+            cache_hit=cache_hit,
+            tile_count=sum(len(page.tile_refs) for page in pages),
+            provider=self.llm_config.provider,
+            model=self.llm_config.model,
+            attempts=attempts,
+            original_provenance=original_provenance,
         )
+        self.trace.record_request(request_trace)
+        return request_trace
 
 
 def _validated_page_hashes(pages: tuple[ContactSheetPage, ...]) -> tuple[str, ...]:
@@ -198,6 +216,17 @@ def _validated_page_hashes(pages: tuple[ContactSheetPage, ...]) -> tuple[str, ..
     if any(digest != page.sha256 for digest, page in zip(hashes, pages, strict=True)):
         raise ValueError("contact sheet digest does not match its exact bytes")
     return hashes
+
+
+def _provider_prompt(request: VisualEditorialRequest) -> str:
+    if not request.grounded_annotations:
+        return request.prompt
+    annotations = json.dumps(
+        request.grounded_annotations,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return f"{request.prompt}\n\nGrounded annotations (ordered JSON):\n{annotations}"
 
 
 def _run_sync(coroutine: object) -> str:

--- a/src/immich_memories/analysis/editorial_gateway.py
+++ b/src/immich_memories/analysis/editorial_gateway.py
@@ -1,0 +1,260 @@
+"""Provider-neutral, synchronous gateway for banked visual editorial calls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Protocol
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    RequestAttemptTrace,
+    RequestTrace,
+)
+from immich_memories.analysis.llm_query import LLMTransportAttempt, query_llm
+from immich_memories.analysis.selection_trace import Trace
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+from immich_memories.cache.judgment_cache import VisualJudgmentCache, VisualJudgmentIdentity
+from immich_memories.config_models_llm import LLMConfig
+
+__all__ = [
+    "BankedVisualAnswer",
+    "EditorialGateway",
+    "VisualEditorialGateway",
+    "VisualEditorialRequest",
+]
+
+
+@dataclass(frozen=True)
+class VisualEditorialRequest:
+    """All non-semantic evidence and versioning supplied to one visual pass."""
+
+    pass_name: str
+    pass_version: str
+    prompt: str
+    prompt_version: str
+    schema_version: str
+    pages: tuple[ContactSheetPage, ...]
+    ordered_input_ids: tuple[str, ...]
+    ordered_group_ids: tuple[str, ...]
+    grounded_annotations: tuple[str, ...]
+    upstream_material: tuple[str, ...]
+    render_version: str
+    limits: VisionRequestLimits
+    thinking: bool = False
+    image_detail: str = "low"
+    continuation_number: int = 1
+    continuation_count: int = 1
+
+
+@dataclass(frozen=True)
+class BankedVisualAnswer:
+    """The raw model answer and provenance for pass-specific parsers to own."""
+
+    raw_text: str
+    provenance: DecisionProvenance
+    original_provenance: DecisionProvenance
+
+
+class EditorialGateway(Protocol):
+    """The only provider-neutral boundary used by editorial passes."""
+
+    def ask(self, request: VisualEditorialRequest) -> BankedVisualAnswer:
+        """Bank and return a complete raw visual answer."""
+
+
+class VisualEditorialGateway:
+    """Synchronous adapter that reuses the established LLM transport."""
+
+    def __init__(self, *, llm_config: LLMConfig, cache_path: Path, trace: Trace) -> None:
+        self.llm_config = llm_config
+        self.cache = VisualJudgmentCache(cache_path)
+        self.trace = trace
+
+    def ask(self, request: VisualEditorialRequest) -> BankedVisualAnswer:
+        """Attach exact page bytes once, or reuse their already banked answer."""
+        page_hashes = _validated_page_hashes(request.pages)
+        identity = VisualJudgmentIdentity(
+            page_bytes=tuple(page.jpeg_bytes for page in request.pages),
+            ordered_input_ids=request.ordered_input_ids,
+            ordered_group_ids=request.ordered_group_ids,
+            annotations=request.grounded_annotations,
+            model=self.llm_config.model,
+            thinking=request.thinking,
+            image_detail=request.image_detail,
+            pass_name=request.pass_name,
+            pass_version=request.pass_version,
+            prompt_version=request.prompt_version,
+            schema_version=request.schema_version,
+            render_version=request.render_version,
+            layout_versions=tuple(page.layout_version for page in request.pages),
+            upstream_material=request.upstream_material,
+            request_limits=(f"max_pages={request.limits.max_pages_per_request}",),
+            continuation_identity=(request.continuation_number, request.continuation_count),
+            endpoint=self.llm_config.base_url.rstrip("/"),
+        )
+        request_key = identity.key()
+        reused = self.cache.answer_for(request_key)
+        if reused is not None:
+            raw_text, original_serialized = reused
+            original = _provenance_from_json(original_serialized)
+            provenance = _provenance(
+                request, page_hashes, request_key, cache_hit=True, model=self.llm_config.model
+            )
+            self._record(
+                provenance,
+                request.pages,
+                page_hashes,
+                cache_hit=True,
+                original_provenance=original,
+            )
+            return BankedVisualAnswer(raw_text, provenance, original)
+
+        provenance = _provenance(
+            request, page_hashes, request_key, cache_hit=False, model=self.llm_config.model
+        )
+        attempts: list[RequestAttemptTrace] = []
+
+        def record_attempt(attempt: LLMTransportAttempt) -> None:
+            attempts.append(
+                RequestAttemptTrace(
+                    attempt=attempt.attempt,
+                    outcome=attempt.outcome,
+                    status_code=attempt.status_code,
+                    adaptation=attempt.adaptation,
+                )
+            )
+
+        try:
+            raw_text = _run_sync(
+                query_llm(
+                    request.prompt,
+                    self.llm_config,
+                    thinking=request.thinking,
+                    images=tuple(page.jpeg_bytes for page in request.pages),
+                    image_detail=request.image_detail,
+                    transport_observer=record_attempt,
+                    require_complete=True,
+                )
+            )
+            if not raw_text.strip():
+                raise ValueError("visual editorial answer must be nonblank")
+        except Exception:
+            self._record(
+                provenance,
+                request.pages,
+                page_hashes,
+                cache_hit=False,
+                actual_calls=len(attempts),
+                attempts=tuple(attempts),
+            )
+            raise
+        self.cache.remember(request_key, raw_text, _provenance_json(provenance))
+        self._record(
+            provenance,
+            request.pages,
+            page_hashes,
+            cache_hit=False,
+            actual_calls=len(attempts),
+            attempts=tuple(attempts),
+        )
+        return BankedVisualAnswer(raw_text, provenance, provenance)
+
+    def _record(
+        self,
+        provenance: DecisionProvenance,
+        pages: tuple[ContactSheetPage, ...],
+        page_hashes: tuple[str, ...],
+        *,
+        cache_hit: bool,
+        actual_calls: int = 0,
+        original_provenance: DecisionProvenance | None = None,
+        attempts: tuple[RequestAttemptTrace, ...] = (),
+    ) -> None:
+        self.trace.record_request(
+            RequestTrace(
+                provenance=provenance,
+                attached_sheet_hashes=page_hashes,
+                actual_calls=actual_calls,
+                cache_hit=cache_hit,
+                tile_count=sum(len(page.tile_refs) for page in pages),
+                provider=self.llm_config.provider,
+                model=self.llm_config.model,
+                attempts=attempts,
+                original_provenance=original_provenance,
+            )
+        )
+
+
+def _validated_page_hashes(pages: tuple[ContactSheetPage, ...]) -> tuple[str, ...]:
+    if not pages:
+        raise ValueError("visual editorial requests need at least one page")
+    hashes = tuple(sha256(page.jpeg_bytes).hexdigest() for page in pages)
+    if any(digest != page.sha256 for digest, page in zip(hashes, pages, strict=True)):
+        raise ValueError("contact sheet digest does not match its exact bytes")
+    return hashes
+
+
+def _run_sync(coroutine: object) -> str:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)  # type: ignore[arg-type]
+    result: list[str] = []
+    failure: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            result.append(asyncio.run(coroutine))  # type: ignore[arg-type]
+        except BaseException as exc:  # WHY: preserve the provider exception across the bridge
+            failure.append(exc)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join()
+    if failure:
+        raise failure[0]
+    return result[0]
+
+
+def _provenance(
+    request: VisualEditorialRequest,
+    page_hashes: tuple[str, ...],
+    request_key: str,
+    *,
+    cache_hit: bool,
+    model: str,
+) -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name=request.pass_name,
+        pass_version=request.pass_version,
+        schema_version=request.schema_version,
+        model_identity=model,
+        input_ids=request.ordered_input_ids,
+        sheet_hashes=page_hashes,
+        request_key=request_key,
+        cache_hit=cache_hit,
+    )
+
+
+def _provenance_json(provenance: DecisionProvenance) -> str:
+    return json.dumps(provenance.__dict__, sort_keys=True)
+
+
+def _provenance_from_json(serialized: str) -> DecisionProvenance:
+    values = json.loads(serialized)
+    return DecisionProvenance(
+        pass_name=values["pass_name"],
+        pass_version=values["pass_version"],
+        schema_version=values["schema_version"],
+        model_identity=values["model_identity"],
+        input_ids=tuple(values["input_ids"]),
+        sheet_hashes=tuple(values["sheet_hashes"]),
+        request_key=values["request_key"],
+        cache_hit=bool(values["cache_hit"]),
+    )

--- a/src/immich_memories/analysis/episode_scan_request.py
+++ b/src/immich_memories/analysis/episode_scan_request.py
@@ -1,0 +1,180 @@
+"""Provider-visible request for fused episode reading, record, and Cull namespaces."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from immich_memories.analysis.contact_sheets import TileRef
+from immich_memories.analysis.cull_answer import (
+    CULL_SCOPE_WIRE_KEYS,
+    DISCARDED_BUCKETS,
+)
+from immich_memories.analysis.editorial_contracts import (
+    EditorialCandidate,
+)
+from immich_memories.analysis.editorial_gateway import VisualEditorialRequest
+from immich_memories.analysis.period_insight_answer import (
+    EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+    EPISODE_SCAN_SCHEMA_VERSION,
+    EPISODE_VISUAL_SUMMARY_MAX_CHARS,
+)
+from immich_memories.analysis.subject_policy import subject_evidence
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.period_insight import EpisodeScanPack
+
+EPISODE_SCAN_PASS_VERSION = "episode-scan-v4"  # noqa: S105 - editorial pass identity
+EPISODE_SCAN_PROMPT_VERSION = "episode-scan-prompt-v4"
+_RENDER_VERSION = "visual-atlas-v1/contact-sheet-v1"
+
+
+def episode_response_shape(*, episode_alias: int, tile: int) -> str:
+    """One complete example envelope, built from the keys the parser demands.
+
+    Both decision lists are shown EMPTY. Everything in an example is
+    instruction, values included: shown a populated one, the model copied it
+    onto unrelated visuals. An empty list is also the honest default.
+    """
+    return json.dumps(
+        {
+            "schema_version": EPISODE_SCAN_SCHEMA_VERSION,
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": episode_alias,
+                    "page": 1,
+                    "visual_summary": "what this episode shows",
+                    "representative_tiles": [tile],
+                    "representative_reason": "why these read best on a wall",
+                }
+            ],
+            "cull_rejects": [
+                dict.fromkeys((*CULL_SCOPE_WIRE_KEYS[1:], *DISCARDED_BUCKETS), [])
+                | {"episode": episode_alias}
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+
+def build_episode_request(
+    pack: EpisodeScanPack,
+    *,
+    limits: VisionRequestLimits,
+) -> VisualEditorialRequest:
+    """Build the one physical request shared by Pass 0 and Pass 1."""
+    _validate_v3_one_page_pack(pack)
+    return VisualEditorialRequest(
+        pass_name="episode-scan",  # noqa: S106 - versioned editorial pass identity
+        pass_version=EPISODE_SCAN_PASS_VERSION,
+        prompt=_episode_prompt(pack),
+        prompt_version=EPISODE_SCAN_PROMPT_VERSION,
+        schema_version=EPISODE_SCAN_SCHEMA_VERSION,
+        pages=(pack.page,),
+        ordered_input_ids=tuple(ref.entity_id for ref in pack.page.tile_refs),
+        ordered_group_ids=tuple(scope.episode_id for scope in pack.scopes),
+        grounded_annotations=_episode_annotations(pack),
+        upstream_material=(),
+        render_version=_RENDER_VERSION,
+        limits=limits,
+        continuation_number=pack.continuation_number,
+        continuation_count=pack.continuation_count,
+    )
+
+
+def _validate_v3_one_page_pack(pack: EpisodeScanPack) -> None:
+    """Keep v3 aliases pack-local; multi-page requests require a schema/version bump."""
+    page_refs = pack.page.tile_refs
+    page_numbers = tuple(ref.number for ref in page_refs)
+    scoped_refs = tuple(ref for scope in pack.scopes for ref in scope.tile_refs)
+    if len(page_numbers) != len(set(page_numbers)):
+        raise ValueError("episode-scan-v3 needs unique pack-local tile numbers")
+    if any(scope.page_id != pack.page.sheet_id or scope.page_alias != 1 for scope in pack.scopes):
+        raise ValueError("episode-scan-v3 supports exactly one physical page per request")
+    if sorted(scoped_refs, key=lambda ref: ref.number) != sorted(
+        page_refs, key=lambda ref: ref.number
+    ):
+        raise ValueError("episode-scan-v3 scopes must exactly partition the physical page")
+
+
+def _episode_prompt(pack: EpisodeScanPack) -> str:
+    # The example carries a tile this pack really has, so copying it verbatim
+    # costs a wrong mark rather than voiding the namespace on an unknown alias.
+    first_tile = pack.page.tile_refs[0].number
+    scopes = "\n".join(
+        f"episode={scope.episode_alias} page={scope.page_alias} "
+        f"tiles=[{','.join(str(ref.number) for ref in scope.tile_refs)}]"
+        for scope in pack.scopes
+    )
+    return (
+        "Read every numbered visual on this chronological episode pack. The explicit tile map "
+        "below preserves complete episodes even when their members interleave in time:\n"
+        + scopes
+        + "\nReturn only one complete "
+        f'JSON object with schema_version="{EPISODE_SCAN_SCHEMA_VERSION}", pack=1, and one '
+        "episode_readings entry for every mapped episode. Each entry needs the integer episode "
+        "and page aliases, visual_summary (at most "
+        f"{EPISODE_VISUAL_SUMMARY_MAX_CHARS} characters), representative_tiles from that episode, "
+        "and a representative_reason grounded in the visible pixels (at most "
+        f"{EPISODE_REPRESENTATIVE_REASON_MAX_CHARS} characters). Representatives make a later "
+        "wall legible. All episode and record text must use printable ASCII except double quote "
+        "and backslash; use one line with no control characters. Apostrophes and basic punctuation "
+        "are allowed. "
+        "Representatives reject nothing. Then, for EACH episode above, look only at that "
+        "episode's own tiles and sort them into three lists. notes: taken as a note rather than "
+        "as a memory, such as a screen, a document, or an object photographed to record what "
+        "it is. failed: the picture did not come out, being obstructed, smeared, or "
+        "unreadable. ordinary: nothing wrong with it, just unremarkable or one of several "
+        "alike. Most tiles are ordinary, and empty notes and failed lists are the normal "
+        "answer. Never list a tile "
+        "that belongs to another episode. Use exactly these keys and no others:\n"
+        + episode_response_shape(episode_alias=pack.scopes[0].episode_alias, tile=first_tile)
+    )
+
+
+def _episode_annotations(pack: EpisodeScanPack) -> tuple[str, ...]:
+    candidate_by_id = {
+        candidate.asset_id: candidate for scope in pack.scopes for candidate in scope.candidates
+    }
+    episode_alias_by_id = {
+        ref.entity_id: scope.episode_alias for scope in pack.scopes for ref in scope.tile_refs
+    }
+    return tuple(
+        _candidate_annotation(
+            ref,
+            candidate_by_id[ref.entity_id],
+            episode_alias_by_id[ref.entity_id],
+        )
+        for ref in pack.page.tile_refs
+    )
+
+
+def _candidate_annotation(
+    ref: TileRef,
+    candidate: EditorialCandidate,
+    episode_alias: int,
+) -> str:
+    category = next(
+        (
+            annotation.removeprefix("subject:")
+            for annotation in candidate.grounded_annotations
+            if annotation.startswith("subject:")
+        ),
+        None,
+    )
+    return " | ".join(
+        (
+            f"tile:{ref.number}",
+            f"episode:{episode_alias}",
+            f"taken:{candidate.taken_at.isoformat()}",
+            f"media:{candidate.media_kind}",
+            f"favourite:{str(candidate.favourite).lower()}",
+            subject_evidence(
+                tagged_people=len(candidate.source.people or ()),
+                category=category,
+            ),
+            *candidate.grounded_annotations,
+        )
+    )

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -163,10 +163,18 @@ def build_llm_timeout(read_timeout: float) -> httpx.Timeout:
     )
 
 
+# Every model call this project makes is a judgement it wants back the same way
+# twice: a description that feeds a decision, or a decision itself. Sampling was
+# measured turning one real pack's answer over four repeats into four different
+# answers, one of which named all 105 tiles. Greedy decoding also makes the
+# judgement cache honest -- a banked answer is what re-asking would return.
+DEFAULT_TEMPERATURE = 0.0
+
+
 async def query_llm(
     prompt: str,
     llm_config: LLMConfig,
-    temperature: float = 0.3,
+    temperature: float = DEFAULT_TEMPERATURE,
     max_tokens: int = 500,
     timeout_seconds: int = 30,
     thinking: bool = False,
@@ -286,6 +294,7 @@ async def _dispatch(
             prompt,
             llm_config,
             temperature,
+            max_tokens,
             timeout_seconds,
             images,
             transport_observer,
@@ -322,6 +331,7 @@ async def _query_ollama(
     prompt: str,
     config: LLMConfig,
     temperature: float,
+    max_tokens: int,
     timeout: int,
     images: Sequence[bytes] = (),
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
@@ -344,6 +354,7 @@ async def _query_ollama(
             payload["options"].update(value)
         else:
             payload[name] = value
+    payload["options"]["num_predict"] = max_tokens
     async with httpx.AsyncClient(timeout=build_llm_timeout(float(timeout))) as client:
         try:
             resp = await client.post(f"{base_url}/api/generate", json=payload)

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import logging
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
@@ -22,10 +23,21 @@ from immich_memories.analysis import llm_metrics
 from immich_memories.config_models_llm import LLMConfig
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LLMTransportAttempt:
+    """One actual HTTP POST outcome, kept separate from accepted-reply metrics."""
+
+    attempt: int
+    outcome: str
+    status_code: int | None
+    adaptation: str | None = None
+
 
 # A stuck server should fail while connecting, not hold the full generation
 # budget. httpx timeouts are per-I/O-operation rather than per-request totals,
@@ -110,16 +122,32 @@ def _shape_for_provider(payload: dict, config: LLMConfig) -> None:
 
 
 async def _post_adapted(
-    client: httpx.AsyncClient, url: str, payload: dict, adaptations: set[str]
+    client: httpx.AsyncClient,
+    url: str,
+    payload: dict,
+    adaptations: set[str],
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> httpx.Response:
     """POST, negotiating parameter dialects on explicit 400s (one per rule)."""
     while True:
-        resp = await client.post(url, json=payload)
+        try:
+            resp = await client.post(url, json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
         if resp.status_code != 400:
             return resp
-        adaptation = _adaptation_for(resp.json().get("error", {}).get("message", ""))
+        try:
+            error = _response_body(resp).get("error", {})
+            if not isinstance(error, dict):
+                raise TypeError("LLM error body is not an object")
+            adaptation = _adaptation_for(str(error.get("message", "")))
+        except (TypeError, ValueError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
         if adaptation is None or adaptation in adaptations:
             return resp
+        _observe(transport_observer, 1, "dialect_adaptation", resp.status_code, adaptation)
         adaptations.add(adaptation)
         _apply_adaptations(payload, adaptations)
         logger.info("LLM server dialect: adapting request (%s)", adaptation)
@@ -145,6 +173,8 @@ async def query_llm(
     images: Sequence[bytes] = (),
     image_detail: str = "low",
     cache_path: Path | None = None,
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     """Send a prompt, optionally with JPEG images, and return the response.
 
@@ -172,6 +202,18 @@ async def query_llm(
         logger.debug("Reusing the answer to an identical question")
         llm_metrics.record_cache_hit()
         return remembered
+    attempt_number = 0
+
+    def observe(attempt: LLMTransportAttempt) -> None:
+        nonlocal attempt_number
+        attempt_number += 1
+        if transport_observer is not None:
+            transport_observer(
+                LLMTransportAttempt(
+                    attempt_number, attempt.outcome, attempt.status_code, attempt.adaptation
+                )
+            )
+
     started = time.monotonic()
     try:
         answer = await _dispatch(
@@ -183,6 +225,8 @@ async def query_llm(
             thinking,
             images,
             image_detail,
+            observe,
+            require_complete,
         )
     finally:
         # In `finally` so a failed call still shows the time it burned; a run
@@ -234,16 +278,43 @@ async def _dispatch(
     thinking: bool,
     images: Sequence[bytes],
     image_detail: str,
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     if llm_config.provider == "ollama":
-        return await _query_ollama(prompt, llm_config, temperature, timeout_seconds, images)
+        return await _query_ollama(
+            prompt,
+            llm_config,
+            temperature,
+            timeout_seconds,
+            images,
+            transport_observer,
+            require_complete,
+        )
     think = thinking and llm_config.thinking and not images
     if llm_config.provider == "anthropic":
         return await _query_anthropic(
-            prompt, llm_config, temperature, max_tokens, timeout_seconds, think, images
+            prompt,
+            llm_config,
+            temperature,
+            max_tokens,
+            timeout_seconds,
+            think,
+            images,
+            transport_observer,
+            require_complete,
         )
     return await _query_openai(
-        prompt, llm_config, temperature, max_tokens, timeout_seconds, think, images, image_detail
+        prompt,
+        llm_config,
+        temperature,
+        max_tokens,
+        timeout_seconds,
+        think,
+        images,
+        image_detail,
+        transport_observer,
+        require_complete,
     )
 
 
@@ -253,6 +324,8 @@ async def _query_ollama(
     temperature: float,
     timeout: int,
     images: Sequence[bytes] = (),
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     payload: dict = {
@@ -272,14 +345,37 @@ async def _query_ollama(
         else:
             payload[name] = value
     async with httpx.AsyncClient(timeout=build_llm_timeout(float(timeout))) as client:
-        resp = await client.post(f"{base_url}/api/generate", json=payload)
-        resp.raise_for_status()
-        body = resp.json()
+        try:
+            resp = await client.post(f"{base_url}/api/generate", json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError:
+            _observe(transport_observer, 1, "http_error", resp.status_code)
+            raise
+        try:
+            body = _response_body(resp)
+        except (TypeError, ValueError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
+        if require_complete and body.get("done_reason") in {"length", "max_tokens", "truncated"}:
+            _observe(transport_observer, 1, "incomplete", resp.status_code)
+            raise ValueError("LLM returned incomplete content")
         llm_metrics.record_reply(
             prompt_tokens=body.get("prompt_eval_count", 0) or 0,
             completion_tokens=body.get("eval_count", 0) or 0,
         )
-        return body["response"]
+        try:
+            raw_text = body["response"]
+            if not isinstance(raw_text, str):
+                raise TypeError("Ollama response content is not text")
+        except (KeyError, TypeError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
+        _observe(transport_observer, 1, "response", resp.status_code)
+        return raw_text
 
 
 def _anthropic_content(prompt: str, images: Sequence[bytes]) -> str | list[dict]:
@@ -310,6 +406,8 @@ async def _query_anthropic(
     timeout: int,
     thinking: bool = False,
     images: Sequence[bytes] = (),
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     """Native /v1/messages dialect: Claude, or z.ai's Anthropic endpoint."""
     base_url = config.base_url.rstrip("/")
@@ -331,21 +429,42 @@ async def _query_anthropic(
     async with httpx.AsyncClient(
         timeout=build_llm_timeout(float(timeout)), headers=headers
     ) as client:
-        resp = await client.post(f"{base_url}/v1/messages", json=payload)
-        resp.raise_for_status()
-        body = resp.json()
-        usage = body.get("usage") or {}
+        try:
+            resp = await client.post(f"{base_url}/v1/messages", json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError:
+            _observe(transport_observer, 1, "http_error", resp.status_code)
+            raise
+        body, usage = _anthropic_usage(resp, transport_observer)
         llm_metrics.record_reply(
             prompt_tokens=usage.get("input_tokens", 0) or 0,
             completion_tokens=usage.get("output_tokens", 0) or 0,
         )
+        raw_text = _anthropic_answer(body, resp, transport_observer)
+        if body.get("stop_reason") == "max_tokens" and require_complete:
+            _observe(transport_observer, 1, "incomplete", resp.status_code)
+            raise ValueError("LLM returned incomplete content")
         if thinking and body.get("stop_reason") == "max_tokens":
+            _observe(transport_observer, 1, "thinking_fallback", resp.status_code)
             llm_metrics.record_truncation()
             logger.warning("Thinking hit the token budget; retrying without thinking")
             return await _query_anthropic(
-                prompt, config, temperature, max_tokens, timeout, thinking=False, images=images
+                prompt,
+                config,
+                temperature,
+                max_tokens,
+                timeout,
+                thinking=False,
+                images=images,
+                transport_observer=transport_observer,
+                require_complete=require_complete,
             )
-        return "".join(b.get("text", "") for b in body["content"] if b.get("type") == "text")
+        _observe(transport_observer, 1, "response", resp.status_code)
+        return raw_text
 
 
 def _openai_content(
@@ -381,6 +500,8 @@ async def _query_openai(
     thinking: bool = False,
     images: Sequence[bytes] = (),
     image_detail: str = "low",
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     headers: dict[str, str] = {}
@@ -413,16 +534,18 @@ async def _query_openai(
         timeout=build_llm_timeout(float(timeout)), headers=headers
     ) as client:
         for attempt in range(3):
-            resp = await _post_adapted(client, f"{base_url}/chat/completions", payload, adaptations)
-            resp.raise_for_status()
-            body = resp.json()
-            choice = body["choices"][0]
-            usage = body.get("usage") or {}
-            llm_metrics.record_reply(
-                prompt_tokens=usage.get("prompt_tokens", 0) or 0,
-                completion_tokens=usage.get("completion_tokens", 0) or 0,
+            resp = await _post_adapted(
+                client, f"{base_url}/chat/completions", payload, adaptations, transport_observer
             )
-            if thinking and choice.get("finish_reason") == "length":
+            _ensure_success(resp, transport_observer)
+            content, retry_without_thinking = _interpret_openai_response(
+                resp,
+                thinking,
+                require_complete,
+                transport_observer,
+                attempt + 1,
+            )
+            if retry_without_thinking:
                 llm_metrics.record_truncation()
                 # Truncation mid-think leaves the unfinished reasoning in the
                 # content channel — unparseable. A fast answer beats no answer.
@@ -436,10 +559,127 @@ async def _query_openai(
                     thinking=False,
                     images=images,
                     image_detail=image_detail,
+                    transport_observer=transport_observer,
+                    require_complete=require_complete,
                 )
-            content = choice["message"]["content"]
             if content is not None:
+                _observe(transport_observer, attempt + 1, "response", resp.status_code)
                 return content
+            _observe(transport_observer, attempt + 1, "null_content", resp.status_code)
             logger.debug("LLM null content (attempt %d/3)", attempt + 1)
     msg = "LLM returned null content after 3 retries"
     raise ValueError(msg)
+
+
+def _openai_completion(
+    choice: dict,
+    thinking: bool,
+    require_complete: bool,
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+    status_code: int,
+) -> tuple[str | None, bool]:
+    truncated = choice.get("finish_reason") == "length"
+    if truncated and require_complete:
+        _observe(observer, attempt, "incomplete", status_code)
+        raise ValueError("LLM returned incomplete content")
+    if truncated and thinking:
+        _observe(observer, attempt, "thinking_fallback", status_code)
+        return None, True
+    return choice["message"]["content"], False
+
+
+def _anthropic_usage(
+    response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> tuple[dict, dict]:
+    """Decode the native Anthropic body far enough to retain usage metrics."""
+    try:
+        body = _response_body(response)
+        usage = body.get("usage") or {}
+        if not isinstance(usage, dict):
+            raise TypeError("Anthropic usage is not an object")
+    except (TypeError, ValueError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    return body, usage
+
+
+def _anthropic_answer(
+    body: dict, response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> str:
+    """Validate the Anthropic content after its parseable usage was counted."""
+    try:
+        content = body["content"]
+        if not isinstance(content, list):
+            raise TypeError("Anthropic response content is not a list")
+        return "".join(block.get("text", "") for block in content if block.get("type") == "text")
+    except (KeyError, TypeError, AttributeError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+
+
+def _interpret_openai_response(
+    response: httpx.Response,
+    thinking: bool,
+    require_complete: bool,
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+) -> tuple[str | None, bool]:
+    """Parse one OpenAI-style reply and preserve its completed-post outcome."""
+    try:
+        body = _response_body(response)
+        choice = body["choices"][0]
+        usage = body.get("usage") or {}
+        if not isinstance(choice, dict) or not isinstance(usage, dict):
+            raise TypeError("OpenAI response has an invalid body shape")
+    except (KeyError, TypeError, ValueError, IndexError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    llm_metrics.record_reply(
+        prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+        completion_tokens=usage.get("completion_tokens", 0) or 0,
+    )
+    try:
+        content, retry_without_thinking = _openai_completion(
+            choice, thinking, require_complete, observer, attempt, response.status_code
+        )
+    except (KeyError, TypeError, AttributeError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    return content, retry_without_thinking
+
+
+def _observe(
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+    outcome: str,
+    status_code: int | None,
+    adaptation: str | None = None,
+) -> None:
+    if observer is not None:
+        observer(LLMTransportAttempt(attempt, outcome, status_code, adaptation))
+
+
+def _response_body(response: httpx.Response) -> dict:
+    """Decode one provider response as the object every dialect requires."""
+    body = response.json()
+    if not isinstance(body, dict):
+        raise TypeError("LLM response body is not an object")
+    return body
+
+
+def _record_invalid_response(
+    observer: Callable[[LLMTransportAttempt], None] | None, status_code: int
+) -> None:
+    """Trace the one completed POST whose content could not be parsed."""
+    _observe(observer, 1, "invalid_response", status_code)
+
+
+def _ensure_success(
+    response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError:
+        _observe(observer, 1, "http_error", response.status_code)
+        raise

--- a/src/immich_memories/analysis/moment_grouping.py
+++ b/src/immich_memories/analysis/moment_grouping.py
@@ -23,6 +23,7 @@ threads, which is what the timeline was hiding.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import Any
 
 # How far apart two photographs can be and still be one moment. Wide enough for
@@ -45,12 +46,17 @@ _EARTH_RADIUS_METRES = 6_371_000.0
 
 
 def _coordinates(asset: Any) -> tuple[float, float] | None:
-    exif = getattr(asset, "exif_info", None)
+    source = getattr(asset, "source", asset)
+    exif = getattr(source, "exif_info", None)
     latitude = getattr(exif, "latitude", None) if exif else None
     longitude = getattr(exif, "longitude", None) if exif else None
     if latitude is None or longitude is None:
         return None
     return float(latitude), float(longitude)
+
+
+def _taken_at(asset: Any) -> Any:
+    return getattr(asset, "taken_at", None) or getattr(asset, "file_created_at", None)
 
 
 def metres_between(first: tuple[float, float], second: tuple[float, float]) -> float:
@@ -65,8 +71,8 @@ def metres_between(first: tuple[float, float], second: tuple[float, float]) -> f
 
 def _belongs_with(asset: Any, moment: list[Any], window_minutes: float, radius: float) -> bool:
     """Whether this asset continues that moment, in time and in place."""
-    when = getattr(asset, "file_created_at", None)
-    last_when = getattr(moment[-1], "file_created_at", None)
+    when = _taken_at(asset)
+    last_when = _taken_at(moment[-1])
     if when is None or last_when is None:
         return False
     if abs((when - last_when).total_seconds()) > window_minutes * 60:
@@ -98,8 +104,8 @@ def _group_by_time_and_place(
     alternation.
     """
     ordered = sorted(
-        (a for a in assets if getattr(a, "file_created_at", None) is not None),
-        key=lambda a: a.file_created_at,
+        (a for a in assets if _taken_at(a) is not None),
+        key=lambda a: (_taken_at(a), str(getattr(a, "asset_id", getattr(a, "id", "")))),
     )
     moments: list[list[Any]] = []
     for asset in ordered:
@@ -110,6 +116,22 @@ def _group_by_time_and_place(
         else:
             moments.append([asset])
     return moments
+
+
+def group_by_time_and_place(
+    assets: Sequence[Any],
+    window_minutes: float,
+    radius_metres: float = MOMENT_RADIUS_METRES,
+) -> tuple[tuple[Any, ...], ...]:
+    """Group already-admitted assets without applying the legacy source filter."""
+    return tuple(
+        tuple(group)
+        for group in _group_by_time_and_place(
+            list(assets),
+            window_minutes=window_minutes,
+            radius_metres=radius_metres,
+        )
+    )
 
 
 def moments_to_read(

--- a/src/immich_memories/analysis/moment_reading.py
+++ b/src/immich_memories/analysis/moment_reading.py
@@ -14,41 +14,36 @@ real day, 215 photographs read in 14 calls and 22 seconds, against roughly
 from __future__ import annotations
 
 import json
-import math
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from immich_memories.analysis.contact_sheets import (
+    LAYOUT_VERSION,
+    ContactSheetPage,
+    build_contact_sheets,
+)
+from immich_memories.analysis.contact_sheets import (
+    sheet_layout as _sheet_layout,
+)
+from immich_memories.analysis.contact_sheets import (
+    sheets_of as _sheets_of,
+)
+from immich_memories.analysis.contact_sheets import (
+    tile_sheet as _tile_sheet,
+)
+from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+MAX_SHEET_TILES = 120
+MAX_SHEET_PX = 2100
 
 if TYPE_CHECKING:
     from PIL.Image import Image
 
     from immich_memories.config_models_llm import LLMConfig
-
-# A moment goes on ONE sheet. Split across several, each sheet answers about
-# its own third of an event and the first answer wins by accident: measured on
-# a 37-photograph episode, sheet one said "cyclists and cars at a race track"
-# while later sheets named the circuit and the car.
-#
-# Past this many photographs a single sheet is postage stamps, so a very large
-# moment is split rather than shrunk to nothing.
-MAX_SHEET_TILES = 120
-
-# How wide a sheet may be before the encoder downscales it and tiles lose the
-# detail the reading depends on.
-MAX_SHEET_PX = 2100
-
-# Sheets are laid out WIDE, never tall. The same 37 photographs at 1920x2240
-# read worse than at 2080x1300 with SMALLER tiles — the tall sheet described
-# less and its shortlist collapsed to "keep all 37". A tall image is
-# downscaled harder before the model ever sees it, so shape matters more than
-# how big each tile is.
-_TARGET_ASPECT = 1.6
-_MAX_TILE = 400
-_MIN_TILE = 120
-_SHEET_BACKGROUND = (18, 18, 18)
-
-T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -61,26 +56,18 @@ class SheetReading:
 
 
 def sheet_layout(count: int) -> tuple[int, int]:
-    """Columns and tile size for one wide sheet of `count` photographs."""
-    columns = max(1, round(math.sqrt(count * _TARGET_ASPECT)))
-    tile = min(_MAX_TILE, MAX_SHEET_PX // columns)
-    rows = -(-count // columns)
-    if rows * tile > MAX_SHEET_PX * 1.2:
-        tile = int(MAX_SHEET_PX * 1.2) // rows
-    return columns, max(_MIN_TILE, tile)
+    """Return the shared wide grid dimensions used by legacy moment reading."""
+    return _sheet_layout(count)
 
 
-def sheets_of(items: list[T], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, T]]]:
-    """Cut a moment into sheets, numbering tiles across the whole moment.
+def sheets_of(items: list[Any], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, Any]]]:
+    """Split legacy moment assets through the shared global-numbering policy."""
+    return _sheets_of(items, per_sheet)
 
-    The model answers in tile numbers, so numbering has to run across the
-    moment rather than restart on each sheet — otherwise sheet three's "4"
-    and sheet one's "4" are the same answer about different photographs.
-    """
-    return [
-        [(offset + n + 1, item) for n, item in enumerate(items[offset : offset + per_sheet])]
-        for offset in range(0, len(items), per_sheet)
-    ]
+
+def tile_sheet(frames: list[tuple[int, Image | None]]) -> Image | None:
+    """Build a legacy sheet through the shared tile renderer."""
+    return _tile_sheet(frames)
 
 
 def _objects_in(raw: str) -> list[str]:
@@ -142,40 +129,6 @@ def read_sheet_verdict(raw: str | None) -> SheetReading | None:
             keep=_numbers(payload.get("best")),
         )
     return None
-
-
-def tile_sheet(frames: list[tuple[int, Image | None]]) -> Image | None:
-    """Lay numbered frames out as one image, or nothing if there are none.
-
-    The model answers in tile numbers, so every tile carries its number burnt
-    into the corner. A frame that could not be fetched leaves its number on an
-    empty tile rather than shifting every frame after it — a 404 thumbnail
-    would otherwise silently renumber the rest of the sheet and make the
-    answer point at the wrong photographs.
-    """
-    from PIL import Image, ImageDraw
-
-    if not frames:
-        return None
-    columns, tile = sheet_layout(len(frames))
-    rows = -(-len(frames) // columns)
-    sheet = Image.new("RGB", (columns * tile, rows * tile), _SHEET_BACKGROUND)
-    draw = ImageDraw.Draw(sheet)
-    label = max(16, tile // 11)
-    for position, (number, frame) in enumerate(frames):
-        left = (position % columns) * tile
-        top = (position // columns) * tile
-        if frame is not None:
-            thumbnail = frame.copy()
-            thumbnail.thumbnail((tile - 6, tile - 6))
-            sheet.paste(thumbnail, (left + 3, top + 3))
-        text = str(number)
-        draw.rectangle(
-            [left + 3, top + 3, left + 3 + label * (0.6 * len(text) + 0.8), top + 3 + label],
-            fill=(0, 0, 0),
-        )
-        draw.text((left + 7, top + 5), text, fill=(255, 255, 255))
-    return sheet
 
 
 # Ages that change how a person should be described. A newborn read as one of
@@ -292,27 +245,25 @@ class MomentReading:
 
 def _read_one_sheet(
     numbered: list[tuple[int, Any]],
-    frames: dict[str, Image],
+    page: ContactSheetPage,
     llm_config: LLMConfig,
 ) -> SheetReading | None:
     """Ask about one sheet, or return nothing if it could not be read."""
     import asyncio
-    import io
 
     from immich_memories.analysis.llm_query import query_llm
 
-    sheet = tile_sheet([(n, frames.get(getattr(a, "id", ""))) for n, a in numbered])
-    if sheet is None:
+    if page.layout_version != LAYOUT_VERSION or tuple(
+        reference.entity_id for reference in page.tile_refs
+    ) != tuple(getattr(asset, "id", "") for _number, asset in numbered):
         return None
-    buffer = io.BytesIO()
-    sheet.save(buffer, "JPEG", quality=_SHEET_QUALITY)
     answer = asyncio.run(
         query_llm(
             prompt_for([asset for _n, asset in numbered]),
             llm_config,
             temperature=_SHEET_TEMPERATURE,
             max_tokens=SHEET_ANSWER_TOKENS,
-            images=[buffer.getvalue()],
+            images=[page.jpeg_bytes],
         )
     )
     return read_sheet_verdict(answer)
@@ -323,6 +274,9 @@ def read_moment(
     frames: dict[str, Image],
     llm_config: LLMConfig,
     keep_cap: int | None = None,
+    *,
+    sheet_output_dir: Path | None = None,
+    sheet_recorder: Callable[[ContactSheetPage], None] | None = None,
 ) -> MomentReading:
     """Read a whole moment from its sheets, and keep what they chose.
 
@@ -336,10 +290,14 @@ def read_moment(
     a shortlist out of one would spend the deep look on frames chosen at
     random.
     """
+    pages = _moment_pages(assets, frames, sheet_output_dir)
+    if sheet_recorder is not None:
+        for page in pages:
+            sheet_recorder(page)
     readings: list[SheetReading] = []
     kept: list[Any] = []
-    for sheet in sheets_of(assets):
-        reading = _read_one_sheet(sheet, frames, llm_config)
+    for sheet, page in zip(sheets_of(assets), pages, strict=True):
+        reading = _read_one_sheet(sheet, page, llm_config)
         if reading is None:
             continue
         readings.append(reading)
@@ -357,6 +315,31 @@ def read_moment(
         subjects=tuple(subjects),
         keep=tuple(kept[:keep_cap] if keep_cap else kept),
     )
+
+
+def _moment_pages(
+    assets: list[Any], frames: dict[str, Image], output_dir: Path | None
+) -> tuple[ContactSheetPage, ...]:
+    """Encode all pages once so legacy requests attach precisely the traced bytes."""
+    import tempfile
+
+    sources: list[AtlasSource] = []
+    for asset in assets:
+        asset_id = getattr(asset, "id", "")
+        sources.append(AtlasSource(asset=asset, preview_jpeg=_jpeg_for(frames.get(asset_id))))
+    destination = output_dir or Path(tempfile.mkdtemp(prefix="moment-sheets-"))
+    atlas = build_visual_atlas(sources, frame_cache_dir=None)
+    return build_contact_sheets(atlas.tiles, "moment", destination)
+
+
+def _jpeg_for(frame: Image | None) -> bytes | None:
+    if frame is None:
+        return None
+    import io
+
+    buffer = io.BytesIO()
+    frame.save(buffer, "JPEG", quality=_SHEET_QUALITY)
+    return buffer.getvalue()
 
 
 def place_of(assets: list[Any]) -> str | None:

--- a/src/immich_memories/analysis/period_insight.py
+++ b/src/immich_memories/analysis/period_insight.py
@@ -1,0 +1,855 @@
+"""Hierarchical visual reading of every source-eligible episode."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from hashlib import sha256
+from pathlib import Path
+
+from immich_memories.analysis.contact_sheets import (
+    MAX_SHEET_TILES,
+    ContactSheetPage,
+    TileRef,
+    build_contact_sheets,
+)
+from immich_memories.analysis.cull_answer import fused_episode_response_fits
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    EditorialCandidate,
+    PassTrace,
+    PeriodInsight,
+    RequestTrace,
+)
+from immich_memories.analysis.editorial_gateway import (
+    BankedVisualAnswer,
+    EditorialGateway,
+    VisualEditorialRequest,
+)
+from immich_memories.analysis.episode_scan_request import build_episode_request
+from immich_memories.analysis.period_insight_answer import (
+    PERIOD_INSIGHT_SCHEMA_VERSION,
+    EpisodePageReading,
+    read_episode_answers,
+    read_period_answer,
+)
+from immich_memories.analysis.selection_flow import EditorialGroup, PreparedEditorialSource
+from immich_memories.analysis.visual_atlas import VisualAtlas, build_visual_atlas
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+
+PASS_ZERO_VERSION = "pass-0-v1"  # noqa: S105 - editorial pass identity
+PERIOD_INSIGHT_PASS_VERSION = "period-insight-v1"  # noqa: S105 - editorial pass identity
+PERIOD_INSIGHT_PROMPT_VERSION = "period-insight-prompt-v1"
+_RENDER_VERSION = "visual-atlas-v1/contact-sheet-v1"
+
+
+@dataclass(frozen=True)
+class EpisodeSheet:
+    """Every chronological contact-sheet page for one source episode."""
+
+    episode_id: str
+    candidates: tuple[EditorialCandidate, ...]
+    pages: tuple[ContactSheetPage, ...]
+
+
+@dataclass(frozen=True)
+class EpisodePackScope:
+    """The exact numbered tiles belonging to one episode on a shared pack page."""
+
+    episode_id: str
+    page_id: str
+    episode_alias: int
+    page_alias: int
+    tile_refs: tuple[TileRef, ...]
+    candidates: tuple[EditorialCandidate, ...]
+    unavailable_asset_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EpisodeScanPack:
+    """One physical chronological page containing only complete episode groups."""
+
+    pack_id: str
+    page: ContactSheetPage
+    scopes: tuple[EpisodePackScope, ...]
+    continuation_number: int = 1
+    continuation_count: int = 1
+
+
+@dataclass(frozen=True)
+class BankedEpisodeScan:
+    """One reusable physical episode response and the request that produced it."""
+
+    pack_id: str
+    page_id: str
+    answer: BankedVisualAnswer
+
+
+@dataclass(frozen=True)
+class EpisodeScanAttempt:
+    """One pack's exact physical attempt, including fail-open transport failures."""
+
+    pack_id: str
+    page_id: str
+    answer: BankedVisualAnswer | None
+    request_trace: RequestTrace | None
+
+
+@dataclass(frozen=True)
+class EpisodePageObservation:
+    """Whether one required visual page produced a valid episode namespace."""
+
+    episode_id: str
+    page_id: str
+    reading: EpisodePageReading | None
+    scan: BankedEpisodeScan | None
+
+
+@dataclass(frozen=True)
+class EpisodeReading:
+    """The combined observations from every page of one complete episode."""
+
+    episode_id: str
+    visual_summary: str
+    representative_asset_ids: tuple[str, ...]
+    representative_reasons: tuple[str, ...]
+    page_provenances: tuple[DecisionProvenance, ...]
+
+
+@dataclass(frozen=True)
+class PassZeroResult:
+    """Observation-only Pass 0 result; membership remains the prepared corpus."""
+
+    retained_ids: tuple[str, ...]
+    atlas: VisualAtlas
+    episode_sheets: tuple[EpisodeSheet, ...]
+    episode_packs: tuple[EpisodeScanPack, ...]
+    scan_attempts: tuple[EpisodeScanAttempt, ...]
+    page_observations: tuple[EpisodePageObservation, ...]
+    episode_readings: tuple[EpisodeReading, ...]
+    banked_scans: tuple[BankedEpisodeScan, ...]
+    period_pages: tuple[ContactSheetPage, ...]
+    period_answer: BankedVisualAnswer | None
+    insight: PeriodInsight
+    warnings: tuple[str, ...]
+    actual_calls: int
+
+    def __post_init__(self) -> None:
+        if len(self.retained_ids) != len(set(self.retained_ids)):
+            raise ValueError("Pass 0 retained IDs must be unique")
+        episode_ids = {sheet.episode_id for sheet in self.episode_sheets}
+        if any(reading.episode_id not in episode_ids for reading in self.episode_readings):
+            raise ValueError("Pass 0 readings must belong to rendered episodes")
+        scan_ids = tuple((scan.pack_id, scan.page_id) for scan in self.banked_scans)
+        if len(scan_ids) != len(set(scan_ids)):
+            raise ValueError("Pass 0 banked scan identities must be unique")
+        attempt_ids = tuple((attempt.pack_id, attempt.page_id) for attempt in self.scan_attempts)
+        if len(attempt_ids) != len(set(attempt_ids)):
+            raise ValueError("Pass 0 scan attempt identities must be unique")
+
+
+def run_period_insight(
+    prepared: PreparedEditorialSource,
+    *,
+    requester: EditorialGateway,
+    sheet_output_dir: Path,
+    frame_cache_dir: Path | None,
+    limits: VisionRequestLimits | None = None,
+) -> PassZeroResult:
+    """Read every required episode page before attempting a period thesis."""
+    request_limits = limits or VisionRequestLimits(max_output_tokens=4000, timeout_seconds=120)
+    atlas = build_visual_atlas(prepared.visual_sources, frame_cache_dir=frame_cache_dir)
+    warnings: list[str] = []
+    for tile in atlas.tiles:
+        if tile.kind == "unavailable":
+            _warn_once(
+                prepared,
+                warnings,
+                f"Pass 0 visual unavailable: {tile.entity_id} ({tile.unavailable_reason})",
+            )
+    # Nothing showable is a fact about the file, not a judgement about it, so it
+    # leaves before any pass is asked anything. Carried onto a sheet it became a
+    # numbered placeholder the model could promote as a representative, and it
+    # voided its whole episode's reading: seventeen such assets in a real dense
+    # month cost that month its thesis.
+    viewable = _viewable_groups(prepared.episode_groups, atlas)
+    retained_ids = tuple(candidate.asset_id for group in viewable for candidate in group.candidates)
+    episode_sheets, episode_packs = _episode_material(
+        viewable,
+        atlas=atlas,
+        output_dir=sheet_output_dir / "episodes",
+        limits=request_limits,
+    )
+    request_start = len(prepared.trace.requests)
+    observations, banked, scan_attempts = _read_episode_packs(
+        episode_packs,
+        requester=requester,
+        limits=request_limits,
+    )
+    readings = _complete_episode_readings(episode_sheets, observations)
+    period_pages: tuple[ContactSheetPage, ...] = ()
+    period_answer: BankedVisualAnswer | None = None
+    insight: PeriodInsight | None = None
+    if not episode_sheets:
+        insight = _unavailable_insight(
+            prepared,
+            episode_packs,
+            banked,
+            reason="source corpus was empty",
+        )
+    elif not readings:
+        _warn_once(
+            prepared,
+            warnings,
+            "Pass 0 no episode could be read; period thesis unavailable",
+        )
+        insight = _unavailable_insight(
+            prepared,
+            episode_packs,
+            banked,
+            reason="no episode page could be read",
+        )
+    else:
+        # An episode nobody could read costs its own pictures a reading, not the
+        # month its thesis: a real dense month read 100 of 101 and was refused a
+        # thesis over the hundred-and-first. The wall is built from what was
+        # read, the trace names what was not, and those pictures stay in the
+        # corpus for the passes that come after.
+        if len(readings) != len(episode_sheets):
+            _warn_once(
+                prepared,
+                warnings,
+                f"Pass 0 {len(episode_sheets) - len(readings)} of "
+                f"{len(episode_sheets)} episodes could not be read",
+            )
+        period_pages, period_answer, insight = _read_period_wall(
+            prepared,
+            readings,
+            warnings,
+            atlas=atlas,
+            requester=requester,
+            output_dir=sheet_output_dir / "period",
+            limits=request_limits,
+        )
+        if period_answer is None or insight is None:
+            _warn_once(
+                prepared,
+                warnings,
+                "Pass 0 period synthesis unreadable; thesis unavailable",
+            )
+            insight = _unavailable_insight(
+                prepared,
+                episode_packs,
+                banked,
+                period_pages=period_pages,
+                period_answer=period_answer,
+                reason="period synthesis was unreadable",
+            )
+    assert insight is not None
+    provenance = _pass_provenance(
+        prepared,
+        episode_packs,
+        banked,
+        period_pages=period_pages,
+        period_answer=period_answer,
+    )
+    logical_answers = tuple(scan.answer for scan in banked) + (
+        (period_answer,) if period_answer is not None else ()
+    )
+    logical_requests = tuple(
+        replace(answer.request_trace, actual_calls=0, attempts=()) for answer in logical_answers
+    )
+    _record_pass_zero(prepared, provenance, logical_requests)
+    physical_requests = prepared.trace.requests[request_start:]
+    return PassZeroResult(
+        retained_ids=retained_ids,
+        atlas=atlas,
+        episode_sheets=episode_sheets,
+        episode_packs=episode_packs,
+        scan_attempts=scan_attempts,
+        page_observations=observations,
+        episode_readings=readings,
+        banked_scans=banked,
+        period_pages=period_pages,
+        period_answer=period_answer,
+        insight=insight,
+        warnings=tuple(warnings),
+        actual_calls=sum(request.actual_calls for request in physical_requests),
+    )
+
+
+def _wall_sample(representative_ids: tuple[str, ...]) -> tuple[str, ...]:
+    """At most a wall's worth, spread evenly across the period in order.
+
+    Every episode still reaches the synthesis in words: only the PIXELS are
+    sampled, and they are sampled chronologically so the wall still reads as
+    the period's shape rather than as its first sixty minutes.
+    """
+    if len(representative_ids) <= MAX_WALL_TILES:
+        return representative_ids
+    step = len(representative_ids) / MAX_WALL_TILES
+    picked = {
+        representative_ids[min(int(index * step), len(representative_ids) - 1)]
+        for index in range(MAX_WALL_TILES)
+    }
+    return tuple(asset_id for asset_id in representative_ids if asset_id in picked)
+
+
+def _read_period_wall(
+    prepared: PreparedEditorialSource,
+    readings: tuple[EpisodeReading, ...],
+    warnings: list[str],
+    *,
+    atlas: VisualAtlas,
+    requester: EditorialGateway,
+    output_dir: Path,
+    limits: VisionRequestLimits,
+) -> tuple[tuple[ContactSheetPage, ...], BankedVisualAnswer | None, PeriodInsight | None]:
+    candidates = {candidate.asset_id: candidate for candidate in prepared.candidates}
+    episode_by_asset = {
+        asset_id: reading.episode_id
+        for reading in readings
+        for asset_id in reading.representative_asset_ids
+    }
+    representative_ids = tuple(
+        sorted(
+            episode_by_asset,
+            key=lambda asset_id: (candidates[asset_id].taken_at, asset_id),
+        )
+    )
+    shown_ids = _wall_sample(representative_ids)
+    if len(shown_ids) != len(representative_ids):
+        _warn_once(
+            prepared,
+            warnings,
+            f"Pass 0 wall reads {len(shown_ids)} of {len(representative_ids)} "
+            "representatives, spread across the period",
+        )
+    period_pages = build_contact_sheets(
+        tuple(atlas.tile_for(asset_id) for asset_id in shown_ids),
+        "period-wall",
+        output_dir,
+    )
+    if not period_pages or len(period_pages) > limits.max_pages_per_request:
+        return period_pages, None, None
+    # The wall's words must describe the wall's tiles. Listing every episode
+    # beside a sampled sheet gave the model two numbering universes, and it
+    # answered with evidence about tiles 61 and 70 of a sixty-tile wall.
+    shown = set(shown_ids)
+    upstream = tuple(
+        f"episode:{reading.episode_id} | {reading.visual_summary} | "
+        f"representatives:{','.join(reading.representative_asset_ids)} | "
+        f"reasons:{' / '.join(reading.representative_reasons)}"
+        for reading in readings
+        if shown.intersection(reading.representative_asset_ids)
+    )
+    request = VisualEditorialRequest(
+        pass_name="period-insight",  # noqa: S106 - versioned editorial pass identity
+        pass_version=PERIOD_INSIGHT_PASS_VERSION,
+        prompt=_period_prompt(upstream, period_pages),
+        prompt_version=PERIOD_INSIGHT_PROMPT_VERSION,
+        schema_version=PERIOD_INSIGHT_SCHEMA_VERSION,
+        pages=period_pages,
+        ordered_input_ids=representative_ids,
+        ordered_group_ids=tuple(reading.episode_id for reading in readings),
+        grounded_annotations=upstream,
+        upstream_material=upstream,
+        render_version=_RENDER_VERSION,
+        limits=limits,
+    )
+    try:
+        answer = requester.ask(request)
+    except Exception:  # WHY: a missing thesis cannot remove otherwise valid source membership
+        return period_pages, None, None
+    tile_map = {
+        (page.sheet_id, ref.number): (episode_by_asset[ref.entity_id], ref.entity_id)
+        for page in period_pages
+        for ref in page.tile_refs
+    }
+    parsed = read_period_answer(
+        answer.raw_text,
+        page_ids=tuple(page.sheet_id for page in period_pages),
+        tile_map=tile_map,
+    )
+    if parsed is None:
+        return period_pages, answer, None
+    return (
+        period_pages,
+        answer,
+        PeriodInsight(
+            thesis=parsed.thesis,
+            evidence=parsed.evidence,
+            tensions=parsed.tensions,
+            recurring_threads=parsed.recurring_threads,
+            unavailable_reason=parsed.unavailable_reason,
+            revision=0,
+            provenance=answer.provenance,
+        ),
+    )
+
+
+def period_response_shape(*, tile: int) -> str:
+    """One complete example envelope for the period synthesis.
+
+    Its nesting and its scalar types are the part a prose description leaves to
+    the model, and the parser voids the whole answer on either.
+    """
+    return json.dumps(
+        {
+            "schema_version": PERIOD_INSIGHT_SCHEMA_VERSION,
+            "period_insight": {
+                "thesis": "what this period was about, or null",
+                "evidence": [
+                    {
+                        "observation": "what these tiles show",
+                        "representative_tiles": [tile],
+                    }
+                ],
+                "tensions": ["one sentence, as plain text"],
+                "recurring_threads": ["one sentence, as plain text"],
+                "unavailable_reason": None,
+            },
+        },
+        separators=(",", ":"),
+    )
+
+
+def _period_prompt(upstream: tuple[str, ...], pages: tuple[ContactSheetPage, ...]) -> str:
+    page_names = ", ".join(page.sheet_id for page in pages)
+    return (
+        "Read this complete chronological period wall of actual representative pixels. The prior "
+        "episode observations follow as grounded context, not substitutes for the images:\n"
+        + "\n".join(upstream)
+        + f"\nReturn one complete JSON object for pages {page_names}. A null thesis is honest "
+        "when the material does not support one, and it is the only case that fills "
+        "unavailable_reason. tensions and recurring_threads are lists of plain sentences. "
+        "Use exactly this shape and these keys:\n" + period_response_shape(tile=1)
+    )
+
+
+def _viewable_groups(
+    groups: tuple[EditorialGroup, ...], atlas: VisualAtlas
+) -> tuple[EditorialGroup, ...]:
+    """The same groups without the candidates that have no pixels to show."""
+    kept = []
+    for group in groups:
+        members = tuple(
+            candidate
+            for candidate in group.candidates
+            if atlas.tile_for(candidate.asset_id).kind != "unavailable"
+        )
+        if members:
+            kept.append(replace(group, candidates=members))
+    return tuple(kept)
+
+
+def _episode_material(
+    groups: tuple[EditorialGroup, ...],
+    *,
+    atlas: VisualAtlas,
+    output_dir: Path,
+    limits: VisionRequestLimits,
+) -> tuple[tuple[EpisodeSheet, ...], tuple[EpisodeScanPack, ...]]:
+    sheets: list[EpisodeSheet] = []
+    packs: list[EpisodeScanPack] = []
+    pending: list[EditorialGroup] = []
+    pending_count = 0
+
+    def flush_pending() -> None:
+        nonlocal pending, pending_count
+        if not pending:
+            return
+        page, scopes = _shared_pack_page(tuple(pending), atlas=atlas, output_dir=output_dir)
+        pack_id = page.sheet_id.removesuffix("-001")
+        packs.append(EpisodeScanPack(pack_id, page, scopes))
+        sheets.extend(EpisodeSheet(group.group_id, group.candidates, (page,)) for group in pending)
+        pending, pending_count = [], 0
+
+    for group in groups:
+        size = len(group.candidates)
+        if size > MAX_SHEET_TILES or not _episode_groups_fit((group,), limits):
+            flush_pending()
+            episode_sheet, continuation_packs = _episode_continuation_material(
+                group,
+                atlas=atlas,
+                output_dir=output_dir,
+                limits=limits,
+            )
+            sheets.append(episode_sheet)
+            packs.extend(continuation_packs)
+            continue
+        proposed = (*pending, group)
+        if pending and (
+            pending_count + size > MAX_SHEET_TILES or not _episode_groups_fit(proposed, limits)
+        ):
+            flush_pending()
+        pending.append(group)
+        pending_count += size
+    flush_pending()
+    return tuple(sheets), tuple(packs)
+
+
+def _episode_continuation_material(
+    group: EditorialGroup,
+    *,
+    atlas: VisualAtlas,
+    output_dir: Path,
+    limits: VisionRequestLimits,
+) -> tuple[EpisodeSheet, tuple[EpisodeScanPack, ...]]:
+    size = len(group.candidates)
+    page_sizes = _continuation_page_sizes(size, limits)
+    pages = build_contact_sheets(
+        tuple(atlas.tile_for(candidate.asset_id) for candidate in group.candidates),
+        _pack_id((group.group_id,)),
+        output_dir,
+        page_sizes=page_sizes,
+    )
+    packs = tuple(
+        _episode_continuation_pack(
+            group,
+            page=page,
+            number=number,
+            count=len(pages),
+            atlas=atlas,
+        )
+        for number, page in enumerate(pages, start=1)
+    )
+    return EpisodeSheet(group.group_id, group.candidates, pages), packs
+
+
+def _continuation_page_sizes(size: int, limits: VisionRequestLimits) -> tuple[int, ...]:
+    sizes: list[int] = []
+    offset = 0
+    while offset < size:
+        count = min(MAX_SHEET_TILES, size - offset)
+        while count and not _episode_response_fits(
+            (tuple(range(offset + 1, offset + count + 1)),), limits
+        ):
+            count -= 1
+        if count == 0:
+            raise ValueError("episode scan output budget cannot fit one continuation tile")
+        sizes.append(count)
+        offset += count
+    return tuple(sizes)
+
+
+def _episode_continuation_pack(
+    group: EditorialGroup,
+    *,
+    page: ContactSheetPage,
+    number: int,
+    count: int,
+    atlas: VisualAtlas,
+) -> EpisodeScanPack:
+    page_asset_ids = {ref.entity_id for ref in page.tile_refs}
+    page_candidates = tuple(
+        candidate for candidate in group.candidates if candidate.asset_id in page_asset_ids
+    )
+    unavailable_asset_ids = tuple(
+        candidate.asset_id
+        for candidate in page_candidates
+        if atlas.tile_for(candidate.asset_id).kind == "unavailable"
+    )
+    return EpisodeScanPack(
+        pack_id=page.sheet_id.rsplit("-", 1)[0],
+        page=page,
+        scopes=(
+            EpisodePackScope(
+                group.group_id,
+                page.sheet_id,
+                1,
+                1,
+                page.tile_refs,
+                page_candidates,
+                unavailable_asset_ids,
+            ),
+        ),
+        continuation_number=number,
+        continuation_count=count,
+    )
+
+
+def _shared_pack_page(
+    groups: tuple[EditorialGroup, ...],
+    *,
+    atlas: VisualAtlas,
+    output_dir: Path,
+) -> tuple[ContactSheetPage, tuple[EpisodePackScope, ...]]:
+    candidates = tuple(
+        sorted(
+            (candidate for group in groups for candidate in group.candidates),
+            key=lambda candidate: (candidate.taken_at, candidate.asset_id),
+        )
+    )
+    pages = build_contact_sheets(
+        tuple(atlas.tile_for(candidate.asset_id) for candidate in candidates),
+        _pack_id(tuple(group.group_id for group in groups)),
+        output_dir,
+    )
+    if len(pages) != 1:
+        raise ValueError("complete episode pack must fit one contact-sheet page")
+    page = pages[0]
+    episode_by_asset = {
+        candidate.asset_id: group.group_id for group in groups for candidate in group.candidates
+    }
+    scopes = tuple(
+        EpisodePackScope(
+            episode_id=group.group_id,
+            page_id=page.sheet_id,
+            episode_alias=episode_alias,
+            page_alias=1,
+            tile_refs=tuple(
+                ref for ref in page.tile_refs if episode_by_asset[ref.entity_id] == group.group_id
+            ),
+            candidates=group.candidates,
+            unavailable_asset_ids=tuple(
+                candidate.asset_id
+                for candidate in group.candidates
+                if atlas.tile_for(candidate.asset_id).kind == "unavailable"
+            ),
+        )
+        for episode_alias, group in enumerate(groups, start=1)
+    )
+    return page, scopes
+
+
+def _pack_id(group_ids: tuple[str, ...]) -> str:
+    digest = sha256("\x00".join(group_ids).encode()).hexdigest()
+    return f"episode-pack-v1-{digest}"
+
+
+# The output budget bounds how much a pack can SAY, not how much it can be asked
+# about. Measured at temperature 0 on two real months: a 36-episode pack came
+# back complete, valid, and with every Cull list empty -- no refusal, no warning,
+# just silence on the second half of the question. The same month split into six
+# smaller packs culled 4.6%, and a dense month whose packs held 4 to 14 episodes
+# culled 4.4%. Fourteen answered; thirty-six did not.
+MAX_EPISODES_PER_PACK = 14
+# A wall too big is not refused, it is answered wrongly. Measured at temperature
+# 0 on a real dense month: walls of 10, 20, 40 and 60 representatives produced
+# theses that matched the month, and a wall of 100 fixated on one tile and
+# invented a fact about the period. A confident wrong thesis is the worst
+# failure this pass has, so the bound is structural rather than a warning.
+MAX_WALL_TILES = 60
+
+
+def _episode_groups_fit(groups: tuple[EditorialGroup, ...], limits: VisionRequestLimits) -> bool:
+    if len(groups) > MAX_EPISODES_PER_PACK:
+        return False
+    candidates = tuple(
+        sorted(
+            (candidate for group in groups for candidate in group.candidates),
+            key=lambda candidate: (candidate.taken_at, candidate.asset_id),
+        )
+    )
+    number_by_asset = {
+        candidate.asset_id: number for number, candidate in enumerate(candidates, start=1)
+    }
+    displayed_by_episode = tuple(
+        tuple(number_by_asset[candidate.asset_id] for candidate in group.candidates)
+        for group in groups
+    )
+    return _episode_response_fits(displayed_by_episode, limits)
+
+
+def _episode_response_fits(
+    displayed_by_episode: tuple[tuple[int, ...], ...], limits: VisionRequestLimits
+) -> bool:
+    return fused_episode_response_fits(
+        displayed_by_episode,
+        max_output_tokens=limits.max_output_tokens,
+    )
+
+
+def _read_episode_packs(
+    packs: tuple[EpisodeScanPack, ...],
+    *,
+    requester: EditorialGateway,
+    limits: VisionRequestLimits,
+) -> tuple[
+    tuple[EpisodePageObservation, ...],
+    tuple[BankedEpisodeScan, ...],
+    tuple[EpisodeScanAttempt, ...],
+]:
+    observations: list[EpisodePageObservation] = []
+    banked: list[BankedEpisodeScan] = []
+    attempts: list[EpisodeScanAttempt] = []
+    for pack in packs:
+        scan: BankedEpisodeScan | None = None
+        parsed = None
+        request_trace: RequestTrace | None = None
+        try:
+            answer = requester.ask(build_episode_request(pack, limits=limits))
+        except Exception as exc:  # WHY: optional model failure cannot remove source membership
+            answer = None
+            request_trace = getattr(exc, "request_trace", None)
+            if not isinstance(request_trace, RequestTrace):
+                request_trace = None
+        if answer is not None:
+            scan = BankedEpisodeScan(pack.pack_id, pack.page.sheet_id, answer)
+            banked.append(scan)
+            tile_map = {
+                (scope.episode_alias, scope.page_alias, ref.number): ref.entity_id
+                for scope in pack.scopes
+                for ref in scope.tile_refs
+            }
+            observation_map = {
+                (scope.episode_alias, scope.page_alias): (scope.episode_id, scope.page_id)
+                for scope in pack.scopes
+            }
+            parsed = read_episode_answers(
+                answer.raw_text,
+                pack_alias=1,
+                expected_observations=tuple(
+                    (scope.episode_id, scope.page_id) for scope in pack.scopes
+                ),
+                observation_map=observation_map,
+                tile_map=tile_map,
+            )
+            request_trace = answer.request_trace
+        attempts.append(EpisodeScanAttempt(pack.pack_id, pack.page.sheet_id, answer, request_trace))
+        by_identity = {
+            (reading.episode_id, reading.page_id): reading
+            for reading in (() if parsed is None else parsed.readings)
+        }
+        invalid_observations = set(() if parsed is None else parsed.invalid_observations)
+        observations.extend(
+            EpisodePageObservation(
+                scope.episode_id,
+                scope.page_id,
+                # Unviewable candidates left before the sheet was built, so a
+                # scope with no tiles is an empty episode rather than a blind one.
+                None
+                if not scope.tile_refs or (scope.episode_id, scope.page_id) in invalid_observations
+                else by_identity.get((scope.episode_id, scope.page_id)),
+                scan,
+            )
+            for scope in pack.scopes
+        )
+    return tuple(observations), tuple(banked), tuple(attempts)
+
+
+def _complete_episode_readings(
+    episodes: tuple[EpisodeSheet, ...],
+    observations: tuple[EpisodePageObservation, ...],
+) -> tuple[EpisodeReading, ...]:
+    readings: list[EpisodeReading] = []
+    for episode in episodes:
+        page_observations = tuple(
+            observation
+            for observation in observations
+            if observation.episode_id == episode.episode_id
+        )
+        if len(page_observations) != len(episode.pages) or any(
+            observation.reading is None or observation.scan is None
+            for observation in page_observations
+        ):
+            continue
+        page_readings: list[EpisodePageReading] = []
+        page_provenances: list[DecisionProvenance] = []
+        for observation in page_observations:
+            assert observation.reading is not None
+            assert observation.scan is not None
+            page_readings.append(observation.reading)
+            page_provenances.append(observation.scan.answer.provenance)
+        readings.append(
+            EpisodeReading(
+                episode_id=episode.episode_id,
+                visual_summary=" ".join(
+                    page_reading.visual_summary for page_reading in page_readings
+                ),
+                representative_asset_ids=tuple(
+                    asset_id
+                    for page_reading in page_readings
+                    for asset_id in page_reading.representative_asset_ids
+                ),
+                representative_reasons=tuple(
+                    page_reading.representative_reason for page_reading in page_readings
+                ),
+                page_provenances=tuple(page_provenances),
+            )
+        )
+    return tuple(readings)
+
+
+def _pass_provenance(
+    prepared: PreparedEditorialSource,
+    packs: tuple[EpisodeScanPack, ...],
+    scans: tuple[BankedEpisodeScan, ...],
+    *,
+    period_pages: tuple[ContactSheetPage, ...] = (),
+    period_answer: BankedVisualAnswer | None = None,
+) -> DecisionProvenance:
+    answers = tuple(scan.answer for scan in scans) + (
+        (period_answer,) if period_answer is not None else ()
+    )
+    request_keys = tuple(answer.provenance.request_key for answer in answers)
+    pages = (*(pack.page for pack in packs), *period_pages)
+    return DecisionProvenance(
+        pass_name="pass-0",  # noqa: S106 - public editorial pass identity
+        pass_version=PASS_ZERO_VERSION,
+        schema_version="period-insight-v1",
+        model_identity=answers[0].provenance.model_identity if answers else "",
+        input_ids=prepared.candidate_ids,
+        sheet_hashes=tuple(page.sha256 for page in pages),
+        request_key=sha256("\x00".join(request_keys).encode()).hexdigest(),
+        cache_hit=bool(answers) and all(answer.provenance.cache_hit for answer in answers),
+    )
+
+
+def _unavailable_insight(
+    prepared: PreparedEditorialSource,
+    packs: tuple[EpisodeScanPack, ...],
+    scans: tuple[BankedEpisodeScan, ...],
+    *,
+    reason: str,
+    period_pages: tuple[ContactSheetPage, ...] = (),
+    period_answer: BankedVisualAnswer | None = None,
+) -> PeriodInsight:
+    return PeriodInsight(
+        thesis=None,
+        evidence=(),
+        tensions=(),
+        recurring_threads=(),
+        unavailable_reason=reason,
+        revision=0,
+        provenance=_pass_provenance(
+            prepared,
+            packs,
+            scans,
+            period_pages=period_pages,
+            period_answer=period_answer,
+        ),
+    )
+
+
+def _record_pass_zero(
+    prepared: PreparedEditorialSource,
+    provenance: DecisionProvenance,
+    request_traces: tuple[RequestTrace, ...],
+) -> None:
+    prepared.trace.record_editorial_pass(
+        PassTrace(
+            name="pass-0",
+            input_ids=prepared.candidate_ids,
+            kept_ids=prepared.candidate_ids,
+            rejected=(),
+            unresolved=(),
+            duration_before=sum(item.shippable_duration for item in prepared.candidates),
+            duration_after=sum(item.shippable_duration for item in prepared.candidates),
+            provenance=provenance,
+            request_traces=request_traces,
+        )
+    )
+
+
+def _warn_once(
+    prepared: PreparedEditorialSource,
+    result_warnings: list[str],
+    message: str,
+) -> None:
+    marked = f"!! {message}"
+    if marked not in prepared.trace.warnings:
+        prepared.trace.warnings.append(marked)
+    if marked not in result_warnings:
+        result_warnings.append(marked)

--- a/src/immich_memories/analysis/period_insight_answer.py
+++ b/src/immich_memories/analysis/period_insight_answer.py
@@ -1,0 +1,355 @@
+"""Strict answers for hierarchical visual insight."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, TypeGuard
+
+from immich_memories.analysis.editorial_contracts import InsightEvidence
+from immich_memories.analysis.strict_json import (
+    bounded_model_text,
+    final_json_object,
+    is_safe_model_text,
+)
+
+EpisodeObservationKey = tuple[int, int]
+EpisodeObservationValue = tuple[str, str]
+EpisodeTileKey = tuple[int, int, int]
+PeriodTileKey = tuple[str, int]
+PeriodTileValue = tuple[str, str]
+EPISODE_SCAN_SCHEMA_VERSION = "episode-scan-v4"
+PERIOD_INSIGHT_SCHEMA_VERSION = "period-insight-v1"
+# Declining is the decision; explaining the decline is prose. A model that
+# sets thesis to null and says nothing beside it has still answered.
+THESIS_DECLINED_WITHOUT_REASON = "no thesis offered, and no reason stated"
+EPISODE_VISUAL_SUMMARY_MAX_CHARS = 64
+EPISODE_REPRESENTATIVE_REASON_MAX_CHARS = 96
+
+
+@dataclass(frozen=True)
+class EpisodePageReading:
+    """One complete page observation resolved back to stable asset IDs."""
+
+    episode_id: str
+    page_id: str
+    visual_summary: str
+    representative_asset_ids: tuple[str, ...]
+    representative_reason: str
+
+    def __post_init__(self) -> None:
+        if not is_safe_model_text(
+            self.visual_summary,
+            max_chars=EPISODE_VISUAL_SUMMARY_MAX_CHARS,
+        ) or not is_safe_model_text(
+            self.representative_reason,
+            max_chars=EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+        ):
+            raise ValueError("episode page reading needs bounded safe single-line text")
+
+
+@dataclass(frozen=True)
+class PeriodInsightAnswer:
+    """A complete provisional reading before request provenance is attached."""
+
+    thesis: str | None
+    evidence: tuple[InsightEvidence, ...]
+    tensions: tuple[str, ...]
+    recurring_threads: tuple[str, ...]
+    unavailable_reason: str | None
+
+    def __post_init__(self) -> None:
+        if (self.thesis is None) == (self.unavailable_reason is None):
+            raise ValueError("period insight answer needs exactly one outcome")
+        if self.thesis is not None and (not self.thesis.strip() or not self.evidence):
+            raise ValueError("period insight answer thesis needs visual evidence")
+        if self.unavailable_reason is not None and not self.unavailable_reason.strip():
+            raise ValueError("period insight answer unavailable reason cannot be blank")
+        if any(not item.episode_ids or not item.asset_ids for item in self.evidence):
+            raise ValueError("period insight answer evidence must identify episodes and assets")
+
+
+@dataclass(frozen=True)
+class EpisodeScanReadings:
+    """Valid episode namespaces and the required observations that did not parse."""
+
+    readings: tuple[EpisodePageReading, ...]
+    invalid_observations: tuple[tuple[str, str], ...]
+
+
+def read_episode_answer(
+    raw: str,
+    *,
+    episode_alias: int,
+    page_alias: int,
+    observation_map: Mapping[EpisodeObservationKey, EpisodeObservationValue],
+    tile_map: Mapping[EpisodeTileKey, str],
+) -> EpisodePageReading | None:
+    """Read one complete page namespace without repairing malformed JSON."""
+    payload = final_json_object(raw)
+    if payload is None:
+        return None
+    if payload.get("schema_version") != EPISODE_SCAN_SCHEMA_VERSION:
+        return None
+    if (
+        not _is_integer_alias(payload.get("episode"))
+        or not _is_integer_alias(payload.get("page"))
+        or payload.get("episode") != episode_alias
+        or payload.get("page") != page_alias
+    ):
+        return None
+    stable_identity = observation_map.get((episode_alias, page_alias))
+    if stable_identity is None:
+        return None
+    reading = payload.get("episode_reading")
+    if not isinstance(reading, dict):
+        return None
+    return _read_episode_namespace(
+        reading,
+        episode_alias=episode_alias,
+        page_alias=page_alias,
+        episode_id=stable_identity[0],
+        page_id=stable_identity[1],
+        tile_map=tile_map,
+    )
+
+
+def read_episode_answers(
+    raw: str,
+    *,
+    pack_alias: int,
+    expected_observations: tuple[tuple[str, str], ...],
+    observation_map: Mapping[EpisodeObservationKey, EpisodeObservationValue],
+    tile_map: Mapping[EpisodeTileKey, str],
+) -> EpisodeScanReadings | None:
+    """Parse each required episode namespace independently from one physical pack."""
+    payload = final_json_object(raw)
+    if (
+        payload is None
+        or payload.get("schema_version") != EPISODE_SCAN_SCHEMA_VERSION
+        or not _is_integer_alias(payload.get("pack"))
+        or payload.get("pack") != pack_alias
+        or len(expected_observations) != len(set(expected_observations))
+        or len(observation_map) != len(set(observation_map.values()))
+        or set(observation_map.values()) != set(expected_observations)
+    ):
+        return None
+    values = payload.get("episode_readings")
+    if not isinstance(values, list):
+        return None
+    by_alias: dict[EpisodeObservationKey, list[dict[str, Any]]] = {}
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        episode_alias = value.get("episode")
+        page_alias = value.get("page")
+        if not _is_integer_alias(episode_alias) or not _is_integer_alias(page_alias):
+            continue
+        by_alias.setdefault((episode_alias, page_alias), []).append(value)
+    alias_by_observation = {stable: alias for alias, stable in observation_map.items()}
+    readings: list[EpisodePageReading] = []
+    invalid: list[tuple[str, str]] = []
+    for episode_id, page_id in expected_observations:
+        episode_alias, page_alias = alias_by_observation[(episode_id, page_id)]
+        candidates = by_alias.get((episode_alias, page_alias), [])
+        reading = None
+        if len(candidates) == 1:
+            singular_raw = json.dumps(
+                {
+                    "schema_version": EPISODE_SCAN_SCHEMA_VERSION,
+                    "episode": episode_alias,
+                    "page": page_alias,
+                    "episode_reading": candidates[0],
+                },
+                separators=(",", ":"),
+            )
+            reading = read_episode_answer(
+                singular_raw,
+                episode_alias=episode_alias,
+                page_alias=page_alias,
+                observation_map=observation_map,
+                tile_map=tile_map,
+            )
+        if reading is None:
+            invalid.append((episode_id, page_id))
+        else:
+            readings.append(reading)
+    return EpisodeScanReadings(tuple(readings), tuple(invalid))
+
+
+def _read_episode_namespace(
+    reading: Mapping[str, object],
+    *,
+    episode_alias: int,
+    page_alias: int,
+    episode_id: str,
+    page_id: str,
+    tile_map: Mapping[EpisodeTileKey, str],
+) -> EpisodePageReading | None:
+    summary = bounded_model_text(
+        reading.get("visual_summary"), max_chars=EPISODE_VISUAL_SUMMARY_MAX_CHARS
+    )
+    displayed = reading.get("representative_tiles")
+    representative_reason = bounded_model_text(
+        reading.get("representative_reason"),
+        max_chars=EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+    )
+    numbers = _tile_numbers(displayed)
+    if summary is None or representative_reason is None or not numbers:
+        return None
+    if len(numbers) != len(set(numbers)):
+        return None
+    keys = tuple((episode_alias, page_alias, number) for number in numbers)
+    if any(key not in tile_map for key in keys):
+        return None
+    return EpisodePageReading(
+        episode_id=episode_id,
+        page_id=page_id,
+        visual_summary=summary,
+        representative_asset_ids=tuple(tile_map[key] for key in keys),
+        representative_reason=representative_reason,
+    )
+
+
+def _stated_outcome(insight: dict[str, object]) -> tuple[str | None, str | None] | None:
+    """The thesis and the reason there is none, or None when they contradict.
+
+    Exactly one of the two is the answer. Both set is a contradiction; neither
+    set is an omission, resolved once the rest of the answer is known.
+    """
+    thesis = insight.get("thesis")
+    unavailable_reason = insight.get("unavailable_reason")
+    for value in (thesis, unavailable_reason):
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            return None
+    if thesis is not None and unavailable_reason is not None:
+        return None
+    return (
+        thesis.strip() if isinstance(thesis, str) else None,
+        unavailable_reason.strip() if isinstance(unavailable_reason, str) else None,
+    )
+
+
+def read_period_answer(
+    raw: str,
+    *,
+    page_ids: tuple[str, ...],
+    tile_map: Mapping[PeriodTileKey, PeriodTileValue],
+) -> PeriodInsightAnswer | None:
+    """Read a complete period synthesis whose evidence resolves to visible tiles."""
+    payload = final_json_object(raw)
+    if payload is None or payload.get("schema_version") != PERIOD_INSIGHT_SCHEMA_VERSION:
+        return None
+    insight = payload.get("period_insight")
+    if not isinstance(insight, dict) or not page_ids or len(page_ids) != len(set(page_ids)):
+        return None
+    outcome = _stated_outcome(insight)
+    if outcome is None:
+        return None
+    thesis, unavailable_reason = outcome
+    evidence = _evidence(insight.get("evidence"), page_ids=page_ids, tile_map=tile_map)
+    tensions = _texts(insight.get("tensions"))
+    recurring_threads = _texts(insight.get("recurring_threads"))
+    if (
+        evidence is None
+        or tensions is None
+        or recurring_threads is None
+        or (thesis is not None and not evidence)
+    ):
+        return None
+    if thesis is unavailable_reason is None:
+        # An answer that declined a thesis but still read the wall has answered.
+        # One that says nothing at all has not, and stays unreadable.
+        if not (evidence or tensions or recurring_threads):
+            return None
+        unavailable_reason = THESIS_DECLINED_WITHOUT_REASON
+    return PeriodInsightAnswer(
+        thesis=thesis,
+        evidence=evidence,
+        tensions=tensions,
+        recurring_threads=recurring_threads,
+        unavailable_reason=unavailable_reason,
+    )
+
+
+def _evidence(
+    value: object,
+    *,
+    page_ids: tuple[str, ...],
+    tile_map: Mapping[PeriodTileKey, PeriodTileValue],
+) -> tuple[InsightEvidence, ...] | None:
+    if not isinstance(value, list):
+        return None
+    parsed: list[InsightEvidence] = []
+    for item in value:
+        if not isinstance(item, dict):
+            return None
+        observation = item.get("observation")
+        keys = _period_tile_keys(item.get("representative_tiles"), page_ids)
+        if (
+            not isinstance(observation, str)
+            or not observation.strip()
+            or not keys
+            or len(keys) != len(set(keys))
+            or any(key not in tile_map for key in keys)
+        ):
+            return None
+        references = tuple(tile_map[key] for key in keys)
+        try:
+            evidence = InsightEvidence(
+                observation=observation.strip(),
+                episode_ids=_unique(reference[0] for reference in references),
+                asset_ids=_unique(reference[1] for reference in references),
+            )
+        except ValueError:
+            return None
+        parsed.append(evidence)
+    return tuple(parsed)
+
+
+def _period_tile_keys(value: object, page_ids: tuple[str, ...]) -> tuple[PeriodTileKey, ...]:
+    numbers = _tile_numbers(value)
+    if numbers:
+        return tuple((page_ids[0], number) for number in numbers) if len(page_ids) == 1 else ()
+    if not isinstance(value, list):
+        return ()
+    keys: list[PeriodTileKey] = []
+    for item in value:
+        if not isinstance(item, dict):
+            return ()
+        page_id = item.get("page_id")
+        number = item.get("tile")
+        if (
+            not isinstance(page_id, str)
+            or page_id not in page_ids
+            or not isinstance(number, int)
+            or isinstance(number, bool)
+        ):
+            return ()
+        keys.append((page_id, number))
+    return tuple(keys)
+
+
+def _texts(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, list):
+        return None
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        return None
+    return tuple(item.strip() for item in value)
+
+
+def _unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+def _tile_numbers(value: object) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        return ()
+    if any(not isinstance(item, int) or isinstance(item, bool) for item in value):
+        return ()
+    return tuple(value)
+
+
+def _is_integer_alias(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1

--- a/src/immich_memories/analysis/selection_cull.py
+++ b/src/immich_memories/analysis/selection_cull.py
@@ -1,0 +1,536 @@
+"""Reject-only Pass 1 over banked episode scans and retained atlas pixels."""
+
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass, replace
+from hashlib import sha256
+from itertools import starmap
+from pathlib import Path
+from typing import Any, Literal
+
+from immich_memories.analysis.contact_sheets import (
+    ContactSheetPage,
+    build_contact_sheets,
+    sheet_layout,
+)
+from immich_memories.analysis.cull_answer import CullDecision, read_cull_namespaces
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    EditorialCandidate,
+    PassTrace,
+    RequestTrace,
+    TraceDecision,
+)
+from immich_memories.analysis.period_insight import (
+    EpisodeScanAttempt,
+    EpisodeScanPack,
+    PassZeroResult,
+)
+from immich_memories.analysis.selection_flow import PreparedEditorialSource
+from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+
+PASS_ONE_VERSION = "pass-1-v1"  # noqa: S105 - public editorial pass identity
+_REVIEW_STATE_COLOURS = {
+    "KEEP": (45, 65, 75),
+    "RECORD": (0, 115, 150),
+    "CULL": (170, 20, 20),
+}
+_REVIEW_FAVOURITE_COLOUR = (180, 130, 0)
+
+
+# Scopes a remembered verdict to what the buckets MEANT. Re-rendering a picture
+# must not clear a judgement about what it is; redefining `notes` must.
+CULL_PASS_VERSION = "pass-1-cull-v1"  # noqa: S105 - editorial pass identity
+
+
+@dataclass(frozen=True)
+class CullReviewEntry:
+    """One globally numbered owner-review visual and its Pass 1 state."""
+
+    number: int
+    page_id: str
+    asset_id: str
+    taken_at: str
+    favourite: bool
+    status: Literal["KEEP", "RECORD", "CULL"]
+    reason: str | None
+    source_tile_sha256: str | None
+
+
+@dataclass(frozen=True)
+class CullReviewArtifacts:
+    """Zero-call owner pages and their complete machine-readable legend."""
+
+    pages: tuple[ContactSheetPage, ...]
+    entries: tuple[CullReviewEntry, ...]
+    warnings: tuple[str, ...]
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class CullPassResult:
+    """Chronological Pass 1 membership after junk and failures are removed."""
+
+    survivors: tuple[EditorialCandidate, ...]
+    rejected: tuple[CullDecision, ...]
+    warnings: tuple[str, ...]
+    trace: PassTrace
+    review: CullReviewArtifacts
+    actual_calls: int = 0
+
+
+@dataclass(frozen=True)
+class _PackCullReading:
+    rejects: tuple[CullDecision, ...] = ()
+    warnings: tuple[str, ...] = ()
+    requests: tuple[RequestTrace, ...] = ()
+
+
+def run_cull(
+    prepared: PreparedEditorialSource,
+    pass_zero: PassZeroResult,
+    *,
+    review_output_dir: Path,
+    verdicts: EditorialVerdicts | None = None,
+) -> CullPassResult:
+    """Reparse banked v3 Pass 1 namespaces without making another model request."""
+    attempts = {(attempt.pack_id, attempt.page_id): attempt for attempt in pass_zero.scan_attempts}
+    readings = tuple(
+        _read_pack_cull(pack, attempts.get((pack.pack_id, pack.page.sheet_id)))
+        for pack in pass_zero.episode_packs
+    )
+    rejects, pass_one_warnings, logical_requests = _combine_pack_readings(readings)
+    # What a picture IS does not change between memories, so a verdict reached
+    # once stands for all of them. What it sat beside does change, which is why
+    # only the two removing buckets are remembered.
+    rejects, remembered_warnings = _with_remembered_verdicts(prepared, rejects, verdicts)
+    pass_one_warnings = _ordered_unique((*pass_one_warnings, *remembered_warnings))
+    rejects, favourite_warnings = _protect_favourites(prepared, rejects)
+    pass_one_warnings = _ordered_unique((*pass_one_warnings, *favourite_warnings))
+    ordered_rejects, survivors = _apply_cull(prepared, rejects)
+    pass_one_warnings = _with_over_cull_warning(
+        pass_one_warnings,
+        len(ordered_rejects),
+        len(prepared.candidates),
+    )
+    _record_new_warnings(prepared, pass_one_warnings)
+    recorded_trace = _record_cull_trace(
+        prepared,
+        pass_zero,
+        survivors,
+        ordered_rejects,
+        logical_requests,
+    )
+    if verdicts is not None:
+        verdicts.remember(
+            ((item.asset_id, item.bucket) for item in ordered_rejects),
+            pass_version=CULL_PASS_VERSION,
+        )
+    warnings = _authoritative_warnings(prepared)
+    review = _render_review(
+        prepared,
+        pass_zero,
+        ordered_rejects,
+        warnings,
+        review_output_dir,
+    )
+    return CullPassResult(
+        survivors,
+        ordered_rejects,
+        warnings,
+        recorded_trace,
+        review,
+    )
+
+
+def _read_pack_cull(
+    pack: EpisodeScanPack,
+    attempt: EpisodeScanAttempt | None,
+) -> _PackCullReading:
+    if attempt is None:
+        return _PackCullReading(warnings=(f"!! Pass 1 missing episode scan: {pack.page.sheet_id}",))
+    requests = (
+        ()
+        if attempt.request_trace is None
+        else (replace(attempt.request_trace, actual_calls=0, attempts=()),)
+    )
+    if attempt.answer is None:
+        return _PackCullReading(
+            warnings=(f"!! Pass 1 failed episode scan: {pack.page.sheet_id}",),
+            requests=requests,
+        )
+    if not _bank_matches_pack(pack, attempt.answer.request_trace):
+        return _PackCullReading(
+            warnings=(f"!! Pass 1 mismatched episode scan provenance: {pack.page.sheet_id}",),
+            requests=requests,
+        )
+    parsed = read_cull_namespaces(
+        attempt.answer.raw_text,
+        pack_alias=1,
+        tile_map=_tile_map(pack),
+        episode_tiles=_episode_tiles(pack),
+        unavailable_asset_ids=frozenset(
+            asset_id for scope in pack.scopes for asset_id in scope.unavailable_asset_ids
+        ),
+    )
+    if parsed is None:
+        return _PackCullReading(
+            warnings=(f"!! Pass 1 unreadable episode scan: {pack.page.sheet_id}",),
+            requests=requests,
+        )
+    return _PackCullReading(
+        rejects=parsed.cull_rejects,
+        warnings=_namespace_warnings(pack.page.sheet_id, parsed.cull_valid) + parsed.warnings,
+        requests=requests,
+    )
+
+
+def _namespace_warnings(page_id: str, cull_valid: bool) -> tuple[str, ...]:
+    return () if cull_valid else (f"!! Pass 1 invalid Cull namespace: {page_id}",)
+
+
+def _combine_pack_readings(
+    readings: tuple[_PackCullReading, ...],
+) -> tuple[
+    tuple[CullDecision, ...],
+    tuple[str, ...],
+    tuple[RequestTrace, ...],
+]:
+    rejects = tuple(reject for reading in readings for reject in reading.rejects)
+    warnings = _ordered_unique(
+        tuple(warning for reading in readings for warning in reading.warnings)
+    )
+    requests = tuple(request for reading in readings for request in reading.requests)
+    return rejects, warnings, requests
+
+
+def _apply_cull(
+    prepared: PreparedEditorialSource,
+    rejects: tuple[CullDecision, ...],
+) -> tuple[tuple[CullDecision, ...], tuple[EditorialCandidate, ...]]:
+    order = {candidate.asset_id: index for index, candidate in enumerate(prepared.candidates)}
+    ordered_rejects = tuple(sorted(rejects, key=lambda item: order[item.asset_id]))
+    rejected_ids = {decision.asset_id for decision in ordered_rejects}
+    survivors = tuple(
+        candidate for candidate in prepared.candidates if candidate.asset_id not in rejected_ids
+    )
+    return ordered_rejects, survivors
+
+
+def _with_remembered_verdicts(
+    prepared: PreparedEditorialSource,
+    rejects: tuple[CullDecision, ...],
+    verdicts: EditorialVerdicts | None,
+) -> tuple[tuple[CullDecision, ...], tuple[str, ...]]:
+    """This run's rejects, plus the standing verdicts about the same pictures."""
+    if verdicts is None:
+        return rejects, ()
+    decided = {decision.asset_id for decision in rejects}
+    remembered = verdicts.recall(prepared.candidate_ids, pass_version=CULL_PASS_VERSION)
+    added = tuple(
+        starmap(
+            CullDecision,
+            (pair for pair in remembered.items() if pair[0] not in decided),
+        )
+    )
+    warnings = tuple(
+        f"!! remembered verdict culled {decision.asset_id}: {decision.reason}" for decision in added
+    )
+    return (*rejects, *added), warnings
+
+
+def _protect_favourites(
+    prepared: PreparedEditorialSource,
+    rejects: tuple[CullDecision, ...],
+) -> tuple[tuple[CullDecision, ...], tuple[str, ...]]:
+    favourite_ids = {candidate.asset_id for candidate in prepared.candidates if candidate.favourite}
+    protected = tuple(decision for decision in rejects if decision.asset_id in favourite_ids)
+    accepted = tuple(decision for decision in rejects if decision.asset_id not in favourite_ids)
+    warnings = tuple(
+        f"!! cull reject conflicted with protected favourite: {decision.asset_id}"
+        for decision in protected
+    )
+    return accepted, warnings
+
+
+def _with_over_cull_warning(
+    warnings: tuple[str, ...],
+    reject_count: int,
+    candidate_count: int,
+) -> tuple[str, ...]:
+    if reject_count * 4 > candidate_count * 3:
+        return (*warnings, "!! possible over-cull")
+    return warnings
+
+
+def _record_new_warnings(
+    prepared: PreparedEditorialSource,
+    warnings: tuple[str, ...],
+) -> None:
+    prepared.trace.warnings.extend(
+        warning for warning in warnings if warning not in prepared.trace.warnings
+    )
+
+
+def _authoritative_warnings(prepared: PreparedEditorialSource) -> tuple[str, ...]:
+    return _ordered_unique(
+        tuple(
+            warning if warning.startswith("!!") else f"!! {warning}"
+            for warning in prepared.trace.warnings
+        )
+    )
+
+
+def _record_cull_trace(
+    prepared: PreparedEditorialSource,
+    pass_zero: PassZeroResult,
+    survivors: tuple[EditorialCandidate, ...],
+    rejects: tuple[CullDecision, ...],
+    requests: tuple[RequestTrace, ...],
+) -> PassTrace:
+    provenance = _pass_provenance(prepared, pass_zero, requests)
+    prepared.trace.record_editorial_pass(
+        PassTrace(
+            name="pass-1-cull",
+            input_ids=prepared.candidate_ids,
+            kept_ids=tuple(candidate.asset_id for candidate in survivors),
+            rejected=tuple(TraceDecision(item.asset_id, item.reason) for item in rejects),
+            unresolved=(),
+            duration_before=sum(item.shippable_duration for item in prepared.candidates),
+            duration_after=sum(item.shippable_duration for item in survivors),
+            provenance=provenance,
+            request_traces=requests,
+        )
+    )
+    return prepared.trace.editorial_passes[-1]
+
+
+def _episode_tiles(pack: EpisodeScanPack) -> dict[int, tuple[int, ...]]:
+    return {
+        scope.episode_alias: tuple(ref.number for ref in scope.tile_refs) for scope in pack.scopes
+    }
+
+
+def _tile_map(pack: EpisodeScanPack) -> dict[int, str]:
+    return {ref.number: ref.entity_id for scope in pack.scopes for ref in scope.tile_refs}
+
+
+def _bank_matches_pack(pack: EpisodeScanPack, request_trace: RequestTrace) -> bool:
+    expected_ids = tuple(ref.entity_id for ref in pack.page.tile_refs)
+    return (
+        request_trace.provenance.input_ids == expected_ids
+        and request_trace.provenance.sheet_hashes
+        == request_trace.attached_sheet_hashes
+        == (pack.page.sha256,)
+    )
+
+
+def _pass_provenance(
+    prepared: PreparedEditorialSource,
+    pass_zero: PassZeroResult,
+    requests: tuple[RequestTrace, ...],
+) -> DecisionProvenance:
+    keys = tuple(request.provenance.request_key for request in requests)
+    return DecisionProvenance(
+        pass_name="pass-1-cull",  # noqa: S106 - public editorial pass identity
+        pass_version=PASS_ONE_VERSION,
+        schema_version="episode-scan-v3",
+        model_identity=requests[0].provenance.model_identity if requests else "",
+        input_ids=prepared.candidate_ids,
+        sheet_hashes=tuple(pack.page.sha256 for pack in pass_zero.episode_packs),
+        request_key=sha256("\x00".join(keys).encode()).hexdigest(),
+        cache_hit=bool(requests) and all(request.cache_hit for request in requests),
+    )
+
+
+def _render_review(
+    prepared: PreparedEditorialSource,
+    pass_zero: PassZeroResult,
+    rejects: tuple[CullDecision, ...],
+    warnings: tuple[str, ...],
+    output_dir: Path,
+) -> CullReviewArtifacts:
+    reject_by_id = {decision.asset_id: decision for decision in rejects}
+    atlas_tiles = tuple(
+        pass_zero.atlas.tile_for(candidate.asset_id) for candidate in prepared.candidates
+    )
+    pages = build_contact_sheets(atlas_tiles, "pass-0-1-review", output_dir)
+    page_by_asset = {ref.entity_id: page.sheet_id for page in pages for ref in page.tile_refs}
+    number_by_asset = {ref.entity_id: ref.number for page in pages for ref in page.tile_refs}
+    entries = tuple(
+        CullReviewEntry(
+            number=number_by_asset[candidate.asset_id],
+            page_id=page_by_asset[candidate.asset_id],
+            asset_id=candidate.asset_id,
+            taken_at=candidate.taken_at.isoformat(),
+            favourite=candidate.favourite,
+            status="CULL" if candidate.asset_id in reject_by_id else "KEEP",
+            reason=(
+                f"{reject_by_id[candidate.asset_id].bucket}: "
+                f"{reject_by_id[candidate.asset_id].reason}"
+                if candidate.asset_id in reject_by_id
+                else None
+            ),
+            source_tile_sha256=pass_zero.atlas.tile_for(candidate.asset_id).sha256,
+        )
+        for candidate in prepared.candidates
+    )
+    pages = tuple(
+        _decorate_review_page(
+            page,
+            tuple(entry for entry in entries if entry.page_id == page.sheet_id),
+        )
+        for page in pages
+    )
+    if warnings:
+        pages = tuple(_add_warning_banner(page, warnings) for page in pages)
+    manifest_path = output_dir / "pass-0-1-review.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "warnings": list(warnings),
+                "entries": [_review_entry_dict(entry) for entry in entries],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return CullReviewArtifacts(pages, entries, warnings, manifest_path)
+
+
+def _review_entry_dict(entry: CullReviewEntry) -> dict[str, object]:
+    return {
+        "number": entry.number,
+        "page_id": entry.page_id,
+        "asset_id": entry.asset_id,
+        "taken_at": entry.taken_at,
+        "favourite": entry.favourite,
+        "status": entry.status,
+        "reason": entry.reason,
+        "source_tile_sha256": entry.source_tile_sha256,
+    }
+
+
+def _decorate_review_page(
+    page: ContactSheetPage,
+    entries: tuple[CullReviewEntry, ...],
+) -> ContactSheetPage:
+    from PIL import Image, ImageDraw
+
+    with Image.open(io.BytesIO(page.jpeg_bytes)) as decoded:
+        sheet = decoded.convert("RGB")
+    draw = ImageDraw.Draw(sheet)
+    columns, tile = sheet_layout(len(page.tile_refs))
+    entry_by_number = {entry.number: entry for entry in entries}
+    for position, ref in enumerate(page.tile_refs):
+        _draw_review_markers(
+            draw,
+            left=(position % columns) * tile,
+            top=(position // columns) * tile,
+            tile=tile,
+            entry=entry_by_number[ref.number],
+        )
+    with_legend = _append_review_legend(sheet, entries)
+    return _replace_page_image(page, with_legend)
+
+
+def _draw_review_markers(
+    draw: Any,
+    *,
+    left: int,
+    top: int,
+    tile: int,
+    entry: CullReviewEntry,
+) -> None:
+    strip_height = max(18, min(26, tile // 6))
+    strip_top = top + tile - strip_height - 3
+    draw.rectangle(
+        (left + 3, strip_top, left + tile - 3, top + tile - 3),
+        fill=_REVIEW_STATE_COLOURS[entry.status],
+    )
+    draw.text((left + 7, strip_top + 4), entry.status, fill=(255, 255, 255))
+    if entry.favourite:
+        fav_width = 38
+        draw.rectangle(
+            (left + tile - fav_width - 3, top + 3, left + tile - 3, top + 21),
+            fill=_REVIEW_FAVOURITE_COLOUR,
+        )
+        draw.text((left + tile - fav_width + 2, top + 6), "FAV", fill=(255, 255, 255))
+
+
+def _append_review_legend(image: Any, entries: tuple[CullReviewEntry, ...]):
+    from PIL import Image, ImageDraw
+
+    decisions = tuple(entry for entry in entries if entry.status != "KEEP")
+    lines = tuple(
+        f"#{entry.number} {entry.status} {entry.reason}"
+        for entry in decisions
+        if entry.reason is not None
+    ) or ("No RECORD/CULL decisions on this page.",)
+    columns = 2
+    rows = -(-len(lines) // columns)
+    line_height = 14
+    footer_height = 34 + rows * line_height
+    composed = Image.new(
+        "RGB",
+        (image.width, image.height + footer_height),
+        (25, 25, 25),
+    )
+    composed.paste(image, (0, 0))
+    draw = ImageDraw.Draw(composed)
+    draw.text(
+        (8, image.height + 7),
+        "VISIBLE DECISION LEGEND - number -> function/defect/reason",
+        fill=(255, 255, 255),
+    )
+    column_width = image.width // columns
+    for index, line in enumerate(lines):
+        column = index % columns
+        row = index // columns
+        draw.text(
+            (8 + column * column_width, image.height + 25 + row * line_height),
+            line,
+            fill=(225, 225, 225),
+        )
+    return composed
+
+
+def _replace_page_image(page: ContactSheetPage, image: Any) -> ContactSheetPage:
+    output = io.BytesIO()
+    image.save(output, "JPEG", quality=88)
+    data = output.getvalue()
+    page.path.write_bytes(data)
+    return replace(page, jpeg_bytes=data, sha256=sha256(data).hexdigest())
+
+
+def _add_warning_banner(
+    page: ContactSheetPage,
+    warnings: tuple[str, ...],
+) -> ContactSheetPage:
+    from PIL import Image, ImageDraw
+
+    with Image.open(io.BytesIO(page.jpeg_bytes)) as decoded:
+        sheet = decoded.convert("RGB")
+    banner_height = 28 + 18 * len(warnings)
+    warned = Image.new("RGB", (sheet.width, sheet.height + banner_height), (185, 18, 18))
+    warned.paste(sheet, (0, banner_height))
+    draw = ImageDraw.Draw(warned)
+    draw.text((10, 7), "!! INVALID FOR OWNER VERDICT", fill=(255, 255, 255))
+    for index, warning in enumerate(warnings):
+        draw.text((10, 25 + index * 18), warning, fill=(255, 255, 255))
+    output = io.BytesIO()
+    warned.save(output, "JPEG", quality=88)
+    data = output.getvalue()
+    page.path.write_bytes(data)
+    return replace(page, jpeg_bytes=data, sha256=sha256(data).hexdigest())
+
+
+def _warn_once(warnings: list[str], warning: str) -> None:
+    if warning not in warnings:
+        warnings.append(warning)
+
+
+def _ordered_unique(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))

--- a/src/immich_memories/analysis/selection_flow.py
+++ b/src/immich_memories/analysis/selection_flow.py
@@ -1,0 +1,798 @@
+"""Prepare source-eligible visuals for the editorial selection passes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime
+from hashlib import sha256
+from operator import itemgetter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    EditorialCandidate,
+    LivePhotoRenderingFamily,
+    PassTrace,
+    SourceEvidence,
+    TraceDecision,
+    live_photo_rendering_family_id,
+)
+from immich_memories.analysis.moment_grouping import (
+    EPISODE_WINDOW_MINUTES,
+    MOMENT_WINDOW_MINUTES,
+    group_by_time_and_place,
+)
+from immich_memories.analysis.selection_trace import Trace
+from immich_memories.analysis.source_filter import (
+    is_editorial_source_asset,
+    live_photo_component_ids,
+    not_shot_here,
+)
+from immich_memories.analysis.source_quality import grounded_source_annotations
+from immich_memories.analysis.visual_atlas import AtlasSource
+from immich_memories.api.models import AssetType, VideoClipInfo
+
+if TYPE_CHECKING:
+    from immich_memories.analysis.editorial_gateway import EditorialGateway
+    from immich_memories.analysis.period_insight import PassZeroResult
+    from immich_memories.analysis.selection_cull import CullPassResult
+    from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+    from immich_memories.api.models import Asset
+
+__all__ = [
+    "EditorialDependencies",
+    "EditorialGroup",
+    "EditorialInsightCullResult",
+    "EditorialSelectionRequest",
+    "PreparedEditorialSource",
+    "SourceScope",
+    "build_episode_groups",
+    "build_moment_groups",
+    "prepare_editorial_source",
+    "run_editorial_insight_cull",
+]
+
+
+@dataclass(frozen=True)
+class SourceScope:
+    """The date and library boundaries used to acquire an editorial source."""
+
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    library_ids: tuple[str, ...] = ()
+    # Provenance, not quality: whether a file came off this library's camera is
+    # a fact about the file, so it settles scope rather than waiting for a pass
+    # to judge it. Every other pool builder asks the same question here.
+    excluded_filename_patterns: tuple[str, ...] = ()
+    stills_need_a_camera: bool = False
+
+
+@dataclass(frozen=True)
+class EditorialSelectionRequest:
+    """The source boundary and owner choices for one editorial selection."""
+
+    scope: SourceScope
+    owner_excluded_asset_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EditorialDependencies:
+    """External acquisition required before the pure editorial passes begin."""
+
+    source_fetcher: Callable[[SourceScope], Sequence[Asset | VideoClipInfo]]
+    library_membership: Callable[[Asset, tuple[str, ...]], bool] | None = None
+    source_evidence: Callable[[Asset | VideoClipInfo], SourceEvidence | None] | None = None
+    preview_jpeg: Callable[[Asset], bytes | None] | None = None
+
+
+@dataclass(frozen=True)
+class EditorialGroup:
+    """A chronological source group that has not selected a representative."""
+
+    group_id: str
+    candidates: tuple[EditorialCandidate, ...]
+
+    @property
+    def candidate_ids(self) -> tuple[str, ...]:
+        """Return the ordered IDs represented by this visual group."""
+        return tuple(candidate.asset_id for candidate in self.candidates)
+
+
+@dataclass(frozen=True)
+class PreparedEditorialSource:
+    """Chronological candidates and their admission record for subsequent passes."""
+
+    candidates: tuple[EditorialCandidate, ...]
+    visual_sources: tuple[AtlasSource, ...]
+    rendering_families: tuple[LivePhotoRenderingFamily, ...]
+    source_warnings: tuple[str, ...]
+    trace: Trace
+    episode_groups: tuple[EditorialGroup, ...]
+    moment_groups: tuple[EditorialGroup, ...]
+
+    @property
+    def candidate_ids(self) -> tuple[str, ...]:
+        """Return the stable source order without exposing mutable collection state."""
+        return tuple(candidate.asset_id for candidate in self.candidates)
+
+    @property
+    def excluded_ids(self) -> tuple[str, ...]:
+        """Return exclusions from the durable source-eligibility trace."""
+        source_pass = next(
+            pass_trace
+            for pass_trace in self.trace.editorial_passes
+            if pass_trace.name == "source-eligibility"
+        )
+        return tuple(decision.asset_id for decision in source_pass.rejected)
+
+
+@dataclass(frozen=True)
+class EditorialInsightCullResult:
+    """The public replacement slice through source, Insight, and Cull."""
+
+    prepared: PreparedEditorialSource
+    pass_zero: PassZeroResult
+    pass_one: CullPassResult
+
+
+def run_editorial_insight_cull(
+    request: EditorialSelectionRequest,
+    dependencies: EditorialDependencies,
+    *,
+    gateway_factory: Callable[[Trace], EditorialGateway],
+    sheet_output_dir: Path,
+    frame_cache_dir: Path | None,
+    review_output_dir: Path,
+    limits: VisionRequestLimits | None = None,
+) -> EditorialInsightCullResult:
+    """Run the single source-to-Pass-1 path on one shared trace and gateway."""
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    prepared = prepare_editorial_source(request, dependencies)
+    gateway = gateway_factory(prepared.trace)
+    pass_zero = run_period_insight(
+        prepared,
+        requester=gateway,
+        sheet_output_dir=sheet_output_dir,
+        frame_cache_dir=frame_cache_dir,
+        limits=limits,
+    )
+    pass_one = run_cull(prepared, pass_zero, review_output_dir=review_output_dir)
+    return EditorialInsightCullResult(prepared, pass_zero, pass_one)
+
+
+def prepare_editorial_source(
+    request: EditorialSelectionRequest,
+    dependencies: EditorialDependencies,
+) -> PreparedEditorialSource:
+    """Acquire, normalize, and admit the complete source-eligible corpus."""
+    excluded = set(request.owner_excluded_asset_ids)
+    sources, normalization_warnings = _coalesce_sources(
+        tuple(
+            sorted(
+                dependencies.source_fetcher(request.scope),
+                key=lambda source: (_asset(source).file_created_at, _asset_id(source)),
+            )
+        )
+    )
+    components = live_photo_component_ids(_asset(source) for source in sources)
+    source_decisions = tuple(
+        (source, _source_exclusion_reason(source, request, dependencies, excluded, components))
+        for source in sources
+    )
+    eligible_sources = tuple(
+        source for source, exclusion_reason in source_decisions if exclusion_reason is None
+    )
+    (
+        rendering_families,
+        stitch_memberships,
+        rendering_family_ids,
+        family_warnings,
+    ) = _rendering_family_material(eligible_sources)
+    source_warnings = (*normalization_warnings, *family_warnings)
+    candidates = tuple(
+        sorted(
+            (
+                _candidate_from(
+                    source,
+                    stitch_memberships.get(_asset_id(source), ()),
+                    rendering_family_ids.get(_asset_id(source)),
+                    dependencies.source_evidence(source)
+                    if dependencies.source_evidence is not None
+                    else None,
+                )
+                for source in eligible_sources
+            ),
+            key=lambda candidate: (candidate.taken_at, candidate.asset_id),
+        )
+    )
+    visual_sources = tuple(
+        _visual_source_from(source, dependencies.preview_jpeg) for source in eligible_sources
+    )
+    episode_groups = build_episode_groups(candidates)
+    moment_groups = build_moment_groups(candidates)
+    crossing_family_ids = _cross_moment_family_ids(rendering_families, moment_groups)
+    if crossing_family_ids:
+        source_warnings = (
+            *source_warnings,
+            *(
+                f"!! Live Photo rendering family crosses moment groups: {family_id}"
+                for family_id in crossing_family_ids
+            ),
+        )
+        rendering_families = tuple(
+            family for family in rendering_families if family.family_id not in crossing_family_ids
+        )
+        candidates = tuple(
+            _without_rendering_family(candidate)
+            if candidate.rendering_family_id in crossing_family_ids
+            else candidate
+            for candidate in candidates
+        )
+        episode_groups = build_episode_groups(candidates)
+        moment_groups = build_moment_groups(candidates)
+    trace = Trace()
+    trace.warnings.extend(source_warnings)
+    candidate_ids = tuple(candidate.asset_id for candidate in candidates)
+    source_ids = tuple(_asset_id(source) for source in sources)
+    trace.record_editorial_pass(
+        PassTrace(
+            name="source-eligibility",
+            input_ids=source_ids,
+            kept_ids=candidate_ids,
+            rejected=tuple(
+                TraceDecision(_asset_id(source), reason)
+                for source, reason in source_decisions
+                if reason is not None
+            ),
+            unresolved=(),
+            duration_before=sum(_duration_of(source) for source in sources),
+            duration_after=sum(candidate.shippable_duration for candidate in candidates),
+            provenance=_source_provenance("source-eligibility", source_ids),
+        )
+    )
+    prepared = PreparedEditorialSource(
+        candidates=candidates,
+        visual_sources=visual_sources,
+        rendering_families=rendering_families,
+        source_warnings=source_warnings,
+        trace=trace,
+        episode_groups=episode_groups,
+        moment_groups=moment_groups,
+    )
+    _validate_prepared_source(prepared)
+    return prepared
+
+
+def _candidate_from(
+    source: Asset | VideoClipInfo,
+    live_photo_stitch_member_ids: tuple[str, ...],
+    rendering_family_id: str | None,
+    evidence: SourceEvidence | None,
+) -> EditorialCandidate:
+    asset = source.asset if isinstance(source, VideoClipInfo) else source
+    is_video = asset.type == AssetType.VIDEO
+    grounded_annotations = grounded_source_annotations(
+        asset,
+        source if isinstance(source, VideoClipInfo) else None,
+        evidence,
+    )
+    if rendering_family_id is not None:
+        grounded_annotations = (
+            *grounded_annotations,
+            f"live-photo-rendering-family:{rendering_family_id}",
+            f"live-photo-stitch-members:{','.join(live_photo_stitch_member_ids)}",
+        )
+    return EditorialCandidate(
+        asset_id=asset.id,
+        taken_at=asset.file_created_at,
+        media_kind=("live_photo" if asset.is_live_photo else "video" if is_video else "photo"),
+        live_photo_stitch_member_ids=live_photo_stitch_member_ids,
+        rendering_family_id=rendering_family_id,
+        favourite=asset.is_favorite,
+        source=asset,
+        proposed_segment=None,
+        shippable_duration=(
+            source.duration_seconds
+            if isinstance(source, VideoClipInfo)
+            else (asset.duration_seconds or 0.0)
+        ),
+        grounded_annotations=grounded_annotations,
+    )
+
+
+def _visual_source_from(
+    source: Asset | VideoClipInfo,
+    preview_jpeg: Callable[[Asset], bytes | None] | None,
+) -> AtlasSource:
+    asset = _asset(source)
+    preview: bytes | None = None
+    unavailable_reason: str | None = None
+    if preview_jpeg is not None:
+        try:
+            preview = preview_jpeg(asset)
+        except Exception as exc:  # WHY: one failed external preview read cannot abort the corpus
+            unavailable_reason = (
+                f"preview provider raised {type(exc).__name__} and no usable motion frames"
+            )
+    return AtlasSource(
+        asset=asset,
+        preview_jpeg=preview,
+        motion_path=(
+            Path(source.local_path)
+            if isinstance(source, VideoClipInfo) and source.local_path is not None
+            else None
+        ),
+        unavailable_reason=unavailable_reason,
+    )
+
+
+def _asset_id(source: Asset | VideoClipInfo) -> str:
+    return source.asset.id if isinstance(source, VideoClipInfo) else source.id
+
+
+def _asset(source: Asset | VideoClipInfo) -> Asset:
+    return source.asset if isinstance(source, VideoClipInfo) else source
+
+
+def _coalesce_sources(
+    sources: Sequence[Asset | VideoClipInfo],
+) -> tuple[tuple[Asset | VideoClipInfo, ...], tuple[str, ...]]:
+    """Keep one canonical source per asset ID, preferring richer clip evidence."""
+    coalesced: dict[str, Asset | VideoClipInfo] = {}
+    conflicting_render_manifests: set[str] = set()
+    warnings: list[str] = []
+    for source in sources:
+        asset_id = _asset_id(source)
+        existing = coalesced.get(asset_id)
+        if existing is None:
+            coalesced[asset_id] = source
+            continue
+        if _asset_signature(existing) != _asset_signature(source):
+            raise ValueError(f"conflicting source representations for asset {asset_id}")
+        preferred = (
+            source if _source_evidence_rank(source) > _source_evidence_rank(existing) else existing
+        )
+        existing_manifest = _rendering_manifest_signature(existing)
+        source_manifest = _rendering_manifest_signature(source)
+        if (
+            existing_manifest is not None
+            and source_manifest is not None
+            and existing_manifest != source_manifest
+            and asset_id not in conflicting_render_manifests
+        ):
+            conflicting_render_manifests.add(asset_id)
+            warnings.append(
+                f"!! conflicting Live Photo rendering manifests for duplicate asset {asset_id}"
+            )
+        coalesced[asset_id] = _with_favourite(
+            _without_rendering_evidence(preferred)
+            if asset_id in conflicting_render_manifests
+            else preferred,
+            _asset(existing).is_favorite or _asset(source).is_favorite,
+        )
+    return tuple(coalesced.values()), tuple(warnings)
+
+
+def _rendering_manifest_signature(source: Asset | VideoClipInfo) -> tuple[object, ...] | None:
+    if not isinstance(source, VideoClipInfo) or not _has_rendering_family_evidence(source):
+        return None
+    manifests = (
+        source.live_burst_still_ids,
+        source.live_burst_video_ids,
+        source.live_burst_trim_points,
+        source.live_burst_shutter_timestamps,
+    )
+    if all(value is not None for value in manifests):
+        still_ids, video_ids, trim_points, timestamps = manifests
+        assert still_ids is not None
+        assert video_ids is not None
+        assert trim_points is not None
+        assert timestamps is not None
+        if len(still_ids) == len(video_ids) == len(trim_points) == len(timestamps):
+            return (
+                "aligned",
+                tuple(
+                    sorted(
+                        zip(timestamps, still_ids, video_ids, trim_points, strict=True),
+                        key=itemgetter(0, 1),
+                    )
+                ),
+            )
+    return (
+        "invalid",
+        tuple(source.live_burst_still_ids or ()),
+        tuple(source.live_burst_video_ids or ()),
+        tuple(source.live_burst_trim_points or ()),
+        tuple(source.live_burst_shutter_timestamps or ()),
+    )
+
+
+def _without_rendering_evidence(source: Asset | VideoClipInfo) -> Asset | VideoClipInfo:
+    if not isinstance(source, VideoClipInfo):
+        return source
+    return source.model_copy(
+        update={
+            "live_burst_still_ids": None,
+            "live_burst_video_ids": None,
+            "live_burst_trim_points": None,
+            "live_burst_shutter_timestamps": None,
+        }
+    )
+
+
+def _with_favourite(source: Asset | VideoClipInfo, favourite: bool) -> Asset | VideoClipInfo:
+    asset = _asset(source)
+    if asset.is_favorite is favourite:
+        return source
+    merged_asset = asset.model_copy(update={"is_favorite": favourite})
+    if isinstance(source, VideoClipInfo):
+        return source.model_copy(update={"asset": merged_asset})
+    return merged_asset
+
+
+def _rendering_family_material(
+    sources: Sequence[Asset | VideoClipInfo],
+) -> tuple[
+    tuple[LivePhotoRenderingFamily, ...],
+    dict[str, tuple[str, ...]],
+    dict[str, str],
+    tuple[str, ...],
+]:
+    families: dict[str, LivePhotoRenderingFamily] = {}
+    family_by_member: dict[str, str] = {}
+    warnings: list[str] = []
+    conflicting_family_ids: set[str] = set()
+    admitted_ids = {_asset_id(source) for source in sources}
+    for source in sources:
+        if not isinstance(source, VideoClipInfo) or not _has_rendering_family_evidence(source):
+            continue
+        try:
+            family = _rendering_family_from(source, admitted_ids)
+        except ValueError as exc:
+            warnings.append(f"!! invalid Live Photo rendering family for {source.asset.id}: {exc}")
+            continue
+        families[family.family_id] = family
+        for asset_id in family.still_ids:
+            existing = family_by_member.get(asset_id)
+            if existing is not None and existing != family.family_id:
+                conflicting_family_ids.update((existing, family.family_id))
+                warnings.append(
+                    f"!! conflicting Live Photo rendering family for admitted asset {asset_id}"
+                )
+            family_by_member[asset_id] = family.family_id
+    if conflicting_family_ids:
+        families = {
+            family_id: family
+            for family_id, family in families.items()
+            if family_id not in conflicting_family_ids
+        }
+        family_by_member = {
+            asset_id: family_id
+            for asset_id, family_id in family_by_member.items()
+            if family_id not in conflicting_family_ids
+        }
+    memberships = {
+        asset_id: families[family_id].still_ids for asset_id, family_id in family_by_member.items()
+    }
+    return (
+        tuple(sorted(families.values(), key=lambda family: family.family_id)),
+        memberships,
+        family_by_member,
+        tuple(dict.fromkeys(warnings)),
+    )
+
+
+def _has_rendering_family_evidence(source: VideoClipInfo) -> bool:
+    return any(
+        value is not None
+        for value in (
+            source.live_burst_still_ids,
+            source.live_burst_video_ids,
+            source.live_burst_trim_points,
+            source.live_burst_shutter_timestamps,
+        )
+    )
+
+
+def _rendering_family_from(
+    source: VideoClipInfo,
+    admitted_ids: set[str],
+) -> LivePhotoRenderingFamily:
+    manifests = (
+        source.live_burst_still_ids,
+        source.live_burst_video_ids,
+        source.live_burst_trim_points,
+        source.live_burst_shutter_timestamps,
+    )
+    if any(value is None for value in manifests):
+        raise ValueError("incomplete aligned manifest")
+    still_ids, video_ids, trim_points, timestamps = manifests
+    assert still_ids is not None
+    assert video_ids is not None
+    assert trim_points is not None
+    assert timestamps is not None
+    if not still_ids or not (
+        len(still_ids) == len(video_ids) == len(trim_points) == len(timestamps)
+    ):
+        raise ValueError("unaligned manifest lengths")
+    if source.asset.id not in still_ids:
+        raise ValueError("enriched source is absent from its still manifest")
+    admitted_entries = tuple(
+        sorted(
+            (
+                (timestamp, still_id, video_id, trim_point)
+                for still_id, video_id, trim_point, timestamp in zip(
+                    still_ids,
+                    video_ids,
+                    trim_points,
+                    timestamps,
+                    strict=True,
+                )
+                if still_id in admitted_ids
+            ),
+            key=itemgetter(0, 1),
+        )
+    )
+    if not admitted_entries:
+        raise ValueError("manifest has no admitted still")
+    ordered_timestamps = tuple(entry[0] for entry in admitted_entries)
+    ordered_still_ids = tuple(entry[1] for entry in admitted_entries)
+    ordered_video_ids = tuple(entry[2] for entry in admitted_entries)
+    ordered_trim_points = tuple(entry[3] for entry in admitted_entries)
+    family_id = live_photo_rendering_family_id(
+        ordered_still_ids,
+        ordered_video_ids,
+        ordered_trim_points,
+        ordered_timestamps,
+        motion_duration_seconds=None,
+        minimum_motion_seconds=None,
+    )
+    return LivePhotoRenderingFamily(
+        family_id=family_id,
+        still_ids=ordered_still_ids,
+        video_ids=ordered_video_ids,
+        trim_points=ordered_trim_points,
+        shutter_timestamps=ordered_timestamps,
+    )
+
+
+def _cross_moment_family_ids(
+    families: tuple[LivePhotoRenderingFamily, ...],
+    moment_groups: tuple[EditorialGroup, ...],
+) -> frozenset[str]:
+    moment_by_asset = {
+        asset_id: group.group_id for group in moment_groups for asset_id in group.candidate_ids
+    }
+    return frozenset(
+        family.family_id
+        for family in families
+        if len({moment_by_asset[asset_id] for asset_id in family.still_ids}) > 1
+    )
+
+
+def _without_rendering_family(candidate: EditorialCandidate) -> EditorialCandidate:
+    annotations = tuple(
+        annotation
+        for annotation in candidate.grounded_annotations
+        if not annotation.startswith(("live-photo-rendering-family:", "live-photo-stitch-members:"))
+    )
+    return replace(
+        candidate,
+        live_photo_stitch_member_ids=(),
+        rendering_family_id=None,
+        grounded_annotations=annotations,
+    )
+
+
+def _asset_signature(source: Asset | VideoClipInfo) -> tuple[object, ...]:
+    """Identify the immutable asset facts that must agree across representations."""
+    asset = _asset(source)
+    return (
+        asset.owner_id,
+        asset.device_asset_id,
+        asset.type,
+        asset.file_created_at,
+        asset.original_path,
+        asset.original_file_name,
+        asset.original_mime_type,
+        asset.checksum,
+        asset.live_photo_video_id,
+    )
+
+
+def _source_evidence_rank(source: Asset | VideoClipInfo) -> tuple[float, ...]:
+    if not isinstance(source, VideoClipInfo):
+        return (0.0, 0.0, 0.0, 0.0, 0.0)
+    return (
+        1.0,
+        source.duration_seconds,
+        float(source.width * source.height),
+        float(len(source.live_burst_still_ids or ())),
+        float(sum(value is not None for value in (source.llm_category, source.llm_quality))),
+    )
+
+
+def _source_exclusion_reason(
+    source: Asset | VideoClipInfo,
+    request: EditorialSelectionRequest,
+    dependencies: EditorialDependencies,
+    owner_exclusions: set[str],
+    components: frozenset[str],
+) -> str | None:
+    asset = _asset(source)
+    if asset.id in owner_exclusions:
+        return "owner exclusion"
+    if asset.id in components:
+        return "Live Photo component"
+    if not_shot_here(
+        asset,
+        patterns=request.scope.excluded_filename_patterns,
+        stills_need_a_camera=request.scope.stills_need_a_camera,
+    ):
+        return "not shot on this camera"
+    if request.scope.library_ids:
+        if dependencies.library_membership is None:
+            raise ValueError("library scope requires a library_membership dependency")
+        if not dependencies.library_membership(asset, request.scope.library_ids):
+            return "outside library scope"
+    if not is_editorial_source_asset(
+        asset,
+        start_at=request.scope.start_at,
+        end_at=request.scope.end_at,
+    ):
+        return _scope_exclusion_reason(asset, request.scope)
+    return None
+
+
+def _validate_prepared_source(prepared: PreparedEditorialSource) -> None:
+    if set(prepared.candidate_ids).intersection(prepared.excluded_ids):
+        raise ValueError("editorial source cannot both admit and exclude an asset")
+    visual_ids = tuple(str(source.asset.id) for source in prepared.visual_sources)
+    if visual_ids != prepared.candidate_ids:
+        raise ValueError("editorial candidates and visual sources must conserve order and identity")
+    _validate_rendering_family_references(prepared)
+
+
+def _validate_rendering_family_references(prepared: PreparedEditorialSource) -> None:
+    families = {family.family_id: family for family in prepared.rendering_families}
+    if len(families) != len(prepared.rendering_families):
+        raise ValueError("editorial rendering family IDs must be unique")
+    candidates = {candidate.asset_id: candidate for candidate in prepared.candidates}
+    for candidate in prepared.candidates:
+        _validate_candidate_family_reference(candidate, families)
+    for family in prepared.rendering_families:
+        if not _family_members_are_admitted(family, candidates):
+            raise ValueError("rendering family may contain only admitted referenced candidates")
+
+
+def _validate_candidate_family_reference(
+    candidate: EditorialCandidate,
+    families: dict[str, LivePhotoRenderingFamily],
+) -> None:
+    if candidate.rendering_family_id is None:
+        if candidate.live_photo_stitch_member_ids:
+            raise ValueError("diagnostic stitch membership requires a rendering family")
+        return
+    family = families.get(candidate.rendering_family_id)
+    if family is None or candidate.asset_id not in family.still_ids:
+        raise ValueError("editorial candidate references an unavailable rendering family")
+    if candidate.live_photo_stitch_member_ids != family.still_ids:
+        raise ValueError("editorial candidate stitch membership must match its family")
+
+
+def _family_members_are_admitted(
+    family: LivePhotoRenderingFamily,
+    candidates: dict[str, EditorialCandidate],
+) -> bool:
+    return all(
+        asset_id in candidates and candidates[asset_id].rendering_family_id == family.family_id
+        for asset_id in family.still_ids
+    )
+
+
+def _scope_exclusion_reason(asset: Asset, scope: SourceScope) -> str:
+    from immich_memories.api.models import AssetType
+
+    if asset.type not in (AssetType.IMAGE, AssetType.VIDEO):
+        return "unsupported media"
+    if scope.start_at is not None and asset.file_created_at < scope.start_at:
+        return "outside date scope"
+    if scope.end_at is not None and asset.file_created_at > scope.end_at:
+        return "outside date scope"
+    return "missing capture time"
+
+
+def _duration_of(source: Asset | VideoClipInfo) -> float:
+    return (
+        source.duration_seconds
+        if isinstance(source, VideoClipInfo)
+        else (source.duration_seconds or 0.0)
+    )
+
+
+def _source_provenance(pass_name: str, input_ids: tuple[str, ...]) -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name=pass_name,  # noqa: S106 - public source pass identity
+        pass_version="1",  # noqa: S106 - public pass version
+        schema_version="1",
+        model_identity="",
+        input_ids=input_ids,
+        sheet_hashes=(),
+        request_key="source-eligibility",
+        cache_hit=False,
+    )
+
+
+def build_episode_groups(candidates: Sequence[EditorialCandidate]) -> tuple[EditorialGroup, ...]:
+    """Build chronological visual episodes from source-eligible candidates."""
+    return _build_groups(candidates, kind="episode", window_minutes=EPISODE_WINDOW_MINUTES)
+
+
+def build_moment_groups(candidates: Sequence[EditorialCandidate]) -> tuple[EditorialGroup, ...]:
+    """Build chronological visual moments from source-eligible candidates."""
+    return _build_groups(candidates, kind="moment", window_minutes=MOMENT_WINDOW_MINUTES)
+
+
+def _build_groups(
+    candidates: Sequence[EditorialCandidate],
+    *,
+    kind: str,
+    window_minutes: float,
+) -> tuple[EditorialGroup, ...]:
+    ordered = tuple(
+        sorted(candidates, key=lambda candidate: (candidate.taken_at, candidate.asset_id))
+    )
+    _validate_unique_ids(ordered)
+    member_groups = tuple(
+        sorted(
+            group_by_time_and_place(ordered, window_minutes=window_minutes),
+            key=lambda members: (members[0].taken_at, members[0].asset_id),
+        )
+    )
+    groups = tuple(
+        EditorialGroup(
+            group_id=_group_id(kind, members),
+            candidates=members,
+        )
+        for members in member_groups
+    )
+    _validate_conservation(ordered, groups)
+    return groups
+
+
+def _group_id(kind: str, members: tuple[EditorialCandidate, ...]) -> str:
+    digest = sha256("\x00".join(candidate.asset_id for candidate in members).encode()).hexdigest()
+    return f"{kind}-v1-{digest}"
+
+
+def _validate_unique_ids(candidates: Sequence[EditorialCandidate]) -> None:
+    asset_ids = tuple(candidate.asset_id for candidate in candidates)
+    if len(asset_ids) != len(set(asset_ids)):
+        raise ValueError("editorial candidates must have unique asset IDs")
+
+
+def _validate_conservation(
+    candidates: Sequence[EditorialCandidate], groups: Sequence[EditorialGroup]
+) -> None:
+    expected_ids = tuple(candidate.asset_id for candidate in candidates)
+    grouped_ids = tuple(asset_id for group in groups for asset_id in group.candidate_ids)
+    if Counter(grouped_ids) != Counter(expected_ids):
+        raise ValueError("editorial grouping must conserve every candidate exactly once")
+    for group in groups:
+        ordered_members = tuple(
+            sorted(group.candidates, key=lambda candidate: (candidate.taken_at, candidate.asset_id))
+        )
+        if group.candidates != ordered_members:
+            raise ValueError("editorial group members must be chronological")
+    ordered_groups = tuple(
+        sorted(
+            groups, key=lambda group: (group.candidates[0].taken_at, group.candidates[0].asset_id)
+        )
+    )
+    if tuple(groups) != ordered_groups:
+        raise ValueError("editorial groups must be ordered by their first candidate")

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -54,6 +54,7 @@ class ClipStory:
     admitted_at: str | None
     # Why the stage that dropped it did so, when that stage said.
     reason: str | None = None
+    first_pass: str | None = None
 
 
 @dataclass(frozen=True)
@@ -160,6 +161,25 @@ class Trace:
         dropped_at: str | None = None
         admitted_at: str | None = None
         reason: str | None = None
+        first_pass = next(
+            (
+                pass_trace.name
+                for pass_trace in self.editorial_passes
+                if pass_trace.name != "source-eligibility" and asset_id in pass_trace.input_ids
+            ),
+            None,
+        )
+        for pass_trace in self.editorial_passes:
+            rejected = next(
+                (decision for decision in pass_trace.rejected if decision.asset_id == asset_id),
+                None,
+            )
+            if rejected is not None:
+                dropped_at = pass_trace.name
+                reason = rejected.reason
+                survived = []
+            elif asset_id in pass_trace.kept_ids:
+                admitted_at = pass_trace.name
         for stage in self.stages:
             if asset_id in stage.gained_ids:
                 admitted_at = stage.name
@@ -178,6 +198,7 @@ class Trace:
             dropped_at=None if shipped else dropped_at,
             admitted_at=admitted_at,
             reason=None if shipped else reason,
+            first_pass=first_pass,
         )
 
     def _favourite_law_lines(self) -> list[str]:
@@ -278,7 +299,13 @@ class Trace:
         """What a reader must see before anything else in the report."""
         if not self.warnings:
             return []
-        return [*(f"!! {warning}" for warning in self.warnings), ""]
+        return [
+            *(
+                warning if warning.startswith("!! ") else f"!! {warning}"
+                for warning in self.warnings
+            ),
+            "",
+        ]
 
     def _coverage_lines(self) -> list[str]:
         """The pool's coverage, above the funnel — it frames everything below."""

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -15,10 +15,17 @@ from __future__ import annotations
 
 import json
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.analysis.editorial_contracts import (
+    ConservationCheck,
+    DecisionProvenance,
+    PassTrace,
+    RequestTrace,
+    TraceDecision,
+)
 from immich_memories.analysis.selection_coverage import AnalysisCoverage
 
 if TYPE_CHECKING:
@@ -29,6 +36,10 @@ _active: ContextVar[Trace | None] = ContextVar("selection_trace", default=None)
 
 # How many dropped clips to name per stage before summarising the rest.
 _ACCOUNT_LIMIT = 12
+
+
+# A trace is complete in JSON. Markdown names a useful sample and points to it.
+_EDITORIAL_DECISION_LIMIT = 12
 
 
 @dataclass(frozen=True)
@@ -84,6 +95,21 @@ class Trace:
     # could not run is the one this exists for: "0 dropped" has meant both
     # "approved" and "never answered" for as long as the review has existed.
     warnings: list[str] = field(default_factory=list)
+    # New editorial passes sit beside the legacy stage adapter until Task 14.
+    editorial_passes: list[PassTrace] = field(default_factory=list)
+    requests: list[RequestTrace] = field(default_factory=list)
+
+    def record_request(self, request_trace: RequestTrace) -> None:
+        """Record one planned visual request and every wire outcome it caused."""
+        self.requests.append(request_trace)
+
+    def record_editorial_pass(self, pass_trace: PassTrace) -> None:
+        """Record one immutable editorial pass and its conservation result."""
+        conservation = _check_conservation(pass_trace)
+        recorded = replace(pass_trace, conservation=conservation)
+        self.editorial_passes.append(recorded)
+        if not conservation.valid:
+            self.warnings.append(f"conservation failure in {pass_trace.name}")
 
     def record(
         self,
@@ -96,8 +122,9 @@ class Trace:
         """Note that `name` turned `before` into `after`."""
         before_list, after_list = list(before), list(after)
         before_ids = {_asset_id(item) for item in before_list}
-        after_ids = {_asset_id(item) for item in after_list}
-        lost = [item for item in before_list if _asset_id(item) not in after_ids]
+        kept_ids = tuple(_asset_id(item) for item in after_list)
+        after_id_set = set(kept_ids)
+        lost = [item for item in before_list if _asset_id(item) not in after_id_set]
         self._remember(before_list)
         self._remember(after_list)
         self.stages.append(
@@ -109,9 +136,9 @@ class Trace:
                 favorites_out=sum(_is_favorite(i) for i in after_list),
                 reasons=reasons or [],
                 notes=dict(notes or {}),
-                kept_ids=tuple(sorted(after_ids)),
+                kept_ids=kept_ids,
                 lost_ids=tuple(_asset_id(i) for i in lost),
-                gained_ids=tuple(sorted(after_ids - before_ids)),
+                gained_ids=tuple(asset_id for asset_id in kept_ids if asset_id not in before_ids),
             )
         )
 
@@ -171,9 +198,9 @@ class Trace:
 
     def report(self) -> str:
         """The funnel, as text — widest column is where the pool went."""
-        if not self.stages:
+        if not self.stages and not self.editorial_passes:
             return "No selection stages were recorded.\n"
-        width = max(len(s.name) for s in self.stages)
+        width = max((len(s.name) for s in self.stages), default=len("stage"))
         lines = [
             *self._warning_lines(),
             *self._coverage_lines(),
@@ -193,7 +220,28 @@ class Trace:
                 f"{favorites:>12}{marker}"
             )
             lines.extend(f"{' ' * width}    - {reason}" for reason in stage.reasons)
-        return "\n".join([*lines, *self._account_lines()]) + "\n"
+        return "\n".join([*lines, *self._editorial_pass_lines(), *self._account_lines()]) + "\n"
+
+    def _editorial_pass_lines(self) -> list[str]:
+        if not self.editorial_passes:
+            return []
+        lines = ["", "editorial passes", "-" * 16]
+        for pass_trace in self.editorial_passes:
+            decisions = [*pass_trace.rejected, *pass_trace.unresolved]
+            lines.append(
+                f"  {pass_trace.name}: {len(pass_trace.kept_ids)} kept, "
+                f"{len(pass_trace.rejected)} rejected, {len(pass_trace.unresolved)} unresolved"
+            )
+            lines.extend(
+                f"      {decision.asset_id} — {decision.reason}"
+                for decision in decisions[:_EDITORIAL_DECISION_LIMIT]
+            )
+            if len(decisions) > _EDITORIAL_DECISION_LIMIT:
+                lines.append(
+                    f"      showing {_EDITORIAL_DECISION_LIMIT} of {len(decisions)}; "
+                    "full list in JSON"
+                )
+        return lines
 
     def _account_lines(self) -> list[str]:
         """Why each clip is in the cut, and why the rest are not."""
@@ -265,8 +313,110 @@ class Trace:
                 }
                 for s in self.stages
             ],
+            "editorial_passes": [
+                _editorial_pass_dict(pass_trace) for pass_trace in self.editorial_passes
+            ],
+            "requests": [_request_dict(request) for request in self.requests],
             "clips": self.clips,
         }
+
+
+def _check_conservation(pass_trace: PassTrace) -> ConservationCheck:
+    fates = (
+        *pass_trace.kept_ids,
+        *(decision.asset_id for decision in pass_trace.rejected),
+        *(decision.asset_id for decision in pass_trace.unresolved),
+    )
+    fate_counts: dict[str, int] = {}
+    for asset_id in fates:
+        fate_counts[asset_id] = fate_counts.get(asset_id, 0) + 1
+    input_ids = _unique_ids(pass_trace.input_ids)
+    missing_ids = tuple(asset_id for asset_id in input_ids if asset_id not in fate_counts)
+    duplicate_ids = tuple(asset_id for asset_id in input_ids if fate_counts.get(asset_id, 0) > 1)
+    unexpected_ids = tuple(
+        asset_id for asset_id in _unique_ids(fates) if asset_id not in set(input_ids)
+    )
+    return ConservationCheck(
+        valid=not missing_ids and not duplicate_ids and not unexpected_ids,
+        missing_ids=missing_ids,
+        duplicate_ids=duplicate_ids,
+        unexpected_ids=unexpected_ids,
+    )
+
+
+def _unique_ids(asset_ids: tuple[str, ...]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for asset_id in asset_ids:
+        if asset_id not in seen:
+            unique.append(asset_id)
+            seen.add(asset_id)
+    return tuple(unique)
+
+
+def _editorial_pass_dict(pass_trace: PassTrace) -> dict:
+    conservation = pass_trace.conservation or _check_conservation(pass_trace)
+    return {
+        "name": pass_trace.name,
+        "input_ids": list(pass_trace.input_ids),
+        "kept_ids": list(pass_trace.kept_ids),
+        "rejected": [_decision_dict(decision) for decision in pass_trace.rejected],
+        "unresolved": [_decision_dict(decision) for decision in pass_trace.unresolved],
+        "duration_before": pass_trace.duration_before,
+        "duration_after": pass_trace.duration_after,
+        "provenance": _provenance_dict(pass_trace.provenance),
+        "request_traces": [_request_dict(request) for request in pass_trace.request_traces],
+        "conservation": {
+            "valid": conservation.valid,
+            "missing_ids": list(conservation.missing_ids),
+            "duplicate_ids": list(conservation.duplicate_ids),
+            "unexpected_ids": list(conservation.unexpected_ids),
+        },
+    }
+
+
+def _decision_dict(decision: TraceDecision) -> dict:
+    return {"asset_id": decision.asset_id, "reason": decision.reason}
+
+
+def _request_dict(request: RequestTrace) -> dict:
+    return {
+        "provenance": _provenance_dict(request.provenance),
+        "attached_sheet_hashes": list(request.attached_sheet_hashes),
+        "planned_calls": request.planned_calls,
+        "actual_calls": request.actual_calls,
+        "cache_hit": request.cache_hit,
+        "tile_count": request.tile_count,
+        "provider": request.provider,
+        "model": request.model,
+        "attempts": [
+            {
+                "attempt": attempt.attempt,
+                "outcome": attempt.outcome,
+                "status_code": attempt.status_code,
+                "adaptation": attempt.adaptation,
+            }
+            for attempt in request.attempts
+        ],
+        "original_provenance": (
+            None
+            if request.original_provenance is None
+            else _provenance_dict(request.original_provenance)
+        ),
+    }
+
+
+def _provenance_dict(provenance: DecisionProvenance) -> dict:
+    return {
+        "pass_name": provenance.pass_name,
+        "pass_version": provenance.pass_version,
+        "schema_version": provenance.schema_version,
+        "model_identity": provenance.model_identity,
+        "input_ids": list(provenance.input_ids),
+        "sheet_hashes": list(provenance.sheet_hashes),
+        "request_key": provenance.request_key,
+        "cache_hit": provenance.cache_hit,
+    }
 
 
 def _asset_id(item: object) -> str:
@@ -346,16 +496,22 @@ def active() -> Trace | None:
 
 
 def record(
-    name: str,
-    before: Iterable,
-    after: Iterable,
+    name: str | PassTrace,
+    before: Iterable | None = None,
+    after: Iterable | None = None,
     reasons: list[str] | None = None,
     notes: dict[str, str] | None = None,
 ) -> None:
-    """Record a stage when tracing is on; do nothing when it is not."""
+    """Record a legacy stage or editorial pass when tracing is on."""
     trace = _active.get()
-    if trace is not None:
-        trace.record(name, before, after, reasons, notes)
+    if trace is None:
+        return
+    if isinstance(name, PassTrace):
+        trace.record_editorial_pass(name)
+        return
+    if before is None or after is None:
+        raise TypeError("legacy selection stages require both before and after candidates")
+    trace.record(name, before, after, reasons, notes)
 
 
 def warn(message: str) -> None:

--- a/src/immich_memories/analysis/source_filter.py
+++ b/src/immich_memories/analysis/source_filter.py
@@ -16,12 +16,48 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from collections.abc import Iterable
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
+
+
+def is_editorial_source_asset(
+    asset: Any,
+    *,
+    start_at: datetime | None,
+    end_at: datetime | None,
+) -> bool:
+    """Whether an asset is in the requested editorial scope before Pass 0."""
+    from immich_memories.api.models import AssetType
+
+    if getattr(asset, "type", None) not in (AssetType.IMAGE, AssetType.VIDEO):
+        return False
+    taken_at = getattr(asset, "file_created_at", None)
+    if taken_at is None:
+        return False
+    return (start_at is None or taken_at >= start_at) and (end_at is None or taken_at <= end_at)
+
+
+def live_photo_component_ids(sources: Iterable[Any]) -> frozenset[str]:
+    """The video halves claimed by the stills in this pool.
+
+    Immich lists a Live Photo's motion component as its own video asset, so one
+    query returns both halves of the same photograph. The still is the
+    photograph; the component is how it can be rendered. Reading the pool for
+    the components its own stills claim is what `drop_live_photo_components`
+    does for every other pool builder, expressed as a set the editorial path
+    can put on the record instead of dropping silently.
+    """
+    return frozenset(
+        component
+        for source in sources
+        if (component := getattr(source, "live_photo_video_id", None))
+    )
 
 
 def from_an_excluded_source(name: str | None, patterns: Sequence[str]) -> bool:

--- a/src/immich_memories/analysis/source_quality.py
+++ b/src/immich_memories/analysis/source_quality.py
@@ -13,6 +13,12 @@ better. One clip had no EXIF and full resolution, and it survives the rule.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
+
+from immich_memories.analysis.editorial_contracts import SourceEvidence
+
+if TYPE_CHECKING:
+    from immich_memories.api.models import Asset, VideoClipInfo
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +39,71 @@ def is_usable_source(
     if short_side >= min_short_side:
         return True
     return has_camera_exif
+
+
+def grounded_source_annotations(
+    asset: Asset,
+    clip: VideoClipInfo | None = None,
+    evidence: SourceEvidence | None = None,
+) -> tuple[str, ...]:
+    """Return existing technical and semantic observations without judging a source."""
+    width, height = _dimensions(asset, clip)
+    annotations: list[str] = []
+    if width and height:
+        annotations.append(f"resolution:{width}x{height}")
+    if _is_reencode_suspected(width, height, _has_camera_exif(asset)):
+        annotations.append("reencode-suspected")
+    duration = clip.duration_seconds if clip is not None else asset.duration_seconds
+    if duration is not None:
+        annotations.append(f"duration:{duration:.3f}s")
+    annotations.extend(_available_image_observations(asset, clip, evidence))
+    return tuple(annotations)
+
+
+def _dimensions(asset: Asset, clip: VideoClipInfo | None) -> tuple[int, int]:
+    if clip is not None and clip.width and clip.height:
+        return clip.width, clip.height
+    return asset.width, asset.height
+
+
+def _is_reencode_suspected(width: int, height: int, has_camera_exif: bool) -> bool:
+    return bool(width and height and min(width, height) < 1080 and not has_camera_exif)
+
+
+def _has_camera_exif(asset: Asset) -> bool:
+    exif = asset.exif_info
+    return bool(exif and (exif.make or exif.model))
+
+
+def _available_image_observations(
+    asset: Asset,
+    clip: VideoClipInfo | None,
+    evidence: SourceEvidence | None,
+) -> list[str]:
+    annotations: list[str] = []
+    exif = asset.exif_info
+    if exif and exif.exposure_time:
+        annotations.append(f"exposure:{exif.exposure_time}")
+    if clip is not None:
+        annotations.append("motion:available")
+        if clip.live_burst_still_ids:
+            annotations.append(f"burst-members:{len(clip.live_burst_still_ids)}")
+        if clip.llm_category:
+            annotations.append(f"subject:{clip.llm_category}")
+        if clip.llm_quality is not None:
+            annotations.append(f"analysis-quality:{clip.llm_quality}")
+    if evidence is not None:
+        annotations.extend(_precomputed_annotations(evidence))
+    return annotations
+
+
+def _precomputed_annotations(evidence: SourceEvidence) -> list[str]:
+    return [
+        f"{label}:{value}"
+        for value, label in (
+            (evidence.blur, "blur"),
+            (evidence.exposure, "exposure"),
+            (evidence.similarity, "similarity"),
+        )
+        if value is not None
+    ]

--- a/src/immich_memories/analysis/strict_json.py
+++ b/src/immich_memories/analysis/strict_json.py
@@ -1,0 +1,46 @@
+"""Small shared decoder for complete, non-repaired model JSON envelopes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TypeGuard
+
+
+def is_safe_model_text(value: object, *, max_chars: int) -> TypeGuard[str]:
+    """Whether model prose has the exact bounded no-escaping wire alphabet."""
+    return (
+        isinstance(value, str)
+        and value == value.strip()
+        and 0 < len(value) <= max_chars
+        and all(32 <= ord(character) <= 126 and character not in {'"', "\\"} for character in value)
+    )
+
+
+def bounded_model_text(value: object, *, max_chars: int) -> str | None:
+    """Model prose fitted to its bound, or None when it is not usable text.
+
+    Length is the one property worth coercing. Everything else here says
+    something about whether the text can be trusted or displayed at all, but a
+    reason that runs nine characters long still says what it meant, and the
+    decision it explains is not improved by discarding it. Measured on the same
+    images twice: 91/84/76 characters one run, 103/105/104 the next.
+    """
+    if not isinstance(value, str):
+        return None
+    fitted = value.strip()[:max_chars].strip()
+    return fitted if is_safe_model_text(fitted, max_chars=max_chars) else None
+
+
+def final_json_object(raw: str) -> dict[str, Any] | None:
+    """Return one complete final object, allowing only a trailing Markdown fence."""
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(raw):
+        if character != "{":
+            continue
+        try:
+            value, end = decoder.raw_decode(raw, index)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and raw[end:].strip() in ("", "```"):
+            return value
+    return None

--- a/src/immich_memories/analysis/subject_policy.py
+++ b/src/immich_memories/analysis/subject_policy.py
@@ -56,6 +56,13 @@ def classify_subject(
     return _stated_category(category) or SubjectCategory.UNKNOWN
 
 
+def subject_evidence(*, tagged_people: int, category: str | None) -> str:
+    """Expose the closed-set observation without making a membership decision."""
+    return (
+        f"subject-evidence:{classify_subject(tagged_people=tagged_people, category=category).value}"
+    )
+
+
 def _stated_category(category: str | None) -> SubjectCategory | None:
     """The model's own label, when it is one of the ones we asked for."""
     if not category:

--- a/src/immich_memories/analysis/thumbnail_prefetch.py
+++ b/src/immich_memories/analysis/thumbnail_prefetch.py
@@ -35,6 +35,11 @@ logger = logging.getLogger(__name__)
 THUMBNAIL_SIZE = "preview"
 
 
+def cached_preview_bytes(thumbnail_cache: ThumbnailCache, asset_id: str) -> bytes | None:
+    """Read an already-fetched preview without turning atlas construction into a network call."""
+    return thumbnail_cache.get(asset_id, THUMBNAIL_SIZE)
+
+
 class ThumbnailPrefetcher:
     """Best-effort preview fetcher; failures degrade de-dup, never abort the run."""
 

--- a/src/immich_memories/analysis/visual_atlas.py
+++ b/src/immich_memories/analysis/visual_atlas.py
@@ -1,0 +1,174 @@
+"""Local visual evidence that can be reused across editorial contact sheets."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Literal
+
+from immich_memories.analysis.thumbnail_prefetch import cached_preview_bytes
+from immich_memories.processing.frame_sampling import probe_duration, sample_segment_frames
+
+FILMSTRIP_FRAME_COUNT = 3
+FILMSTRIP_WIDTH = 360
+
+
+@dataclass(frozen=True)
+class AtlasSource:
+    """One source asset and the locally available pixels that represent it."""
+
+    asset: Any
+    preview_jpeg: bytes | None = None
+    motion_path: Path | None = None
+    proposed_segment: tuple[float, float] | None = None
+
+
+@dataclass(frozen=True)
+class AtlasTile:
+    """One stable visual tile, including an explicit unavailable state."""
+
+    entity_id: str
+    kind: Literal["photo", "filmstrip", "unavailable"]
+    jpeg_bytes: bytes | None
+    sha256: str | None
+    frame_count: int
+    unavailable_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class VisualAtlas:
+    """Chronological tiles that derived contact sheets can reuse without new reads."""
+
+    tiles: tuple[AtlasTile, ...]
+
+    def tile_for(self, entity_id: str) -> AtlasTile:
+        """Return the tile for one source entity."""
+        for tile in self.tiles:
+            if tile.entity_id == entity_id:
+                return tile
+        raise KeyError(entity_id)
+
+
+def build_visual_atlas(
+    sources: tuple[AtlasSource, ...] | list[AtlasSource],
+    *,
+    frame_cache_dir: Path | None,
+    thumbnail_cache: Any | None = None,
+) -> VisualAtlas:
+    """Build one local visual tile per source, preserving input order exactly."""
+    entity_ids = tuple(_entity_id(source) for source in sources)
+    if len(set(entity_ids)) != len(entity_ids):
+        raise ValueError("visual atlas sources must have unique entity IDs")
+    atlas = VisualAtlas(
+        tuple(_tile_for(source, frame_cache_dir, thumbnail_cache) for source in sources)
+    )
+    for entity_id in entity_ids:
+        atlas.tile_for(entity_id)
+    return atlas
+
+
+def _entity_id(source: AtlasSource) -> str:
+    entity_id = getattr(source.asset, "id", None)
+    if not isinstance(entity_id, str) or not entity_id:
+        raise ValueError("visual atlas sources need a non-empty asset ID")
+    return entity_id
+
+
+def _tile_for(
+    source: AtlasSource, frame_cache_dir: Path | None, thumbnail_cache: Any | None
+) -> AtlasTile:
+    entity_id = _entity_id(source)
+    if _has_motion(source):
+        filmstrip = _filmstrip_for(source, frame_cache_dir)
+        if filmstrip is not None:
+            return AtlasTile(
+                entity_id=entity_id,
+                kind="filmstrip",
+                jpeg_bytes=filmstrip[0],
+                sha256=sha256(filmstrip[0]).hexdigest(),
+                frame_count=filmstrip[1],
+            )
+    preview_jpeg = source.preview_jpeg or _cached_preview(thumbnail_cache, entity_id)
+    if preview_jpeg is not None and _is_jpeg(preview_jpeg):
+        return AtlasTile(
+            entity_id=entity_id,
+            kind="photo",
+            jpeg_bytes=preview_jpeg,
+            sha256=sha256(preview_jpeg).hexdigest(),
+            frame_count=1,
+        )
+    return AtlasTile(
+        entity_id=entity_id,
+        kind="unavailable",
+        jpeg_bytes=None,
+        sha256=None,
+        frame_count=0,
+        unavailable_reason="no usable local preview or motion frames",
+    )
+
+
+def _cached_preview(thumbnail_cache: Any | None, entity_id: str) -> bytes | None:
+    if thumbnail_cache is None:
+        return None
+    return cached_preview_bytes(thumbnail_cache, entity_id)
+
+
+def _has_motion(source: AtlasSource) -> bool:
+    return source.motion_path is not None and bool(
+        getattr(source.asset, "is_video", False) or getattr(source.asset, "is_live_photo", False)
+    )
+
+
+def _filmstrip_for(source: AtlasSource, frame_cache_dir: Path | None) -> tuple[bytes, int] | None:
+    assert source.motion_path is not None
+    start, end = source.proposed_segment or (0.0, probe_duration(source.motion_path))
+    if end <= start:
+        return None
+    frame_paths = sample_segment_frames(
+        source.motion_path,
+        start_time=start,
+        end_time=end,
+        count=FILMSTRIP_FRAME_COUNT,
+        width=FILMSTRIP_WIDTH,
+        cache_dir=frame_cache_dir,
+    )
+    frames = [_open_jpeg(path) for path in frame_paths]
+    usable = [frame for frame in frames if frame is not None]
+    if not usable:
+        return None
+    return _compose_filmstrip(usable), len(usable)
+
+
+def _open_jpeg(path: Path):
+    from PIL import Image
+
+    try:
+        with Image.open(path) as image:
+            return image.convert("RGB")
+    except OSError:
+        return None
+
+
+def _is_jpeg(data: bytes) -> bool:
+    from PIL import Image
+
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            image.verify()
+    except OSError:
+        return False
+    return True
+
+
+def _compose_filmstrip(frames: list[Any]) -> bytes:
+    from PIL import Image, ImageOps
+
+    panel = FILMSTRIP_WIDTH // len(frames)
+    strip = Image.new("RGB", (FILMSTRIP_WIDTH, panel), (18, 18, 18))
+    for index, frame in enumerate(frames):
+        strip.paste(ImageOps.fit(frame, (panel, panel)), (index * panel, 0))
+    buffer = io.BytesIO()
+    strip.save(buffer, "JPEG", quality=85)
+    return buffer.getvalue()

--- a/src/immich_memories/analysis/visual_atlas.py
+++ b/src/immich_memories/analysis/visual_atlas.py
@@ -23,6 +23,7 @@ class AtlasSource:
     preview_jpeg: bytes | None = None
     motion_path: Path | None = None
     proposed_segment: tuple[float, float] | None = None
+    unavailable_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -105,7 +106,9 @@ def _tile_for(
         jpeg_bytes=None,
         sha256=None,
         frame_count=0,
-        unavailable_reason="no usable local preview or motion frames",
+        unavailable_reason=(
+            source.unavailable_reason or "no usable local preview or motion frames"
+        ),
     )
 
 

--- a/src/immich_memories/analysis/visual_request_planner.py
+++ b/src/immich_memories/analysis/visual_request_planner.py
@@ -14,10 +14,16 @@ class VisionRequestLimits:
     """The empirically approved limits for one endpoint and model."""
 
     max_pages_per_request: int = 1
+    max_output_tokens: int = 500
+    timeout_seconds: int = 30
 
     def __post_init__(self) -> None:
         if self.max_pages_per_request < 1:
             raise ValueError("max_pages_per_request must be at least one")
+        if self.max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be at least one")
+        if self.timeout_seconds < 1:
+            raise ValueError("timeout_seconds must be at least one")
 
 
 @dataclass(frozen=True)

--- a/src/immich_memories/analysis/visual_request_planner.py
+++ b/src/immich_memories/analysis/visual_request_planner.py
@@ -1,0 +1,86 @@
+"""Pure planning for bounded visual editorial requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage
+
+__all__ = ["SheetGroup", "VisionRequestLimits", "VisualRequestPlan", "plan_visual_requests"]
+
+
+@dataclass(frozen=True)
+class VisionRequestLimits:
+    """The empirically approved limits for one endpoint and model."""
+
+    max_pages_per_request: int = 1
+
+    def __post_init__(self) -> None:
+        if self.max_pages_per_request < 1:
+            raise ValueError("max_pages_per_request must be at least one")
+
+
+@dataclass(frozen=True)
+class SheetGroup:
+    """One ordered editorial unit that must not be silently separated."""
+
+    group_id: str
+    pages: tuple[ContactSheetPage, ...]
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("sheet groups need an ID")
+        if not self.pages:
+            raise ValueError("sheet groups need at least one page")
+
+
+@dataclass(frozen=True)
+class VisualRequestPlan:
+    """One request and the explicit continuation it represents, if any."""
+
+    group_ids: tuple[str, ...]
+    pages: tuple[ContactSheetPage, ...]
+    continuation_number: int = 1
+    continuation_count: int = 1
+
+
+def plan_visual_requests(
+    *, groups: tuple[SheetGroup, ...], limits: VisionRequestLimits
+) -> tuple[VisualRequestPlan, ...]:
+    """Plan ordered group requests without assuming any provider capability."""
+    plans: list[VisualRequestPlan] = []
+    pending_groups: list[str] = []
+    pending_pages: list[ContactSheetPage] = []
+    for group in groups:
+        if len(group.pages) <= limits.max_pages_per_request:
+            if (
+                pending_pages
+                and len(pending_pages) + len(group.pages) > limits.max_pages_per_request
+            ):
+                plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+                pending_groups, pending_pages = [], []
+            pending_groups.append(group.group_id)
+            pending_pages.extend(group.pages)
+            continue
+        if pending_pages:
+            plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+            pending_groups, pending_pages = [], []
+        chunks = _page_chunks(group.pages, limits.max_pages_per_request)
+        for number, pages in enumerate(chunks, start=1):
+            plans.append(
+                VisualRequestPlan(
+                    group_ids=(group.group_id,),
+                    pages=pages,
+                    continuation_number=number,
+                    continuation_count=len(chunks),
+                )
+            )
+    if pending_pages:
+        plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+    return tuple(plans)
+
+
+def _page_chunks(
+    pages: tuple[ContactSheetPage, ...], maximum: int
+) -> tuple[tuple[ContactSheetPage, ...], ...]:
+    return tuple(pages[index : index + maximum] for index in range(0, len(pages), maximum))

--- a/src/immich_memories/cache/editorial_verdicts.py
+++ b/src/immich_memories/cache/editorial_verdicts.py
@@ -1,0 +1,82 @@
+"""What a picture IS, remembered across every memory it could appear in.
+
+Cull answers two durable questions and one contextual one. Whether a frame is a
+photographed screen or a document, and whether it came out at all, are facts
+about the picture: true in a month, a year, a person's spotlight, a trip. That
+a frame is "one of several alike" is not — it is a fact about what it happened
+to sit beside, and it is deliberately not stored here.
+
+So a year stops paying to re-decide the same fifteen thousand pictures twelve
+times, and a Person or Trip memory inherits the judgement rather than needing
+Cull to be gentler on a corpus that was already filtered.
+
+The cost of being wrong rises with the reuse: a bad cull used to spoil one
+video and now follows the picture everywhere. That is why the trace says a
+visual was culled on a remembered verdict rather than quietly omitting it, why
+a star still outranks anything stored here, and why this file can be deleted at
+any time — it costs only the calls it saved.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS editorial_verdicts (
+    asset_id TEXT NOT NULL,
+    pass_version TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    decided_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (asset_id, pass_version)
+)
+"""
+
+
+class EditorialVerdicts:
+    """Durable per-asset Cull verdicts, scoped to what the buckets meant."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._open() as connection:
+            connection.execute(_SCHEMA)
+
+    def remember(self, verdicts: Iterable[tuple[str, str]], *, pass_version: str) -> None:
+        """Store one standing verdict per asset; the most recent look wins.
+
+        Takes plain (asset, bucket) pairs so the cache layer stays ignorant of
+        the editorial contracts, and so the caller decides which buckets are
+        durable enough to remember.
+        """
+        rows = [(asset_id, pass_version, bucket) for asset_id, bucket in verdicts]
+        if not rows:
+            return
+        with self._open() as connection:
+            connection.executemany(
+                "INSERT INTO editorial_verdicts (asset_id, pass_version, bucket) "
+                "VALUES (?, ?, ?) ON CONFLICT(asset_id, pass_version) DO UPDATE SET "
+                "bucket = excluded.bucket, decided_at = datetime('now')",
+                rows,
+            )
+
+    def recall(self, asset_ids: Sequence[str], *, pass_version: str) -> dict[str, str]:
+        """The standing verdicts for these assets under this definition."""
+        if not asset_ids:
+            return {}
+        # Only the number of placeholders is interpolated; every value is bound.
+        placeholders = ",".join("?" for _ in asset_ids)
+        with self._open() as connection:
+            rows = connection.execute(
+                "SELECT asset_id, bucket FROM editorial_verdicts "  # noqa: S608
+                f"WHERE pass_version = ? AND asset_id IN ({placeholders})",
+                (pass_version, *asset_ids),
+            ).fetchall()
+        return dict(rows)
+
+    def _open(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.path)

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -18,8 +18,10 @@ file can be deleted at any time and costs only the calls it saved.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,63 @@ CREATE TABLE IF NOT EXISTS judgments (
     answered_at TEXT NOT NULL DEFAULT (datetime('now'))
 )
 """
+
+_VISUAL_SCHEMA = """
+CREATE TABLE IF NOT EXISTS visual_judgments (
+    key TEXT PRIMARY KEY,
+    answer TEXT NOT NULL,
+    original_provenance TEXT NOT NULL,
+    answered_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+@dataclass(frozen=True)
+class VisualJudgmentIdentity:
+    """All evidence and request settings that could change a visual answer."""
+
+    page_bytes: tuple[bytes, ...]
+    ordered_input_ids: tuple[str, ...]
+    ordered_group_ids: tuple[str, ...]
+    annotations: tuple[str, ...]
+    model: str | None
+    thinking: bool
+    image_detail: str
+    pass_name: str
+    pass_version: str
+    prompt_version: str
+    schema_version: str
+    render_version: str
+    layout_versions: tuple[str, ...]
+    upstream_material: tuple[str, ...]
+    request_limits: tuple[str, ...]
+    continuation_identity: tuple[int, int]
+    endpoint: str = ""
+
+    def key(self) -> str:
+        """Return the deterministic key without including credentials or paths."""
+        material = {
+            "version": "visual1",
+            "page_hashes": [hashlib.sha256(page).hexdigest() for page in self.page_bytes],
+            "ordered_input_ids": self.ordered_input_ids,
+            "ordered_group_ids": self.ordered_group_ids,
+            "annotations": self.annotations,
+            "model": self.model or "",
+            "thinking": self.thinking,
+            "image_detail": self.image_detail,
+            "pass_name": self.pass_name,
+            "pass_version": self.pass_version,
+            "prompt_version": self.prompt_version,
+            "schema_version": self.schema_version,
+            "render_version": self.render_version,
+            "layout_versions": self.layout_versions,
+            "upstream_material": self.upstream_material,
+            "request_limits": self.request_limits,
+            "continuation_identity": self.continuation_identity,
+            "endpoint": self.endpoint,
+        }
+        encoded = json.dumps(material, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
 
 
 def judgment_key(*, model: str | None, prompt: str, thinking: bool) -> str:
@@ -106,5 +165,57 @@ class JudgmentCache:
             conn.commit()
         except sqlite3.Error as exc:
             logger.debug("Judgment cache unwritable (%s): the answer is not kept", exc)
+        finally:
+            conn.close()
+
+
+class VisualJudgmentCache:
+    """A visual-answer cache independent of the legacy prompt-only table."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.execute(_VISUAL_SCHEMA)
+        return conn
+
+    def answer_for(self, key: str) -> tuple[str, str] | None:
+        """Return a banked answer and its original provenance, if available."""
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Visual judgment cache unreadable (%s): asking again", exc)
+            return None
+        try:
+            row = conn.execute(
+                "SELECT answer, original_provenance FROM visual_judgments WHERE key = ?", (key,)
+            ).fetchone()
+        except sqlite3.Error as exc:
+            logger.debug("Visual judgment cache unreadable (%s): asking again", exc)
+            return None
+        finally:
+            conn.close()
+        return (str(row[0]), str(row[1])) if row else None
+
+    def remember(self, key: str, answer: str, original_provenance: str) -> None:
+        """Bank a complete visual answer with the decision that first produced it."""
+        if not answer.strip():
+            return
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Visual judgment cache unwritable (%s): answer not kept", exc)
+            return
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO visual_judgments (key, answer, original_provenance) "
+                "VALUES (?, ?, ?)",
+                (key, answer, original_provenance),
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.debug("Visual judgment cache unwritable (%s): answer not kept", exc)
         finally:
             conn.close()

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 # Bump to abandon every stored answer — for a change in how the answer is used
 # that the prompt text itself does not capture.
 _ANSWER_VERSION = "judge1"
+# Bump when the shared visual gateway changes what identity material the
+# provider actually sees. visual1 keyed annotations without sending them.
+_VISUAL_ANSWER_VERSION = "visual2"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS judgments (
@@ -73,7 +76,7 @@ class VisualJudgmentIdentity:
     def key(self) -> str:
         """Return the deterministic key without including credentials or paths."""
         material = {
-            "version": "visual1",
+            "version": _VISUAL_ANSWER_VERSION,
             "page_hashes": [hashlib.sha256(page).hexdigest() for page in self.page_bytes],
             "ordered_input_ids": self.ordered_input_ids,
             "ordered_group_ids": self.ordered_group_ids,

--- a/src/immich_memories/processing/frame_sampling.py
+++ b/src/immich_memories/processing/frame_sampling.py
@@ -24,6 +24,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _FALLBACK_DURATION_SECONDS = 60.0
+SEGMENT_RENDER_VERSION = "1"
 
 
 def even_timestamps(duration: float, count: int) -> list[float]:
@@ -90,20 +91,6 @@ def _extract_one(video: Path, timestamp: float, width: int, out_path: Path) -> b
     return out_path.exists()
 
 
-def _key_for(video: Path, count: int, width: int) -> str:
-    """What identifies these frames: which video, how many, how wide.
-
-    Size and mtime stand in for content — hashing gigabytes to decide whether
-    to skip a decode would cost more than the decode.
-    """
-    try:
-        stat = video.stat()
-        identity = f"{video.name}:{stat.st_size}:{int(stat.st_mtime)}"
-    except OSError:
-        identity = video.name
-    return hashlib.sha256(f"{identity}:{count}:{width}".encode()).hexdigest()[:16]
-
-
 def sample_frames(
     video: Path,
     *,
@@ -117,23 +104,90 @@ def sample_frames(
     nothing returns an empty list rather than raising: a caller that cannot see
     the pictures should degrade, not fail.
     """
-    target = _prepared_dir(cache_dir, _key_for(video, count, width))
+    duration = probe_duration(video)
+    return list(
+        sample_segment_frames(
+            video,
+            start_time=0.0,
+            end_time=duration if duration > 0 else _FALLBACK_DURATION_SECONDS,
+            count=count,
+            width=width,
+            cache_dir=cache_dir,
+        )
+    )
+
+
+def sample_segment_frames(
+    video: Path,
+    *,
+    start_time: float,
+    end_time: float,
+    count: int,
+    width: int,
+    cache_dir: Path | None,
+    render_version: str | None = None,
+) -> tuple[Path, ...]:
+    """Sample a bounded video segment, caching only complete usable frame sets."""
+    if count <= 0 or width <= 0 or end_time <= start_time or not _usable_video(video):
+        return ()
+    version = render_version or SEGMENT_RENDER_VERSION
+    key = _segment_key_for(video, start_time, end_time, count, width, version)
+    target = _prepared_dir(cache_dir, key)
     if target is not None:
-        cached = sorted(target.glob("frame_*.jpg"))
+        cached = _usable_cached_frames(target, count)
         if len(cached) == count:
-            logger.debug("Reusing %d cached frame(s) for %s", count, video.name)
-            return cached
+            logger.debug("Reusing %d segment frame(s) for %s", count, video.name)
+            return tuple(cached)
 
     out_dir = target if target is not None else _scratch_dir(video)
     if out_dir is None:
-        return []
-
-    frames = []
-    for index, timestamp in enumerate(even_timestamps(probe_duration(video), count)):
+        return ()
+    timestamps = [start_time + moment for moment in even_timestamps(end_time - start_time, count)]
+    frames: list[Path] = []
+    for index, timestamp in enumerate(timestamps):
         out_path = out_dir / f"frame_{index:03d}.jpg"
-        if _extract_one(video, timestamp, width, out_path):
+        if _extract_one(video, timestamp, width, out_path) or (
+            timestamp != start_time and _extract_one(video, start_time, width, out_path)
+        ):
             frames.append(out_path)
-    return frames
+    return tuple(frames)
+
+
+def _segment_key_for(
+    video: Path,
+    start_time: float,
+    end_time: float,
+    count: int,
+    width: int,
+    render_version: str,
+) -> str:
+    """Identify pixels by resolved source metadata and every rendering choice."""
+    try:
+        stat = video.stat()
+        identity = f"{video.resolve()}:{stat.st_size}:{stat.st_mtime_ns}"
+    except OSError:
+        identity = str(video.resolve())
+    payload = f"{identity}:{start_time:.9f}:{end_time:.9f}:{count}:{width}:{render_version}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _usable_video(video: Path) -> bool:
+    """Reject incomplete downloads and empty inputs before invoking FFmpeg."""
+    try:
+        return video.is_file() and video.suffix != ".part" and video.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _usable_cached_frames(target: Path, count: int) -> list[Path]:
+    frames: list[Path] = []
+    for frame in sorted(target.glob("frame_*.jpg")):
+        try:
+            if frame.is_file() and frame.suffix != ".part" and frame.stat().st_size > 0:
+                frames.append(frame)
+        except OSError:
+            continue
+    return frames if len(frames) == count else []
 
 
 def _prepared_dir(cache_dir: Path | None, key: str) -> Path | None:

--- a/tests/test_contact_sheets.py
+++ b/tests/test_contact_sheets.py
@@ -1,0 +1,68 @@
+"""Encoded contact sheets preserve their exact evidence bytes and references."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from immich_memories.analysis.visual_atlas import AtlasTile
+
+
+def _tile(entity_id: str, colour: str) -> AtlasTile:
+    image = Image.new("RGB", (32, 24), colour)
+    buffer = BytesIO()
+    image.save(buffer, "JPEG")
+    jpeg = buffer.getvalue()
+    return AtlasTile(entity_id, "photo", jpeg, sha256(jpeg).hexdigest(), 1)
+
+
+def test_contact_sheet_writes_and_exposes_the_same_encoded_jpeg_bytes(tmp_path: Path) -> None:
+    """Disk, hash, attachment bytes, and chronological tile references cannot drift."""
+    from immich_memories.analysis.contact_sheets import TileRef, build_contact_sheets
+
+    tiles = tuple(
+        _tile(f"asset-{number}", colour) for number, colour in enumerate(("red", "green"))
+    )
+    page = build_contact_sheets(tiles, scope_id="episode-1", output_dir=tmp_path)[0]
+
+    assert page.path.read_bytes() == page.jpeg_bytes
+    assert sha256(page.jpeg_bytes).hexdigest() == page.sha256
+    assert page.tile_refs == tuple(TileRef(i + 1, tile.entity_id) for i, tile in enumerate(tiles))
+
+
+def test_contact_sheets_preserve_an_unavailable_asset_as_a_numbered_tile(tmp_path: Path) -> None:
+    """Missing pixels must not shift the number of every later visual decision."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    tiles = (
+        _tile("before", "red"),
+        AtlasTile("unavailable", "unavailable", None, None, 0, "no thumbnail"),
+        _tile("after", "blue"),
+    )
+
+    page = build_contact_sheets(tiles, scope_id="episode-1", output_dir=tmp_path)[0]
+
+    assert [ref.entity_id for ref in page.tile_refs] == ["before", "unavailable", "after"]
+
+
+def test_contact_sheets_reject_duplicate_entity_ids(tmp_path: Path) -> None:
+    """A numbered tile can point at exactly one stable entity."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    with pytest.raises(ValueError, match="unique entity IDs"):
+        build_contact_sheets((_tile("same", "red"), _tile("same", "blue")), "scope", tmp_path)
+
+
+@pytest.mark.parametrize("per_sheet", (0, -1, 121))
+def test_contact_sheets_reject_per_sheet_outside_the_visual_evidence_limit(
+    tmp_path: Path, per_sheet: int
+) -> None:
+    """Every public override keeps pages positive and at most 120 numbered tiles."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    with pytest.raises(ValueError, match="between 1 and 120"):
+        build_contact_sheets((_tile("asset-1", "red"),), "scope", tmp_path, per_sheet=per_sheet)

--- a/tests/test_cull_answer.py
+++ b/tests/test_cull_answer.py
@@ -1,0 +1,380 @@
+"""Strict parsing for the two Cull buckets, asked inside each episode's scope."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_the_bucket_derives_the_reason_so_model_prose_never_actuates() -> None:
+    """A rejection's human explanation is local data, not text the model supplied."""
+    from immich_memories.analysis.cull_answer import CullDecision
+
+    assert CullDecision("asset", "notes").reason == "taken as a note rather than as a moment"
+    assert CullDecision("asset", "failed").reason == "the picture did not come out"
+
+
+@pytest.mark.parametrize(
+    "bucket",
+    (
+        "A relative alternative is stronger.",
+        "This is an uninteresting selfie.",
+        "repetitive",
+        "ordinary",
+        "NOTES",
+        "",
+    ),
+)
+def test_only_the_two_known_buckets_can_remove_a_visual(bucket: str) -> None:
+    """Cull may sort into buckets; it may not invent a reason to reject something."""
+    from immich_memories.analysis.cull_answer import CullDecision
+
+    with pytest.raises(ValueError, match="known bucket"):
+        CullDecision("asset", bucket)
+
+
+def test_a_decision_needs_a_stable_asset() -> None:
+    """A fate with nothing to attach to is not a fate."""
+    from immich_memories.analysis.cull_answer import CullDecision
+
+    with pytest.raises(ValueError, match="stable asset"):
+        CullDecision("   ", "notes")
+
+
+def test_reads_two_buckets_inside_each_episode_scope() -> None:
+    """The unit of the question decides whether a small model can answer it.
+
+    Probed on one real 57-tile pack, three repeats each: a flat answer over the
+    whole pack parsed once in three and gave fifty-five of fifty-seven tiles the
+    same label. The same question asked inside each episode's own scope parsed
+    three times in three and returned identical tiles every run.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [1], "failed": [2]},
+                    {"episode": 2, "notes": [], "failed": []},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "a-screen", 2: "a-smeared-frame", 3: "a-moment"},
+        episode_tiles={1: (1, 2), 2: (3,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert {d.asset_id: d.reason for d in parsed.cull_rejects} == {
+        "a-screen": "taken as a note rather than as a moment",
+        "a-smeared-frame": "the picture did not come out",
+    }
+
+
+def test_an_empty_answer_is_a_valid_answer_that_removes_nothing() -> None:
+    """Most tiles are neither junk nor failed, so empty is the normal reply."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "kept"},
+        episode_tiles={1: (1,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert parsed.cull_rejects == ()
+
+
+@pytest.mark.parametrize(
+    "rejects",
+    (
+        # a tile nothing on this sheet shows
+        [{"episode": 1, "notes": [99], "failed": []}],
+        # an episode this pack does not have
+        [{"episode": 7, "notes": [1], "failed": []}],
+        # the same episode answered twice
+        [
+            {"episode": 1, "notes": [1], "failed": []},
+            {"episode": 1, "notes": [2], "failed": []},
+        ],
+        # a boolean is not a tile alias
+        [{"episode": 1, "notes": [True], "failed": []}],
+        # an unexpected key
+        [{"episode": 1, "notes": [], "failed": [], "why": "blurry"}],
+        # a bucket that is not a list
+        [{"episode": 1, "notes": 1, "failed": []}],
+    ),
+)
+def test_an_answer_that_left_its_scope_removes_nothing(rejects: list[dict[str, object]]) -> None:
+    """Scope is the whole mechanism; failing open here is what makes Cull safe."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps({"schema_version": "episode-scan-v4", "pack": 1, "cull_rejects": rejects}),
+        pack_alias=1,
+        tile_map={1: "a", 2: "b", 3: "c"},
+        episode_tiles={1: (1, 2), 2: (3,)},
+    )
+
+    assert parsed is not None
+    assert not parsed.cull_valid
+    assert parsed.cull_rejects == ()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "",
+        "I cannot help with that.",
+        '{"schema_version":"episode-scan-v4","pack":1,"cull_rejects":[{"episode":1,',
+        # a stale schema: v3 answers must never be reinterpreted as v4
+        '{"schema_version":"episode-scan-v3","pack":1,"cull_rejects":[]}',
+        # another pack's answer
+        '{"schema_version":"episode-scan-v4","pack":2,"cull_rejects":[]}',
+        # no pack alias at all
+        '{"schema_version":"episode-scan-v4","cull_rejects":[]}',
+    ),
+)
+def test_a_malformed_or_foreign_envelope_has_no_decisions_at_all(raw: str) -> None:
+    """Refusal, truncation, a stale schema or another pack's answer kills nothing."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    assert (
+        read_cull_namespaces(
+            raw,
+            pack_alias=1,
+            tile_map={1: "a"},
+            episode_tiles={1: (1,)},
+        )
+        is None
+    )
+
+
+def test_a_decision_about_pixels_nobody_could_see_is_not_a_decision() -> None:
+    """An unreadable tile is not a tile nobody looked at, and cannot be actuated."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [{"episode": 1, "notes": [1], "failed": [2]}],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "unreadable", 2: "visible"},
+        episode_tiles={1: (1, 2)},
+        unavailable_asset_ids=frozenset({"unreadable"}),
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("visible",)
+    assert parsed.warnings == ("!! unavailable Cull decision: unreadable",)
+
+
+def _wire_objects_in(prompt: str) -> tuple[dict[str, object], ...]:
+    """Every complete JSON object the prompt shows the model."""
+    decoder = json.JSONDecoder()
+    found: list[dict[str, object]] = []
+    for index, character in enumerate(prompt):
+        if character != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(prompt, index)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            found.append(value)
+    return tuple(found)
+
+
+def test_the_prompt_shows_the_exact_shape_its_parser_accepts() -> None:
+    """Prose asks for a shape; the parser demands one; nothing keeps them equal.
+
+    Measured against the local model: the prompt asked for "function ... and
+    visible reason", the model sent "visible_reason", the parser required
+    "reason", and every real record namespace was voided on every answer.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+    from immich_memories.analysis.episode_scan_request import episode_response_shape
+
+    shown = _wire_objects_in(episode_response_shape(episode_alias=1, tile=1))
+    envelope = next(item for item in shown if "cull_rejects" in item)
+
+    parsed = read_cull_namespaces(
+        json.dumps(envelope),
+        pack_alias=1,
+        tile_map={1: "asset"},
+        episode_tiles={1: (1,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    # The shown envelope decides nothing, which is the honest default.
+    assert parsed.cull_rejects == ()
+
+
+def test_a_tile_filed_under_the_wrong_episode_still_decides_its_own_pixels() -> None:
+    """One misattributed tile must not void every correct judgement beside it.
+
+    Measured on a real month: a pack of fifteen episodes came back with every
+    bucket right except a single tile filed one episode early. Voiding the
+    namespace threw away all fifteen episodes' work over the bookkeeping.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [1], "failed": []},
+                    {"episode": 2, "notes": [2, 3], "failed": []},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "a", 2: "b", 3: "c"},
+        episode_tiles={1: (1, 2), 2: (3,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("a", "b", "c")
+    assert parsed.warnings == ("!! Cull filed tile 2 under episode 2",)
+
+
+def test_an_ordinary_list_absorbs_what_cull_must_not_remove() -> None:
+    """Give 'merely unremarkable' its own place or it lands in notes.
+
+    Measured at temperature 0 on one real pack: with two lists, notes held 19
+    tiles of which nine were fields and cycling paths. With a third list to put
+    them in, notes held four -- a photographed document and three shots of a
+    television -- and nothing else. The list is read, validated, and discarded:
+    choosing between similar frames is a later pass's work.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [1], "failed": [2], "ordinary": [3]},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "a-screen", 2: "a-smeared-frame", 3: "an-ordinary-field"},
+        episode_tiles={1: (1, 2, 3)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("a-screen", "a-smeared-frame")
+
+
+def test_a_repeated_ordinary_tile_does_not_void_the_decisions_beside_it() -> None:
+    """The partition binds the lists that remove things, not the one thrown away.
+
+    Measured on a real month: two packs of five came back with episode 1's
+    ordinary list naming every tile on the sheet and each later episode naming
+    its own again. Held to the partition, that voided both packs entirely --
+    over repeats in a list nothing acts on.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [1], "failed": [], "ordinary": [1, 2, 3]},
+                    {"episode": 2, "notes": [], "failed": [], "ordinary": [2, 3]},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "a-screen", 2: "b", 3: "c"},
+        episode_tiles={1: (1, 2), 2: (3,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    # the removal stands; the ordinary mentions of the same tile change nothing
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("a-screen",)
+
+
+def test_the_same_verdict_twice_is_one_verdict_not_a_broken_answer() -> None:
+    """Repeating a decision agrees with itself; it is not a contradiction.
+
+    Measured on a real dense month: one pack of fifteen named tiles 27 and 28
+    as notes under episode 1 and again under episode 3, and the partition check
+    voided all four of its episodes over a verdict that did not disagree with
+    anything.
+    """
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [3], "failed": [], "ordinary": []},
+                    {"episode": 2, "notes": [3], "failed": [], "ordinary": []},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "a", 2: "b", 3: "a-screen"},
+        episode_tiles={1: (1, 3), 2: (2,)},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("a-screen",)
+
+
+def test_two_different_verdicts_about_one_tile_keep_the_tile() -> None:
+    """A contradiction resolves toward keeping, and never voids its neighbours."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    parsed = read_cull_namespaces(
+        json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "cull_rejects": [
+                    {"episode": 1, "notes": [1], "failed": [2], "ordinary": []},
+                    {"episode": 2, "notes": [], "failed": [1], "ordinary": []},
+                ],
+            }
+        ),
+        pack_alias=1,
+        tile_map={1: "argued-over", 2: "plainly-failed"},
+        episode_tiles={1: (1, 2), 2: ()},
+    )
+
+    assert parsed is not None
+    assert parsed.cull_valid
+    assert tuple(d.asset_id for d in parsed.cull_rejects) == ("plainly-failed",)
+    assert any("contradict" in warning for warning in parsed.warnings)

--- a/tests/test_editorial_contracts.py
+++ b/tests/test_editorial_contracts.py
@@ -1,0 +1,53 @@
+"""Editorial pass records are safe to hand from one pass to the next."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from immich_memories.analysis.editorial_contracts import (
+    ConservationCheck,
+    DecisionProvenance,
+    PassTrace,
+    RequestTrace,
+    TraceDecision,
+)
+
+
+def test_editorial_contracts_cannot_rewrite_a_previous_pass() -> None:
+    """A later pass cannot mutate the inputs, fate, or request it inherited."""
+    provenance = DecisionProvenance(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="1",  # noqa: S106 - test-only pass identity
+        schema_version="1",
+        model_identity="test-model",
+        input_ids=("first", "second"),
+        sheet_hashes=("sheet-hash",),
+        request_key="request-key",
+        cache_hit=False,
+    )
+    decision = TraceDecision("second", "unusable exposure")
+    pass_trace = PassTrace(
+        name="cull",
+        input_ids=("first", "second"),
+        kept_ids=("first",),
+        rejected=(decision,),
+        unresolved=(),
+        duration_before=8.0,
+        duration_after=4.0,
+        provenance=provenance,
+    )
+    request = RequestTrace(provenance=provenance, attached_sheet_hashes=("sheet-hash",))
+    conservation = ConservationCheck(valid=True, missing_ids=(), duplicate_ids=())
+
+    with pytest.raises(FrozenInstanceError):
+        provenance.input_ids = ("replacement",)  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        decision.reason = "replacement"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        pass_trace.kept_ids = ()  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        request.attached_sheet_hashes = ()  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        conservation.valid = False  # type: ignore[misc]

--- a/tests/test_editorial_gateway.py
+++ b/tests/test_editorial_gateway.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
+from immich_memories.analysis.llm_query import LLMTransportAttempt
 from immich_memories.analysis.selection_trace import Trace
 from immich_memories.analysis.visual_request_planner import VisionRequestLimits
 from immich_memories.config_models_llm import LLMConfig
@@ -73,6 +74,133 @@ def test_gateway_attaches_exact_page_bytes_and_traces_the_same_hash(tmp_path) ->
     assert request_trace["actual_calls"] == 1
 
 
+def test_gateway_sends_the_exact_grounded_annotations_used_by_cache_identity(tmp_path) -> None:
+    """Visible provider evidence and cache evidence cannot silently diverge."""
+    from dataclasses import replace
+
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    prompts: list[str] = []
+
+    async def _answer(prompt, _config, **kwargs):
+        prompts.append(prompt)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"rejected":[]}'
+
+    first_request = replace(
+        _request(_page()),
+        grounded_annotations=(
+            "tile:1 | episode:1 | taken:2026-08-25T12:00:00+00:00 | media:photo | "
+            "favourite:true | source:camera",
+            "tile:2 | episode:1 | taken:2026-08-25T12:01:00+00:00 | media:video | "
+            "favourite:false | source:motion",
+        ),
+    )
+    changed_request = replace(
+        first_request,
+        grounded_annotations=(
+            first_request.grounded_annotations[0].replace("favourite:true", "favourite:false"),
+            first_request.grounded_annotations[1],
+        ),
+    )
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+
+    # WHY: query_llm is the sole provider boundary; cache and request composition stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        first = gateway.ask(first_request)
+        changed = gateway.ask(changed_request)
+
+    assert prompts == [
+        "name only clear failures\n\nGrounded annotations (ordered JSON):\n"
+        '["tile:1 | episode:1 | taken:2026-08-25T12:00:00+00:00 | media:photo | '
+        'favourite:true | source:camera","tile:2 | episode:1 | '
+        'taken:2026-08-25T12:01:00+00:00 | media:video | favourite:false | source:motion"]',
+        "name only clear failures\n\nGrounded annotations (ordered JSON):\n"
+        '["tile:1 | episode:1 | taken:2026-08-25T12:00:00+00:00 | media:photo | '
+        'favourite:false | source:camera","tile:2 | episode:1 | '
+        'taken:2026-08-25T12:01:00+00:00 | media:video | favourite:false | source:motion"]',
+    ]
+    assert first.provenance.request_key != changed.provenance.request_key
+
+
+def test_gateway_returns_its_physical_trace_and_uses_explicit_request_budget(tmp_path) -> None:
+    """A fused logical consumer can reuse one answer without recounting its wire call."""
+    from dataclasses import replace
+
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    captured: dict[str, object] = {}
+
+    async def _answer(_prompt, _config, **kwargs):
+        from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+        captured.update(kwargs)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"episode_reading":{}}'
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+    request = replace(
+        _request(_page()),
+        pass_name="episode-scan",  # noqa: S106 - test-only pass identity
+        limits=VisionRequestLimits(max_output_tokens=2400, timeout_seconds=90),
+    )
+
+    # WHY: query_llm is the sole external provider transport this gateway may use.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        answer = gateway.ask(request)
+
+    assert captured["max_tokens"] == 2400
+    assert captured["timeout_seconds"] == 90
+    assert answer.request_trace.actual_calls == 1
+    assert answer.request_trace.provenance.request_key == answer.provenance.request_key
+    assert trace.requests == [answer.request_trace]
+
+
+def test_visual_request_budget_changes_cache_identity(tmp_path) -> None:
+    """A larger response envelope cannot reuse an answer truncated to a smaller budget."""
+    from dataclasses import replace
+
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    calls: list[None] = []
+
+    async def _answer(*_args, **kwargs):
+        calls.append(None)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"episode_reading":{}}'
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+    first = replace(
+        _request(_page()),
+        limits=VisionRequestLimits(max_output_tokens=1200, timeout_seconds=60),
+    )
+    second = replace(
+        first,
+        limits=VisionRequestLimits(max_output_tokens=2400, timeout_seconds=90),
+    )
+
+    # WHY: query_llm is the external transport; the visual cache remains real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        first_answer = gateway.ask(first)
+        second_answer = gateway.ask(second)
+
+    assert len(calls) == 2
+    assert first_answer.provenance.request_key != second_answer.provenance.request_key
+
+
 def test_gateway_reuses_banked_answer_with_original_and_reuse_provenance(tmp_path) -> None:
     from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
 
@@ -99,6 +227,8 @@ def test_gateway_reuses_banked_answer_with_original_and_reuse_provenance(tmp_pat
     assert len(calls) == 1
     assert reused.provenance.cache_hit is True
     assert reused.original_provenance.cache_hit is False
+    assert reused.request_trace.actual_calls == 0
+    assert reused.request_trace.cache_hit is True
     reuse_trace = trace.as_dict()["requests"][-1]
     assert reuse_trace["cache_hit"] is True
     assert reuse_trace["original_provenance"]["cache_hit"] is False
@@ -207,6 +337,34 @@ def test_gateway_traces_an_invalid_provider_response_as_one_real_post(tmp_path) 
     assert gateway.cache.answer_for(request_trace["provenance"]["request_key"]) is None
 
 
+def test_gateway_failure_carries_the_exact_recorded_request_trace(tmp_path) -> None:
+    """A fail-open pass can retain failed-pack provenance without searching a shared ledger."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=trace,
+    )
+
+    async def _fail(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "timeout", None))
+        raise TimeoutError("generated timeout")
+
+    # WHY: query_llm is the external provider; failure provenance belongs to the real gateway.
+    with (
+        patch("immich_memories.analysis.editorial_gateway.query_llm", new=_fail),
+        pytest.raises(TimeoutError, match="generated timeout") as caught,
+    ):
+        gateway.ask(_request(_page()))
+
+    assert caught.value.request_trace is trace.requests[0]
+    assert caught.value.request_trace.actual_calls == 1
+    assert caught.value.request_trace.attached_sheet_hashes == (_page().sha256,)
+
+
 @pytest.mark.asyncio
 async def test_gateway_works_inside_an_active_event_loop(tmp_path) -> None:
     from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
@@ -225,3 +383,33 @@ async def test_gateway_works_inside_an_active_event_loop(tmp_path) -> None:
     # WHY: query_llm is the provider boundary; the active loop is the behavior under test.
     with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
         assert gateway.ask(_request(_page())).raw_text == "complete"
+
+
+def test_a_decision_pass_asks_for_the_same_answer_every_time(tmp_path: Path) -> None:
+    """Sampling a decision makes the same evidence yield different verdicts.
+
+    Measured on one real pack, four repeats each: at the transport default of
+    0.3 the answers differed every run and one named all 105 tiles in the pack;
+    at 0 all four responses were byte-identical. A pass that decides membership
+    must be reproducible, and a banked answer is only meaningful if re-asking
+    would have produced it again.
+    """
+    seen: list[float | None] = []
+
+    async def _answer(_prompt, _config, **kwargs):
+        seen.append(kwargs.get("temperature"))
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return "{}"
+
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+    # WHY: query_llm is the provider boundary; the request identity stays real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        gateway.ask(_request(_page()))
+
+    assert seen == [0.0]

--- a/tests/test_editorial_gateway.py
+++ b/tests/test_editorial_gateway.py
@@ -1,0 +1,227 @@
+"""The visual gateway banks exact contact-sheet evidence."""
+
+from hashlib import sha256
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
+from immich_memories.analysis.selection_trace import Trace
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+from immich_memories.config_models_llm import LLMConfig
+
+
+def _page() -> ContactSheetPage:
+    jpeg = b"exact sheet jpeg"
+    return ContactSheetPage(
+        sheet_id="episode-001",
+        path=Path("/private-sheet.jpg"),
+        jpeg_bytes=jpeg,
+        sha256=sha256(jpeg).hexdigest(),
+        tile_refs=(TileRef(1, "asset-a"), TileRef(2, "asset-b")),
+        layout_version="layout-1",
+    )
+
+
+def _request(page: ContactSheetPage):
+    from immich_memories.analysis.editorial_gateway import VisualEditorialRequest
+
+    return VisualEditorialRequest(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="pass-1",  # noqa: S106 - test-only pass identity
+        prompt="name only clear failures",
+        prompt_version="prompt-1",
+        schema_version="schema-1",
+        pages=(page,),
+        ordered_input_ids=("asset-a", "asset-b"),
+        ordered_group_ids=("episode",),
+        grounded_annotations=("known place",),
+        upstream_material=("insight-1",),
+        render_version="render-1",
+        limits=VisionRequestLimits(),
+    )
+
+
+def test_gateway_attaches_exact_page_bytes_and_traces_the_same_hash(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    page = _page()
+    captured: dict[str, object] = {}
+
+    async def _answer(prompt, config, **kwargs):
+        from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+        captured["images"] = kwargs["images"]
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"rejected": []}'
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: query_llm is the sole external provider transport this gateway may use.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        answer = gateway.ask(_request(page))
+
+    assert sha256(captured["images"][0]).hexdigest() == page.sha256
+    assert answer.raw_text == '{"rejected": []}'
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["attached_sheet_hashes"] == [page.sha256]
+    assert request_trace["tile_count"] == 2
+    assert request_trace["actual_calls"] == 1
+
+
+def test_gateway_reuses_banked_answer_with_original_and_reuse_provenance(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    page = _page()
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    calls: list[None] = []
+
+    async def _answer(*_args, **_kwargs):
+        from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+        calls.append(None)
+        _kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"rejected": []}'
+
+    # WHY: query_llm is the sole external provider transport this gateway may use.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        gateway.ask(_request(page))
+        reused = gateway.ask(_request(page))
+
+    assert len(calls) == 1
+    assert reused.provenance.cache_hit is True
+    assert reused.original_provenance.cache_hit is False
+    reuse_trace = trace.as_dict()["requests"][-1]
+    assert reuse_trace["cache_hit"] is True
+    assert reuse_trace["original_provenance"]["cache_hit"] is False
+
+
+def test_gateway_rejects_a_page_whose_digest_does_not_match_its_bytes(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    bad_page = ContactSheetPage(
+        sheet_id="episode-001",
+        path=Path("/private-sheet.jpg"),
+        jpeg_bytes=b"wrong bytes",
+        sha256="not-a-real-digest",
+        tile_refs=(TileRef(1, "asset-a"),),
+        layout_version="layout-1",
+    )
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+
+    import pytest
+
+    with pytest.raises(ValueError, match="digest"):
+        gateway.ask(_request(bad_page))
+
+
+def test_gateway_traces_each_null_content_retry_as_a_wire_attempt(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    response = AsyncMock(status_code=200)
+    response.raise_for_status = lambda: None
+    response.json = MagicMock(
+        return_value={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    )
+    null = AsyncMock(status_code=200)
+    null.raise_for_status = lambda: None
+    null.json = MagicMock(
+        return_value={"choices": [{"message": {"content": None}, "finish_reason": "stop"}]}
+    )
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: the LLM server is the external boundary; this verifies its retry ledger.
+    with patch("httpx.AsyncClient.post", side_effect=[null, response]):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 2
+    assert [attempt["outcome"] for attempt in request_trace["attempts"]] == [
+        "null_content",
+        "response",
+    ]
+
+
+def test_gateway_rejects_whitespace_without_banking_the_real_post(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    async def _whitespace(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return " \n\t"
+
+    # WHY: a completed transport with blank editorial content must still be traceable, not banked.
+    with (
+        patch("immich_memories.analysis.editorial_gateway.query_llm", new=_whitespace),
+        pytest.raises(ValueError, match="nonblank"),
+    ):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 1
+    assert request_trace["attempts"][0]["outcome"] == "response"
+    assert gateway.cache.answer_for(request_trace["provenance"]["request_key"]) is None
+
+
+def test_gateway_traces_an_invalid_provider_response_as_one_real_post(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: malformed provider content arrives after a real POST and must not look like a free failure.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(ValueError, match="not json"),
+    ):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 1
+    assert [attempt["outcome"] for attempt in request_trace["attempts"]] == ["invalid_response"]
+    assert gateway.cache.answer_for(request_trace["provenance"]["request_key"]) is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_works_inside_an_active_event_loop(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+
+    async def _answer(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return "complete"
+
+    # WHY: query_llm is the provider boundary; the active loop is the behavior under test.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        assert gateway.ask(_request(_page())).raw_text == "complete"

--- a/tests/test_editorial_trace.py
+++ b/tests/test_editorial_trace.py
@@ -1,0 +1,128 @@
+"""Editorial decision tracing stays complete without changing chronology."""
+
+from __future__ import annotations
+
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    PassTrace,
+    TraceDecision,
+)
+from immich_memories.analysis.selection_trace import Trace, record, tracing
+
+
+def _provenance(input_ids: tuple[str, ...]) -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="1",  # noqa: S106 - test-only pass identity
+        schema_version="1",
+        model_identity="test-model",
+        input_ids=input_ids,
+        sheet_hashes=("sheet-hash",),
+        request_key="request-key",
+        cache_hit=False,
+    )
+
+
+def test_editorial_pass_keeps_chronology_and_conserves_every_input() -> None:
+    """A pass preserves the editor's order while accounting for every input."""
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=("late", "early", "middle"),
+            kept_ids=("late", "middle"),
+            rejected=(TraceDecision("early", "unusable exposure"),),
+            unresolved=(),
+            duration_before=12.0,
+            duration_after=8.0,
+            provenance=_provenance(("late", "early", "middle")),
+        )
+    )
+
+    payload = trace.as_dict()
+
+    assert payload["editorial_passes"][0]["kept_ids"] == ["late", "middle"]
+    assert payload["editorial_passes"][0]["conservation"]["valid"] is True
+
+
+def test_active_trace_accepts_an_editorial_pass_through_the_existing_adapter() -> None:
+    """The module adapter remains the one trace entry point during migration."""
+    with tracing() as trace:
+        record(
+            PassTrace(
+                name="cull",
+                input_ids=("first",),
+                kept_ids=("first",),
+                rejected=(),
+                unresolved=(),
+                duration_before=4.0,
+                duration_after=4.0,
+                provenance=_provenance(("first",)),
+            )
+        )
+
+    assert trace.as_dict()["editorial_passes"][0]["name"] == "cull"
+
+
+def test_editorial_pass_reports_duplicate_and_missing_fates() -> None:
+    """A bad pass is visible rather than silently losing an editorial input."""
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=("kept-twice", "missing", "rejected"),
+            kept_ids=("kept-twice",),
+            rejected=(
+                TraceDecision("kept-twice", "also rejected"),
+                TraceDecision("rejected", "unusable exposure"),
+            ),
+            unresolved=(),
+            duration_before=12.0,
+            duration_after=4.0,
+            provenance=_provenance(("kept-twice", "missing", "rejected")),
+        )
+    )
+
+    payload = trace.as_dict()
+
+    assert payload["editorial_passes"][0]["conservation"] == {
+        "valid": False,
+        "missing_ids": ["missing"],
+        "duplicate_ids": ["kept-twice"],
+        "unexpected_ids": [],
+    }
+    assert "!! conservation failure" in trace.report()
+
+
+def test_editorial_report_marks_abbreviated_decisions_as_display_only() -> None:
+    """Markdown samples long decisions while JSON keeps every named fate."""
+    input_ids = tuple(f"reject-{number}" for number in range(13))
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=input_ids,
+            kept_ids=(),
+            rejected=tuple(
+                TraceDecision(asset_id, f"reason {number}")
+                for number, asset_id in enumerate(input_ids)
+            ),
+            unresolved=(),
+            duration_before=52.0,
+            duration_after=0.0,
+            provenance=_provenance(input_ids),
+        )
+    )
+
+    report = trace.report()
+    payload = trace.as_dict()
+
+    assert "showing 12 of 13; full list in JSON" in report
+    assert "reject-12 — reason 12" not in report
+    assert payload["editorial_passes"][0]["rejected"][-1] == {
+        "asset_id": "reject-12",
+        "reason": "reason 12",
+    }

--- a/tests/test_editorial_verdicts.py
+++ b/tests/test_editorial_verdicts.py
@@ -1,0 +1,111 @@
+"""Verdicts about what a picture IS, remembered across memories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Bandit reads a "..._version" keyword as a credential; these are pass identities.
+from immich_memories.analysis.selection_cull import CULL_PASS_VERSION
+
+CULL_V1 = CULL_PASS_VERSION
+CULL_V2 = "cull-v2"
+
+
+def test_a_verdict_about_the_picture_survives_into_another_memory(tmp_path: Path) -> None:
+    """A photographed receipt is a receipt in every memory it could appear in."""
+    from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+
+    store = EditorialVerdicts(tmp_path / "verdicts.db")
+    store.remember(
+        (("a-receipt", "notes"), ("a-smear", "failed")),
+        pass_version=CULL_V1,
+    )
+
+    recalled = EditorialVerdicts(tmp_path / "verdicts.db").recall(
+        ("a-receipt", "a-smear", "never-seen"), pass_version=CULL_V1
+    )
+
+    assert recalled == {"a-receipt": "notes", "a-smear": "failed"}
+
+
+def test_changing_what_a_bucket_means_forgets_the_old_verdicts(tmp_path: Path) -> None:
+    """The store answers for a definition, not for all time.
+
+    Re-rendering a picture must not clear a verdict about what it is, but
+    changing what `notes` MEANS has to, or a year of judgement silently answers
+    a question nobody asked any more.
+    """
+    from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+
+    store = EditorialVerdicts(tmp_path / "verdicts.db")
+    store.remember((("a-receipt", "notes"),), pass_version=CULL_V1)
+
+    assert store.recall(("a-receipt",), pass_version=CULL_V2) == {}
+    assert store.recall(("a-receipt",), pass_version=CULL_V1) == {"a-receipt": "notes"}
+
+
+def test_a_later_verdict_replaces_an_earlier_one(tmp_path: Path) -> None:
+    """One asset, one standing verdict; the most recent look wins."""
+    from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+
+    store = EditorialVerdicts(tmp_path / "verdicts.db")
+    store.remember((("argued-over", "notes"),), pass_version=CULL_V1)
+    store.remember((("argued-over", "failed"),), pass_version=CULL_V1)
+
+    assert store.recall(("argued-over",), pass_version=CULL_V1) == {"argued-over": "failed"}
+
+
+def test_a_remembered_verdict_culls_without_asking_again(tmp_path: Path) -> None:
+    """The picture was judged once; every later memory inherits that judgement."""
+    from datetime import UTC, datetime
+
+    from immich_memories.analysis.selection_cull import run_cull
+    from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+    from tests.test_selection_cull import _pass_zero_for
+
+    store = EditorialVerdicts(tmp_path / "verdicts.db")
+    store.remember((("a-receipt", "notes"),), pass_version=CULL_V1)
+
+    prepared, pass_zero = _pass_zero_for(
+        tmp_path,
+        assets=("a-receipt", "a-moment"),
+        when=datetime(2026, 8, 25, 12, tzinfo=UTC),
+    )
+    result = run_cull(
+        prepared,
+        pass_zero,
+        review_output_dir=tmp_path / "review",
+        verdicts=store,
+    )
+
+    assert tuple(decision.asset_id for decision in result.rejected) == ("a-receipt",)
+    assert tuple(candidate.asset_id for candidate in result.survivors) == ("a-moment",)
+    assert any("remembered" in warning for warning in result.warnings)
+
+
+def test_a_star_outranks_a_remembered_verdict(tmp_path: Path) -> None:
+    """The star settles it here as it settles every other hard gate."""
+    from datetime import UTC, datetime
+
+    from immich_memories.analysis.selection_cull import run_cull
+    from immich_memories.cache.editorial_verdicts import EditorialVerdicts
+    from tests.test_selection_cull import _pass_zero_for
+
+    store = EditorialVerdicts(tmp_path / "verdicts.db")
+    store.remember((("a-receipt", "notes"),), pass_version=CULL_V1)
+
+    prepared, pass_zero = _pass_zero_for(
+        tmp_path,
+        assets=("a-receipt",),
+        when=datetime(2026, 8, 25, 12, tzinfo=UTC),
+        favourites=("a-receipt",),
+    )
+    result = run_cull(
+        prepared,
+        pass_zero,
+        review_output_dir=tmp_path / "review",
+        verdicts=store,
+    )
+
+    assert result.rejected == ()
+    assert tuple(candidate.asset_id for candidate in result.survivors) == ("a-receipt",)

--- a/tests/test_frame_extraction.py
+++ b/tests/test_frame_extraction.py
@@ -10,7 +10,11 @@ run re-decoded the same video forever.
 from pathlib import Path
 from unittest.mock import patch
 
-from immich_memories.processing.frame_sampling import even_timestamps, sample_frames
+from immich_memories.processing.frame_sampling import (
+    even_timestamps,
+    sample_frames,
+    sample_segment_frames,
+)
 
 
 def test_frames_are_spread_evenly_across_the_video() -> None:
@@ -61,6 +65,73 @@ def test_a_different_width_is_a_different_ask(tmp_path) -> None:
         sample_frames(video, count=2, width=320, cache_dir=tmp_path / "frames")
 
     assert len({w for _, w in calls}) == 2, "one width served the other's frames"
+
+
+def test_segment_cache_identity_changes_for_bounds_and_render_version(tmp_path) -> None:
+    """Filmstrip frames never survive a change to the portion or pixel recipe."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    calls: list[float] = []
+
+    def _fake_extract(_video, timestamp, _width, out_path):
+        calls.append(timestamp)
+        out_path.write_bytes(b"jpeg")
+        return True
+
+    # WHY: FFmpeg extraction is external; cache identity is the behavior under test.
+    with patch("immich_memories.processing.frame_sampling._extract_one", new=_fake_extract):
+        first = sample_segment_frames(
+            video, start_time=0, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        same = sample_segment_frames(
+            video, start_time=0, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_segment = sample_segment_frames(
+            video, start_time=1, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_end = sample_segment_frames(
+            video, start_time=0, end_time=3, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_render = sample_segment_frames(
+            video,
+            start_time=0,
+            end_time=2,
+            count=2,
+            width=320,
+            cache_dir=tmp_path / "frames",
+            render_version="new-filmstrip",
+        )
+
+    assert first == same
+    assert changed_segment != first
+    assert changed_end != first
+    assert changed_render != first
+    assert len(calls) == 8
+
+
+def test_segment_sampler_rejects_partial_and_empty_video_inputs(tmp_path) -> None:
+    """An in-flight download or empty placeholder must never be sent to FFmpeg."""
+    partial = tmp_path / "clip.mp4.part"
+    empty = tmp_path / "empty.mp4"
+    partial.write_bytes(b"in flight")
+    empty.touch()
+
+    # WHY: FFmpeg is external and must not run for rejected cache entries.
+    with patch("immich_memories.processing.frame_sampling._extract_one") as extract:
+        assert (
+            sample_segment_frames(
+                partial, start_time=0, end_time=1, count=1, width=320, cache_dir=tmp_path
+            )
+            == ()
+        )
+        assert (
+            sample_segment_frames(
+                empty, start_time=0, end_time=1, count=1, width=320, cache_dir=tmp_path
+            )
+            == ()
+        )
+
+    extract.assert_not_called()
 
 
 def test_a_cache_that_cannot_be_written_still_returns_frames(tmp_path) -> None:

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -7,6 +7,8 @@ of the same memory presents them again. In reasoning mode each of those costs
 measured ~15 minutes a memory spent almost entirely here.
 """
 
+import hashlib
+import json
 from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -205,6 +207,60 @@ def test_visual_identity_changes_for_each_piece_of_visual_evidence() -> None:
     assert base.key() != replace(base, layout_versions=("l2", "l1")).key()
     assert base.key() != replace(base, upstream_material=("insight-v2",)).key()
     assert base.key() != replace(base, pass_version="pass-2").key()  # noqa: S106
+
+
+def test_visible_annotation_protocol_abandons_the_annotation_invisible_v1_bank(tmp_path) -> None:
+    """Answers produced before annotations reached the provider cannot be reused."""
+    from immich_memories.cache.judgment_cache import (
+        VisualJudgmentCache,
+        VisualJudgmentIdentity,
+    )
+
+    identity = VisualJudgmentIdentity(
+        page_bytes=(b"first", b"second"),
+        ordered_input_ids=("a", "b"),
+        ordered_group_ids=("g",),
+        annotations=("known place",),
+        model="vision-a",
+        thinking=True,
+        image_detail="low",
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="pass-1",  # noqa: S106 - test-only pass identity
+        prompt_version="p1",
+        schema_version="s1",
+        render_version="r1",
+        layout_versions=("l1", "l1"),
+        upstream_material=("insight-v1",),
+        request_limits=("pages=1",),
+        continuation_identity=(1, 1),
+    )
+    legacy_material = {
+        "version": "visual1",
+        "page_hashes": [hashlib.sha256(page).hexdigest() for page in identity.page_bytes],
+        "ordered_input_ids": identity.ordered_input_ids,
+        "ordered_group_ids": identity.ordered_group_ids,
+        "annotations": identity.annotations,
+        "model": identity.model or "",
+        "thinking": identity.thinking,
+        "image_detail": identity.image_detail,
+        "pass_name": identity.pass_name,
+        "pass_version": identity.pass_version,
+        "prompt_version": identity.prompt_version,
+        "schema_version": identity.schema_version,
+        "render_version": identity.render_version,
+        "layout_versions": identity.layout_versions,
+        "upstream_material": identity.upstream_material,
+        "request_limits": identity.request_limits,
+        "continuation_identity": identity.continuation_identity,
+        "endpoint": identity.endpoint,
+    }
+    encoded = json.dumps(legacy_material, separators=(",", ":"), sort_keys=True).encode()
+    legacy_v1_key = hashlib.sha256(encoded).hexdigest()
+    cache = VisualJudgmentCache(tmp_path / "judgments.db")
+    cache.remember(legacy_v1_key, "annotation-invisible answer", '{"legacy":true}')
+
+    assert identity.key() != legacy_v1_key
+    assert cache.answer_for(identity.key()) is None
 
 
 def test_visual_cache_keeps_original_provenance_when_reused(tmp_path) -> None:

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -7,6 +7,7 @@ of the same memory presents them again. In reasoning mode each of those costs
 measured ~15 minutes a memory spent almost entirely here.
 """
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -170,3 +171,56 @@ def test_without_a_cache_path_nothing_is_remembered(tmp_path) -> None:
         review_selection(_selection(), _config())
 
     assert len(calls) == 2
+
+
+def test_visual_identity_changes_for_each_piece_of_visual_evidence() -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentIdentity
+
+    base = VisualJudgmentIdentity(
+        page_bytes=(b"first", b"second"),
+        ordered_input_ids=("a", "b"),
+        ordered_group_ids=("g",),
+        annotations=("known place",),
+        model="vision-a",
+        thinking=True,
+        image_detail="low",
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="pass-1",  # noqa: S106 - test-only pass identity
+        prompt_version="p1",
+        schema_version="s1",
+        render_version="r1",
+        layout_versions=("l1", "l1"),
+        upstream_material=("insight-v1",),
+        request_limits=("pages=1",),
+        continuation_identity=(1, 1),
+    )
+
+    assert base.key() != replace(base, page_bytes=(b"changed", b"second")).key()
+    assert base.key() != replace(base, page_bytes=(b"second", b"first")).key()
+    assert base.key() != replace(base, annotations=("other place",)).key()
+    assert base.key() != replace(base, model="vision-b").key()
+    assert base.key() != replace(base, prompt_version="p2").key()
+    assert base.key() != replace(base, schema_version="s2").key()
+    assert base.key() != replace(base, render_version="r2").key()
+    assert base.key() != replace(base, layout_versions=("l2", "l1")).key()
+    assert base.key() != replace(base, upstream_material=("insight-v2",)).key()
+    assert base.key() != replace(base, pass_version="pass-2").key()  # noqa: S106
+
+
+def test_visual_cache_keeps_original_provenance_when_reused(tmp_path) -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentCache
+
+    cache = VisualJudgmentCache(tmp_path / "judgments.db")
+    cache.remember("visual-key", "raw answer", '{"request": "original"}')
+
+    assert cache.answer_for("visual-key") == ("raw answer", '{"request": "original"}')
+
+
+def test_visual_cache_does_not_bank_whitespace_only_answers(tmp_path) -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentCache
+
+    cache = VisualJudgmentCache(tmp_path / "judgments.db")
+
+    cache.remember("visual-key", " \n\t", '{"request": "original"}')
+
+    assert cache.answer_for("visual-key") is None

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -55,7 +55,39 @@ class TestQueryLlmOllama:
 
         call_payload = mock_post.call_args[1]["json"]
         assert call_payload["format"] == "json"
-        assert call_payload["options"] == {"temperature": 0.3, "num_ctx": 8192}
+        assert call_payload["options"] == {
+            "temperature": 0.0,
+            "num_ctx": 8192,
+            "num_predict": 500,
+        }
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_reaches_ollama_as_num_predict_beside_existing_options(self):
+        """The provider receives the same output ceiling recorded by the editorial request."""
+        from immich_memories.analysis.llm_query import query_llm
+
+        config = LLMConfig(
+            provider="ollama",
+            base_url="http://localhost:11434",
+            model="llava",
+            extra_params={"format": "json", "options": {"num_ctx": 8192, "top_k": 20}},
+        )
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(return_value={"response": "{}"})
+        mock_response.raise_for_status = lambda: None
+
+        # WHY: the LLM server is the external boundary whose exact provider payload matters.
+        with patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
+            await query_llm("Read this sheet", config, max_tokens=733)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["options"] == {
+            "temperature": 0.0,
+            "num_ctx": 8192,
+            "top_k": 20,
+            "num_predict": 733,
+        }
 
 
 class TestQueryLlmOpenAI:

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -530,3 +530,324 @@ class TestBulkCallsDoNotThink:
             await query_llm("Describe this photo", _thinking_config(model="picky"))
 
         assert "chat_template_kwargs" not in mock_post.call_args_list[-1][1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_each_null_content_wire_retry() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    responses = [_openai_response(content=None), _openai_response(content=None), _openai_response()]
+    # WHY: the LLM server is the external boundary; null-content retries happen at its response.
+    with patch("httpx.AsyncClient.post", side_effect=responses):
+        await query_llm(
+            "Describe this",
+            _thinking_config(thinking=False),
+            transport_observer=attempts.append,
+        )
+
+    assert [(attempt.attempt, attempt.outcome, attempt.status_code) for attempt in attempts] == [
+        (1, "null_content", 200),
+        (2, "null_content", 200),
+        (3, "response", 200),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic"])
+async def test_transport_observer_records_provider_http_failures(provider: str) -> None:
+    import httpx
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=503)
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "503", request=MagicMock(), response=response
+    )
+    attempts = []
+    config = LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+
+    # WHY: a provider's rejected HTTP response is still one real wire attempt.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        await query_llm("look", config, transport_observer=attempts.append)
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "http_error", 503)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_openai_adaptation_and_success() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    rejected = AsyncMock(status_code=400)
+    rejected.json = MagicMock(
+        return_value={"error": {"message": "Unrecognized request argument: chat_template_kwargs"}}
+    )
+    attempts = []
+
+    # WHY: the compatibility retry posts twice, once rejected and once accepted.
+    with (
+        patch("httpx.AsyncClient.post", side_effect=[rejected, _openai_response()]),
+        patch("immich_memories.analysis.llm_query._PARAM_ADAPTATIONS", {}),
+    ):
+        await query_llm("look", _thinking_config(), transport_observer=attempts.append)
+
+    assert [
+        (event.attempt, event.outcome, event.status_code, event.adaptation) for event in attempts
+    ] == [(1, "dialect_adaptation", 400, "no_chat_template_kwargs"), (2, "response", 200, None)]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_connection_errors() -> None:
+    import httpx
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    # WHY: no response object exists when the wire connection itself fails.
+    with (
+        patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("offline")),
+        pytest.raises(httpx.ConnectError),
+    ):
+        await query_llm("look", _thinking_config(), transport_observer=attempts.append)
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "connection_error", None)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_survives_thinking_fallback() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    # WHY: the fallback owns a new request but must retain the original observer.
+    with patch(
+        "httpx.AsyncClient.post",
+        side_effect=[_openai_response(finish_reason="length"), _openai_response()],
+    ):
+        await query_llm(
+            "judge", _thinking_config(), thinking=True, transport_observer=attempts.append
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "thinking_fallback", 200),
+        (2, "response", 200),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observers_are_isolated_across_concurrent_queries() -> None:
+    import asyncio
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    first: list = []
+    second: list = []
+    # WHY: per-query attempt numbers must not leak between concurrent callers.
+    with patch("httpx.AsyncClient.post", return_value=_openai_response()):
+        await asyncio.gather(
+            query_llm("first", _thinking_config(), transport_observer=first.append),
+            query_llm("second", _thinking_config(), transport_observer=second.append),
+        )
+
+    assert [(event.attempt, event.outcome) for event in first] == [(1, "response")]
+    assert [(event.attempt, event.outcome) for event in second] == [(1, "response")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_each_provider_payload_carries_the_exact_jpeg_bytes(provider: str) -> None:
+    import base64
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    image = b"exact-contact-sheet"
+    config = LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+    response = _openai_response()
+    if provider == "ollama":
+        response.json = MagicMock(return_value={"response": "ok"})
+    elif provider == "anthropic":
+        response.json = MagicMock(return_value={"content": [{"type": "text", "text": "ok"}]})
+
+    # WHY: the provider is the external boundary; this decodes its real dialect payload.
+    with patch("httpx.AsyncClient.post", return_value=response) as post:
+        await query_llm("look", config, images=(image,))
+
+    payload = post.call_args.kwargs["json"]
+    if provider == "ollama":
+        encoded = payload["images"][0]
+    elif provider == "anthropic":
+        encoded = payload["messages"][0]["content"][0]["source"]["data"]
+    else:
+        encoded = payload["messages"][0]["content"][1]["image_url"]["url"].split(",", 1)[1]
+    assert base64.b64decode(encoded) == image
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body"),
+    [
+        ("ollama", {"response": "partial", "done_reason": "length"}),
+        (
+            "anthropic",
+            {"content": [{"type": "text", "text": "partial"}], "stop_reason": "max_tokens"},
+        ),
+        (
+            "openai-compatible",
+            {"choices": [{"message": {"content": "partial"}, "finish_reason": "length"}]},
+        ),
+    ],
+)
+async def test_visual_completion_mode_rejects_known_truncation(provider: str, body: dict) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = AsyncMock(status_code=200)
+    response.json = MagicMock(return_value=body)
+    response.raise_for_status = lambda: None
+    attempts = []
+    # WHY: the provider response status is the external completion boundary.
+    with patch("httpx.AsyncClient.post", return_value=response), pytest.raises(ValueError):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            images=(b"jpeg",),
+            require_complete=True,
+            transport_observer=attempts.append,
+        )
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "incomplete", 200)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_transport_observer_records_invalid_json_for_each_provider(provider: str) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+    attempts = []
+
+    # WHY: a successful POST with unparseable provider content still costs one call.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(ValueError, match="not json"),
+    ):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            transport_observer=attempts.append,
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "invalid_response", 200)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body"),
+    [
+        ("ollama", {"response": []}),
+        ("anthropic", {"content": "not blocks"}),
+        ("openai-compatible", {"choices": "not choices"}),
+    ],
+)
+async def test_transport_observer_records_invalid_shape_for_each_provider(
+    provider: str, body: dict
+) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.return_value = body
+    attempts = []
+
+    # WHY: a syntactically valid but unusable provider body also spent one wire attempt.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises((KeyError, TypeError, AttributeError)),
+    ):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            transport_observer=attempts.append,
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "invalid_response", 200)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body", "usage"),
+    [
+        ("ollama", {"prompt_eval_count": 3, "eval_count": 5, "response": []}, (3, 5)),
+        (
+            "anthropic",
+            {"usage": {"input_tokens": 3, "output_tokens": 5}, "content": "not blocks"},
+            (3, 5),
+        ),
+        (
+            "openai-compatible",
+            {
+                "usage": {"prompt_tokens": 3, "completion_tokens": 5},
+                "choices": [{"message": {}}],
+            },
+            (3, 5),
+        ),
+    ],
+)
+async def test_parseable_malformed_content_keeps_legacy_reply_metrics(
+    provider: str, body: dict, usage: tuple[int, int]
+) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.return_value = body
+
+    # WHY: content may be malformed after the provider has supplied billable usage.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        patch("immich_memories.analysis.llm_query.llm_metrics.record_reply") as record_reply,
+        pytest.raises((KeyError, TypeError, AttributeError)),
+    ):
+        await query_llm(
+            "look", LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+        )
+
+    assert record_reply.call_args.kwargs == {
+        "prompt_tokens": usage[0],
+        "completion_tokens": usage[1],
+    }
+    assert record_reply.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_invalid_json_does_not_create_legacy_reply_metrics(provider: str) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+
+    # WHY: a body that cannot be decoded has no trustworthy usage to count.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        patch("immich_memories.analysis.llm_query.llm_metrics.record_reply") as record_reply,
+        pytest.raises(ValueError, match="not json"),
+    ):
+        await query_llm(
+            "look", LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+        )
+
+    record_reply.assert_not_called()

--- a/tests/test_moment_reading.py
+++ b/tests/test_moment_reading.py
@@ -202,6 +202,40 @@ class TestReadingAMoment:
         assert reading.about == ""
         assert reading.keep == ()
 
+    def test_legacy_reading_attaches_the_exact_page_bytes_it_records(self, tmp_path) -> None:
+        """The model sees precisely the local JPEG whose trace can later reproduce it."""
+        from datetime import UTC, datetime
+        from hashlib import sha256
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, patch
+
+        from PIL import Image
+
+        from immich_memories.analysis.moment_reading import read_moment
+        from immich_memories.config_models_llm import LLMConfig
+
+        asset = SimpleNamespace(
+            id="asset-1", people=[], file_created_at=datetime(2020, 1, 1, tzinfo=UTC)
+        )
+        pages = []
+        # WHY: the model is external; this test checks its request evidence.
+        with patch(
+            "immich_memories.analysis.llm_query.query_llm",
+            new=AsyncMock(return_value='{"about": "a walk", "subjects": [], "best": [1]}'),
+        ) as asked:
+            read_moment(
+                [asset],
+                {asset.id: Image.new("RGB", (24, 24), "red")},
+                LLMConfig(model="m"),
+                sheet_output_dir=tmp_path,
+                sheet_recorder=pages.append,
+            )
+
+        assert len(pages) == 1
+        assert pages[0].path.read_bytes() == pages[0].jpeg_bytes
+        assert sha256(pages[0].jpeg_bytes).hexdigest() == pages[0].sha256
+        assert asked.await_args.kwargs["images"] == [pages[0].jpeg_bytes]
+
 
 class TestASheetIsLaidOutWide:
     """One image for a whole moment, and wide rather than tall.

--- a/tests/test_period_insight.py
+++ b/tests/test_period_insight.py
@@ -1,0 +1,1410 @@
+"""Pass 0 reads the exact prepared visual corpus before making any cut."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from immich_memories.analysis.editorial_contracts import SourceEvidence
+from immich_memories.analysis.selection_flow import (
+    EditorialDependencies,
+    EditorialSelectionRequest,
+    SourceScope,
+    prepare_editorial_source,
+)
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+from immich_memories.api.models import AssetType, VideoClipInfo
+from immich_memories.config_models_llm import LLMConfig
+from tests.conftest import make_asset
+
+
+def _jpeg(colour: str) -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (24, 18), colour).save(output, "JPEG")
+    return output.getvalue()
+
+
+def _episode_pack_answer(prompt: str, *, summary: str = "Visible stages develop.") -> str:
+    scopes = re.findall(
+        r"episode=(\d+) page=(\d+) tiles=\[([^\]]+)\]",
+        prompt,
+    )
+    assert scopes
+    readings = []
+    for episode_alias, page_alias, displayed in scopes:
+        numbers = [int(value) for value in displayed.split(",")]
+        readings.append(
+            {
+                "episode": int(episode_alias),
+                "page": int(page_alias),
+                "visual_summary": summary,
+                "representative_tiles": numbers[:3],
+                "representative_reason": "These visible stages distinguish the episode.",
+            }
+        )
+    return json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": readings,
+            "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+        },
+        separators=(",", ":"),
+    )
+
+
+# v4's envelope is a fraction of v3's per tile, so the split boundaries these
+# tests exist to prove need a proportionally tighter budget to stay reachable.
+_TIGHT_BUDGET = 1100
+_SINGLE_EPISODE_BUDGET = 250
+
+
+def _maximum_fused_response_for(
+    displayed_by_episode: tuple[tuple[int, ...], ...],
+) -> str:
+    readings = [
+        {
+            "episode": episode,
+            "page": 1,
+            "visual_summary": "s" * 64,
+            "representative_tiles": list(displayed),
+            "representative_reason": "r" * 96,
+        }
+        for episode, displayed in enumerate(displayed_by_episode, start=1)
+    ]
+    # Worst case is every tile named once: a tile cannot sit in both buckets.
+    cull_rejects = [
+        {"episode": episode, "notes": list(displayed), "failed": []}
+        for episode, displayed in enumerate(displayed_by_episode, start=1)
+    ]
+    return json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": readings,
+            "cull_rejects": cull_rejects,
+        },
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _maximum_fused_response(pack) -> str:
+    return _maximum_fused_response_for(
+        tuple(tuple(ref.number for ref in scope.tile_refs) for scope in pack.scopes)
+    )
+
+
+def _assert_next_episode_would_overflow(packs, *, max_output_tokens: int = 4000) -> None:
+    """Prove each greedy pack stops for a reason: the budget, or the episode cap."""
+    from immich_memories.analysis.period_insight import MAX_EPISODES_PER_PACK
+
+    for pack, next_pack in zip(packs, packs[1:], strict=False):
+        if len(pack.scopes) >= MAX_EPISODES_PER_PACK:
+            continue
+        displayed = [tuple(ref.number for ref in scope.tile_refs) for scope in pack.scopes]
+        next_size = len(next_pack.scopes[0].tile_refs)
+        first_new_number = len(pack.page.tile_refs) + 1
+        displayed.append(tuple(range(first_new_number, first_new_number + next_size)))
+        assert len(_maximum_fused_response_for(tuple(displayed))) > max_output_tokens * 3
+
+
+def _assert_next_continuation_tile_would_overflow(packs, *, max_output_tokens: int = 4000) -> None:
+    """Prove each non-final continuation is maximal under the fused response budget."""
+    for pack in packs[:-1]:
+        displayed = tuple(ref.number for ref in pack.scopes[0].tile_refs)
+        assert (
+            len(_maximum_fused_response_for(((*displayed, displayed[-1] + 1),)))
+            > max_output_tokens * 3
+        )
+
+
+def test_source_preparation_preserves_real_visual_sources_in_candidate_order(
+    tmp_path: Path,
+) -> None:
+    """Only source-eligible, coalesced assets acquire previews and retain local motion."""
+    noon = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    photo = make_asset("photo", file_created_at=noon)
+    photo.type = AssetType.IMAGE
+    video_asset = make_asset("video", file_created_at=noon + timedelta(minutes=1))
+    video = VideoClipInfo(
+        asset=video_asset,
+        local_path=str(tmp_path / "video.mp4"),
+        duration_seconds=4.0,
+        width=1920,
+        height=1080,
+    )
+    excluded = make_asset("excluded", file_created_at=noon + timedelta(minutes=2))
+    preview_calls: list[str] = []
+
+    def preview_jpeg(asset) -> bytes:
+        preview_calls.append(asset.id)
+        return _jpeg("red" if asset.id == "photo" else "blue")
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(
+            scope=SourceScope(),
+            owner_excluded_asset_ids=("excluded",),
+        ),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (excluded, video_asset, photo, video),
+            preview_jpeg=preview_jpeg,
+        ),
+    )
+
+    assert prepared.candidate_ids == ("photo", "video")
+    assert tuple(source.asset.id for source in prepared.visual_sources) == prepared.candidate_ids
+    assert preview_calls == ["photo", "video"]
+    assert prepared.visual_sources[0].preview_jpeg == _jpeg("red")
+    assert prepared.visual_sources[1].motion_path == tmp_path / "video.mp4"
+
+
+def test_fused_episode_v4_request_cannot_reuse_a_legacy_v3_bank(
+    tmp_path: Path,
+) -> None:
+    """Changing the wire aliases abandons the old answer even with identical visual evidence."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (make_asset("asset", file_created_at=when),),
+            preview_jpeg=lambda _asset: _jpeg("red"),
+        ),
+    )
+
+    class CaptureAndFail:
+        request = None
+
+        def ask(self, request):
+            if self.request is None:
+                self.request = request
+            raise RuntimeError("capture only")
+
+    capture = CaptureAndFail()
+    run_period_insight(
+        prepared,
+        requester=capture,
+        sheet_output_dir=tmp_path / "capture-sheets",
+        frame_cache_dir=None,
+    )
+    current = capture.request
+    assert current is not None
+    assert (
+        current.pass_version,
+        current.prompt_version,
+        current.schema_version,
+    ) == ("episode-scan-v4", "episode-scan-prompt-v4", "episode-scan-v4")
+    legacy = replace(
+        current,
+        pass_version="episode-scan-v2",  # noqa: S106 - historical pass identity fixture
+        prompt_version="episode-scan-prompt-v2",
+        schema_version="episode-scan-v2",
+    )
+    calls: list[str] = []
+
+    async def answer(_prompt, _config, **kwargs):
+        calls.append("physical")
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"legacy-or-current":"banked"}'
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; the cache and exact generated page stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=answer):
+        legacy_answer = gateway.ask(legacy)
+        calls.clear()
+        current_answer = gateway.ask(current)
+        reused_current = gateway.ask(current)
+
+    assert calls == ["physical"]
+    assert current_answer.provenance.cache_hit is False
+    assert current_answer.request_trace.actual_calls == 1
+    assert current_answer.provenance.request_key != legacy_answer.provenance.request_key
+    assert reused_current.provenance.cache_hit is True
+    assert reused_current.request_trace.actual_calls == 0
+
+
+def test_v4_episode_packs_budget_every_possible_cull_member(
+    tmp_path: Path,
+) -> None:
+    """Maximum valid fused output, rather than an average reply, bounds every pack."""
+    from immich_memories.analysis.episode_scan_request import build_episode_request
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"asset-{index:03d}", file_created_at=start + timedelta(hours=index * 2))
+        for index in range(120)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("navy"),
+        ),
+    )
+
+    class NoProvider:
+        def ask(self, _request):
+            raise TimeoutError("generated timeout")
+
+    result = run_period_insight(
+        prepared,
+        requester=NoProvider(),
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+    )
+
+    planned_ids = tuple(
+        ref.entity_id for pack in result.episode_packs for ref in pack.page.tile_refs
+    )
+    assert planned_ids == prepared.candidate_ids
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [14] * 8 + [8]
+    for pack in result.episode_packs:
+        request = build_episode_request(pack, limits=VisionRequestLimits())
+        assert request.pages == (pack.page,)
+        assert len({ref.number for ref in request.pages[0].tile_refs}) == len(
+            request.pages[0].tile_refs
+        )
+        assert len(_maximum_fused_response(pack)) <= 4000 * 3
+    _assert_next_episode_would_overflow(result.episode_packs)
+
+
+def test_v3_episode_request_rejects_duplicate_pack_local_tile_aliases(tmp_path: Path) -> None:
+    """A future multi-page/alias layout must bump the v3 wire contract first."""
+    from immich_memories.analysis.episode_scan_request import build_episode_request
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (make_asset("asset"),),
+            preview_jpeg=lambda _asset: _jpeg("navy"),
+        ),
+    )
+
+    class NoProvider:
+        def ask(self, _request):
+            raise TimeoutError("generated timeout")
+
+    result = run_period_insight(
+        prepared,
+        requester=NoProvider(),
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+    )
+    pack = result.episode_packs[0]
+    duplicate_page = replace(pack.page, tile_refs=(pack.page.tile_refs[0],) * 2)
+
+    with pytest.raises(ValueError, match="unique pack-local tile numbers"):
+        build_episode_request(
+            replace(pack, page=duplicate_page),
+            limits=VisionRequestLimits(),
+        )
+
+
+def test_one_sub_120_episode_response_splits_into_bounded_continuations(
+    tmp_path: Path,
+) -> None:
+    """One large episode continues by response capacity even below the visual tile limit."""
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"asset-{index:02d}", file_created_at=when + timedelta(seconds=index))
+        for index in range(80)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("orange"),
+        ),
+    )
+
+    class NoProvider:
+        def ask(self, _request):
+            raise TimeoutError("generated timeout")
+
+    result = run_period_insight(
+        prepared,
+        requester=NoProvider(),
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+        limits=VisionRequestLimits(max_output_tokens=_SINGLE_EPISODE_BUDGET),
+    )
+
+    assert len(result.episode_sheets) == 1
+    assert len(result.episode_packs) > 1
+    assert tuple(
+        ref.number for pack in result.episode_packs for ref in pack.page.tile_refs
+    ) == tuple(range(1, 81))
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [65, 15]
+    assert all(len(_maximum_fused_response(pack)) <= 4000 * 3 for pack in result.episode_packs)
+    _assert_next_continuation_tile_would_overflow(
+        result.episode_packs, max_output_tokens=_SINGLE_EPISODE_BUDGET
+    )
+    assert {pack.continuation_count for pack in result.episode_packs} == {len(result.episode_packs)}
+
+
+def test_pass_zero_retains_the_atlas_and_failed_pack_provenance(tmp_path: Path) -> None:
+    """A timeout keeps both reusable pixels and the exact failed request association."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    asset = make_asset("asset", file_created_at=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (asset,),
+            preview_jpeg=lambda _asset: _jpeg("purple"),
+        ),
+    )
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+
+    async def _timeout(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "timeout", None))
+        raise TimeoutError("generated timeout")
+
+    # WHY: query_llm is the provider boundary; atlas construction and trace association stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_timeout):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert result.atlas.tile_for("asset").jpeg_bytes == _jpeg("purple")
+    assert len(result.scan_attempts) == 1
+    assert result.scan_attempts[0].answer is None
+    assert result.scan_attempts[0].request_trace is prepared.trace.requests[0]
+    assert result.scan_attempts[0].pack_id == result.episode_packs[0].pack_id
+    assert result.scan_attempts[0].page_id == result.episode_packs[0].page.sheet_id
+
+
+def test_task5_provider_prompt_maps_source_evidence_to_compact_visual_aliases(
+    tmp_path: Path,
+) -> None:
+    """The model sees the same concise tile evidence that keys the visual request."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    stable_asset_id = "asset-" + "a" * 64
+    photo = make_asset(
+        stable_asset_id,
+        is_favorite=True,
+        file_created_at=when,
+        duration=None,
+    )
+    photo.type = AssetType.IMAGE
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (photo,),
+            preview_jpeg=lambda _asset: _jpeg("blue"),
+            source_evidence=lambda _source: SourceEvidence(
+                blur=0.125,
+                similarity="source-one",
+            ),
+        ),
+    )
+    prompts: list[str] = []
+
+    async def answer(prompt, _config, **kwargs):
+        prompts.append(prompt)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return _episode_pack_answer(prompt)
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "One visual does not support a period thesis.",
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; source prep, atlas, sheets, and gateway stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=answer):
+        run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert len(prompts) == 2
+    episode_grounding = prompts[0].split("Grounded annotations (ordered JSON):\n", 1)[1]
+    assert episode_grounding == (
+        '["tile:1 | episode:1 | taken:2026-08-25T12:00:00+00:00 | media:photo | '
+        "favourite:true | subject-evidence:unknown | blur:0.125 | "
+        'similarity:source-one"]'
+    )
+    assert stable_asset_id not in episode_grounding
+    assert "Grounded annotations (ordered JSON):" in prompts[1]
+    assert "representatives:" in prompts[1]
+
+
+def test_incomplete_121_tile_episode_banks_valid_page_but_blocks_period_thesis(
+    tmp_path: Path,
+) -> None:
+    """Page-one success cannot conceal an unread continuation or remove its assets."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    captured_images: list[tuple[bytes, ...]] = []
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(make_asset(f"asset-{number:03d}", file_created_at=when) for number in range(121))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("purple"),
+        ),
+    )
+    trace = prepared.trace
+
+    async def _answer(prompt, _config, **kwargs):
+        captured_images.append(kwargs["images"])
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        complete = _episode_pack_answer(prompt, summary="A dense day continues.")
+        return complete if len(captured_images) == 1 else complete[:-1]
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=trace,
+    )
+    # WHY: query_llm is the only external provider boundary; atlas, sheets, gateway, and trace stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=tmp_path / "frames",
+            limits=VisionRequestLimits(
+                max_output_tokens=_SINGLE_EPISODE_BUDGET, timeout_seconds=90
+            ),
+        )
+
+    episode = result.episode_sheets[0]
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [65, 55, 1]
+    _assert_next_continuation_tile_would_overflow(
+        result.episode_packs, max_output_tokens=_SINGLE_EPISODE_BUDGET
+    )
+    assert tuple(ref.number for ref in episode.pages[-1].tile_refs) == (121,)
+    assert captured_images == [(page.jpeg_bytes,) for page in episode.pages]
+    assert [observation.reading is not None for observation in result.page_observations] == [
+        True,
+        False,
+        False,
+    ]
+    assert result.retained_ids == prepared.candidate_ids
+    assert result.insight.thesis is None
+    assert result.period_pages == ()
+    assert len(result.banked_scans) == 3
+    assert sum(request.actual_calls for request in trace.requests) == 3
+    assert len([item for item in trace.editorial_passes if item.name == "pass-0"]) == 1
+    assert trace.editorial_passes[-1].provenance.sheet_hashes == tuple(
+        page.sha256 for page in episode.pages
+    )
+    # its only episode is a continuation whose page is invalid, so nothing read
+    assert any("no episode could be read" in warning for warning in result.warnings)
+    assert trace.as_dict()["warnings"] == [
+        "!! Pass 0 no episode could be read; period thesis unavailable"
+    ]
+    assert trace.report().count("!! Pass 0 no episode could be read") == 1
+
+
+def test_complete_episode_builds_one_pixel_bearing_period_wall_and_visual_trace(
+    tmp_path: Path,
+) -> None:
+    """The period thesis sees saved representative pixels and records their exact bytes."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = (
+        make_asset("effort", file_created_at=when),
+        make_asset("medal", file_created_at=when + timedelta(minutes=1)),
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda asset: _jpeg("red" if asset.id == "effort" else "gold"),
+        ),
+    )
+    captured_images: list[tuple[bytes, ...]] = []
+
+    async def _answer(prompt, _config, **kwargs):
+        captured_images.append(kwargs["images"])
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if len(captured_images) == 1:
+            return _episode_pack_answer(prompt, summary="Effort leads to a medal.")
+        return (
+            '{"schema_version":"period-insight-v1","period_insight":{'
+            '"thesis":"Effort becomes celebration.",'
+            '"evidence":[{"observation":"Action resolves in a medal.",'
+            '"representative_tiles":[1,2]}],'
+            '"tensions":["effort versus reward"],'
+            '"recurring_threads":["movement"],"unavailable_reason":null}}'
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the only external provider boundary; encoded visual evidence stays real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=tmp_path / "frames",
+        )
+
+    assert result.insight.thesis == "Effort becomes celebration."
+    assert result.warnings == ()
+    assert len(result.period_pages) == 1
+    period_page = result.period_pages[0]
+    assert captured_images[-1] == (period_page.jpeg_bytes,)
+    assert period_page.path.read_bytes() == period_page.jpeg_bytes
+    assert prepared.trace.requests[-1].attached_sheet_hashes == (period_page.sha256,)
+    assert result.insight.evidence[0].asset_ids == ("effort", "medal")
+    pass_zero = [item for item in prepared.trace.editorial_passes if item.name == "pass-0"]
+    assert len(pass_zero) == 1
+    assert pass_zero[0].provenance.sheet_hashes == (
+        result.episode_sheets[0].pages[0].sha256,
+        period_page.sha256,
+    )
+    assert sum(item.actual_calls for item in pass_zero[0].request_traces) == 0
+    assert sum(item.actual_calls for item in prepared.trace.requests) == 2
+    assert prepared.trace.story_of("effort").first_pass == "pass-0"  # noqa: S105
+
+
+def test_a_period_wall_is_capped_rather_than_split(tmp_path: Path) -> None:
+    """A default one-page budget yields no independent partial-period theses."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    assets = tuple(
+        make_asset(
+            f"visual-{episode:02d}-{member}",
+            file_created_at=start + timedelta(hours=episode * 2, seconds=member),
+        )
+        for episode in range(41)
+        for member in range(3)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("teal"),
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return _episode_pack_answer(prompt, summary="Three related unfamiliar visuals.")
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the only external provider boundary; request planning remains real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            limits=VisionRequestLimits(max_output_tokens=_TIGHT_BUDGET),
+        )
+
+    # four episode packs, a fifth, and the wall -- which is now capped to one
+    # page rather than refused for needing two
+    assert calls == 6
+    assert [len(pack.scopes) for pack in result.episode_packs] == [10, 10, 10, 10, 1]
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [30, 30, 30, 30, 3]
+    _assert_next_episode_would_overflow(result.episode_packs, max_output_tokens=_TIGHT_BUDGET)
+    # capped to a single readable page, so the wall is asked rather than refused
+    assert len(result.period_pages) == 1
+    # this fixture answers only episode packs, so the wall has nothing to parse
+    assert result.insight.thesis is None
+    assert result.retained_ids == prepared.candidate_ids
+    assert result.warnings == (
+        "!! Pass 0 wall reads 60 of 123 representatives, spread across the period",
+        "!! Pass 0 period synthesis unreadable; thesis unavailable",
+    )
+
+
+def test_interleaved_episodes_share_one_chronological_pack_with_explicit_membership(
+    tmp_path: Path,
+) -> None:
+    """Parallel place threads render A/B/A while each complete episode stays identifiable."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    noon = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    a_early = make_asset("a-early", file_created_at=noon)
+    b = make_asset("b", file_created_at=noon + timedelta(minutes=3))
+    a_late = make_asset("a-late", file_created_at=noon + timedelta(minutes=6))
+    for asset, location in (
+        (a_early, (50.437, 5.971)),
+        (b, (50.878, 4.326)),
+        (a_late, (50.437, 5.971)),
+    ):
+        assert asset.exif_info is not None
+        asset.exif_info.latitude, asset.exif_info.longitude = location
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (a_early, b, a_late),
+            preview_jpeg=lambda _asset: _jpeg("silver"),
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if calls == 1:
+            return _episode_pack_answer(prompt)
+        return (
+            '{"schema_version":"period-insight-v1","period_insight":{'
+            '"thesis":null,"evidence":[],"tensions":[],"recurring_threads":[],'
+            '"unavailable_reason":"No credible period thesis from this small corpus."}}'
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the only external provider boundary; pack layout and mapping stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    pack = result.episode_packs[0]
+    assert tuple(ref.entity_id for ref in pack.page.tile_refs) == ("a-early", "b", "a-late")
+    assert tuple(tuple(ref.entity_id for ref in scope.tile_refs) for scope in pack.scopes) == (
+        ("a-early", "a-late"),
+        ("b",),
+    )
+    assert tuple(ref.entity_id for ref in result.period_pages[0].tile_refs) == (
+        "a-early",
+        "b",
+        "a-late",
+    )
+    assert len(result.episode_readings) == 2
+    assert result.insight.thesis is None
+    assert result.warnings == ()
+
+
+def test_packer_keeps_a_four_tile_episode_whole_at_the_v4_response_boundary(
+    tmp_path: Path,
+) -> None:
+    """Response-bounded packs still keep the following four-tile episode whole."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    assets = tuple(
+        make_asset(
+            f"triple-{episode:02d}-{member}",
+            file_created_at=start + timedelta(hours=episode * 2, seconds=member),
+        )
+        for episode in range(39)
+        for member in range(3)
+    ) + tuple(
+        make_asset(
+            f"quad-{member}",
+            file_created_at=start + timedelta(hours=78, seconds=member),
+        )
+        for member in range(4)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("olive"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "complete chronological period wall" in prompt:
+            return (
+                '{"schema_version":"period-insight-v1","period_insight":{'
+                '"thesis":null,"evidence":[],"tensions":[],"recurring_threads":[],'
+                '"unavailable_reason":"No single thesis."}}'
+            )
+        return _episode_pack_answer(prompt)
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; the real packer owns group boundaries.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            limits=VisionRequestLimits(max_output_tokens=_TIGHT_BUDGET),
+        )
+
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [30, 30, 30, 31]
+    assert [len(pack.scopes) for pack in result.episode_packs] == [10, 10, 10, 10]
+    _assert_next_episode_would_overflow(result.episode_packs, max_output_tokens=_TIGHT_BUDGET)
+    assert tuple(ref.entity_id for ref in result.episode_packs[-1].scopes[-1].tile_refs) == (
+        "quad-0",
+        "quad-1",
+        "quad-2",
+        "quad-3",
+    )
+    mapped_ids = tuple(
+        ref.entity_id
+        for pack in result.episode_packs
+        for scope in pack.scopes
+        for ref in scope.tile_refs
+    )
+    assert Counter(mapped_ids) == Counter(prepared.candidate_ids)
+    assert len(result.page_observations) == len(prepared.episode_groups) == 40
+    assert (
+        len(
+            [
+                request
+                for request in prepared.trace.requests
+                if request.provenance.pass_name == "episode-scan"  # noqa: S105
+            ]
+        )
+        == 4
+    )
+
+
+def test_singleton_episode_packs_fit_their_complete_response_budget(tmp_path: Path) -> None:
+    """Many tiny episodes split before their required JSON can exceed the token envelope."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    assets = tuple(
+        make_asset(
+            f"singleton-{number:03d}",
+            file_created_at=start + timedelta(hours=number * 2),
+        )
+        for number in range(120)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("maroon"),
+        ),
+    )
+    response_envelopes: list[tuple[int, int, int]] = []
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "complete chronological period wall" in prompt:
+            return (
+                '{"schema_version":"period-insight-v1","period_insight":{'
+                '"thesis":null,"evidence":[],"tensions":[],"recurring_threads":[],'
+                '"unavailable_reason":"No honest thesis."}}'
+            )
+        scopes = re.findall(
+            r"episode=(\d+) page=(\d+) tiles=\[([^\]]+)\]",
+            prompt,
+        )
+        assert scopes
+        readings = []
+        for episode_alias, page_alias, displayed in scopes:
+            readings.append(
+                {
+                    "episode": int(episode_alias),
+                    "page": int(page_alias),
+                    "visual_summary": "s" * 64,
+                    "representative_tiles": [int(value) for value in displayed.split(",")],
+                    "representative_reason": "r" * 96,
+                }
+            )
+        rejects = [
+            {
+                "episode": episode_alias,
+                "notes": [int(value) for value in displayed.split(",")],
+                "failed": [],
+            }
+            for episode_alias, _page_alias, displayed in scopes
+        ]
+        raw = json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": readings,
+                "cull_rejects": rejects,
+            },
+            separators=(",", ":"),
+        )
+        response_envelopes.append((len(scopes), len(raw), kwargs["max_tokens"] * 3))
+        return raw
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; source grouping, packing, pages, and parsing stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            limits=VisionRequestLimits(max_output_tokens=_TIGHT_BUDGET),
+        )
+
+    assert [item[0] for item in response_envelopes] == [10] * 12
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [10] * 12
+    _assert_next_episode_would_overflow(result.episode_packs, max_output_tokens=_TIGHT_BUDGET)
+    assert all(
+        response_chars <= budget_chars for _, response_chars, budget_chars in response_envelopes
+    )
+    assert Counter(reading.episode_id for reading in result.episode_readings) == Counter(
+        group.group_id for group in prepared.episode_groups
+    )
+    assert Counter(
+        ref.entity_id
+        for pack in result.episode_packs
+        for scope in pack.scopes
+        for ref in scope.tile_refs
+    ) == Counter(prepared.candidate_ids)
+    assert result.retained_ids == prepared.candidate_ids
+    assert len(result.episode_readings) == 120
+
+
+def test_empty_prepared_corpus_records_pass_zero_without_visual_calls(tmp_path: Path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: ()),
+    )
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+
+    result = run_period_insight(
+        prepared,
+        requester=gateway,
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+    )
+
+    assert result.retained_ids == ()
+    assert result.actual_calls == 0
+    assert result.insight.thesis is None
+    assert result.insight.unavailable_reason == "source corpus was empty"
+    assert result.warnings == ()
+    assert [item.name for item in prepared.trace.editorial_passes] == [
+        "source-eligibility",
+        "pass-0",
+    ]
+
+
+def test_one_packed_raw_answer_banks_valid_siblings_when_one_episode_is_invalid(
+    tmp_path: Path,
+) -> None:
+    """Pack-level storage and episode-level completeness are separate contracts."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 8, 25, 8, tzinfo=UTC)
+    assets = tuple(
+        make_asset(label, file_created_at=start + timedelta(hours=index * 2))
+        for index, label in enumerate(("asset-a", "asset-b", "asset-c"))
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("cyan"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        scopes = re.findall(r"episode=(\d+) page=(\d+)", prompt)
+        assert len(scopes) == 3
+        entries = [
+            {
+                "episode": int(episode_alias),
+                "page": int(page_alias),
+                "visual_summary": f"Visible episode {episode_alias}",
+                "representative_tiles": [99 if index == 1 else index + 1],
+                "representative_reason": "The named tile is visible.",
+            }
+            for index, (episode_alias, page_alias) in enumerate(scopes)
+        ]
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": entries,
+                "future_namespace": {"tile": True},
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; packed parsing and banking stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert len(result.banked_scans) == 1
+    assert [item.reading is not None for item in result.page_observations] == [True, False, True]
+    assert tuple(item.episode_id for item in result.episode_readings) == (
+        prepared.episode_groups[0].group_id,
+        prepared.episode_groups[2].group_id,
+    )
+    # the valid sibling still carries the wall, so the thesis is attempted
+    assert len(prepared.trace.requests) == 2
+
+
+def test_complete_121_tile_episode_combines_every_continuation_provenance(
+    tmp_path: Path,
+) -> None:
+    """One episode conclusion carries both physical page hashes and request keys."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"continuation-{number:03d}", file_created_at=when) for number in range(121)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("coral"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "complete chronological period wall" in prompt:
+            return (
+                '{"schema_version":"period-insight-v1","period_insight":{'
+                '"thesis":null,"evidence":[],"tensions":[],"recurring_threads":[],'
+                '"unavailable_reason":"No honest thesis."}}'
+            )
+        return _episode_pack_answer(prompt, summary="One chronological continuation.")
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; continuation provenance stays real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            limits=VisionRequestLimits(max_output_tokens=_SINGLE_EPISODE_BUDGET),
+        )
+
+    reading = result.episode_readings[0]
+    assert [len(pack.page.tile_refs) for pack in result.episode_packs] == [65, 55, 1]
+    _assert_next_continuation_tile_would_overflow(
+        result.episode_packs, max_output_tokens=_SINGLE_EPISODE_BUDGET
+    )
+    assert len(reading.page_provenances) == 3
+    assert tuple(item.sheet_hashes for item in reading.page_provenances) == tuple(
+        (pack.page.sha256,) for pack in result.episode_packs
+    )
+    assert tuple(item.request_key for item in reading.page_provenances) == tuple(
+        scan.answer.request_trace.provenance.request_key for scan in result.banked_scans
+    )
+    assert len({item.request_key for item in reading.page_provenances}) == 3
+    assert result.insight.thesis is None
+    assert result.warnings == ()
+
+
+def test_banked_episode_scan_can_be_reparsed_after_a_later_physical_failure(
+    tmp_path: Path,
+) -> None:
+    """Task 6 can consume the first raw envelope without issuing another model request."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.period_insight_answer import read_episode_answers
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"replay-{number:03d}", file_created_at=when) for number in range(121)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("indigo"),
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            kwargs["transport_observer"](LLMTransportAttempt(1, "connection_error", None))
+            raise ConnectionError("synthetic continuation failure")
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return _episode_pack_answer(prompt)
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; gateway failure tracing and raw replay stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert calls == 2
+    assert len(result.banked_scans) == 1
+    first_pack = result.episode_packs[0]
+    banked = result.banked_scans[0]
+    before = (
+        len(prepared.trace.requests),
+        sum(item.actual_calls for item in prepared.trace.requests),
+        banked.answer.request_trace.provenance.request_key,
+    )
+    replay = read_episode_answers(
+        banked.answer.raw_text,
+        pack_alias=1,
+        expected_observations=tuple(
+            (scope.episode_id, scope.page_id) for scope in first_pack.scopes
+        ),
+        observation_map={
+            (scope.episode_alias, scope.page_alias): (scope.episode_id, scope.page_id)
+            for scope in first_pack.scopes
+        },
+        tile_map={
+            (scope.episode_alias, scope.page_alias, ref.number): ref.entity_id
+            for scope in first_pack.scopes
+            for ref in scope.tile_refs
+        },
+    )
+    after = (
+        len(prepared.trace.requests),
+        sum(item.actual_calls for item in prepared.trace.requests),
+        banked.answer.request_trace.provenance.request_key,
+    )
+
+    assert replay is not None and replay.invalid_observations == ()
+    assert before == after == (2, 2, banked.answer.provenance.request_key)
+
+
+def test_a_pack_holds_no_more_episodes_than_the_model_will_answer_about(
+    tmp_path: Path,
+) -> None:
+    """Too many episodes on one sheet and the second half of the question dies.
+
+    Measured on two real months at temperature 0. A 36-episode pack returned a
+    complete, valid answer whose Cull lists were all empty -- silently, with no
+    warning -- while the same month split into six smaller packs culled 4.6% and
+    a dense month whose packs held 4 to 14 episodes culled 4.4%. The token
+    budget alone does not bound this, so the pack bounds it directly.
+    """
+    from immich_memories.analysis.period_insight import (
+        MAX_EPISODES_PER_PACK,
+        run_period_insight,
+    )
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    # one asset per hour: every asset lands in its own episode
+    assets = tuple(
+        make_asset(f"asset-{index:03d}", file_created_at=start + timedelta(days=index))
+        for index in range(MAX_EPISODES_PER_PACK * 2 + 3)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("teal"),
+        ),
+    )
+
+    class NoProvider:
+        def ask(self, _request):
+            raise TimeoutError("packs only")
+
+    result = run_period_insight(
+        prepared,
+        requester=NoProvider(),
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+    )
+
+    assert len(prepared.episode_groups) == len(assets)
+    assert all(len(pack.scopes) <= MAX_EPISODES_PER_PACK for pack in result.episode_packs)
+    # still greedy: only the last pack is allowed to be short
+    assert all(len(pack.scopes) == MAX_EPISODES_PER_PACK for pack in result.episode_packs[:-1])
+
+
+def test_a_visual_nobody_can_see_is_not_asked_about(tmp_path: Path) -> None:
+    """No pixels, no tile, no question — and it never reaches a sheet.
+
+    An asset with no preview and no usable frames was carried onto the sheet as
+    a numbered placeholder, which the model could then promote as a
+    representative and which voided its whole episode's reading. Seventeen such
+    assets in a real dense month cost the month its thesis. Nothing showable is
+    a fact about the file, so it leaves before any pass is asked anything.
+    """
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    seen = make_asset("seen", file_created_at=when)
+    blind = make_asset("blind", file_created_at=when + timedelta(seconds=30))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (seen, blind),
+            # WHY: the preview provider is the external boundary; one asset has none.
+            preview_jpeg=lambda asset: None if asset.id == "blind" else _jpeg("olive"),
+        ),
+    )
+
+    class NoProvider:
+        def ask(self, _request):
+            raise TimeoutError("no model needed to build the sheets")
+
+    result = run_period_insight(
+        prepared,
+        requester=NoProvider(),
+        sheet_output_dir=tmp_path / "sheets",
+        frame_cache_dir=None,
+    )
+
+    assert result.retained_ids == ("seen",)
+    shown = {ref.entity_id for pack in result.episode_packs for ref in pack.page.tile_refs}
+    assert shown == {"seen"}
+    assert not any(
+        scope.unavailable_asset_ids for pack in result.episode_packs for scope in pack.scopes
+    )
+    assert any("blind" in warning for warning in result.warnings)
+
+
+def test_an_unread_episode_costs_its_own_pictures_not_the_month(tmp_path: Path) -> None:
+    """A pack that failed hands its pictures on; it does not veto the period.
+
+    Measured on a real dense month: 100 of 101 episodes read, and the thesis was
+    refused because of the hundred-and-first. The wall is built from the
+    episodes that could be read, the trace names the one that could not, and its
+    pictures stay in the corpus for the passes that come after.
+    """
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    start = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"asset-{index:02d}", file_created_at=start + timedelta(days=index))
+        for index in range(16)  # one per day: 16 episodes, so more than one pack
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("sienna"),
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            # the first pack refuses; the rest answer
+            if calls == 1:
+                return "I cannot help with that."
+            return _episode_pack_answer(prompt)
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": "Built from the episodes that could be read.",
+                    "evidence": [
+                        {"observation": "What tile 1 shows.", "representative_tiles": [1]}
+                    ],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": None,
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; packing, reading and synthesis stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert len(result.episode_readings) < len(result.episode_sheets)
+    assert result.insight is not None
+    assert result.insight.thesis == "Built from the episodes that could be read."
+    assert any("episodes could not be read" in warning for warning in result.warnings)
+    # the unread episode's pictures are still in the corpus for later passes
+    assert result.retained_ids == prepared.candidate_ids
+
+
+def test_a_wall_holds_no_more_representatives_than_it_can_be_read_from(
+    tmp_path: Path,
+) -> None:
+    """A wall too big is not refused, it is answered wrongly.
+
+    Measured at temperature 0 on a real dense month's own representatives:
+    walls of 10, 20, 40 and 60 produced theses that matched the month, and a
+    wall of 100 fixated on a single tile and invented a fact about the period.
+    The failure is a confident wrong answer, so the bound has to be structural.
+    """
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import MAX_WALL_TILES, run_period_insight
+
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"asset-{index:03d}", file_created_at=start + timedelta(days=index))
+        for index in range(MAX_WALL_TILES + 20)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("indigo"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return _episode_pack_answer(prompt)
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": "A period read from a wall it could hold.",
+                    "evidence": [
+                        {"observation": "What tile 1 shows.", "representative_tiles": [1]}
+                    ],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": None,
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; the wall is built for real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert len(result.episode_readings) > MAX_WALL_TILES
+    assert result.period_pages
+    shown = sum(len(page.tile_refs) for page in result.period_pages)
+    assert shown <= MAX_WALL_TILES
+    assert result.insight is not None
+    assert result.insight.thesis == "A period read from a wall it could hold."
+    assert any("representatives" in warning for warning in result.warnings)

--- a/tests/test_period_insight_answer.py
+++ b/tests/test_period_insight_answer.py
@@ -1,0 +1,763 @@
+"""Strict parsing for the visual episode-scan envelope."""
+
+import json
+
+import pytest
+
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    InsightEvidence,
+    PeriodInsight,
+)
+from immich_memories.analysis.period_insight_answer import (
+    EPISODE_REPRESENTATIVE_REASON_MAX_CHARS,
+    EpisodePageReading,
+    PeriodInsightAnswer,
+    read_episode_answer,
+    read_episode_answers,
+    read_period_answer,
+)
+
+
+@pytest.mark.parametrize(
+    "unsafe", ('quote"mark', "back\\slash", "line\nbreak", "caf\N{LATIN SMALL LETTER E WITH ACUTE}")
+)
+@pytest.mark.parametrize("field", ("visual_summary", "representative_reason"))
+def test_episode_reading_constructor_rejects_text_outside_the_safe_wire_alphabet(
+    field: str,
+    unsafe: str,
+) -> None:
+    """Direct episode readings cannot bypass the response estimator's alphabet."""
+    values = {
+        "visual_summary": "A visible finish.",
+        "representative_reason": "The finish summarizes the page.",
+    }
+    values[field] = unsafe
+
+    with pytest.raises(ValueError, match="episode page reading"):
+        EpisodePageReading(
+            "episode",
+            "page",
+            values["visual_summary"],
+            ("asset",),
+            values["representative_reason"],
+        )
+
+
+def test_invalid_episode_text_fails_open_without_erasing_the_cull_namespace() -> None:
+    """Unsafe episode prose does not poison independently valid record and Cull arrays."""
+    from immich_memories.analysis.cull_answer import read_cull_namespaces
+
+    raw = json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": 1,
+                    "page": 1,
+                    "visual_summary": "A caf\N{LATIN SMALL LETTER E WITH ACUTE} finish.",
+                    "representative_tiles": [1],
+                    "representative_reason": "The finish identifies the page.",
+                }
+            ],
+            "cull_rejects": [{"episode": 1, "notes": [], "failed": [2]}],
+        }
+    )
+
+    readings = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("episode", "page"),),
+        observation_map={(1, 1): ("episode", "page")},
+        tile_map={(1, 1, 1): "record", (1, 1, 2): "dark"},
+    )
+    pass_one = read_cull_namespaces(
+        raw,
+        pack_alias=1,
+        tile_map={1: "record", 2: "dark"},
+        episode_tiles={1: (1, 2)},
+    )
+
+    assert readings is not None
+    assert readings.readings == ()
+    assert readings.invalid_observations == (("episode", "page"),)
+    assert pass_one is not None
+    assert pass_one.cull_valid
+    assert tuple(decision.asset_id for decision in pass_one.cull_rejects) == ("dark",)
+
+
+def test_episode_safe_text_keeps_apostrophes_and_basic_punctuation() -> None:
+    """Useful terse episode prose remains valid inside the canonical alphabet."""
+    reading = EpisodePageReading(
+        "episode",
+        "page",
+        "Rider's finish: medal #1!",
+        ("asset",),
+        "Effort -> payoff; both are visible.",
+    )
+
+    assert reading.visual_summary == "Rider's finish: medal #1!"
+
+
+def _provenance() -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name="period-insight",  # noqa: S106 - test-only pass identity
+        pass_version="1",  # noqa: S106 - test-only pass version
+        schema_version="1",
+        model_identity="generated-test",
+        input_ids=("asset",),
+        sheet_hashes=("hash",),
+        request_key="request",
+        cache_hit=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("observation", "episode_ids", "asset_ids"),
+    (
+        (" ", ("episode",), ("asset",)),
+        ("Visible change.", (), ("asset",)),
+        ("Visible change.", ("",), ("asset",)),
+        ("Visible change.", ("episode",), ()),
+        ("Visible change.", ("episode",), (" ",)),
+    ),
+)
+def test_insight_evidence_constructor_rejects_unqualified_visual_references(
+    observation: str,
+    episode_ids: tuple[str, ...],
+    asset_ids: tuple[str, ...],
+) -> None:
+    """Direct callers cannot create evidence the strict parser would reject."""
+    with pytest.raises(ValueError, match="insight evidence"):
+        InsightEvidence(observation, episode_ids, asset_ids)
+
+
+def test_honest_unavailable_period_records_need_no_invented_evidence() -> None:
+    """No-thesis records stay constructible when their unavailable reason is explicit."""
+    insight = PeriodInsight(
+        thesis=None,
+        evidence=(),
+        tensions=(),
+        recurring_threads=(),
+        unavailable_reason="The complete wall was unavailable.",
+        revision=0,
+        provenance=_provenance(),
+    )
+    answer = PeriodInsightAnswer(
+        thesis=None,
+        evidence=(),
+        tensions=(),
+        recurring_threads=(),
+        unavailable_reason="The complete wall was unavailable.",
+    )
+
+    assert insight.evidence == answer.evidence == ()
+
+
+def test_truncated_episode_answer_cannot_select_representatives() -> None:
+    """An auto-closable fragment is still not a completed visual observation."""
+    raw = (
+        '{"schema_version":"episode-scan-v4","episode":1,'
+        '"page":1,"episode_reading":{"visual_summary":"the finish",'
+        '"representative_tiles":[1,2]'
+    )
+    tile_map = {(1, 1, 1): "asset-121", (1, 1, 2): "asset-122"}
+
+    assert (
+        read_episode_answer(
+            raw,
+            episode_alias=1,
+            page_alias=1,
+            observation_map={(1, 1): ("day-1", "day-1-002")},
+            tile_map=tile_map,
+        )
+        is None
+    )
+
+
+def test_complete_final_episode_object_resolves_only_its_page_tiles() -> None:
+    """Compact wire aliases map back through the qualified stable episode page."""
+    raw = """The requested visual observation follows.
+```json
+ {"schema_version":"episode-scan-v4","episode":7,"page":2,
+ "episode_reading":{"visual_summary":"A rider reaches the finish and shows the medal.",
+ "representative_tiles":[121,122],
+ "representative_reason":"The effort and payoff summarize this page."}}
+```"""
+    tile_map = {
+        (7, 1, 121): "wrong-page-a",
+        (7, 1, 122): "wrong-page-b",
+        (7, 2, 121): "finish",
+        (7, 2, 122): "medal",
+    }
+
+    answer = read_episode_answer(
+        raw,
+        episode_alias=7,
+        page_alias=2,
+        observation_map={(7, 2): ("day-1", "day-1-002")},
+        tile_map=tile_map,
+    )
+
+    assert answer is not None
+    assert answer.visual_summary == "A rider reaches the finish and shows the medal."
+    assert answer.representative_asset_ids == ("finish", "medal")
+    assert answer.representative_reason == "The effort and payoff summarize this page."
+
+
+def test_complete_period_object_grounds_evidence_in_representative_pixels() -> None:
+    """Period evidence names stable episodes and assets derived from its visible tiles."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":"Training, racing, and the people around both.",
+        "evidence":[
+          {"observation":"Effort becomes celebration.","representative_tiles":[1,2]}
+        ],
+        "tensions":["private effort versus public spectacle"],
+        "recurring_threads":["movement", "companionship"],
+        "unavailable_reason":null
+      }
+    }"""
+    tile_map = {
+        ("period-wall-001", 1): ("training", "effort"),
+        ("period-wall-001", 2): ("race-day", "medal"),
+    }
+
+    answer = read_period_answer(raw, page_ids=("period-wall-001",), tile_map=tile_map)
+
+    assert answer is not None
+    assert answer.thesis == "Training, racing, and the people around both."
+    assert answer.evidence[0].episode_ids == ("training", "race-day")
+    assert answer.evidence[0].asset_ids == ("effort", "medal")
+
+
+def test_period_answer_rejects_thesis_with_an_unavailable_reason() -> None:
+    """A response cannot claim a grounded thesis and claim that thesis was unavailable."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":"A claimed visual arc.",
+        "evidence":[{"observation":"Visible change.","representative_tiles":[1]}],
+        "tensions":[],
+        "recurring_threads":[],
+        "unavailable_reason":"The evidence was incomplete."
+      }
+    }"""
+
+    assert (
+        read_period_answer(
+            raw,
+            page_ids=("period-wall-001",),
+            tile_map={("period-wall-001", 1): ("episode", "asset")},
+        )
+        is None
+    )
+
+
+def test_period_answer_rejects_a_thesis_without_visual_evidence() -> None:
+    """A thesis needs at least one page-qualified visual observation."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":"An unsupported visual arc.",
+        "evidence":[],
+        "tensions":[],
+        "recurring_threads":[],
+        "unavailable_reason":null
+      }
+    }"""
+
+    assert (
+        read_period_answer(
+            raw,
+            page_ids=("period-wall-001",),
+            tile_map={("period-wall-001", 1): ("episode", "asset")},
+        )
+        is None
+    )
+
+
+def test_period_answer_rejects_evidence_with_blank_stable_identifiers() -> None:
+    """A page-qualified tile is not grounded when its stable identity is blank."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":"An unsupported visual arc.",
+        "evidence":[{"observation":"Visible change.","representative_tiles":[1]}],
+        "tensions":[],
+        "recurring_threads":[],
+        "unavailable_reason":null
+      }
+    }"""
+
+    assert (
+        read_period_answer(
+            raw,
+            page_ids=("period-wall-001",),
+            tile_map={("period-wall-001", 1): (" ", "asset")},
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("evidence", "unavailable_reason"),
+    (
+        (
+            (InsightEvidence("Visible change.", ("episode",), ("asset",)),),
+            "The same thesis was unavailable.",
+        ),
+        ((), None),
+    ),
+)
+def test_period_insight_constructor_cannot_bypass_grounded_exclusive_state(
+    evidence: tuple[InsightEvidence, ...], unavailable_reason: str | None
+) -> None:
+    """Direct construction rejects contradictory or visually unsupported theses."""
+    with pytest.raises(ValueError, match="period insight"):
+        PeriodInsight(
+            thesis="A claimed visual arc.",
+            evidence=evidence,
+            tensions=(),
+            recurring_threads=(),
+            unavailable_reason=unavailable_reason,
+            revision=0,
+            provenance=_provenance(),
+        )
+
+
+def test_period_answer_constructor_cannot_bypass_grounded_exclusive_state() -> None:
+    """The parsed-answer record independently rejects an unsupported thesis."""
+    with pytest.raises(ValueError, match="period insight answer"):
+        PeriodInsightAnswer(
+            thesis="A claimed visual arc.",
+            evidence=(),
+            tensions=(),
+            recurring_threads=(),
+            unavailable_reason=None,
+        )
+
+
+def test_period_answer_cannot_hide_a_missing_thesis_without_a_reason() -> None:
+    """A null thesis is valid only when the answer says why insight was unavailable."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":null,
+        "evidence":[],
+        "tensions":[],
+        "recurring_threads":[],
+        "unavailable_reason":null
+      }
+    }"""
+
+    assert read_period_answer(raw, page_ids=("period-wall-001",), tile_map={}) is None
+
+
+def test_multi_page_period_evidence_requires_page_qualified_tile_references() -> None:
+    """One holistic answer can cite multiple attached pages without number collisions."""
+    raw = """{
+      "schema_version":"period-insight-v1",
+      "period_insight":{
+        "thesis":"Preparation becomes performance.",
+        "evidence":[{"observation":"A rehearsal contrasts with the stage.",
+          "representative_tiles":[
+            {"page_id":"period-wall-001","tile":1},
+            {"page_id":"period-wall-002","tile":121}
+          ]}],
+        "tensions":["private versus public"],
+        "recurring_threads":["practice"],
+        "unavailable_reason":null
+      }
+    }"""
+    tile_map = {
+        ("period-wall-001", 1): ("rehearsal", "warmup"),
+        ("period-wall-002", 121): ("show", "stage"),
+    }
+
+    answer = read_period_answer(
+        raw,
+        page_ids=("period-wall-001", "period-wall-002"),
+        tile_map=tile_map,
+    )
+
+    assert answer is not None
+    assert answer.evidence[0].episode_ids == ("rehearsal", "show")
+    assert answer.evidence[0].asset_ids == ("warmup", "stage")
+
+
+def test_one_episode_scan_pack_returns_independent_page_qualified_readings() -> None:
+    """Many complete small episodes share one physical answer without sharing tile scope."""
+    raw = """{
+      "schema_version":"episode-scan-v4",
+      "pack":1,
+      "episode_readings":[
+        {"episode":1,"page":1,
+         "visual_summary":"Preparation in a quiet room {before the crowd}.",
+         "representative_tiles":[1],"representative_reason":"The setup is visible."},
+        {"episode":2,"page":1,
+         "visual_summary":"A public performance.",
+         "representative_tiles":[2],"representative_reason":"The stage is the visible peak."}
+      ],
+      "record_shots":"not-yet-valid",
+      "cull_rejects":[{"tile":true}]
+    }"""
+    expected = (("morning", "pack-1-001"), ("evening", "pack-1-001"))
+    observation_map = {
+        (1, 1): ("morning", "pack-1-001"),
+        (2, 1): ("evening", "pack-1-001"),
+    }
+    tile_map = {(1, 1, 1): "warmup", (2, 1, 2): "stage"}
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=expected,
+        observation_map=observation_map,
+        tile_map=tile_map,
+    )
+
+    assert answer is not None
+    assert tuple(reading.episode_id for reading in answer.readings) == ("morning", "evening")
+    assert tuple(reading.representative_asset_ids for reading in answer.readings) == (
+        ("warmup",),
+        ("stage",),
+    )
+    assert answer.invalid_observations == ()
+
+
+@pytest.mark.parametrize(
+    ("unusable_summary", "unusable_reason"),
+    (
+        ("Visible\tA", "visible A"),
+        ("Visible A", 'he said "visible"'),
+        ("Visible A", 42),
+        ("Visible A", "   "),
+    ),
+)
+def test_unusable_episode_prose_invalidates_only_that_packed_reading(
+    unusable_summary: object, unusable_reason: object
+) -> None:
+    """Text that cannot be trusted or shown poisons its own reading and no other.
+
+    Length is not in this list: an over-long reason is fitted to its bound
+    instead, because the reading is a decision and the prose only explains it.
+    """
+    raw = json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": 1,
+                    "page": 1,
+                    "visual_summary": unusable_summary,
+                    "representative_tiles": [1],
+                    "representative_reason": unusable_reason,
+                },
+                {
+                    "episode": 2,
+                    "page": 1,
+                    "visual_summary": "Visible B",
+                    "representative_tiles": [2],
+                    "representative_reason": "visible B",
+                },
+            ],
+        }
+    )
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("a", "stable-page"), ("b", "stable-page")),
+        observation_map={
+            (1, 1): ("a", "stable-page"),
+            (2, 1): ("b", "stable-page"),
+        },
+        tile_map={(1, 1, 1): "asset-a", (2, 1, 2): "asset-b"},
+    )
+
+    assert answer is not None
+    assert tuple(reading.episode_id for reading in answer.readings) == ("b",)
+    assert answer.invalid_observations == (("a", "stable-page"),)
+
+
+def test_episode_namespace_keeps_four_reasoned_representatives_without_a_topic_cap() -> None:
+    """Representative count emerges from the pixels; only the global wall bounds it."""
+    raw = """{
+      "schema_version":"episode-scan-v4","pack":1,
+      "episode_readings":[{"episode":1,"page":1,
+        "visual_summary":"Four frames.","representative_tiles":[1,2,3,4],
+        "representative_reason":"All four differ."}]
+    }"""
+    tile_map = {(1, 1, number): f"asset-{number}" for number in range(1, 5)}
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("episode", "pack-1-001"),),
+        observation_map={(1, 1): ("episode", "pack-1-001")},
+        tile_map=tile_map,
+    )
+
+    assert answer is not None
+    assert answer.readings[0].representative_asset_ids == (
+        "asset-1",
+        "asset-2",
+        "asset-3",
+        "asset-4",
+    )
+    assert answer.invalid_observations == ()
+
+
+def test_unknown_episode_alias_keeps_valid_pack_siblings() -> None:
+    """An unknown alias leaves its expected episode invalid without poisoning siblings."""
+    raw = """{
+      "schema_version":"episode-scan-v4","pack":1,
+      "episode_readings":[
+        {"episode":1,"page":1,"visual_summary":"A",
+         "representative_tiles":[1],"representative_reason":"visible A"},
+        {"episode":99,"page":1,"visual_summary":"B",
+         "representative_tiles":[2],"representative_reason":"invented B"},
+        {"episode":3,"page":1,"visual_summary":"C",
+         "representative_tiles":[3],"representative_reason":"visible C"}
+      ]
+    }"""
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("a", "page"), ("b", "page"), ("c", "page")),
+        observation_map={
+            (1, 1): ("a", "page"),
+            (2, 1): ("b", "page"),
+            (3, 1): ("c", "page"),
+        },
+        tile_map={
+            (1, 1, 1): "asset-a",
+            (2, 1, 2): "asset-b",
+            (3, 1, 3): "asset-c",
+        },
+    )
+
+    assert answer is not None
+    assert tuple(reading.episode_id for reading in answer.readings) == ("a", "c")
+    assert answer.invalid_observations == (("b", "page"),)
+
+
+def test_duplicate_and_missing_episode_entries_do_not_poison_valid_sibling() -> None:
+    """Completeness is checked per expected episode namespace inside one pack."""
+    duplicate = (
+        '{"episode":1,"page":1,"visual_summary":"A",'
+        '"representative_tiles":[1],"representative_reason":"visible A"}'
+    )
+    raw = (
+        '{"schema_version":"episode-scan-v4","pack":1,'
+        f'"episode_readings":[{duplicate},{duplicate},'
+        '{"episode":3,"page":1,"visual_summary":"C",'
+        '"representative_tiles":[3],"representative_reason":"visible C"}]}'
+    )
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("a", "page"), ("b", "page"), ("c", "page")),
+        observation_map={
+            (1, 1): ("a", "page"),
+            (2, 1): ("b", "page"),
+            (3, 1): ("c", "page"),
+        },
+        tile_map={
+            (1, 1, 1): "asset-a",
+            (2, 1, 2): "asset-b",
+            (3, 1, 3): "asset-c",
+        },
+    )
+
+    assert answer is not None
+    assert tuple(reading.episode_id for reading in answer.readings) == ("c",)
+    assert answer.invalid_observations == (("a", "page"), ("b", "page"))
+
+
+def test_boolean_tile_ids_are_not_accepted_as_json_integers() -> None:
+    """Python's bool-is-int quirk cannot resolve true to displayed tile one."""
+    raw = """{
+      "schema_version":"episode-scan-v4","pack":1,
+      "episode_readings":[{"episode":1,"page":1,
+        "visual_summary":"A claimed frame.","representative_tiles":[true],
+        "representative_reason":"Claimed visible."}]
+    }"""
+
+    answer = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("a", "page"),),
+        observation_map={(1, 1): ("a", "page")},
+        tile_map={(1, 1, 1): "asset-a"},
+    )
+
+    assert answer is not None
+    assert answer.readings == ()
+    assert answer.invalid_observations == (("a", "page"),)
+
+
+def test_singular_and_packed_episode_parsers_share_strict_namespace_validation() -> None:
+    """The packed transport delegates each member through the singular validation path."""
+    singular_raw = """{
+      "schema_version":"episode-scan-v4","episode":1,"page":1,
+      "episode_reading":{"visual_summary":"Claimed frame.",
+        "representative_tiles":[1,1],"representative_reason":"Claimed visible."}
+    }"""
+    packed_raw = """{
+      "schema_version":"episode-scan-v4","pack":1,
+      "episode_readings":[{"episode":1,"page":1,
+        "visual_summary":"Claimed frame.","representative_tiles":[1,1],
+        "representative_reason":"Claimed visible."}]
+    }"""
+    observation_map = {(1, 1): ("a", "page")}
+    tile_map = {(1, 1, 1): "asset-a"}
+
+    assert (
+        read_episode_answer(
+            singular_raw,
+            episode_alias=1,
+            page_alias=1,
+            observation_map=observation_map,
+            tile_map=tile_map,
+        )
+        is None
+    )
+    packed = read_episode_answers(
+        packed_raw,
+        pack_alias=1,
+        expected_observations=(("a", "page"),),
+        observation_map=observation_map,
+        tile_map=tile_map,
+    )
+    assert packed is not None
+    assert packed.readings == ()
+    assert packed.invalid_observations == (("a", "page"),)
+
+
+def test_the_period_prompt_shows_the_exact_shape_its_parser_accepts() -> None:
+    """Naming fields in prose leaves their nesting and their types to the model.
+
+    Measured against the local model: it put thesis and evidence at the top
+    level instead of under period_insight, and returned tensions and
+    recurring_threads as objects where the parser demands plain strings. A good
+    thesis was discarded three times over.
+    """
+    from immich_memories.analysis.period_insight import period_response_shape
+    from immich_memories.analysis.period_insight_answer import read_period_answer
+
+    answer = read_period_answer(
+        period_response_shape(tile=1),
+        page_ids=("page-1",),
+        tile_map={("page-1", 1): ("episode-1", "asset-1")},
+    )
+
+    assert answer is not None
+    assert answer.thesis
+    assert answer.tensions
+    assert answer.recurring_threads
+
+
+def test_an_overlong_reason_trims_instead_of_discarding_its_episode() -> None:
+    """The prose is display text; the reading it explains is a decision.
+
+    Measured against the local model: the same prompt on the same images
+    produced 91/84/76-character reasons on one run and 103/105/104 on the next.
+    At a 96-character bound that is a coin flip on whether the whole period
+    thesis exists, and nothing downstream can tell it was ever attempted.
+    """
+    overlong = "T" + "x" * 200
+    raw = json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": 1,
+                    "page": 1,
+                    "visual_summary": "A finish line.",
+                    "representative_tiles": [1],
+                    "representative_reason": overlong,
+                }
+            ],
+            "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+        }
+    )
+
+    readings = read_episode_answers(
+        raw,
+        pack_alias=1,
+        expected_observations=(("episode", "page"),),
+        observation_map={(1, 1): ("episode", "page")},
+        tile_map={(1, 1, 1): "asset"},
+    )
+
+    assert readings is not None
+    assert readings.invalid_observations == ()
+    assert len(readings.readings) == 1
+    reading = readings.readings[0]
+    assert reading.representative_asset_ids == ("asset",)
+    assert len(reading.representative_reason) <= EPISODE_REPRESENTATIVE_REASON_MAX_CHARS
+    assert reading.representative_reason.startswith("Tx")
+
+
+def test_a_thesis_declined_without_a_stated_reason_is_still_an_answer() -> None:
+    """Declining is the decision; explaining the decline is prose.
+
+    Measured: the model set thesis to null and left unavailable_reason null
+    beside it. The parser demanded exactly one of the two and discarded the
+    evidence, tensions and threads that had all parsed correctly.
+    """
+    answer = read_period_answer(
+        json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [
+                        {"observation": "What tile 1 shows.", "representative_tiles": [1]}
+                    ],
+                    "tensions": ["A stated tension."],
+                    "recurring_threads": ["A stated thread."],
+                    "unavailable_reason": None,
+                },
+            }
+        ),
+        page_ids=("page-1",),
+        tile_map={("page-1", 1): ("episode-1", "asset-1")},
+    )
+
+    assert answer is not None
+    assert answer.thesis is None
+    assert answer.unavailable_reason
+    assert answer.tensions == ("A stated tension.",)
+
+
+def test_a_thesis_and_a_reason_not_to_have_one_stay_contradictory() -> None:
+    """Claiming both remains unreadable: that is a contradiction, not an omission."""
+    answer = read_period_answer(
+        json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": "The period was about a move.",
+                    "evidence": [
+                        {"observation": "What tile 1 shows.", "representative_tiles": [1]}
+                    ],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "there was not enough to say",
+                },
+            }
+        ),
+        page_ids=("page-1",),
+        tile_map={("page-1", 1): ("episode-1", "asset-1")},
+    )
+
+    assert answer is None

--- a/tests/test_period_insight_generalisation.py
+++ b/tests/test_period_insight_generalisation.py
@@ -1,0 +1,114 @@
+"""Generated controls keep Pass 0 structural, not topic-specific."""
+
+import json
+
+import pytest
+
+from immich_memories.analysis.period_insight_answer import (
+    read_episode_answers,
+    read_period_answer,
+)
+
+
+@pytest.mark.parametrize(
+    ("first_label", "second_label"),
+    (
+        ("cycling", "live-show"),
+        ("live-show", "cycling"),
+        ("glassblowing", "night-market"),
+    ),
+)
+def test_topic_label_swaps_preserve_grounded_insight_shape(
+    first_label: str,
+    second_label: str,
+) -> None:
+    """Labels may change prose, but they cannot alter qualified pixel-to-ID grounding."""
+    episode_ids = ("ep::δ/42", "occasion|q9")
+    page_id = "generated-pack-π-001"
+    asset_ids = ("asset#left:001", "asset/right?002")
+    episode_raw = json.dumps(
+        {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": number,
+                    "page": 1,
+                    "visual_summary": f"Generated {label} evidence.",
+                    "representative_tiles": [number],
+                    "representative_reason": f"The {label} contribution is visible.",
+                }
+                for number, (_episode_id, label) in enumerate(
+                    zip(episode_ids, (first_label, second_label), strict=True),
+                    start=1,
+                )
+            ],
+        }
+    )
+    episode_answer = read_episode_answers(
+        episode_raw,
+        pack_alias=1,
+        expected_observations=tuple((episode_id, page_id) for episode_id in episode_ids),
+        observation_map={
+            (number, 1): (episode_id, page_id)
+            for number, episode_id in enumerate(episode_ids, start=1)
+        },
+        tile_map={
+            (number, 1, number): asset_id
+            for number, (_episode_id, asset_id) in enumerate(
+                zip(episode_ids, asset_ids, strict=True),
+                start=1,
+            )
+        },
+    )
+    assert episode_answer is not None
+
+    period_raw = json.dumps(
+        {
+            "schema_version": "period-insight-v1",
+            "period_insight": {
+                "thesis": f"{first_label} contrasts with {second_label}.",
+                "evidence": [
+                    {
+                        "observation": f"Generated relationship {index}.",
+                        "representative_tiles": [index],
+                    }
+                    for index in (1, 2)
+                ],
+                "tensions": ["generated contrast"],
+                "recurring_threads": ["generated recurrence"],
+                "unavailable_reason": None,
+            },
+        }
+    )
+    period_answer = read_period_answer(
+        period_raw,
+        page_ids=("generated-period-001",),
+        tile_map={
+            ("generated-period-001", number): (episode_id, asset_id)
+            for number, (episode_id, asset_id) in enumerate(
+                zip(episode_ids, asset_ids, strict=True),
+                start=1,
+            )
+        },
+    )
+    assert period_answer is not None
+
+    shape = (
+        len(episode_answer.readings),
+        tuple(len(reading.representative_asset_ids) for reading in episode_answer.readings),
+        len(period_answer.evidence),
+        tuple(len(item.episode_ids) for item in period_answer.evidence),
+        tuple(len(item.asset_ids) for item in period_answer.evidence),
+        len(period_answer.tensions),
+        len(period_answer.recurring_threads),
+    )
+    assert shape == (2, (1, 1), 2, (1, 1), (1, 1), 1, 1)
+    assert tuple(reading.representative_asset_ids for reading in episode_answer.readings) == (
+        (asset_ids[0],),
+        (asset_ids[1],),
+    )
+    assert tuple(item.asset_ids for item in period_answer.evidence) == (
+        (asset_ids[0],),
+        (asset_ids[1],),
+    )

--- a/tests/test_selection_accountability.py
+++ b/tests/test_selection_accountability.py
@@ -65,6 +65,17 @@ class TestEveryClipCanAccountForItself:
         assert story.admitted_at == "duration backfill"
 
 
+class TestLegacyTraceSerialization:
+    def test_the_legacy_adapter_keeps_the_selector_order(self):
+        """The old selector cannot reorder material while it remains supported."""
+        late, early = _clip("late"), _clip("early")
+        trace = Trace()
+
+        trace.record("legacy cull", [late, early], [late, early])
+
+        assert trace.as_dict()["stages"][0]["kept_ids"] == ["late", "early"]
+
+
 class TestTheReportShowsIt:
     def test_the_report_accounts_for_each_clip(self):
         report = _traced().report()

--- a/tests/test_selection_cull.py
+++ b/tests/test_selection_cull.py
@@ -1,0 +1,1639 @@
+"""Pass 1 reuses banked episode pixels to reject only clear defects."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from immich_memories.analysis.selection_flow import (
+    EditorialDependencies,
+    EditorialSelectionRequest,
+    SourceScope,
+    prepare_editorial_source,
+)
+from immich_memories.config_models_llm import LLMConfig
+from tests.conftest import make_asset
+
+
+def _jpeg(colour: str) -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (24, 18), colour).save(output, "JPEG")
+    return output.getvalue()
+
+
+def _survivor_ids(result) -> tuple[str, ...]:
+    return tuple(candidate.asset_id for candidate in result.survivors)
+
+
+def _assert_pixel_near(
+    image: Image.Image,
+    point: tuple[int, int],
+    expected: tuple[int, int, int],
+    *,
+    tolerance: int = 35,
+) -> None:
+    actual = image.convert("RGB").getpixel(point)
+    assert all(
+        abs(channel - target) <= tolerance for channel, target in zip(actual, expected, strict=True)
+    )
+
+
+def _pass_zero_for(tmp_path: Path, *, assets: tuple[str, ...], when, favourites: tuple = ()):
+    """A prepared corpus and a Pass 0 whose model answered, culling nothing."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+
+    built = tuple(
+        make_asset(
+            asset_id,
+            file_created_at=when + timedelta(seconds=index),
+            is_favorite=asset_id in favourites,
+        )
+        for index, asset_id in enumerate(assets)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: built,
+            preview_jpeg=lambda _asset: _jpeg("slate"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": 1,
+                            "page": 1,
+                            "visual_summary": "Generated frames.",
+                            "representative_tiles": [1],
+                            "representative_reason": "The first tile stands for the page.",
+                        }
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "Too little for a thesis.",
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; source, atlas and packing stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+    return prepared, pass_zero
+
+
+def _run_single_protection_case(tmp_path: Path, *, favourite: bool):
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    asset = make_asset(
+        "asset",
+        file_created_at=datetime(2026, 8, 25, 12, tzinfo=UTC),
+        is_favorite=favourite,
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (asset,),
+            preview_jpeg=lambda _asset: _jpeg("navy"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": 1,
+                            "page": 1,
+                            "visual_summary": "One generated visual.",
+                            "representative_tiles": [1],
+                            "representative_reason": "The tile is the complete page.",
+                        }
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": [1]}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "One visual has no period thesis.",
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider boundary; protection and review stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+    return run_cull(prepared, pass_zero, review_output_dir=tmp_path / "review")
+
+
+def _run_unstarred_stitch_case(tmp_path: Path):
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+    from immich_memories.api.models import AssetType, VideoClipInfo
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    noncarrier = make_asset("noncarrier", file_created_at=when)
+    noncarrier.type = AssetType.IMAGE
+    noncarrier.live_photo_video_id = "noncarrier-motion"
+    carrier = make_asset("carrier", file_created_at=when + timedelta(seconds=1))
+    carrier.type = AssetType.IMAGE
+    carrier.live_photo_video_id = "carrier-motion"
+    enriched = VideoClipInfo(
+        asset=carrier,
+        duration_seconds=4.0,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["noncarrier", "carrier"],
+        live_burst_video_ids=["noncarrier-motion", "carrier-motion"],
+        live_burst_trim_points=[(0.0, 1.0), (0.5, 1.5)],
+        live_burst_shutter_timestamps=[
+            noncarrier.file_created_at.timestamp(),
+            carrier.file_created_at.timestamp(),
+        ],
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" not in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "period-insight-v1",
+                    "period_insight": {
+                        "thesis": None,
+                        "evidence": [],
+                        "tensions": [],
+                        "recurring_threads": [],
+                        "unavailable_reason": "No thesis needed.",
+                    },
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "Two unstarred members share a motion option.",
+                        "representative_tiles": [1],
+                        "representative_reason": "The first tile remains on visible merit.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [2]}],
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; stitch membership and Cull stay production-real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        return run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (noncarrier, enriched),
+                preview_jpeg=lambda _asset: _jpeg("violet"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+
+def test_a_favourite_survives_a_cull_that_named_it(tmp_path: Path) -> None:
+    """The star settles it here as it settles every other hard gate."""
+    result = _run_single_protection_case(tmp_path, favourite=True)
+
+    assert _survivor_ids(result) == ("asset",)
+    assert result.rejected == ()
+    assert result.warnings == ("!! cull reject conflicted with protected favourite: asset",)
+    assert result.review.entries[0].favourite is True
+    assert result.review.entries[0].status == "KEEP"
+
+
+def test_an_unstarred_failed_picture_is_culled(tmp_path: Path) -> None:
+    """Protection is the exception; a picture that did not come out still goes."""
+    result = _run_single_protection_case(tmp_path, favourite=False)
+
+    assert _survivor_ids(result) == ()
+    assert tuple(decision.asset_id for decision in result.rejected) == ("asset",)
+    assert tuple(decision.bucket for decision in result.rejected) == ("failed",)
+    assert result.warnings == ("!! possible over-cull",)
+    assert result.review.entries[0].status == "CULL"
+
+
+def test_live_photo_favourite_shields_only_its_exact_candidate_not_stitch_sibling(
+    tmp_path: Path,
+) -> None:
+    """Cull preserves the star without choosing its later still-or-motion rendering."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+    from immich_memories.api.models import AssetType, VideoClipInfo
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    favourite = make_asset("favourite", file_created_at=when, is_favorite=True)
+    favourite.type = AssetType.IMAGE
+    favourite.live_photo_video_id = "favourite-motion"
+    sibling = make_asset("sibling", file_created_at=when + timedelta(seconds=1))
+    sibling.type = AssetType.IMAGE
+    sibling.live_photo_video_id = "sibling-motion"
+    enriched = VideoClipInfo(
+        asset=sibling,
+        duration_seconds=4.0,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["favourite", "sibling"],
+        live_burst_video_ids=["favourite-motion", "sibling-motion"],
+        live_burst_trim_points=[(0.0, 1.0), (0.5, 1.5)],
+        live_burst_shutter_timestamps=[
+            favourite.file_created_at.timestamp(),
+            sibling.file_created_at.timestamp(),
+        ],
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" not in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "period-insight-v1",
+                    "period_insight": {
+                        "thesis": None,
+                        "evidence": [],
+                        "tensions": [],
+                        "recurring_threads": [],
+                        "unavailable_reason": "No thesis needed.",
+                    },
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "Two still candidates share a later motion option.",
+                        "representative_tiles": [1],
+                        "representative_reason": "The first tile identifies the moment.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [1, 2]}],
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; exact favourite protection stays production-real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (favourite, enriched),
+                preview_jpeg=lambda _asset: _jpeg("purple"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert result.prepared.candidate_ids == ("favourite", "sibling")
+    assert tuple(
+        candidate.live_photo_stitch_member_ids for candidate in result.prepared.candidates
+    ) == (
+        ("favourite", "sibling"),
+        ("favourite", "sibling"),
+    )
+    assert len(result.prepared.rendering_families) == 1
+    family_id = result.prepared.rendering_families[0].family_id
+    assert {candidate.rendering_family_id for candidate in result.prepared.candidates} == {
+        family_id
+    }
+    assert _survivor_ids(result.pass_one) == ("favourite",)
+    assert tuple(decision.asset_id for decision in result.pass_one.rejected) == ("sibling",)
+    assert tuple(entry.status for entry in result.pass_one.review.entries) == ("KEEP", "CULL")
+    assert tuple(entry.favourite for entry in result.pass_one.review.entries) == (True, False)
+
+
+def test_unstarred_noncarrier_keeps_stitch_family_on_merit_when_carrier_is_culled(
+    tmp_path: Path,
+) -> None:
+    """Legacy carrier identity cannot own the later motion option."""
+    result = _run_unstarred_stitch_case(tmp_path)
+
+    assert _survivor_ids(result.pass_one) == ("noncarrier",)
+    assert tuple(decision.asset_id for decision in result.pass_one.rejected) == ("carrier",)
+    survivor = result.pass_one.survivors[0]
+    assert survivor.favourite is False
+    assert survivor.live_photo_stitch_member_ids == ("noncarrier", "carrier")
+    assert survivor.rendering_family_id == result.prepared.rendering_families[0].family_id
+    assert result.pass_one.warnings == ()
+
+
+def test_cull_reparses_one_bank_and_never_asks_again(
+    tmp_path: Path,
+) -> None:
+    """Cull is a logical pass, not a request: it costs no model call of its own."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    test = make_asset("test", file_created_at=when, is_favorite=True)
+    blur = make_asset("blur", file_created_at=when + timedelta(seconds=1))
+    neutral = make_asset(
+        "neutral",
+        file_created_at=when + timedelta(seconds=2),
+        is_favorite=True,
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (test, blur, neutral),
+            preview_jpeg=lambda asset: _jpeg(
+                "white" if asset.id == "test" else "grey" if asset.id == "blur" else "blue"
+            ),
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": 1,
+                            "page": 1,
+                            "visual_summary": "A result record beside an unreadable frame.",
+                            "representative_tiles": [1, 2, 3],
+                            "representative_reason": "Both visible functions describe the episode.",
+                        }
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": [1, 2, 3]}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "One episode does not support a period thesis.",
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the sole provider boundary; source, atlas, bank, and Pass 1 stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+    before = (calls, len(prepared.trace.requests))
+
+    result = run_cull(prepared, pass_zero, review_output_dir=tmp_path / "review")
+
+    assert _survivor_ids(result) == ("test", "neutral")
+    assert tuple(decision.asset_id for decision in result.rejected) == ("blur",)
+    assert before == (calls, len(prepared.trace.requests))
+    assert result.actual_calls == 0
+    assert result.warnings == (
+        "!! cull reject conflicted with protected favourite: test",
+        "!! cull reject conflicted with protected favourite: neutral",
+    )
+    pass_one = prepared.trace.editorial_passes[-1]
+    assert pass_one.name == "pass-1-cull"
+    assert sum(request.actual_calls for request in pass_one.request_traces) == 0
+    assert tuple(entry.asset_id for entry in result.review.entries) == prepared.candidate_ids
+    assert tuple(entry.number for entry in result.review.entries) == (1, 2, 3)
+    assert tuple(entry.status for entry in result.review.entries) == ("KEEP", "CULL", "KEEP")
+    assert tuple(entry.favourite for entry in result.review.entries) == (True, False, True)
+    assert tuple(entry.source_tile_sha256 for entry in result.review.entries) == tuple(
+        pass_zero.atlas.tile_for(asset_id).sha256 for asset_id in prepared.candidate_ids
+    )
+    manifest = json.loads(result.review.manifest_path.read_text())
+    assert manifest["warnings"] == [
+        "!! cull reject conflicted with protected favourite: test",
+        "!! cull reject conflicted with protected favourite: neutral",
+    ]
+    assert [entry["asset_id"] for entry in manifest["entries"]] == list(prepared.candidate_ids)
+    assert manifest["entries"][2]["status"] == "KEEP"
+    assert manifest["entries"][2]["favourite"] is True
+    with Image.open(BytesIO(result.review.pages[0].jpeg_bytes)) as review_page:
+        red, green, blue = review_page.convert("RGB").getpixel((2, 2))
+    assert red > 120 and green < 80 and blue < 80
+
+
+def test_unavailable_pixels_cannot_actuate_record_or_cull_but_visible_sibling_still_culls(
+    tmp_path: Path,
+) -> None:
+    """A visual nobody can see is never asked about, and never blocks its sibling.
+
+    It leaves before the sheet is built, so it occupies no numbered square and
+    the tiles renumber around it. It survives Pass 1 unjudged rather than being
+    removed on evidence that does not exist.
+    """
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    unavailable = make_asset("unavailable", file_created_at=when)
+    visible = make_asset("visible", file_created_at=when + timedelta(seconds=1))
+
+    async def _answer(_prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "One placeholder and one visible frame.",
+                        "representative_tiles": [1],
+                        "representative_reason": "The only tile with source pixels.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [1]}],
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; source, atlas, bank, Cull, and review stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (unavailable, visible),
+                preview_jpeg=lambda asset: None if asset.id == "unavailable" else _jpeg("green"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert _survivor_ids(result.pass_one) == ("unavailable",)
+    assert tuple(decision.asset_id for decision in result.pass_one.rejected) == ("visible",)
+    # It is reported as unseeable, not as a decision that had to be thrown away:
+    # Cull was never shown it and so could not name it.
+    assert any("visual unavailable: unavailable" in item for item in result.pass_one.warnings)
+    assert not any("unavailable Cull decision" in item for item in result.pass_one.warnings)
+    assert tuple(entry.status for entry in result.pass_one.review.entries) == ("KEEP", "CULL")
+    assert result.pass_one.review.warnings == result.pass_one.warnings
+    with Image.open(BytesIO(result.pass_one.review.pages[0].jpeg_bytes)) as review_page:
+        red, green, blue = review_page.convert("RGB").getpixel((2, 2))
+    assert red > 120 and green < 80 and blue < 80
+
+
+def test_preview_exception_is_one_unavailable_tile_and_does_not_abort_visible_sibling(
+    tmp_path: Path,
+) -> None:
+    """A failed preview read stays local to its asset and remains owner-visible."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    broken = make_asset("broken", file_created_at=when)
+    visible = make_asset("visible", file_created_at=when + timedelta(seconds=1))
+    attached_images: list[tuple[bytes, ...]] = []
+
+    def preview(asset):
+        if asset.id == "broken":
+            raise RuntimeError("generated preview failure")
+        return _jpeg("blue")
+
+    async def _answer(_prompt, _config, **kwargs):
+        attached_images.append(tuple(kwargs["images"]))
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "A placeholder beside one visible frame.",
+                        "representative_tiles": [2],
+                        "representative_reason": "The second tile retains source pixels.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; preview containment and the rest of the flow are real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (broken, visible),
+                preview_jpeg=preview,
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert result.prepared.candidate_ids == ("broken", "visible")
+    assert _survivor_ids(result.pass_one) == ("broken", "visible")
+    assert result.pass_zero.atlas.tile_for("broken").kind == "unavailable"
+    assert result.pass_zero.atlas.tile_for("broken").unavailable_reason == (
+        "preview provider raised RuntimeError and no usable motion frames"
+    )
+    assert result.pass_zero.atlas.tile_for("visible").kind == "photo"
+    assert len(attached_images) == 1
+    assert attached_images[0]
+    assert any("visual unavailable: broken" in warning for warning in result.pass_one.warnings)
+    assert result.pass_one.review.warnings == result.pass_one.warnings
+    with Image.open(BytesIO(result.pass_one.review.pages[0].jpeg_bytes)) as review_page:
+        red, green, blue = review_page.convert("RGB").getpixel((2, 2))
+    assert red > 120 and green < 80 and blue < 80
+
+
+def test_owner_banner_uses_conservation_warning_recorded_during_pass_one(
+    tmp_path: Path,
+) -> None:
+    """The review reads final trace warnings, including ones born while recording Cull."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    first = make_asset("first", file_created_at=when)
+    second = make_asset("second", file_created_at=when + timedelta(seconds=1))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (first, second),
+            preview_jpeg=lambda _asset: _jpeg("green"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" not in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "period-insight-v1",
+                    "period_insight": {
+                        "thesis": None,
+                        "evidence": [],
+                        "tensions": [],
+                        "recurring_threads": [],
+                        "unavailable_reason": "No thesis needed.",
+                    },
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "Two generated frames.",
+                        "representative_tiles": [2],
+                        "representative_reason": "The second frame remains visible.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [1]}],
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; the duplicated bank is injected local trace input.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+    duplicated_pack = replace(
+        pass_zero,
+        episode_packs=(pass_zero.episode_packs[0], pass_zero.episode_packs[0]),
+    )
+
+    result = run_cull(prepared, duplicated_pack, review_output_dir=tmp_path / "review")
+
+    assert result.trace.conservation is not None
+    assert result.trace.conservation.valid is False
+    assert "conservation failure in pass-1-cull" in prepared.trace.warnings
+    assert "!! conservation failure in pass-1-cull" in result.warnings
+    assert result.review.warnings == result.warnings
+    with Image.open(BytesIO(result.review.pages[0].jpeg_bytes)) as review_page:
+        red, green, blue = review_page.convert("RGB").getpixel((2, 2))
+    assert red > 120 and green < 80 and blue < 80
+
+
+def test_failed_middle_pack_does_not_shift_later_bank_or_reused_wire_alias(
+    tmp_path: Path,
+) -> None:
+    """Exact pack keys isolate three identical wire aliases around one timeout."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+    from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+
+    start = datetime(2026, 8, 25, 8, tzinfo=UTC)
+    assets = tuple(
+        make_asset(asset_id, file_created_at=start + timedelta(hours=index * 2))
+        for index, asset_id in enumerate(("first", "middle", "third"))
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("blue"),
+        ),
+    )
+    episode_asks = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal episode_asks
+        assert "chronological episode pack" in prompt
+        episode_asks += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if episode_asks == 2:
+            raise TimeoutError("generated middle timeout")
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "One generated visual.",
+                        "representative_tiles": [1],
+                        "representative_reason": "It is the only visible stage.",
+                    }
+                ],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [1]}],
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the external provider; packing, failure provenance, and replay stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            limits=VisionRequestLimits(max_output_tokens=170, timeout_seconds=30),
+        )
+
+    assert len(pass_zero.episode_packs) == 3
+    assert [attempt.answer is not None for attempt in pass_zero.scan_attempts] == [
+        True,
+        False,
+        True,
+    ]
+    original_attempts = pass_zero.scan_attempts
+    with pytest.raises(ValueError, match="attempt identities"):
+        replace(pass_zero, scan_attempts=(original_attempts[0], original_attempts[0]))
+    assert original_attempts[1].request_trace is prepared.trace.requests[1]
+    assert original_attempts[1].request_trace.actual_calls == 1
+    swapped = replace(
+        pass_zero,
+        scan_attempts=(
+            replace(original_attempts[0], answer=original_attempts[2].answer),
+            original_attempts[1],
+            replace(original_attempts[2], answer=original_attempts[0].answer),
+        ),
+    )
+    swapped_result = run_cull(
+        prepared,
+        swapped,
+        review_output_dir=tmp_path / "review-swapped",
+    )
+    assert _survivor_ids(swapped_result) == ("first", "middle", "third")
+    assert (
+        sum("mismatched episode scan provenance" in item for item in swapped_result.warnings) == 2
+    )
+
+    pass_zero = replace(pass_zero, scan_attempts=tuple(reversed(pass_zero.scan_attempts)))
+    result = run_cull(prepared, pass_zero, review_output_dir=tmp_path / "review")
+
+    assert _survivor_ids(result) == ("middle",)
+    assert tuple(decision.asset_id for decision in result.rejected) == ("first", "third")
+    assert result.warnings == (
+        "!! Pass 0 1 of 3 episodes could not be read",
+        # the wall is now attempted from the two that read, and this fixture's
+        # provider has no period answer for it
+        "!! Pass 0 period synthesis unreadable; thesis unavailable",
+        f"!! Pass 1 mismatched episode scan provenance: {pass_zero.episode_packs[0].page.sheet_id}",
+        f"!! Pass 1 failed episode scan: {pass_zero.episode_packs[1].page.sheet_id}",
+        f"!! Pass 1 mismatched episode scan provenance: {pass_zero.episode_packs[2].page.sheet_id}",
+    )
+    # three episode packs plus the period wall, which is now attempted
+    assert len(prepared.trace.requests) == 4
+    assert sum(request.actual_calls for request in result.trace.request_traces) == 0
+    assert result.trace.request_traces[1].provenance.request_key == (
+        original_attempts[1].request_trace.provenance.request_key
+    )
+
+
+def test_malformed_episode_reading_does_not_erase_valid_pass_one_namespaces(
+    tmp_path: Path,
+) -> None:
+    """Pass 0 can fail open while an independently valid record and Cull still actuate."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    record = make_asset("record", file_created_at=when)
+    bad = make_asset("bad", file_created_at=when + timedelta(seconds=1))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (record, bad),
+            preview_jpeg=lambda _asset: _jpeg("green"),
+        ),
+    )
+
+    async def _answer(_prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [{"episode": 1, "page": 1, "visual_summary": "missing"}],
+                "cull_rejects": [{"episode": 1, "notes": [], "failed": [2]}],
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; namespace isolation is exercised end to end.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    assert pass_zero.episode_readings == ()
+    assert pass_zero.insight.thesis is None
+    result = run_cull(prepared, pass_zero, review_output_dir=tmp_path / "review")
+
+    assert _survivor_ids(result) == ("record",)
+    assert tuple(decision.asset_id for decision in result.rejected) == ("bad",)
+
+
+def test_a_missing_cull_namespace_warns_and_removes_nothing(
+    tmp_path: Path,
+) -> None:
+    """A missing namespace rejects nothing of its own and makes the owner sheet invalid."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    record = make_asset("record", file_created_at=when)
+    bad = make_asset("bad", file_created_at=when + timedelta(seconds=1))
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (record, bad),
+            preview_jpeg=lambda _asset: _jpeg("green"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" not in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "period-insight-v1",
+                    "period_insight": {
+                        "thesis": None,
+                        "evidence": [],
+                        "tensions": [],
+                        "recurring_threads": [],
+                        "unavailable_reason": "No thesis needed.",
+                    },
+                }
+            )
+        payload = {
+            "schema_version": "episode-scan-v4",
+            "pack": 1,
+            "episode_readings": [
+                {
+                    "episode": 1,
+                    "page": 1,
+                    "visual_summary": "A record beside a broken image.",
+                    "representative_tiles": [1],
+                    "representative_reason": "The record is visible.",
+                }
+            ],
+            "cull_rejects": [{"episode": 1, "notes": [], "failed": [2]}],
+        }
+        del payload["cull_rejects"]
+        return json.dumps(payload)
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; namespace parsing and owner warnings stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+
+    result = run_cull(
+        prepared,
+        pass_zero,
+        review_output_dir=tmp_path / "review",
+    )
+
+    assert result.warnings[0].startswith("!! Pass 1 invalid Cull namespace: ")
+    assert result.rejected == ()
+    assert _survivor_ids(result) == ("record", "bad")
+
+
+@pytest.mark.parametrize(
+    ("reject_count", "expected_warning"),
+    ((3, ()), (4, ("!! possible over-cull",))),
+)
+def test_over_cull_warns_only_above_seventy_five_percent_without_restoration(
+    tmp_path: Path,
+    reject_count: int,
+    expected_warning: tuple[str, ...],
+) -> None:
+    """The over-cull guard is a diagnostic integer boundary, never a score repair."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(f"asset-{index}", file_created_at=when + timedelta(seconds=index))
+        for index in range(4)
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=lambda _asset: _jpeg("yellow"),
+        ),
+    )
+
+    async def _answer(prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": 1,
+                            "page": 1,
+                            "visual_summary": "Four generated frames.",
+                            "representative_tiles": [1],
+                            "representative_reason": "The first is a visible representative.",
+                        }
+                    ],
+                    "cull_rejects": [
+                        {
+                            "episode": 1,
+                            "notes": [],
+                            "failed": list(range(1, reject_count + 1)),
+                        }
+                    ],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "No period thesis is necessary.",
+                },
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / f"judgments-{reject_count}.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; threshold behavior and owner artifact stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / f"sheets-{reject_count}",
+            frame_cache_dir=None,
+        )
+    result = run_cull(
+        prepared,
+        pass_zero,
+        review_output_dir=tmp_path / f"review-{reject_count}",
+    )
+
+    assert len(result.rejected) == reject_count
+    assert len(result.survivors) == 4 - reject_count
+    assert result.warnings == expected_warning
+    with Image.open(BytesIO(result.review.pages[0].jpeg_bytes)) as review_page:
+        red, green, blue = review_page.convert("RGB").getpixel((2, 2))
+    if expected_warning:
+        assert red > 120 and green < 80 and blue < 80
+    else:
+        assert not (red > 120 and green < 80 and blue < 80)
+
+
+def test_multi_page_review_reuses_one_atlas_across_every_page(
+    tmp_path: Path,
+) -> None:
+    """Pregnancy proof and an arbitrary ticket survive by visible function, not keywords."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.period_insight import run_period_insight
+    from immich_memories.analysis.selection_cull import run_cull
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    assets = tuple(
+        make_asset(
+            f"asset-{index:03d}",
+            file_created_at=when + timedelta(seconds=index),
+            is_favorite=index == 0,
+        )
+        for index in range(121)
+    )
+    preview_calls = 0
+
+    def _preview(_asset):
+        nonlocal preview_calls
+        preview_calls += 1
+        return _jpeg("purple")
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: assets,
+            preview_jpeg=_preview,
+        ),
+    )
+    calls = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal calls
+        calls += 1
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" not in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "period-insight-v1",
+                    "period_insight": {
+                        "thesis": None,
+                        "evidence": [],
+                        "tensions": [],
+                        "recurring_threads": [],
+                        "unavailable_reason": "One episode does not support a thesis.",
+                    },
+                }
+            )
+        displayed = [
+            int(value) for value in re.search(r"tiles=\[([^\]]+)\]", prompt).group(1).split(",")
+        ]
+        first_page = displayed[0] == 1
+        return json.dumps(
+            {
+                "schema_version": "episode-scan-v4",
+                "pack": 1,
+                "episode_readings": [
+                    {
+                        "episode": 1,
+                        "page": 1,
+                        "visual_summary": "Generated continuation.",
+                        "representative_tiles": [displayed[0]],
+                        "representative_reason": "The first visible tile identifies this page.",
+                    }
+                ],
+                "record_shots": (
+                    [
+                        {
+                            "tile": 1,
+                            "function": "pregnancy result",
+                            "reason": "Records a pregnancy-test result.",
+                        },
+                        {
+                            "tile": 2,
+                            "function": "admission proof",
+                            "reason": "Records admission with a dated ticket.",
+                        },
+                    ]
+                    if first_page
+                    else []
+                ),
+                "cull_rejects": (
+                    [{"episode": 1, "notes": [], "failed": [3]}] if first_page else []
+                ),
+            }
+        )
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=prepared.trace,
+    )
+    # WHY: query_llm is the provider boundary; every visual artifact is generated locally.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        pass_zero = run_period_insight(
+            prepared,
+            requester=gateway,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+        )
+    retained_atlas = pass_zero.atlas
+    physical_before = (
+        calls,
+        preview_calls,
+        json.dumps(prepared.trace.as_dict()["requests"], sort_keys=True),
+    )
+
+    # WHY: a second atlas build would hide an expensive preview/frame-sampling regression.
+    with (
+        patch(
+            "immich_memories.analysis.visual_atlas.build_visual_atlas",
+            side_effect=AssertionError("review must reuse retained atlas"),
+        ),
+        patch(
+            "immich_memories.analysis.period_insight.build_visual_atlas",
+            side_effect=AssertionError("review must not rebuild the atlas"),
+        ),
+    ):
+        result = run_cull(prepared, pass_zero, review_output_dir=tmp_path / "review")
+
+    assert pass_zero.atlas is retained_atlas
+    assert physical_before == (
+        calls,
+        preview_calls,
+        json.dumps(prepared.trace.as_dict()["requests"], sort_keys=True),
+    )
+    assert "asset-000" in _survivor_ids(result)
+    assert "asset-001" in _survivor_ids(result)
+    assert "asset-002" not in _survivor_ids(result)
+    assert len(result.review.pages) == 2
+    assert tuple(entry.asset_id for entry in result.review.entries) == prepared.candidate_ids
+    assert tuple(entry.number for entry in result.review.entries) == tuple(range(1, 122))
+    assert [result.review.entries[index].status for index in range(3)] == [
+        "KEEP",
+        "KEEP",
+        "CULL",
+    ]
+    manifest = json.loads(result.review.manifest_path.read_text())
+    # A kept visual carries no reason: Cull only explains what it removed.
+    assert manifest["entries"][0]["reason"] is None
+    assert manifest["entries"][2]["reason"] == "failed: the picture did not come out"
+    assert manifest["warnings"] == []
+
+    from immich_memories.analysis.contact_sheets import sheet_layout
+
+    first_columns, first_tile = sheet_layout(120)
+    first_grid_height = ((120 + first_columns - 1) // first_columns) * first_tile
+    with Image.open(BytesIO(result.review.pages[0].jpeg_bytes)) as first_page:
+        assert first_page.height > first_grid_height
+        _assert_pixel_near(first_page, (4, 4), (0, 0, 0))
+        _assert_pixel_near(first_page, (first_tile - 5, 5), (180, 130, 0))
+        _assert_pixel_near(first_page, (5, first_tile - 5), (45, 65, 75))
+        _assert_pixel_near(first_page, (first_tile + 5, first_tile - 5), (45, 65, 75))
+        _assert_pixel_near(first_page, (2 * first_tile + 5, first_tile - 5), (170, 20, 20))
+        _assert_pixel_near(first_page, (3 * first_tile + 5, first_tile - 5), (45, 65, 75))
+        state_top = first_tile - max(18, min(26, first_tile // 6)) - 3
+        assert state_top > 3 + 16
+        footer = first_page.convert("RGB").crop(
+            (0, first_grid_height, first_page.width, first_page.height)
+        )
+        assert footer.getbbox() is not None
+        assert len(footer.getcolors(maxcolors=1_000_000) or ()) > 2
+
+    second_columns, second_tile = sheet_layout(1)
+    second_grid_height = ((1 + second_columns - 1) // second_columns) * second_tile
+    with Image.open(BytesIO(result.review.pages[1].jpeg_bytes)) as second_page:
+        assert second_page.height > second_grid_height
+        _assert_pixel_near(second_page, (4, 4), (0, 0, 0))
+        _assert_pixel_near(second_page, (5, second_tile - 5), (45, 65, 75))
+
+
+def test_public_source_insight_cull_flow_uses_one_trace_and_never_subject_quotas(
+    tmp_path: Path,
+) -> None:
+    """Every source kind reaches one fused visual request with subject evidence only."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+    from immich_memories.api.models import AssetType, Person, VideoClipInfo
+
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    face = make_asset("face", file_created_at=when)
+    face.people = [Person(id="person")]
+    screen_asset = make_asset("screen", file_created_at=when + timedelta(seconds=1))
+    object_asset = make_asset("object", file_created_at=when + timedelta(seconds=2))
+    screenshot = make_asset(
+        "screenshot",
+        file_created_at=when + timedelta(seconds=3),
+        original_file_name="Screenshot_20260825.png",
+    )
+    document = make_asset(
+        "document",
+        file_created_at=when + timedelta(seconds=4),
+        original_file_name="ticket.jpg",
+    )
+    pregnancy = make_asset(
+        "pregnancy",
+        file_created_at=when + timedelta(seconds=5),
+        original_file_name="IMG_0001.jpg",
+    )
+    for still in (screenshot, document, pregnancy):
+        still.type = AssetType.IMAGE
+    sources = (
+        face,
+        VideoClipInfo(asset=screen_asset, llm_category="screen", duration_seconds=1.0),
+        VideoClipInfo(asset=object_asset, llm_category="object", duration_seconds=1.0),
+        screenshot,
+        document,
+        pregnancy,
+    )
+    prompts: list[str] = []
+    traces = []
+    episode_asks = 0
+
+    async def _answer(prompt, _config, **kwargs):
+        nonlocal episode_asks
+        prompts.append(prompt)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            episode_asks += 1
+            if episode_asks > 1:
+                raise AssertionError("Pass 1 made a second episode ask")
+            scopes = re.findall(r"episode=(\d+) page=(\d+) tiles=\[([^\]]+)\]", prompt)
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": int(episode),
+                            "page": int(page),
+                            "visual_summary": "Generated source types remain visible.",
+                            "representative_tiles": [int(tiles.split(",")[0])],
+                            "representative_reason": "The visible tile represents this episode.",
+                        }
+                        for episode, page, tiles in scopes
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "Generated evidence does not need a thesis.",
+                },
+            }
+        )
+
+    def gateway_factory(trace):
+        traces.append(trace)
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the sole external provider; quota functions are forbidden on this path.
+    with (
+        patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer),
+        patch(
+            "immich_memories.analysis.subject_policy.apply_subject_quotas",
+            side_effect=AssertionError("legacy quota called"),
+        ),
+        patch(
+            "immich_memories.analysis.subject_policy.filter_candidates_by_subject",
+            side_effect=AssertionError("legacy subject filter called"),
+        ),
+    ):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: sources,
+                preview_jpeg=lambda _asset: _jpeg("teal"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert traces == [result.prepared.trace]
+    assert _survivor_ids(result.pass_one) == result.prepared.candidate_ids
+    assert result.prepared.candidate_ids == (
+        "face",
+        "screen",
+        "object",
+        "screenshot",
+        "document",
+        "pregnancy",
+    )
+    assert [item.name for item in result.prepared.trace.editorial_passes] == [
+        "source-eligibility",
+        "pass-0",
+        "pass-1-cull",
+    ]
+    assert len(result.prepared.trace.requests) == 2
+    assert episode_asks == 1
+    assert result.pass_one.warnings == ()
+    assert result.pass_one.review.warnings == ()
+    episode_prompt = next(prompt for prompt in prompts if "chronological episode pack" in prompt)
+    assert "subject-evidence:people" in episode_prompt
+    assert "subject-evidence:screen" in episode_prompt
+    assert "subject-evidence:object" in episode_prompt
+    assert "subject-evidence:unknown" in episode_prompt
+
+
+def test_arbitrary_unrelated_topics_share_the_same_production_flow_without_quotas(
+    tmp_path: Path,
+) -> None:
+    """Topic labels remain evidence; they never select a branch or membership policy."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+    from immich_memories.api.models import VideoClipInfo
+
+    when = datetime(2026, 8, 25, 8, tzinfo=UTC)
+    sources = (
+        VideoClipInfo(
+            asset=make_asset("glass", file_created_at=when),
+            duration_seconds=2.0,
+            width=1920,
+            height=1080,
+            llm_category="glassblowing",
+        ),
+        VideoClipInfo(
+            asset=make_asset("birds", file_created_at=when + timedelta(hours=3)),
+            duration_seconds=2.0,
+            width=1920,
+            height=1080,
+            llm_category="birdwatching",
+        ),
+    )
+    prompts: list[str] = []
+
+    async def _answer(prompt, _config, **kwargs):
+        prompts.append(prompt)
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            scopes = re.findall(r"episode=(\d+) page=(\d+) tiles=\[([^\]]+)\]", prompt)
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": int(episode),
+                            "page": int(page),
+                            "visual_summary": "An arbitrary visible activity.",
+                            "representative_tiles": [int(tiles.split(",")[0])],
+                            "representative_reason": "The first tile identifies its episode.",
+                        }
+                        for episode, page, tiles in scopes
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "Unrelated activities support no single thesis.",
+                },
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the sole provider boundary; legacy quota APIs are forbidden here.
+    with (
+        patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer),
+        patch(
+            "immich_memories.analysis.subject_policy.apply_subject_quotas",
+            side_effect=AssertionError("legacy quota called"),
+        ),
+        patch(
+            "immich_memories.analysis.subject_policy.filter_candidates_by_subject",
+            side_effect=AssertionError("legacy filter called"),
+        ),
+    ):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: sources,
+                preview_jpeg=lambda _asset: _jpeg("orange"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert result.prepared.candidate_ids == ("glass", "birds")
+    assert _survivor_ids(result.pass_one) == ("glass", "birds")
+    assert tuple(
+        candidate.grounded_annotations[-1] for candidate in result.prepared.candidates
+    ) == (
+        "subject:glassblowing",
+        "subject:birdwatching",
+    )
+    episode_prompt = next(prompt for prompt in prompts if "chronological episode pack" in prompt)
+    assert "subject:glassblowing" in episode_prompt
+    assert "subject:birdwatching" in episode_prompt
+    assert [request.provenance.pass_name for request in result.prepared.trace.requests] == [
+        "episode-scan",
+        "period-insight",
+    ]
+    assert sum(request.actual_calls for request in result.prepared.trace.requests) == 2
+
+
+def test_reencode_reaches_fused_visual_request_with_pixels_and_empty_cull_keeps_it(
+    tmp_path: Path,
+) -> None:
+    """A weak metadata prior remains provider-visible evidence, never a source deletion."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+    from immich_memories.api.models import VideoClipInfo
+
+    clip = VideoClipInfo(
+        asset=make_asset("reencode", exif_make=None, exif_model=None, duration="0:00:01.250"),
+        duration_seconds=1.25,
+        width=640,
+        height=480,
+    )
+    preview_output = BytesIO()
+    Image.new("RGB", (200, 150), "red").save(preview_output, "JPEG")
+    preview_bytes = preview_output.getvalue()
+    provider_prompts: list[str] = []
+    attached_images: list[tuple[bytes, ...]] = []
+
+    async def _answer(prompt, _config, **kwargs):
+        provider_prompts.append(prompt)
+        attached_images.append(tuple(kwargs["images"]))
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        if "chronological episode pack" in prompt:
+            return json.dumps(
+                {
+                    "schema_version": "episode-scan-v4",
+                    "pack": 1,
+                    "episode_readings": [
+                        {
+                            "episode": 1,
+                            "page": 1,
+                            "visual_summary": "One visible generated clip frame.",
+                            "representative_tiles": [1],
+                            "representative_reason": "The source pixels are visible.",
+                        }
+                    ],
+                    "cull_rejects": [{"episode": 1, "notes": [], "failed": []}],
+                }
+            )
+        return json.dumps(
+            {
+                "schema_version": "period-insight-v1",
+                "period_insight": {
+                    "thesis": None,
+                    "evidence": [],
+                    "tensions": [],
+                    "recurring_threads": [],
+                    "unavailable_reason": "One visual has no period thesis.",
+                },
+            }
+        )
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; source annotations and attached sheets stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (clip,),
+                preview_jpeg=lambda _asset: preview_bytes,
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert result.prepared.candidate_ids == ("reencode",)
+    assert "reencode-suspected" in result.prepared.candidates[0].grounded_annotations
+    assert _survivor_ids(result.pass_one) == ("reencode",)
+    assert result.pass_one.rejected == ()
+    episode_index = next(
+        index
+        for index, prompt in enumerate(provider_prompts)
+        if "chronological episode pack" in prompt
+    )
+    assert "reencode-suspected" in provider_prompts[episode_index]
+    assert len(attached_images[episode_index]) == 1
+    with Image.open(BytesIO(attached_images[episode_index][0])) as sheet:
+        red, _green, blue = sheet.convert("RGB").getpixel((100, 75))
+    assert red > blue + 50
+
+
+def test_explicit_provider_refusal_is_fail_open_and_owner_visible(tmp_path: Path) -> None:
+    """A refusal is evidence failure, never permission to invent a Pass 1 decision."""
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+    from immich_memories.analysis.selection_flow import run_editorial_insight_cull
+
+    asset = make_asset("safe")
+
+    async def _refuse(_prompt, _config, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return "I cannot evaluate these visuals."
+
+    def gateway_factory(trace):
+        return VisualEditorialGateway(
+            llm_config=LLMConfig(model="vision-test"),
+            cache_path=tmp_path / "judgments.db",
+            trace=trace,
+        )
+
+    # WHY: query_llm is the provider boundary; refusal handling and owner output stay real.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_refuse):
+        result = run_editorial_insight_cull(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(
+                source_fetcher=lambda _scope: (asset,),
+                preview_jpeg=lambda _asset: _jpeg("green"),
+            ),
+            gateway_factory=gateway_factory,
+            sheet_output_dir=tmp_path / "sheets",
+            frame_cache_dir=None,
+            review_output_dir=tmp_path / "review",
+        )
+
+    assert _survivor_ids(result.pass_one) == ("safe",)
+    assert result.pass_one.rejected == ()
+    assert any("Pass 1 unreadable episode scan" in item for item in result.pass_one.warnings)
+    assert result.pass_one.review.warnings == result.pass_one.warnings
+    assert result.prepared.trace.warnings == list(result.pass_one.warnings)
+    assert len(result.prepared.trace.requests) == 1
+    assert result.prepared.trace.requests[0].actual_calls == 1

--- a/tests/test_selection_source.py
+++ b/tests/test_selection_source.py
@@ -1,0 +1,816 @@
+"""The editorial flow starts with every source-eligible asset."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from immich_memories.analysis.editorial_contracts import (
+    LivePhotoRenderingFamily,
+    SourceEvidence,
+    live_photo_rendering_family_id,
+)
+from immich_memories.analysis.selection_flow import (
+    EditorialDependencies,
+    EditorialSelectionRequest,
+    SourceScope,
+    build_episode_groups,
+    build_moment_groups,
+    prepare_editorial_source,
+)
+from immich_memories.api.models import AssetType, VideoClipInfo
+from tests.conftest import make_asset
+
+
+def test_only_source_scope_and_owner_exclusions_apply_before_pass_zero() -> None:
+    """Editorial evidence survives until a later pass can judge its contribution."""
+    pregnancy_test = make_asset("pregnancy-test", original_file_name="IMG_0001.jpg")
+    pregnancy_test.type = AssetType.IMAGE
+    screenshot = make_asset("screenshot", original_file_name="Screenshot 2026-08-25.png")
+    screenshot.type = AssetType.IMAGE
+    short_clip = VideoClipInfo(
+        asset=make_asset("short-clip", duration="0:00:01.000"),
+        duration_seconds=1.0,
+        width=640,
+        height=480,
+    )
+    owner_excluded = make_asset("owner-excluded")
+    request = EditorialSelectionRequest(
+        scope=SourceScope(),
+        owner_excluded_asset_ids=("owner-excluded",),
+    )
+    dependencies = EditorialDependencies(
+        source_fetcher=lambda _scope: (pregnancy_test, screenshot, short_clip, owner_excluded)
+    )
+
+    prepared = prepare_editorial_source(request, dependencies)
+
+    assert prepared.candidate_ids == ("pregnancy-test", "screenshot", "short-clip")
+    assert prepared.excluded_ids == ("owner-excluded",)
+    assert prepared.trace.story_of("pregnancy-test").first_pass is None
+    assert [item.name for item in prepared.trace.editorial_passes] == ["source-eligibility"]
+
+
+def test_source_observations_survive_without_running_legacy_selectors(monkeypatch) -> None:
+    """Observed quality and subject signals inform later passes; they never cull source material."""
+    from immich_memories.analysis import source_filter, source_quality, subject_policy
+    from immich_memories.photos import burst_dedup, moment_suppression
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy selection must not run before pass 0")
+
+    monkeypatch.setattr(source_filter, "not_shot_here", forbidden)
+    monkeypatch.setattr(source_quality, "is_usable_source", forbidden)
+    monkeypatch.setattr(subject_policy, "filter_candidates_by_subject", forbidden)
+    monkeypatch.setattr(burst_dedup, "drop_burst_duplicates", forbidden)
+    monkeypatch.setattr(moment_suppression, "suppress_photos_covered_by_motion", forbidden)
+    clip = VideoClipInfo(
+        asset=make_asset("evidence", exif_make=None, exif_model=None, duration="0:00:01.250"),
+        duration_seconds=1.25,
+        width=640,
+        height=480,
+        live_burst_still_ids=["evidence", "other-burst-member"],
+        llm_category="screen",
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (clip,)),
+    )
+
+    assert prepared.candidate_ids == ("evidence",)
+    assert prepared.candidates[0].grounded_annotations == (
+        "resolution:640x480",
+        "reencode-suspected",
+        "duration:1.250s",
+        "motion:available",
+        "burst-members:2",
+        "subject:screen",
+    )
+
+
+def test_groups_conserve_candidates_in_canonical_order_with_stable_ids() -> None:
+    """Episode and moment walls use time/place grouping without electing a winner."""
+    noon = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    assets = (
+        make_asset("d", file_created_at=noon + timedelta(hours=3)),
+        make_asset("b", file_created_at=noon),
+        make_asset("c", file_created_at=noon + timedelta(minutes=5)),
+        make_asset("a", file_created_at=noon),
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: assets),
+    )
+
+    episodes = build_episode_groups(prepared.candidates)
+    moments = build_moment_groups(tuple(reversed(prepared.candidates)))
+
+    assert prepared.candidate_ids == ("a", "b", "c", "d")
+    assert tuple(group.candidate_ids for group in episodes) == (("a", "b", "c"), ("d",))
+    assert tuple(group.candidate_ids for group in moments) == (("a", "b", "c"), ("d",))
+    assert tuple(
+        group.group_id for group in build_episode_groups(tuple(reversed(prepared.candidates)))
+    ) == (tuple(group.group_id for group in episodes))
+    assert tuple(asset_id for group in moments for asset_id in group.candidate_ids) == (
+        "a",
+        "b",
+        "c",
+        "d",
+    )
+
+
+def test_requested_dates_and_supported_media_define_the_source_scope() -> None:
+    """Acquisition can over-return, but source scope still admits only supported in-range media."""
+    day = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    too_early = make_asset("too-early", file_created_at=day - timedelta(seconds=1))
+    in_window = make_asset("in-window", file_created_at=day)
+    unsupported = make_asset("audio", file_created_at=day)
+    unsupported.type = AssetType.AUDIO
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope(start_at=day, end_at=day)),
+        EditorialDependencies(source_fetcher=lambda _scope: (too_early, unsupported, in_window)),
+    )
+
+    assert prepared.candidate_ids == ("in-window",)
+    assert prepared.excluded_ids == ("too-early", "audio")
+    assert prepared.candidates[0].shippable_duration == 10.0
+    assert prepared.trace.as_dict()["editorial_passes"][0] == {
+        "name": "source-eligibility",
+        "input_ids": ["too-early", "audio", "in-window"],
+        "kept_ids": ["in-window"],
+        "rejected": [
+            {"asset_id": "too-early", "reason": "outside date scope"},
+            {"asset_id": "audio", "reason": "unsupported media"},
+        ],
+        "unresolved": [],
+        "duration_before": 30.0,
+        "duration_after": 10.0,
+        "provenance": {
+            "pass_name": "source-eligibility",
+            "pass_version": "1",
+            "schema_version": "1",
+            "model_identity": "",
+            "input_ids": ["too-early", "audio", "in-window"],
+            "sheet_hashes": [],
+            "request_key": "source-eligibility",
+            "cache_hit": False,
+        },
+        "conservation": {
+            "valid": True,
+            "missing_ids": [],
+            "duplicate_ids": [],
+            "unexpected_ids": [],
+        },
+        "request_traces": [],
+    }
+
+
+def test_library_scope_rejects_an_over_returned_asset_and_records_why() -> None:
+    """The source boundary is enforced even when acquisition over-returns another library's asset."""
+    scoped = make_asset("in-library")
+    other_library = make_asset("elsewhere")
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope(library_ids=("family-library",))),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (scoped, other_library),
+            library_membership=lambda asset, _library_ids: asset.id == "in-library",
+        ),
+    )
+
+    assert prepared.candidate_ids == ("in-library",)
+    assert prepared.excluded_ids == ("elsewhere",)
+    source_trace = prepared.trace.as_dict()["editorial_passes"][0]
+    assert source_trace["rejected"] == [
+        {"asset_id": "elsewhere", "reason": "outside library scope"}
+    ]
+    story = prepared.trace.story_of("elsewhere")
+    assert story.dropped_at == "source-eligibility"
+    assert story.reason == "outside library scope"
+
+
+def test_interleaved_place_threads_preserve_every_group_member() -> None:
+    """Place threads may interleave chronologically without being mistaken for missing assets."""
+    noon = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    circuit = make_asset("circuit", file_created_at=noon)
+    home = make_asset("home", file_created_at=noon + timedelta(minutes=3))
+    circuit2 = make_asset("circuit2", file_created_at=noon + timedelta(minutes=6))
+    for asset, location in (
+        (circuit, (50.437, 5.971)),
+        (home, (50.878, 4.326)),
+        (circuit2, (50.437, 5.971)),
+    ):
+        assert asset.exif_info is not None
+        asset.exif_info.latitude, asset.exif_info.longitude = location
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (circuit, home, circuit2)),
+    )
+
+    assert tuple(group.candidate_ids for group in prepared.moment_groups) == (
+        ("circuit", "circuit2"),
+        ("home",),
+    )
+
+
+def test_duplicate_asset_representations_prefer_the_enriched_clip() -> None:
+    """A Live Photo's still and motion representation remain one editorial candidate."""
+    still = make_asset("live-photo", duration="0:00:00.500")
+    still.type = AssetType.IMAGE
+    still.live_photo_video_id = "live-photo-motion"
+    clip = VideoClipInfo(
+        asset=still,
+        duration_seconds=1.5,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["live-photo", "burst-neighbour"],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (still, clip)),
+    )
+
+    assert prepared.candidate_ids == ("live-photo",)
+    candidate = prepared.candidates[0]
+    assert candidate.media_kind == "live_photo"
+    assert candidate.shippable_duration == 1.5
+    assert "burst-members:2" in candidate.grounded_annotations
+
+
+@pytest.mark.parametrize("richer_first", (False, True))
+def test_duplicate_source_favourite_is_or_merged_without_losing_motion_evidence(
+    tmp_path: Path,
+    richer_first: bool,
+) -> None:
+    """Arrival order cannot trade a star for the richer representation of the same asset."""
+    favourite_snapshot = make_asset("live-photo", is_favorite=True)
+    favourite_snapshot.type = AssetType.IMAGE
+    favourite_snapshot.live_photo_video_id = "live-photo-motion"
+    clip_asset = favourite_snapshot.model_copy(update={"is_favorite": False})
+    local_path = tmp_path / "live-photo.mov"
+    local_path.write_bytes(b"generated motion placeholder")
+    richer = VideoClipInfo(
+        asset=clip_asset,
+        local_path=str(local_path),
+        duration_seconds=3.5,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["live-photo", "neighbour"],
+        live_burst_video_ids=["live-photo-motion", "neighbour-motion"],
+        live_burst_trim_points=[(0.0, 1.0), (0.5, 1.5)],
+        live_burst_shutter_timestamps=[
+            favourite_snapshot.file_created_at.timestamp(),
+            favourite_snapshot.file_created_at.timestamp() + 1.0,
+        ],
+    )
+    sources = (richer, favourite_snapshot) if richer_first else (favourite_snapshot, richer)
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: sources),
+    )
+
+    assert prepared.candidate_ids == ("live-photo",)
+    assert prepared.candidates[0].favourite is True
+    assert prepared.candidates[0].shippable_duration == 3.5
+    assert "burst-members:2" in prepared.candidates[0].grounded_annotations
+    assert prepared.visual_sources[0].motion_path == local_path
+
+
+def test_enriched_stitch_identity_is_propagated_symmetrically_to_admitted_members() -> None:
+    """A later pass can see the exact source-declared stitch without choosing its carrier."""
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    favourite = make_asset("favourite", file_created_at=when, is_favorite=True)
+    favourite.type = AssetType.IMAGE
+    favourite.live_photo_video_id = "favourite-motion"
+    sibling = make_asset("sibling", file_created_at=when + timedelta(seconds=1))
+    sibling.type = AssetType.IMAGE
+    sibling.live_photo_video_id = "sibling-motion"
+    enriched = VideoClipInfo(
+        asset=favourite,
+        duration_seconds=4.0,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["sibling", "favourite"],
+        live_burst_video_ids=["sibling-motion", "favourite-motion"],
+        live_burst_trim_points=[(0.5, 1.5), (0.0, 1.0)],
+        live_burst_shutter_timestamps=[
+            sibling.file_created_at.timestamp(),
+            favourite.file_created_at.timestamp(),
+        ],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (sibling, enriched)),
+    )
+
+    assert prepared.candidate_ids == ("favourite", "sibling")
+    assert tuple(candidate.live_photo_stitch_member_ids for candidate in prepared.candidates) == (
+        ("favourite", "sibling"),
+        ("favourite", "sibling"),
+    )
+    family_ids = tuple(candidate.rendering_family_id for candidate in prepared.candidates)
+    assert len(set(family_ids)) == 1
+    assert family_ids[0] is not None
+    assert family_ids[0].startswith("live-photo-rendering-family-v1-")
+    assert len(prepared.rendering_families) == 1
+    family = prepared.rendering_families[0]
+    assert family.family_id == family_ids[0]
+    assert family.still_ids == ("favourite", "sibling")
+    assert family.video_ids == ("favourite-motion", "sibling-motion")
+    assert family.trim_points == ((0.0, 1.0), (0.5, 1.5))
+    assert family.shutter_timestamps == (
+        favourite.file_created_at.timestamp(),
+        sibling.file_created_at.timestamp(),
+    )
+    assert family.motion_duration_seconds is None
+    assert family.minimum_motion_seconds is None
+
+
+def test_stitch_sidecar_cannot_reintroduce_an_owner_excluded_member() -> None:
+    """Source scope wins over a richer wrapper's broader stitch declaration."""
+    admitted = make_asset("admitted")
+    admitted.type = AssetType.IMAGE
+    admitted.live_photo_video_id = "admitted-motion"
+    excluded = make_asset("excluded")
+    excluded.type = AssetType.IMAGE
+    excluded.live_photo_video_id = "excluded-motion"
+    enriched = VideoClipInfo(
+        asset=admitted,
+        duration_seconds=4.0,
+        width=1920,
+        height=1080,
+        live_burst_still_ids=["admitted", "excluded"],
+        live_burst_video_ids=["admitted-motion", "excluded-motion"],
+        live_burst_trim_points=[(0.0, 1.0), (0.25, 1.25)],
+        live_burst_shutter_timestamps=[
+            admitted.file_created_at.timestamp(),
+            excluded.file_created_at.timestamp(),
+        ],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(
+            scope=SourceScope(),
+            owner_excluded_asset_ids=("excluded",),
+        ),
+        EditorialDependencies(source_fetcher=lambda _scope: (excluded, enriched)),
+    )
+
+    assert prepared.candidate_ids == ("admitted",)
+    assert prepared.excluded_ids == ("excluded",)
+    assert prepared.candidates[0].live_photo_stitch_member_ids == ("admitted",)
+    assert prepared.candidates[0].rendering_family_id == prepared.rendering_families[0].family_id
+    assert prepared.rendering_families[0].still_ids == ("admitted",)
+    assert prepared.rendering_families[0].video_ids == ("admitted-motion",)
+    assert "excluded" not in " ".join(prepared.candidates[0].grounded_annotations)
+
+
+def test_rendering_family_manifest_is_canonical_across_source_and_entry_order() -> None:
+    """The family hash follows aligned chronology, never independent array sorting."""
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    first = make_asset("first", file_created_at=when)
+    first.live_photo_video_id = "video-first"
+    second = make_asset("second", file_created_at=when + timedelta(seconds=1))
+    second.live_photo_video_id = "video-second"
+
+    def prepare(reverse: bool):
+        aligned = (
+            ["second", "first"] if reverse else ["first", "second"],
+            ["video-second", "video-first"] if reverse else ["video-first", "video-second"],
+            [(0.5, 1.5), (0.0, 1.0)] if reverse else [(0.0, 1.0), (0.5, 1.5)],
+            [second.file_created_at.timestamp(), first.file_created_at.timestamp()]
+            if reverse
+            else [first.file_created_at.timestamp(), second.file_created_at.timestamp()],
+        )
+        enriched = VideoClipInfo(
+            asset=second,
+            duration_seconds=4.0,
+            live_burst_still_ids=aligned[0],
+            live_burst_video_ids=aligned[1],
+            live_burst_trim_points=aligned[2],
+            live_burst_shutter_timestamps=aligned[3],
+        )
+        sources = (enriched, first) if reverse else (first, enriched)
+        return prepare_editorial_source(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(source_fetcher=lambda _scope: sources),
+        )
+
+    chronological = prepare(False)
+    permuted = prepare(True)
+
+    assert chronological.rendering_families == permuted.rendering_families
+    family = chronological.rendering_families[0]
+    assert family.still_ids == ("first", "second")
+    assert family.video_ids == ("video-first", "video-second")
+    assert family.trim_points == ((0.0, 1.0), (0.5, 1.5))
+
+
+def test_incomplete_rendering_manifest_fails_visibly_but_keeps_stills() -> None:
+    """Incomplete source evidence cannot invent a later motion option."""
+    still = make_asset("still")
+    enriched = VideoClipInfo(
+        asset=still,
+        duration_seconds=2.0,
+        live_burst_still_ids=["still"],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (enriched,)),
+    )
+
+    assert prepared.candidate_ids == ("still",)
+    assert prepared.rendering_families == ()
+    assert prepared.candidates[0].rendering_family_id is None
+    assert prepared.source_warnings == (
+        "!! invalid Live Photo rendering family for still: incomplete aligned manifest",
+    )
+    assert prepared.trace.warnings == list(prepared.source_warnings)
+
+
+def test_conflicting_rendering_manifests_fail_visibly_without_an_invented_union() -> None:
+    """Two overlapping but different source manifests invalidate both families."""
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    a = make_asset("a", file_created_at=when)
+    b = make_asset("b", file_created_at=when + timedelta(seconds=1))
+    c = make_asset("c", file_created_at=when + timedelta(seconds=2))
+    first = VideoClipInfo(
+        asset=a,
+        live_burst_still_ids=["a", "b"],
+        live_burst_video_ids=["va", "vb"],
+        live_burst_trim_points=[(0.0, 1.0), (0.0, 1.0)],
+        live_burst_shutter_timestamps=[
+            a.file_created_at.timestamp(),
+            b.file_created_at.timestamp(),
+        ],
+    )
+    second = VideoClipInfo(
+        asset=c,
+        live_burst_still_ids=["b", "c"],
+        live_burst_video_ids=["vb-other", "vc"],
+        live_burst_trim_points=[(0.0, 1.0), (0.0, 1.0)],
+        live_burst_shutter_timestamps=[
+            b.file_created_at.timestamp(),
+            c.file_created_at.timestamp(),
+        ],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (first, b, second)),
+    )
+
+    assert prepared.candidate_ids == ("a", "b", "c")
+    assert prepared.rendering_families == ()
+    assert all(candidate.rendering_family_id is None for candidate in prepared.candidates)
+    assert prepared.source_warnings == (
+        "!! conflicting Live Photo rendering family for admitted asset b",
+    )
+
+
+def test_duplicate_enriched_source_conflict_fails_visibly_as_still() -> None:
+    """Coalescing duplicate snapshots cannot hide contradictory render evidence."""
+    still = make_asset("still")
+    still.live_photo_video_id = "motion"
+    first = VideoClipInfo(
+        asset=still,
+        duration_seconds=2.0,
+        live_burst_still_ids=["still"],
+        live_burst_video_ids=["motion"],
+        live_burst_trim_points=[(0.0, 1.0)],
+        live_burst_shutter_timestamps=[still.file_created_at.timestamp()],
+    )
+    contradictory = first.model_copy(
+        update={
+            "live_burst_video_ids": ["different-motion"],
+            "live_burst_trim_points": [(0.25, 1.25)],
+        }
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (first, contradictory)),
+    )
+
+    assert prepared.candidate_ids == ("still",)
+    assert prepared.rendering_families == ()
+    assert prepared.candidates[0].rendering_family_id is None
+    assert prepared.source_warnings == (
+        "!! conflicting Live Photo rendering manifests for duplicate asset still",
+    )
+
+
+def test_rendering_family_cannot_cross_editorial_moment_groups() -> None:
+    """A source declaration spanning two moments fails rather than creating two outputs."""
+    when = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    early = make_asset("early", file_created_at=when)
+    late = make_asset("late", file_created_at=when + timedelta(hours=3))
+    enriched = VideoClipInfo(
+        asset=early,
+        live_burst_still_ids=["early", "late"],
+        live_burst_video_ids=["ve", "vl"],
+        live_burst_trim_points=[(0.0, 1.0), (0.0, 1.0)],
+        live_burst_shutter_timestamps=[
+            early.file_created_at.timestamp(),
+            late.file_created_at.timestamp(),
+        ],
+    )
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (enriched, late)),
+    )
+
+    assert prepared.rendering_families == ()
+    assert all(candidate.rendering_family_id is None for candidate in prepared.candidates)
+    assert prepared.source_warnings[0].startswith(
+        "!! Live Photo rendering family crosses moment groups: live-photo-rendering-family-v1-"
+    )
+
+
+def test_rendering_family_contract_rejects_unsafe_or_misaligned_manifests() -> None:
+    """The immutable bridge accepts only a versioned, safe, chronological manifest."""
+    still_ids = ("a",)
+    video_ids = ("v",)
+    trim_points = ((0.0, 1.0),)
+    timestamps = (1.0,)
+    family_id = live_photo_rendering_family_id(
+        still_ids,
+        video_ids,
+        trim_points,
+        timestamps,
+        motion_duration_seconds=None,
+        minimum_motion_seconds=None,
+    )
+
+    valid = LivePhotoRenderingFamily(
+        family_id=family_id,
+        still_ids=still_ids,
+        video_ids=video_ids,
+        trim_points=trim_points,
+        shutter_timestamps=timestamps,
+    )
+    assert valid.family_id == family_id
+    with pytest.raises(ValueError, match="safe aligned timing"):
+        LivePhotoRenderingFamily(
+            family_id=family_id,
+            still_ids=still_ids,
+            video_ids=video_ids,
+            trim_points=((0.0, float("inf")),),
+            shutter_timestamps=timestamps,
+        )
+    with pytest.raises(ValueError, match="duration and minimum"):
+        LivePhotoRenderingFamily(
+            family_id=family_id,
+            still_ids=still_ids,
+            video_ids=video_ids,
+            trim_points=trim_points,
+            shutter_timestamps=timestamps,
+            motion_duration_seconds=2.0,
+        )
+
+
+def test_failed_preview_does_not_mark_a_video_unavailable_when_motion_frames_work(
+    tmp_path: Path,
+) -> None:
+    """Usable motion pixels outrank a failed still-preview provider."""
+    from immich_memories.analysis.visual_atlas import build_visual_atlas
+
+    asset = make_asset("motion", duration="0:00:03.000")
+    local_path = tmp_path / "motion.mp4"
+    local_path.write_bytes(b"generated motion placeholder")
+    clip = VideoClipInfo(
+        asset=asset,
+        duration_seconds=3.0,
+        width=1920,
+        height=1080,
+        local_path=str(local_path),
+    )
+    frames = []
+    for index, colour in enumerate(("red", "green", "blue")):
+        path = tmp_path / f"frame-{index}.jpg"
+        Image.new("RGB", (48, 32), colour).save(path, "JPEG")
+        frames.append(path)
+
+    def failed_preview(_asset):
+        raise RuntimeError("generated preview failure")
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (clip,),
+            preview_jpeg=failed_preview,
+        ),
+    )
+    # WHY: duration probing and frame decoding are the two external FFmpeg boundaries.
+    with (
+        patch("immich_memories.analysis.visual_atlas.probe_duration", return_value=3.0),
+        patch(
+            "immich_memories.analysis.visual_atlas.sample_segment_frames",
+            return_value=tuple(frames),
+        ),
+    ):
+        atlas = build_visual_atlas(prepared.visual_sources, frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for("motion")
+    assert prepared.candidate_ids == ("motion",)
+    assert tile.kind == "filmstrip"
+    assert tile.unavailable_reason is None
+
+
+def test_conflicting_duplicate_asset_representations_are_rejected() -> None:
+    """Two different records claiming one ID cannot be coalesced silently."""
+    noon = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    first = make_asset("duplicated", file_created_at=noon)
+    conflicting = make_asset(
+        "duplicated",
+        file_created_at=noon,
+        original_file_name="different-source.mov",
+    )
+
+    from pytest import raises
+
+    with raises(ValueError, match="conflicting source representations for asset duplicated"):
+        prepare_editorial_source(
+            EditorialSelectionRequest(scope=SourceScope()),
+            EditorialDependencies(source_fetcher=lambda _scope: (first, conflicting)),
+        )
+
+
+def test_precomputed_evidence_and_clip_analysis_survive_source_preparation() -> None:
+    """Already-available measurements become annotations without triggering new analysis."""
+    clip = VideoClipInfo(
+        asset=make_asset("analysed"),
+        duration_seconds=2.0,
+        width=1920,
+        height=1080,
+        llm_quality=0.875,
+    )
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (clip,),
+            source_evidence=lambda _source: SourceEvidence(
+                blur=0.125,
+                exposure=0.75,
+                similarity="cluster-7",
+            ),
+        ),
+    )
+
+    assert prepared.candidates[0].grounded_annotations == (
+        "resolution:1920x1080",
+        "duration:2.000s",
+        "motion:available",
+        "analysis-quality:0.875",
+        "blur:0.125",
+        "exposure:0.75",
+        "similarity:cluster-7",
+    )
+
+
+def test_precomputed_evidence_survives_raw_photo_source_preparation() -> None:
+    """Already-computed visual evidence remains available when there is no clip wrapper."""
+    photo = make_asset("analysed-photo")
+    photo.type = AssetType.IMAGE
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(
+            source_fetcher=lambda _scope: (photo,),
+            source_evidence=lambda _source: SourceEvidence(
+                blur=0.25,
+                exposure=0.5,
+                similarity="photo-cluster",
+            ),
+        ),
+    )
+
+    assert prepared.candidates[0].grounded_annotations == (
+        "duration:10.000s",
+        "blur:0.25",
+        "exposure:0.5",
+        "similarity:photo-cluster",
+    )
+
+
+def test_a_live_photo_component_is_not_a_candidate_beside_its_still() -> None:
+    """Immich lists the motion half as its own asset; it is the photograph, not a second visual."""
+    shutter = datetime(2023, 6, 16, 6, 52, 28, 616000, tzinfo=UTC)
+    still = make_asset("still", original_file_name="IMG_0955.JPG", file_created_at=shutter)
+    still.type = AssetType.IMAGE
+    still.live_photo_video_id = "motion"
+    # Measured on the real library: the component is filed a beat BEFORE its own
+    # still, so it reaches the pool first and cannot be resolved by arrival order.
+    motion = make_asset(
+        "motion",
+        original_file_name="IMG_0955.MOV",
+        file_created_at=shutter - timedelta(seconds=1, milliseconds=616),
+    )
+    motion.type = AssetType.VIDEO
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (motion, still)),
+    )
+
+    assert prepared.candidate_ids == ("still",)
+    assert prepared.excluded_ids == ("motion",)
+
+
+def test_an_owner_excluded_still_still_claims_its_own_component() -> None:
+    """Dropping the photograph must not readmit the same instant as footage."""
+    shutter = datetime(2023, 6, 16, 6, 52, 28, tzinfo=UTC)
+    still = make_asset("still", file_created_at=shutter)
+    still.type = AssetType.IMAGE
+    still.live_photo_video_id = "motion"
+    motion = make_asset("motion", file_created_at=shutter - timedelta(seconds=1))
+    motion.type = AssetType.VIDEO
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(
+            scope=SourceScope(),
+            owner_excluded_asset_ids=("still",),
+        ),
+        EditorialDependencies(source_fetcher=lambda _scope: (motion, still)),
+    )
+
+    assert prepared.candidate_ids == ()
+    assert prepared.excluded_ids == ("motion", "still")
+
+
+def test_a_video_no_still_claims_is_footage_and_stays_a_candidate() -> None:
+    """Only a claimed component is a photograph's half; everything else was filmed."""
+    shutter = datetime(2023, 6, 16, 7, 4, 10, tzinfo=UTC)
+    still = make_asset("still", file_created_at=shutter)
+    still.type = AssetType.IMAGE
+    still.live_photo_video_id = "claimed"
+    claimed = make_asset("claimed", file_created_at=shutter - timedelta(seconds=1))
+    claimed.type = AssetType.VIDEO
+    filmed = make_asset("filmed", file_created_at=shutter + timedelta(minutes=5))
+    filmed.type = AssetType.VIDEO
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(scope=SourceScope()),
+        EditorialDependencies(source_fetcher=lambda _scope: (claimed, still, filmed)),
+    )
+
+    assert prepared.candidate_ids == ("still", "filmed")
+    assert prepared.excluded_ids == ("claimed",)
+
+
+def test_material_that_never_came_from_this_camera_is_not_editorial_source() -> None:
+    """Half a real month is forwarded graphics, and none of it is theirs to remember.
+
+    Measured on the real library: 282 of 543 June visuals and 350 of 654 in
+    August carry no camera at all. The story built on them was about a festival
+    the owner never attended.
+    """
+    when = datetime(2023, 8, 5, 12, tzinfo=UTC)
+    theirs = make_asset("theirs", original_file_name="IMG_0776.HEIC", file_created_at=when)
+    theirs.type = AssetType.IMAGE
+    forwarded = make_asset(
+        "forwarded",
+        original_file_name="8cfb4458-b9a5-4a2c-afff-f594d861fdb1.jpg",
+        exif_make=None,
+        exif_model=None,
+        file_created_at=when,
+    )
+    forwarded.type = AssetType.IMAGE
+    messaged = make_asset(
+        "messaged",
+        original_file_name="img-20230805-wa0007.jpg",
+        file_created_at=when,
+    )
+    messaged.type = AssetType.IMAGE
+    starred = make_asset(
+        "starred",
+        original_file_name="c810423e-51b7-4a56-8e5b-977cee49338a.jpg",
+        exif_make=None,
+        exif_model=None,
+        is_favorite=True,
+        file_created_at=when,
+    )
+    starred.type = AssetType.IMAGE
+
+    prepared = prepare_editorial_source(
+        EditorialSelectionRequest(
+            scope=SourceScope(
+                excluded_filename_patterns=("img-*-wa[0-9][0-9][0-9][0-9]*",),
+                stills_need_a_camera=True,
+            )
+        ),
+        EditorialDependencies(source_fetcher=lambda _s: (theirs, forwarded, messaged, starred)),
+    )
+
+    # The star settles it here as it settles every other hard gate.
+    assert set(prepared.candidate_ids) == {"theirs", "starred"}
+    assert set(prepared.excluded_ids) == {"forwarded", "messaged"}

--- a/tests/test_subject_policy.py
+++ b/tests/test_subject_policy.py
@@ -231,6 +231,15 @@ def test_a_junk_label_is_unknown_not_a_guess() -> None:
     )
 
 
+def test_new_editorial_path_exposes_subject_as_evidence_without_a_keep_decision() -> None:
+    """The fused scan receives a closed-set observation, not a quota outcome."""
+    from immich_memories.analysis.subject_policy import subject_evidence
+
+    assert subject_evidence(tagged_people=2, category="screen") == "subject-evidence:people"
+    assert subject_evidence(tagged_people=0, category="screen") == "subject-evidence:screen"
+    assert subject_evidence(tagged_people=0, category=None) == "subject-evidence:unknown"
+
+
 def test_the_bar_ignores_candidates_that_were_never_semantically_scored() -> None:
     """ClipWithSegment.score is not one scale. An analysed clip carries its
     segment's semantic score; a clip that was only pre-filtered carries

--- a/tests/test_visual_atlas.py
+++ b/tests/test_visual_atlas.py
@@ -1,0 +1,93 @@
+"""The reusable visual atlas turns local visual evidence into stable tiles."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from PIL import Image
+
+
+def _jpeg(path: Path, colour: str) -> Path:
+    Image.new("RGB", (48, 32), colour).save(path, "JPEG")
+    return path
+
+
+def test_video_tile_is_one_locally_composed_chronological_filmstrip(tmp_path: Path) -> None:
+    """A video consumes one tile even though its locally decoded frames show motion."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+    frames = tuple(_jpeg(tmp_path / f"{colour}.jpg", colour) for colour in ("red", "green", "blue"))
+    source = AtlasSource(
+        asset=SimpleNamespace(id="video-1", is_video=True),
+        motion_path=tmp_path / "video.mp4",
+        proposed_segment=(0.0, 3.0),
+    )
+
+    # WHY: frame decoding is the FFmpeg boundary; this test specifies atlas composition only.
+    with patch(
+        "immich_memories.analysis.visual_atlas.sample_segment_frames", return_value=frames
+    ) as sample:
+        atlas = build_visual_atlas((source,), frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for("video-1")
+    assert sample.call_count == 1
+    assert tile.kind == "filmstrip"
+    assert tile.frame_count == 3
+    assert tile.sha256 == sha256(tile.jpeg_bytes).hexdigest()
+
+
+def test_live_photo_motion_is_one_locally_composed_chronological_filmstrip(
+    tmp_path: Path,
+) -> None:
+    """A Live Photo uses its local motion companion even though it is not a video asset."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+    frames = tuple(
+        _jpeg(tmp_path / f"live-{colour}.jpg", colour) for colour in ("red", "green", "blue")
+    )
+    motion_path = tmp_path / "live-photo.mov"
+    motion_path.write_bytes(b"motion")
+    source = AtlasSource(
+        asset=SimpleNamespace(
+            id="live-photo-1",
+            is_video=False,
+            is_live_photo=True,
+            live_photo_video_id="motion-asset-1",
+        ),
+        motion_path=motion_path,
+        proposed_segment=(0.0, 3.0),
+    )
+
+    # WHY: frame decoding is the FFmpeg boundary; this test specifies atlas composition only.
+    with patch(
+        "immich_memories.analysis.visual_atlas.sample_segment_frames", return_value=frames
+    ) as sample:
+        atlas = build_visual_atlas((source,), frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for("live-photo-1")
+    assert sample.call_count == 1
+    assert tile.kind == "filmstrip"
+    assert tile.frame_count == 3
+
+
+def test_photo_tile_reuses_a_cached_preview_without_a_requester(tmp_path: Path) -> None:
+    """Photo evidence is loaded from the local thumbnail cache, never fetched by the atlas."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+    from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+    preview = _jpeg(tmp_path / "preview.jpg", "purple").read_bytes()
+    cache = ThumbnailCache(tmp_path / "thumbnails")
+    cache.put("photo-1", "preview", preview)
+
+    atlas = build_visual_atlas(
+        (AtlasSource(asset=SimpleNamespace(id="photo-1", is_video=False)),),
+        frame_cache_dir=None,
+        thumbnail_cache=cache,
+    )
+
+    tile = atlas.tile_for("photo-1")
+    assert tile.kind == "photo"
+    assert tile.jpeg_bytes == preview

--- a/tests/test_visual_request_planner.py
+++ b/tests/test_visual_request_planner.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
 from immich_memories.analysis.visual_request_planner import (
     SheetGroup,
@@ -54,3 +56,16 @@ def test_confirmed_limit_packs_only_complete_ordered_groups() -> None:
     )
 
     assert [plan.group_ids for plan in plans] == [("a", "b"), ("c",)]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"max_pages_per_request": 0},
+        {"max_output_tokens": 0},
+        {"timeout_seconds": 0},
+    ),
+)
+def test_visual_request_limits_reject_non_positive_transport_budgets(overrides) -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        VisionRequestLimits(**overrides)

--- a/tests/test_visual_request_planner.py
+++ b/tests/test_visual_request_planner.py
@@ -1,0 +1,56 @@
+"""Visual-request plans preserve groups before any provider call is made."""
+
+from pathlib import Path
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
+from immich_memories.analysis.visual_request_planner import (
+    SheetGroup,
+    VisionRequestLimits,
+    plan_visual_requests,
+)
+
+
+def _page(group_id: str, number: int = 1) -> ContactSheetPage:
+    data = f"jpeg-{group_id}-{number}".encode()
+    return ContactSheetPage(
+        sheet_id=f"{group_id}-{number}",
+        path=Path(f"/{group_id}-{number}.jpg"),
+        jpeg_bytes=data,
+        sha256=__import__("hashlib").sha256(data).hexdigest(),
+        tile_refs=(TileRef(number, f"{group_id}-{number}"),),
+        layout_version="1",
+    )
+
+
+def _group(group_id: str, pages: int = 1) -> SheetGroup:
+    return SheetGroup(
+        group_id=group_id, pages=tuple(_page(group_id, page) for page in range(1, pages + 1))
+    )
+
+
+def test_request_plan_conserves_groups_without_guessing_provider_limits() -> None:
+    plans = plan_visual_requests(groups=(_group("a"), _group("b")), limits=VisionRequestLimits())
+
+    assert tuple(group_id for plan in plans for group_id in plan.group_ids) == ("a", "b")
+    assert all(len(plan.pages) == 1 for plan in plans)
+
+
+def test_oversized_group_has_explicit_ordered_continuations() -> None:
+    plans = plan_visual_requests(groups=(_group("episode", pages=3),), limits=VisionRequestLimits())
+
+    assert [
+        (plan.group_ids, plan.continuation_number, plan.continuation_count) for plan in plans
+    ] == [
+        (("episode",), 1, 3),
+        (("episode",), 2, 3),
+        (("episode",), 3, 3),
+    ]
+
+
+def test_confirmed_limit_packs_only_complete_ordered_groups() -> None:
+    plans = plan_visual_requests(
+        groups=(_group("a"), _group("b"), _group("c")),
+        limits=VisionRequestLimits(max_pages_per_request=2),
+    )
+
+    assert [plan.group_ids for plan in plans] == [("a", "b"), ("c",)]


### PR DESCRIPTION
Refs #764

Umbrella PR for the contact-sheet editing replacement. Do not merge yet.

This branch is the temporary project trunk. Slice PRs target this branch, not main. Main keeps the current selector until the complete Insight -> Cull/record -> Selects -> Structure -> projection -> Fine Cut flow passes synthetic gates, private June/April/August contact-sheet review, renderer conservation, and public-surface parity.

Current contents are documentation and feature-trunk CI bootstrap only. PR #768 is retained as rejected experimental evidence and is not the implementation base.

Final cutover requirements are recorded in docs/designs/2026-08-25-contact-sheet-editing-process.md and docs/implementation-plans/2026-08-25-contact-sheet-editing-process.md.