### PR TITLE
feat(selection): establish the visual editorial foundation (#764)

### DIFF
--- a/src/immich_memories/analysis/contact_sheets.py
+++ b/src/immich_memories/analysis/contact_sheets.py
@@ -92,6 +92,8 @@ def build_contact_sheets(
     per_sheet: int = MAX_SHEET_TILES,
 ) -> tuple[ContactSheetPage, ...]:
     """Encode each page once, write those exact bytes, and retain its stable mapping."""
+    if not 1 <= per_sheet <= MAX_SHEET_TILES:
+        raise ValueError(f"per_sheet must be between 1 and {MAX_SHEET_TILES}")
     entries = list(tiles)
     entity_ids = [getattr(tile, "entity_id", None) for tile in entries]
     if any(not isinstance(entity_id, str) or not entity_id for entity_id in entity_ids):

--- a/src/immich_memories/analysis/contact_sheets.py
+++ b/src/immich_memories/analysis/contact_sheets.py
@@ -1,0 +1,156 @@
+"""One encoded, numbered contact-sheet format for every editorial pass."""
+
+from __future__ import annotations
+
+import io
+import math
+from contextlib import suppress
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, TypeVar
+
+MAX_SHEET_TILES = 120
+MAX_SHEET_PX = 2100
+LAYOUT_VERSION = "1"
+_TARGET_ASPECT = 1.6
+_MAX_TILE = 400
+_MIN_TILE = 120
+_SHEET_BACKGROUND = (18, 18, 18)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class TileRef:
+    """The stable entity represented by one global tile number."""
+
+    number: int
+    entity_id: str
+
+
+@dataclass(frozen=True)
+class ContactSheetPage:
+    """The exact JPEG evidence that is both stored and attached to a request."""
+
+    sheet_id: str
+    path: Path
+    jpeg_bytes: bytes
+    sha256: str
+    tile_refs: tuple[TileRef, ...]
+    layout_version: str
+
+
+def sheet_layout(count: int) -> tuple[int, int]:
+    """Return the wide grid dimensions for one page of visual evidence."""
+    columns = max(1, round(math.sqrt(count * _TARGET_ASPECT)))
+    tile = min(_MAX_TILE, MAX_SHEET_PX // columns)
+    rows = -(-count // columns)
+    if rows * tile > MAX_SHEET_PX * 1.2:
+        tile = int(MAX_SHEET_PX * 1.2) // rows
+    return columns, max(_MIN_TILE, tile)
+
+
+def sheets_of(items: list[T], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, T]]]:
+    """Split items into bounded pages while keeping tile numbers global."""
+    return [
+        [
+            (offset + number + 1, item)
+            for number, item in enumerate(items[offset : offset + per_sheet])
+        ]
+        for offset in range(0, len(items), per_sheet)
+    ]
+
+
+def tile_sheet(frames: list[tuple[int, Any | None]]):
+    """Lay images in a numbered wide grid without dropping unavailable entries."""
+    from PIL import Image, ImageDraw
+
+    if not frames:
+        return None
+    columns, tile = sheet_layout(len(frames))
+    rows = -(-len(frames) // columns)
+    sheet = Image.new("RGB", (columns * tile, rows * tile), _SHEET_BACKGROUND)
+    draw = ImageDraw.Draw(sheet)
+    label = max(16, tile // 11)
+    for position, (number, frame) in enumerate(frames):
+        left = (position % columns) * tile
+        top = (position // columns) * tile
+        if frame is not None:
+            thumbnail = frame.copy()
+            thumbnail.thumbnail((tile - 6, tile - 6))
+            sheet.paste(thumbnail, (left + 3, top + 3))
+        _draw_number(draw, left, top, label, number)
+    return sheet
+
+
+def build_contact_sheets(
+    tiles: tuple[Any, ...] | list[Any],
+    scope_id: str,
+    output_dir: Path,
+    *,
+    per_sheet: int = MAX_SHEET_TILES,
+) -> tuple[ContactSheetPage, ...]:
+    """Encode each page once, write those exact bytes, and retain its stable mapping."""
+    entries = list(tiles)
+    entity_ids = [getattr(tile, "entity_id", None) for tile in entries]
+    if any(not isinstance(entity_id, str) or not entity_id for entity_id in entity_ids):
+        raise ValueError("contact sheet tiles need non-empty entity IDs")
+    if len(set(entity_ids)) != len(entity_ids):
+        raise ValueError("contact sheet tiles must have unique entity IDs")
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(f"cannot create contact sheet directory: {output_dir}") from exc
+
+    pages: list[ContactSheetPage] = []
+    for page_index, numbered in enumerate(sheets_of(entries, per_sheet), start=1):
+        frames = [
+            (number, _image_for(tile, tile_size=sheet_layout(len(numbered))[1]))
+            for number, tile in numbered
+        ]
+        sheet = tile_sheet(frames)
+        assert sheet is not None
+        jpeg_bytes = _encode_jpeg(sheet)
+        sheet_id = f"{scope_id}-{page_index:03d}"
+        path = output_dir / f"{sheet_id}.jpg"
+        path.write_bytes(jpeg_bytes)
+        pages.append(
+            ContactSheetPage(
+                sheet_id=sheet_id,
+                path=path,
+                jpeg_bytes=jpeg_bytes,
+                sha256=sha256(jpeg_bytes).hexdigest(),
+                tile_refs=tuple(TileRef(number, tile.entity_id) for number, tile in numbered),
+                layout_version=LAYOUT_VERSION,
+            )
+        )
+    return tuple(pages)
+
+
+def _image_for(tile: Any, *, tile_size: int):
+    from PIL import Image, ImageDraw
+
+    data = getattr(tile, "jpeg_bytes", None)
+    if isinstance(data, bytes):
+        with suppress(OSError), Image.open(io.BytesIO(data)) as decoded:
+            return decoded.convert("RGB")
+    image = Image.new("RGB", (tile_size - 6, tile_size - 6), (35, 35, 35))
+    reason = getattr(tile, "unavailable_reason", None) or "unavailable"
+    ImageDraw.Draw(image).text((8, 8), reason, fill=(220, 220, 220))
+    return image
+
+
+def _encode_jpeg(sheet: Any) -> bytes:
+    buffer = io.BytesIO()
+    sheet.save(buffer, "JPEG", quality=85)
+    return buffer.getvalue()
+
+
+def _draw_number(draw: Any, left: int, top: int, label: int, number: int) -> None:
+    text = str(number)
+    draw.rectangle(
+        [left + 3, top + 3, left + 3 + label * (0.6 * len(text) + 0.8), top + 3 + label],
+        fill=(0, 0, 0),
+    )
+    draw.text((left + 7, top + 5), text, fill=(255, 255, 255))

--- a/src/immich_memories/analysis/editorial_contracts.py
+++ b/src/immich_memories/analysis/editorial_contracts.py
@@ -59,3 +59,21 @@ class RequestTrace:
 
     provenance: DecisionProvenance
     attached_sheet_hashes: tuple[str, ...]
+    planned_calls: int = 1
+    actual_calls: int = 0
+    cache_hit: bool = False
+    tile_count: int = 0
+    provider: str = ""
+    model: str = ""
+    attempts: tuple[RequestAttemptTrace, ...] = ()
+    original_provenance: DecisionProvenance | None = None
+
+
+@dataclass(frozen=True)
+class RequestAttemptTrace:
+    """One wire attempt, including failures and request dialect adjustments."""
+
+    attempt: int
+    outcome: str
+    status_code: int | None = None
+    adaptation: str | None = None

--- a/src/immich_memories/analysis/editorial_contracts.py
+++ b/src/immich_memories/analysis/editorial_contracts.py
@@ -1,0 +1,61 @@
+"""Immutable records exchanged between editorial selection passes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DecisionProvenance:
+    """Evidence that lets a decision be reproduced from its original request."""
+
+    pass_name: str
+    pass_version: str
+    schema_version: str
+    model_identity: str
+    input_ids: tuple[str, ...]
+    sheet_hashes: tuple[str, ...]
+    request_key: str
+    cache_hit: bool
+
+
+@dataclass(frozen=True)
+class TraceDecision:
+    """One asset's named editorial fate."""
+
+    asset_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ConservationCheck:
+    """Whether an editorial pass gave every input exactly one fate."""
+
+    valid: bool
+    missing_ids: tuple[str, ...]
+    duplicate_ids: tuple[str, ...]
+    unexpected_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PassTrace:
+    """The immutable record of one editorial pass."""
+
+    name: str
+    input_ids: tuple[str, ...]
+    kept_ids: tuple[str, ...]
+    rejected: tuple[TraceDecision, ...]
+    unresolved: tuple[TraceDecision, ...]
+    duration_before: float
+    duration_after: float
+    provenance: DecisionProvenance
+    request_traces: tuple[RequestTrace, ...] = ()
+    conservation: ConservationCheck | None = None
+
+
+@dataclass(frozen=True)
+class RequestTrace:
+    """The request provenance associated with one editorial pass."""
+
+    provenance: DecisionProvenance
+    attached_sheet_hashes: tuple[str, ...]

--- a/src/immich_memories/analysis/editorial_gateway.py
+++ b/src/immich_memories/analysis/editorial_gateway.py
@@ -142,6 +142,8 @@ class VisualEditorialGateway:
                     require_complete=True,
                 )
             )
+            if not raw_text.strip():
+                raise ValueError("visual editorial answer must be nonblank")
         except Exception:
             self._record(
                 provenance,

--- a/src/immich_memories/analysis/editorial_gateway.py
+++ b/src/immich_memories/analysis/editorial_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
@@ -87,6 +88,7 @@ class VisualEditorialGateway:
             thinking=request.thinking,
             image_detail=request.image_detail,
             pass_name=request.pass_name,
+            pass_version=request.pass_version,
             prompt_version=request.prompt_version,
             schema_version=request.schema_version,
             render_version=request.render_version,
@@ -129,7 +131,7 @@ class VisualEditorialGateway:
             )
 
         try:
-            raw_text = asyncio.run(
+            raw_text = _run_sync(
                 query_llm(
                     request.prompt,
                     self.llm_config,
@@ -137,6 +139,7 @@ class VisualEditorialGateway:
                     images=tuple(page.jpeg_bytes for page in request.pages),
                     image_detail=request.image_detail,
                     transport_observer=record_attempt,
+                    require_complete=True,
                 )
             )
         except Exception:
@@ -193,6 +196,28 @@ def _validated_page_hashes(pages: tuple[ContactSheetPage, ...]) -> tuple[str, ..
     if any(digest != page.sha256 for digest, page in zip(hashes, pages, strict=True)):
         raise ValueError("contact sheet digest does not match its exact bytes")
     return hashes
+
+
+def _run_sync(coroutine: object) -> str:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)  # type: ignore[arg-type]
+    result: list[str] = []
+    failure: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            result.append(asyncio.run(coroutine))  # type: ignore[arg-type]
+        except BaseException as exc:  # WHY: preserve the provider exception across the bridge
+            failure.append(exc)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join()
+    if failure:
+        raise failure[0]
+    return result[0]
 
 
 def _provenance(

--- a/src/immich_memories/analysis/editorial_gateway.py
+++ b/src/immich_memories/analysis/editorial_gateway.py
@@ -1,0 +1,233 @@
+"""Provider-neutral, synchronous gateway for banked visual editorial calls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Protocol
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    RequestAttemptTrace,
+    RequestTrace,
+)
+from immich_memories.analysis.llm_query import LLMTransportAttempt, query_llm
+from immich_memories.analysis.selection_trace import Trace
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+from immich_memories.cache.judgment_cache import VisualJudgmentCache, VisualJudgmentIdentity
+from immich_memories.config_models_llm import LLMConfig
+
+__all__ = [
+    "BankedVisualAnswer",
+    "EditorialGateway",
+    "VisualEditorialGateway",
+    "VisualEditorialRequest",
+]
+
+
+@dataclass(frozen=True)
+class VisualEditorialRequest:
+    """All non-semantic evidence and versioning supplied to one visual pass."""
+
+    pass_name: str
+    pass_version: str
+    prompt: str
+    prompt_version: str
+    schema_version: str
+    pages: tuple[ContactSheetPage, ...]
+    ordered_input_ids: tuple[str, ...]
+    ordered_group_ids: tuple[str, ...]
+    grounded_annotations: tuple[str, ...]
+    upstream_material: tuple[str, ...]
+    render_version: str
+    limits: VisionRequestLimits
+    thinking: bool = False
+    image_detail: str = "low"
+    continuation_number: int = 1
+    continuation_count: int = 1
+
+
+@dataclass(frozen=True)
+class BankedVisualAnswer:
+    """The raw model answer and provenance for pass-specific parsers to own."""
+
+    raw_text: str
+    provenance: DecisionProvenance
+    original_provenance: DecisionProvenance
+
+
+class EditorialGateway(Protocol):
+    """The only provider-neutral boundary used by editorial passes."""
+
+    def ask(self, request: VisualEditorialRequest) -> BankedVisualAnswer:
+        """Bank and return a complete raw visual answer."""
+
+
+class VisualEditorialGateway:
+    """Synchronous adapter that reuses the established LLM transport."""
+
+    def __init__(self, *, llm_config: LLMConfig, cache_path: Path, trace: Trace) -> None:
+        self.llm_config = llm_config
+        self.cache = VisualJudgmentCache(cache_path)
+        self.trace = trace
+
+    def ask(self, request: VisualEditorialRequest) -> BankedVisualAnswer:
+        """Attach exact page bytes once, or reuse their already banked answer."""
+        page_hashes = _validated_page_hashes(request.pages)
+        identity = VisualJudgmentIdentity(
+            page_bytes=tuple(page.jpeg_bytes for page in request.pages),
+            ordered_input_ids=request.ordered_input_ids,
+            ordered_group_ids=request.ordered_group_ids,
+            annotations=request.grounded_annotations,
+            model=self.llm_config.model,
+            thinking=request.thinking,
+            image_detail=request.image_detail,
+            pass_name=request.pass_name,
+            prompt_version=request.prompt_version,
+            schema_version=request.schema_version,
+            render_version=request.render_version,
+            layout_versions=tuple(page.layout_version for page in request.pages),
+            upstream_material=request.upstream_material,
+            request_limits=(f"max_pages={request.limits.max_pages_per_request}",),
+            continuation_identity=(request.continuation_number, request.continuation_count),
+            endpoint=self.llm_config.base_url.rstrip("/"),
+        )
+        request_key = identity.key()
+        reused = self.cache.answer_for(request_key)
+        if reused is not None:
+            raw_text, original_serialized = reused
+            original = _provenance_from_json(original_serialized)
+            provenance = _provenance(
+                request, page_hashes, request_key, cache_hit=True, model=self.llm_config.model
+            )
+            self._record(
+                provenance,
+                request.pages,
+                page_hashes,
+                cache_hit=True,
+                original_provenance=original,
+            )
+            return BankedVisualAnswer(raw_text, provenance, original)
+
+        provenance = _provenance(
+            request, page_hashes, request_key, cache_hit=False, model=self.llm_config.model
+        )
+        attempts: list[RequestAttemptTrace] = []
+
+        def record_attempt(attempt: LLMTransportAttempt) -> None:
+            attempts.append(
+                RequestAttemptTrace(
+                    attempt=attempt.attempt,
+                    outcome=attempt.outcome,
+                    status_code=attempt.status_code,
+                    adaptation=attempt.adaptation,
+                )
+            )
+
+        try:
+            raw_text = asyncio.run(
+                query_llm(
+                    request.prompt,
+                    self.llm_config,
+                    thinking=request.thinking,
+                    images=tuple(page.jpeg_bytes for page in request.pages),
+                    image_detail=request.image_detail,
+                    transport_observer=record_attempt,
+                )
+            )
+        except Exception:
+            self._record(
+                provenance,
+                request.pages,
+                page_hashes,
+                cache_hit=False,
+                actual_calls=len(attempts),
+                attempts=tuple(attempts),
+            )
+            raise
+        self.cache.remember(request_key, raw_text, _provenance_json(provenance))
+        self._record(
+            provenance,
+            request.pages,
+            page_hashes,
+            cache_hit=False,
+            actual_calls=len(attempts),
+            attempts=tuple(attempts),
+        )
+        return BankedVisualAnswer(raw_text, provenance, provenance)
+
+    def _record(
+        self,
+        provenance: DecisionProvenance,
+        pages: tuple[ContactSheetPage, ...],
+        page_hashes: tuple[str, ...],
+        *,
+        cache_hit: bool,
+        actual_calls: int = 0,
+        original_provenance: DecisionProvenance | None = None,
+        attempts: tuple[RequestAttemptTrace, ...] = (),
+    ) -> None:
+        self.trace.record_request(
+            RequestTrace(
+                provenance=provenance,
+                attached_sheet_hashes=page_hashes,
+                actual_calls=actual_calls,
+                cache_hit=cache_hit,
+                tile_count=sum(len(page.tile_refs) for page in pages),
+                provider=self.llm_config.provider,
+                model=self.llm_config.model,
+                attempts=attempts,
+                original_provenance=original_provenance,
+            )
+        )
+
+
+def _validated_page_hashes(pages: tuple[ContactSheetPage, ...]) -> tuple[str, ...]:
+    if not pages:
+        raise ValueError("visual editorial requests need at least one page")
+    hashes = tuple(sha256(page.jpeg_bytes).hexdigest() for page in pages)
+    if any(digest != page.sha256 for digest, page in zip(hashes, pages, strict=True)):
+        raise ValueError("contact sheet digest does not match its exact bytes")
+    return hashes
+
+
+def _provenance(
+    request: VisualEditorialRequest,
+    page_hashes: tuple[str, ...],
+    request_key: str,
+    *,
+    cache_hit: bool,
+    model: str,
+) -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name=request.pass_name,
+        pass_version=request.pass_version,
+        schema_version=request.schema_version,
+        model_identity=model,
+        input_ids=request.ordered_input_ids,
+        sheet_hashes=page_hashes,
+        request_key=request_key,
+        cache_hit=cache_hit,
+    )
+
+
+def _provenance_json(provenance: DecisionProvenance) -> str:
+    return json.dumps(provenance.__dict__, sort_keys=True)
+
+
+def _provenance_from_json(serialized: str) -> DecisionProvenance:
+    values = json.loads(serialized)
+    return DecisionProvenance(
+        pass_name=values["pass_name"],
+        pass_version=values["pass_version"],
+        schema_version=values["schema_version"],
+        model_identity=values["model_identity"],
+        input_ids=tuple(values["input_ids"]),
+        sheet_hashes=tuple(values["sheet_hashes"]),
+        request_key=values["request_key"],
+        cache_hit=bool(values["cache_hit"]),
+    )

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import logging
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
@@ -22,10 +23,21 @@ from immich_memories.analysis import llm_metrics
 from immich_memories.config_models_llm import LLMConfig
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LLMTransportAttempt:
+    """One actual HTTP POST outcome, kept separate from accepted-reply metrics."""
+
+    attempt: int
+    outcome: str
+    status_code: int | None
+    adaptation: str | None = None
+
 
 # A stuck server should fail while connecting, not hold the full generation
 # budget. httpx timeouts are per-I/O-operation rather than per-request totals,
@@ -145,6 +157,7 @@ async def query_llm(
     images: Sequence[bytes] = (),
     image_detail: str = "low",
     cache_path: Path | None = None,
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> str:
     """Send a prompt, optionally with JPEG images, and return the response.
 
@@ -183,6 +196,7 @@ async def query_llm(
             thinking,
             images,
             image_detail,
+            transport_observer,
         )
     finally:
         # In `finally` so a failed call still shows the time it burned; a run
@@ -234,16 +248,34 @@ async def _dispatch(
     thinking: bool,
     images: Sequence[bytes],
     image_detail: str,
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> str:
     if llm_config.provider == "ollama":
-        return await _query_ollama(prompt, llm_config, temperature, timeout_seconds, images)
+        return await _query_ollama(
+            prompt, llm_config, temperature, timeout_seconds, images, transport_observer
+        )
     think = thinking and llm_config.thinking and not images
     if llm_config.provider == "anthropic":
         return await _query_anthropic(
-            prompt, llm_config, temperature, max_tokens, timeout_seconds, think, images
+            prompt,
+            llm_config,
+            temperature,
+            max_tokens,
+            timeout_seconds,
+            think,
+            images,
+            transport_observer,
         )
     return await _query_openai(
-        prompt, llm_config, temperature, max_tokens, timeout_seconds, think, images, image_detail
+        prompt,
+        llm_config,
+        temperature,
+        max_tokens,
+        timeout_seconds,
+        think,
+        images,
+        image_detail,
+        transport_observer,
     )
 
 
@@ -253,6 +285,7 @@ async def _query_ollama(
     temperature: float,
     timeout: int,
     images: Sequence[bytes] = (),
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     payload: dict = {
@@ -273,6 +306,7 @@ async def _query_ollama(
             payload[name] = value
     async with httpx.AsyncClient(timeout=build_llm_timeout(float(timeout))) as client:
         resp = await client.post(f"{base_url}/api/generate", json=payload)
+        _observe(transport_observer, 1, "response", resp.status_code)
         resp.raise_for_status()
         body = resp.json()
         llm_metrics.record_reply(
@@ -310,6 +344,7 @@ async def _query_anthropic(
     timeout: int,
     thinking: bool = False,
     images: Sequence[bytes] = (),
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> str:
     """Native /v1/messages dialect: Claude, or z.ai's Anthropic endpoint."""
     base_url = config.base_url.rstrip("/")
@@ -332,6 +367,7 @@ async def _query_anthropic(
         timeout=build_llm_timeout(float(timeout)), headers=headers
     ) as client:
         resp = await client.post(f"{base_url}/v1/messages", json=payload)
+        _observe(transport_observer, 1, "response", resp.status_code)
         resp.raise_for_status()
         body = resp.json()
         usage = body.get("usage") or {}
@@ -343,7 +379,14 @@ async def _query_anthropic(
             llm_metrics.record_truncation()
             logger.warning("Thinking hit the token budget; retrying without thinking")
             return await _query_anthropic(
-                prompt, config, temperature, max_tokens, timeout, thinking=False, images=images
+                prompt,
+                config,
+                temperature,
+                max_tokens,
+                timeout,
+                thinking=False,
+                images=images,
+                transport_observer=transport_observer,
             )
         return "".join(b.get("text", "") for b in body["content"] if b.get("type") == "text")
 
@@ -381,6 +424,7 @@ async def _query_openai(
     thinking: bool = False,
     images: Sequence[bytes] = (),
     image_detail: str = "low",
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     headers: dict[str, str] = {}
@@ -439,7 +483,20 @@ async def _query_openai(
                 )
             content = choice["message"]["content"]
             if content is not None:
+                _observe(transport_observer, attempt + 1, "response", resp.status_code)
                 return content
+            _observe(transport_observer, attempt + 1, "null_content", resp.status_code)
             logger.debug("LLM null content (attempt %d/3)", attempt + 1)
     msg = "LLM returned null content after 3 retries"
     raise ValueError(msg)
+
+
+def _observe(
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+    outcome: str,
+    status_code: int | None,
+    adaptation: str | None = None,
+) -> None:
+    if observer is not None:
+        observer(LLMTransportAttempt(attempt, outcome, status_code, adaptation))

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -122,16 +122,25 @@ def _shape_for_provider(payload: dict, config: LLMConfig) -> None:
 
 
 async def _post_adapted(
-    client: httpx.AsyncClient, url: str, payload: dict, adaptations: set[str]
+    client: httpx.AsyncClient,
+    url: str,
+    payload: dict,
+    adaptations: set[str],
+    transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
 ) -> httpx.Response:
     """POST, negotiating parameter dialects on explicit 400s (one per rule)."""
     while True:
-        resp = await client.post(url, json=payload)
+        try:
+            resp = await client.post(url, json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
         if resp.status_code != 400:
             return resp
         adaptation = _adaptation_for(resp.json().get("error", {}).get("message", ""))
         if adaptation is None or adaptation in adaptations:
             return resp
+        _observe(transport_observer, 1, "dialect_adaptation", resp.status_code, adaptation)
         adaptations.add(adaptation)
         _apply_adaptations(payload, adaptations)
         logger.info("LLM server dialect: adapting request (%s)", adaptation)
@@ -158,6 +167,7 @@ async def query_llm(
     image_detail: str = "low",
     cache_path: Path | None = None,
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     """Send a prompt, optionally with JPEG images, and return the response.
 
@@ -185,6 +195,18 @@ async def query_llm(
         logger.debug("Reusing the answer to an identical question")
         llm_metrics.record_cache_hit()
         return remembered
+    attempt_number = 0
+
+    def observe(attempt: LLMTransportAttempt) -> None:
+        nonlocal attempt_number
+        attempt_number += 1
+        if transport_observer is not None:
+            transport_observer(
+                LLMTransportAttempt(
+                    attempt_number, attempt.outcome, attempt.status_code, attempt.adaptation
+                )
+            )
+
     started = time.monotonic()
     try:
         answer = await _dispatch(
@@ -196,7 +218,8 @@ async def query_llm(
             thinking,
             images,
             image_detail,
-            transport_observer,
+            observe,
+            require_complete,
         )
     finally:
         # In `finally` so a failed call still shows the time it burned; a run
@@ -249,10 +272,17 @@ async def _dispatch(
     images: Sequence[bytes],
     image_detail: str,
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     if llm_config.provider == "ollama":
         return await _query_ollama(
-            prompt, llm_config, temperature, timeout_seconds, images, transport_observer
+            prompt,
+            llm_config,
+            temperature,
+            timeout_seconds,
+            images,
+            transport_observer,
+            require_complete,
         )
     think = thinking and llm_config.thinking and not images
     if llm_config.provider == "anthropic":
@@ -265,6 +295,7 @@ async def _dispatch(
             think,
             images,
             transport_observer,
+            require_complete,
         )
     return await _query_openai(
         prompt,
@@ -276,6 +307,7 @@ async def _dispatch(
         images,
         image_detail,
         transport_observer,
+        require_complete,
     )
 
 
@@ -286,6 +318,7 @@ async def _query_ollama(
     timeout: int,
     images: Sequence[bytes] = (),
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     payload: dict = {
@@ -305,10 +338,21 @@ async def _query_ollama(
         else:
             payload[name] = value
     async with httpx.AsyncClient(timeout=build_llm_timeout(float(timeout))) as client:
-        resp = await client.post(f"{base_url}/api/generate", json=payload)
-        _observe(transport_observer, 1, "response", resp.status_code)
-        resp.raise_for_status()
+        try:
+            resp = await client.post(f"{base_url}/api/generate", json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError:
+            _observe(transport_observer, 1, "http_error", resp.status_code)
+            raise
         body = resp.json()
+        if require_complete and body.get("done_reason") in {"length", "max_tokens", "truncated"}:
+            _observe(transport_observer, 1, "incomplete", resp.status_code)
+            raise ValueError("LLM returned incomplete content")
+        _observe(transport_observer, 1, "response", resp.status_code)
         llm_metrics.record_reply(
             prompt_tokens=body.get("prompt_eval_count", 0) or 0,
             completion_tokens=body.get("eval_count", 0) or 0,
@@ -345,6 +389,7 @@ async def _query_anthropic(
     thinking: bool = False,
     images: Sequence[bytes] = (),
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     """Native /v1/messages dialect: Claude, or z.ai's Anthropic endpoint."""
     base_url = config.base_url.rstrip("/")
@@ -366,16 +411,27 @@ async def _query_anthropic(
     async with httpx.AsyncClient(
         timeout=build_llm_timeout(float(timeout)), headers=headers
     ) as client:
-        resp = await client.post(f"{base_url}/v1/messages", json=payload)
-        _observe(transport_observer, 1, "response", resp.status_code)
-        resp.raise_for_status()
+        try:
+            resp = await client.post(f"{base_url}/v1/messages", json=payload)
+        except httpx.HTTPError:
+            _observe(transport_observer, 1, "connection_error", None)
+            raise
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError:
+            _observe(transport_observer, 1, "http_error", resp.status_code)
+            raise
         body = resp.json()
         usage = body.get("usage") or {}
         llm_metrics.record_reply(
             prompt_tokens=usage.get("input_tokens", 0) or 0,
             completion_tokens=usage.get("output_tokens", 0) or 0,
         )
+        if body.get("stop_reason") == "max_tokens" and require_complete:
+            _observe(transport_observer, 1, "incomplete", resp.status_code)
+            raise ValueError("LLM returned incomplete content")
         if thinking and body.get("stop_reason") == "max_tokens":
+            _observe(transport_observer, 1, "thinking_fallback", resp.status_code)
             llm_metrics.record_truncation()
             logger.warning("Thinking hit the token budget; retrying without thinking")
             return await _query_anthropic(
@@ -387,7 +443,9 @@ async def _query_anthropic(
                 thinking=False,
                 images=images,
                 transport_observer=transport_observer,
+                require_complete=require_complete,
             )
+        _observe(transport_observer, 1, "response", resp.status_code)
         return "".join(b.get("text", "") for b in body["content"] if b.get("type") == "text")
 
 
@@ -425,6 +483,7 @@ async def _query_openai(
     images: Sequence[bytes] = (),
     image_detail: str = "low",
     transport_observer: Callable[[LLMTransportAttempt], None] | None = None,
+    require_complete: bool = False,
 ) -> str:
     base_url = config.base_url.rstrip("/")
     headers: dict[str, str] = {}
@@ -457,8 +516,10 @@ async def _query_openai(
         timeout=build_llm_timeout(float(timeout)), headers=headers
     ) as client:
         for attempt in range(3):
-            resp = await _post_adapted(client, f"{base_url}/chat/completions", payload, adaptations)
-            resp.raise_for_status()
+            resp = await _post_adapted(
+                client, f"{base_url}/chat/completions", payload, adaptations, transport_observer
+            )
+            _ensure_success(resp, transport_observer)
             body = resp.json()
             choice = body["choices"][0]
             usage = body.get("usage") or {}
@@ -466,7 +527,15 @@ async def _query_openai(
                 prompt_tokens=usage.get("prompt_tokens", 0) or 0,
                 completion_tokens=usage.get("completion_tokens", 0) or 0,
             )
-            if thinking and choice.get("finish_reason") == "length":
+            content, retry_without_thinking = _openai_completion(
+                choice,
+                thinking,
+                require_complete,
+                transport_observer,
+                attempt + 1,
+                resp.status_code,
+            )
+            if retry_without_thinking:
                 llm_metrics.record_truncation()
                 # Truncation mid-think leaves the unfinished reasoning in the
                 # content channel — unparseable. A fast answer beats no answer.
@@ -480,8 +549,9 @@ async def _query_openai(
                     thinking=False,
                     images=images,
                     image_detail=image_detail,
+                    transport_observer=transport_observer,
+                    require_complete=require_complete,
                 )
-            content = choice["message"]["content"]
             if content is not None:
                 _observe(transport_observer, attempt + 1, "response", resp.status_code)
                 return content
@@ -489,6 +559,24 @@ async def _query_openai(
             logger.debug("LLM null content (attempt %d/3)", attempt + 1)
     msg = "LLM returned null content after 3 retries"
     raise ValueError(msg)
+
+
+def _openai_completion(
+    choice: dict,
+    thinking: bool,
+    require_complete: bool,
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+    status_code: int,
+) -> tuple[str | None, bool]:
+    truncated = choice.get("finish_reason") == "length"
+    if truncated and require_complete:
+        _observe(observer, attempt, "incomplete", status_code)
+        raise ValueError("LLM returned incomplete content")
+    if truncated and thinking:
+        _observe(observer, attempt, "thinking_fallback", status_code)
+        return None, True
+    return choice["message"]["content"], False
 
 
 def _observe(
@@ -500,3 +588,13 @@ def _observe(
 ) -> None:
     if observer is not None:
         observer(LLMTransportAttempt(attempt, outcome, status_code, adaptation))
+
+
+def _ensure_success(
+    response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError:
+        _observe(observer, 1, "http_error", response.status_code)
+        raise

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -137,7 +137,14 @@ async def _post_adapted(
             raise
         if resp.status_code != 400:
             return resp
-        adaptation = _adaptation_for(resp.json().get("error", {}).get("message", ""))
+        try:
+            error = _response_body(resp).get("error", {})
+            if not isinstance(error, dict):
+                raise TypeError("LLM error body is not an object")
+            adaptation = _adaptation_for(str(error.get("message", "")))
+        except (TypeError, ValueError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
         if adaptation is None or adaptation in adaptations:
             return resp
         _observe(transport_observer, 1, "dialect_adaptation", resp.status_code, adaptation)
@@ -348,7 +355,14 @@ async def _query_ollama(
         except httpx.HTTPStatusError:
             _observe(transport_observer, 1, "http_error", resp.status_code)
             raise
-        body = resp.json()
+        try:
+            body = _response_body(resp)
+            raw_text = body["response"]
+            if not isinstance(raw_text, str):
+                raise TypeError("Ollama response content is not text")
+        except (KeyError, TypeError, ValueError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
         if require_complete and body.get("done_reason") in {"length", "max_tokens", "truncated"}:
             _observe(transport_observer, 1, "incomplete", resp.status_code)
             raise ValueError("LLM returned incomplete content")
@@ -357,7 +371,7 @@ async def _query_ollama(
             prompt_tokens=body.get("prompt_eval_count", 0) or 0,
             completion_tokens=body.get("eval_count", 0) or 0,
         )
-        return body["response"]
+        return raw_text
 
 
 def _anthropic_content(prompt: str, images: Sequence[bytes]) -> str | list[dict]:
@@ -421,8 +435,7 @@ async def _query_anthropic(
         except httpx.HTTPStatusError:
             _observe(transport_observer, 1, "http_error", resp.status_code)
             raise
-        body = resp.json()
-        usage = body.get("usage") or {}
+        body, usage, raw_text = _anthropic_answer(resp, transport_observer)
         llm_metrics.record_reply(
             prompt_tokens=usage.get("input_tokens", 0) or 0,
             completion_tokens=usage.get("output_tokens", 0) or 0,
@@ -446,7 +459,7 @@ async def _query_anthropic(
                 require_complete=require_complete,
             )
         _observe(transport_observer, 1, "response", resp.status_code)
-        return "".join(b.get("text", "") for b in body["content"] if b.get("type") == "text")
+        return raw_text
 
 
 def _openai_content(
@@ -520,20 +533,12 @@ async def _query_openai(
                 client, f"{base_url}/chat/completions", payload, adaptations, transport_observer
             )
             _ensure_success(resp, transport_observer)
-            body = resp.json()
-            choice = body["choices"][0]
-            usage = body.get("usage") or {}
-            llm_metrics.record_reply(
-                prompt_tokens=usage.get("prompt_tokens", 0) or 0,
-                completion_tokens=usage.get("completion_tokens", 0) or 0,
-            )
-            content, retry_without_thinking = _openai_completion(
-                choice,
+            content, retry_without_thinking = _interpret_openai_response(
+                resp,
                 thinking,
                 require_complete,
                 transport_observer,
                 attempt + 1,
-                resp.status_code,
             )
             if retry_without_thinking:
                 llm_metrics.record_truncation()
@@ -579,6 +584,56 @@ def _openai_completion(
     return choice["message"]["content"], False
 
 
+def _anthropic_answer(
+    response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> tuple[dict, dict, str]:
+    """Decode the native Anthropic body before using any of its fields."""
+    try:
+        body = _response_body(response)
+        usage = body.get("usage") or {}
+        content = body["content"]
+        if not isinstance(usage, dict) or not isinstance(content, list):
+            raise TypeError("Anthropic response has an invalid body shape")
+        raw_text = "".join(
+            block.get("text", "") for block in content if block.get("type") == "text"
+        )
+    except (KeyError, TypeError, ValueError, AttributeError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    return body, usage, raw_text
+
+
+def _interpret_openai_response(
+    response: httpx.Response,
+    thinking: bool,
+    require_complete: bool,
+    observer: Callable[[LLMTransportAttempt], None] | None,
+    attempt: int,
+) -> tuple[str | None, bool]:
+    """Parse one OpenAI-style reply and preserve its completed-post outcome."""
+    try:
+        body = _response_body(response)
+        choice = body["choices"][0]
+        usage = body.get("usage") or {}
+        if not isinstance(choice, dict) or not isinstance(usage, dict):
+            raise TypeError("OpenAI response has an invalid body shape")
+    except (KeyError, TypeError, ValueError, IndexError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    try:
+        content, retry_without_thinking = _openai_completion(
+            choice, thinking, require_complete, observer, attempt, response.status_code
+        )
+    except (KeyError, TypeError, AttributeError):
+        _record_invalid_response(observer, response.status_code)
+        raise
+    llm_metrics.record_reply(
+        prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+        completion_tokens=usage.get("completion_tokens", 0) or 0,
+    )
+    return content, retry_without_thinking
+
+
 def _observe(
     observer: Callable[[LLMTransportAttempt], None] | None,
     attempt: int,
@@ -588,6 +643,21 @@ def _observe(
 ) -> None:
     if observer is not None:
         observer(LLMTransportAttempt(attempt, outcome, status_code, adaptation))
+
+
+def _response_body(response: httpx.Response) -> dict:
+    """Decode one provider response as the object every dialect requires."""
+    body = response.json()
+    if not isinstance(body, dict):
+        raise TypeError("LLM response body is not an object")
+    return body
+
+
+def _record_invalid_response(
+    observer: Callable[[LLMTransportAttempt], None] | None, status_code: int
+) -> None:
+    """Trace the one completed POST whose content could not be parsed."""
+    _observe(observer, 1, "invalid_response", status_code)
 
 
 def _ensure_success(

--- a/src/immich_memories/analysis/llm_query.py
+++ b/src/immich_memories/analysis/llm_query.py
@@ -357,20 +357,24 @@ async def _query_ollama(
             raise
         try:
             body = _response_body(resp)
-            raw_text = body["response"]
-            if not isinstance(raw_text, str):
-                raise TypeError("Ollama response content is not text")
-        except (KeyError, TypeError, ValueError):
+        except (TypeError, ValueError):
             _record_invalid_response(transport_observer, resp.status_code)
             raise
         if require_complete and body.get("done_reason") in {"length", "max_tokens", "truncated"}:
             _observe(transport_observer, 1, "incomplete", resp.status_code)
             raise ValueError("LLM returned incomplete content")
-        _observe(transport_observer, 1, "response", resp.status_code)
         llm_metrics.record_reply(
             prompt_tokens=body.get("prompt_eval_count", 0) or 0,
             completion_tokens=body.get("eval_count", 0) or 0,
         )
+        try:
+            raw_text = body["response"]
+            if not isinstance(raw_text, str):
+                raise TypeError("Ollama response content is not text")
+        except (KeyError, TypeError):
+            _record_invalid_response(transport_observer, resp.status_code)
+            raise
+        _observe(transport_observer, 1, "response", resp.status_code)
         return raw_text
 
 
@@ -435,11 +439,12 @@ async def _query_anthropic(
         except httpx.HTTPStatusError:
             _observe(transport_observer, 1, "http_error", resp.status_code)
             raise
-        body, usage, raw_text = _anthropic_answer(resp, transport_observer)
+        body, usage = _anthropic_usage(resp, transport_observer)
         llm_metrics.record_reply(
             prompt_tokens=usage.get("input_tokens", 0) or 0,
             completion_tokens=usage.get("output_tokens", 0) or 0,
         )
+        raw_text = _anthropic_answer(body, resp, transport_observer)
         if body.get("stop_reason") == "max_tokens" and require_complete:
             _observe(transport_observer, 1, "incomplete", resp.status_code)
             raise ValueError("LLM returned incomplete content")
@@ -584,23 +589,33 @@ def _openai_completion(
     return choice["message"]["content"], False
 
 
-def _anthropic_answer(
+def _anthropic_usage(
     response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
-) -> tuple[dict, dict, str]:
-    """Decode the native Anthropic body before using any of its fields."""
+) -> tuple[dict, dict]:
+    """Decode the native Anthropic body far enough to retain usage metrics."""
     try:
         body = _response_body(response)
         usage = body.get("usage") or {}
-        content = body["content"]
-        if not isinstance(usage, dict) or not isinstance(content, list):
-            raise TypeError("Anthropic response has an invalid body shape")
-        raw_text = "".join(
-            block.get("text", "") for block in content if block.get("type") == "text"
-        )
-    except (KeyError, TypeError, ValueError, AttributeError):
+        if not isinstance(usage, dict):
+            raise TypeError("Anthropic usage is not an object")
+    except (TypeError, ValueError):
         _record_invalid_response(observer, response.status_code)
         raise
-    return body, usage, raw_text
+    return body, usage
+
+
+def _anthropic_answer(
+    body: dict, response: httpx.Response, observer: Callable[[LLMTransportAttempt], None] | None
+) -> str:
+    """Validate the Anthropic content after its parseable usage was counted."""
+    try:
+        content = body["content"]
+        if not isinstance(content, list):
+            raise TypeError("Anthropic response content is not a list")
+        return "".join(block.get("text", "") for block in content if block.get("type") == "text")
+    except (KeyError, TypeError, AttributeError):
+        _record_invalid_response(observer, response.status_code)
+        raise
 
 
 def _interpret_openai_response(
@@ -620,6 +635,10 @@ def _interpret_openai_response(
     except (KeyError, TypeError, ValueError, IndexError):
         _record_invalid_response(observer, response.status_code)
         raise
+    llm_metrics.record_reply(
+        prompt_tokens=usage.get("prompt_tokens", 0) or 0,
+        completion_tokens=usage.get("completion_tokens", 0) or 0,
+    )
     try:
         content, retry_without_thinking = _openai_completion(
             choice, thinking, require_complete, observer, attempt, response.status_code
@@ -627,10 +646,6 @@ def _interpret_openai_response(
     except (KeyError, TypeError, AttributeError):
         _record_invalid_response(observer, response.status_code)
         raise
-    llm_metrics.record_reply(
-        prompt_tokens=usage.get("prompt_tokens", 0) or 0,
-        completion_tokens=usage.get("completion_tokens", 0) or 0,
-    )
     return content, retry_without_thinking
 
 

--- a/src/immich_memories/analysis/moment_reading.py
+++ b/src/immich_memories/analysis/moment_reading.py
@@ -14,41 +14,36 @@ real day, 215 photographs read in 14 calls and 22 seconds, against roughly
 from __future__ import annotations
 
 import json
-import math
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from immich_memories.analysis.contact_sheets import (
+    LAYOUT_VERSION,
+    ContactSheetPage,
+    build_contact_sheets,
+)
+from immich_memories.analysis.contact_sheets import (
+    sheet_layout as _sheet_layout,
+)
+from immich_memories.analysis.contact_sheets import (
+    sheets_of as _sheets_of,
+)
+from immich_memories.analysis.contact_sheets import (
+    tile_sheet as _tile_sheet,
+)
+from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+MAX_SHEET_TILES = 120
+MAX_SHEET_PX = 2100
 
 if TYPE_CHECKING:
     from PIL.Image import Image
 
     from immich_memories.config_models_llm import LLMConfig
-
-# A moment goes on ONE sheet. Split across several, each sheet answers about
-# its own third of an event and the first answer wins by accident: measured on
-# a 37-photograph episode, sheet one said "cyclists and cars at a race track"
-# while later sheets named the circuit and the car.
-#
-# Past this many photographs a single sheet is postage stamps, so a very large
-# moment is split rather than shrunk to nothing.
-MAX_SHEET_TILES = 120
-
-# How wide a sheet may be before the encoder downscales it and tiles lose the
-# detail the reading depends on.
-MAX_SHEET_PX = 2100
-
-# Sheets are laid out WIDE, never tall. The same 37 photographs at 1920x2240
-# read worse than at 2080x1300 with SMALLER tiles — the tall sheet described
-# less and its shortlist collapsed to "keep all 37". A tall image is
-# downscaled harder before the model ever sees it, so shape matters more than
-# how big each tile is.
-_TARGET_ASPECT = 1.6
-_MAX_TILE = 400
-_MIN_TILE = 120
-_SHEET_BACKGROUND = (18, 18, 18)
-
-T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -61,26 +56,18 @@ class SheetReading:
 
 
 def sheet_layout(count: int) -> tuple[int, int]:
-    """Columns and tile size for one wide sheet of `count` photographs."""
-    columns = max(1, round(math.sqrt(count * _TARGET_ASPECT)))
-    tile = min(_MAX_TILE, MAX_SHEET_PX // columns)
-    rows = -(-count // columns)
-    if rows * tile > MAX_SHEET_PX * 1.2:
-        tile = int(MAX_SHEET_PX * 1.2) // rows
-    return columns, max(_MIN_TILE, tile)
+    """Return the shared wide grid dimensions used by legacy moment reading."""
+    return _sheet_layout(count)
 
 
-def sheets_of(items: list[T], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, T]]]:
-    """Cut a moment into sheets, numbering tiles across the whole moment.
+def sheets_of(items: list[Any], per_sheet: int = MAX_SHEET_TILES) -> list[list[tuple[int, Any]]]:
+    """Split legacy moment assets through the shared global-numbering policy."""
+    return _sheets_of(items, per_sheet)
 
-    The model answers in tile numbers, so numbering has to run across the
-    moment rather than restart on each sheet — otherwise sheet three's "4"
-    and sheet one's "4" are the same answer about different photographs.
-    """
-    return [
-        [(offset + n + 1, item) for n, item in enumerate(items[offset : offset + per_sheet])]
-        for offset in range(0, len(items), per_sheet)
-    ]
+
+def tile_sheet(frames: list[tuple[int, Image | None]]) -> Image | None:
+    """Build a legacy sheet through the shared tile renderer."""
+    return _tile_sheet(frames)
 
 
 def _objects_in(raw: str) -> list[str]:
@@ -142,40 +129,6 @@ def read_sheet_verdict(raw: str | None) -> SheetReading | None:
             keep=_numbers(payload.get("best")),
         )
     return None
-
-
-def tile_sheet(frames: list[tuple[int, Image | None]]) -> Image | None:
-    """Lay numbered frames out as one image, or nothing if there are none.
-
-    The model answers in tile numbers, so every tile carries its number burnt
-    into the corner. A frame that could not be fetched leaves its number on an
-    empty tile rather than shifting every frame after it — a 404 thumbnail
-    would otherwise silently renumber the rest of the sheet and make the
-    answer point at the wrong photographs.
-    """
-    from PIL import Image, ImageDraw
-
-    if not frames:
-        return None
-    columns, tile = sheet_layout(len(frames))
-    rows = -(-len(frames) // columns)
-    sheet = Image.new("RGB", (columns * tile, rows * tile), _SHEET_BACKGROUND)
-    draw = ImageDraw.Draw(sheet)
-    label = max(16, tile // 11)
-    for position, (number, frame) in enumerate(frames):
-        left = (position % columns) * tile
-        top = (position // columns) * tile
-        if frame is not None:
-            thumbnail = frame.copy()
-            thumbnail.thumbnail((tile - 6, tile - 6))
-            sheet.paste(thumbnail, (left + 3, top + 3))
-        text = str(number)
-        draw.rectangle(
-            [left + 3, top + 3, left + 3 + label * (0.6 * len(text) + 0.8), top + 3 + label],
-            fill=(0, 0, 0),
-        )
-        draw.text((left + 7, top + 5), text, fill=(255, 255, 255))
-    return sheet
 
 
 # Ages that change how a person should be described. A newborn read as one of
@@ -292,27 +245,25 @@ class MomentReading:
 
 def _read_one_sheet(
     numbered: list[tuple[int, Any]],
-    frames: dict[str, Image],
+    page: ContactSheetPage,
     llm_config: LLMConfig,
 ) -> SheetReading | None:
     """Ask about one sheet, or return nothing if it could not be read."""
     import asyncio
-    import io
 
     from immich_memories.analysis.llm_query import query_llm
 
-    sheet = tile_sheet([(n, frames.get(getattr(a, "id", ""))) for n, a in numbered])
-    if sheet is None:
+    if page.layout_version != LAYOUT_VERSION or tuple(
+        reference.entity_id for reference in page.tile_refs
+    ) != tuple(getattr(asset, "id", "") for _number, asset in numbered):
         return None
-    buffer = io.BytesIO()
-    sheet.save(buffer, "JPEG", quality=_SHEET_QUALITY)
     answer = asyncio.run(
         query_llm(
             prompt_for([asset for _n, asset in numbered]),
             llm_config,
             temperature=_SHEET_TEMPERATURE,
             max_tokens=SHEET_ANSWER_TOKENS,
-            images=[buffer.getvalue()],
+            images=[page.jpeg_bytes],
         )
     )
     return read_sheet_verdict(answer)
@@ -323,6 +274,9 @@ def read_moment(
     frames: dict[str, Image],
     llm_config: LLMConfig,
     keep_cap: int | None = None,
+    *,
+    sheet_output_dir: Path | None = None,
+    sheet_recorder: Callable[[ContactSheetPage], None] | None = None,
 ) -> MomentReading:
     """Read a whole moment from its sheets, and keep what they chose.
 
@@ -336,10 +290,14 @@ def read_moment(
     a shortlist out of one would spend the deep look on frames chosen at
     random.
     """
+    pages = _moment_pages(assets, frames, sheet_output_dir)
+    if sheet_recorder is not None:
+        for page in pages:
+            sheet_recorder(page)
     readings: list[SheetReading] = []
     kept: list[Any] = []
-    for sheet in sheets_of(assets):
-        reading = _read_one_sheet(sheet, frames, llm_config)
+    for sheet, page in zip(sheets_of(assets), pages, strict=True):
+        reading = _read_one_sheet(sheet, page, llm_config)
         if reading is None:
             continue
         readings.append(reading)
@@ -357,6 +315,31 @@ def read_moment(
         subjects=tuple(subjects),
         keep=tuple(kept[:keep_cap] if keep_cap else kept),
     )
+
+
+def _moment_pages(
+    assets: list[Any], frames: dict[str, Image], output_dir: Path | None
+) -> tuple[ContactSheetPage, ...]:
+    """Encode all pages once so legacy requests attach precisely the traced bytes."""
+    import tempfile
+
+    sources: list[AtlasSource] = []
+    for asset in assets:
+        asset_id = getattr(asset, "id", "")
+        sources.append(AtlasSource(asset=asset, preview_jpeg=_jpeg_for(frames.get(asset_id))))
+    destination = output_dir or Path(tempfile.mkdtemp(prefix="moment-sheets-"))
+    atlas = build_visual_atlas(sources, frame_cache_dir=None)
+    return build_contact_sheets(atlas.tiles, "moment", destination)
+
+
+def _jpeg_for(frame: Image | None) -> bytes | None:
+    if frame is None:
+        return None
+    import io
+
+    buffer = io.BytesIO()
+    frame.save(buffer, "JPEG", quality=_SHEET_QUALITY)
+    return buffer.getvalue()
 
 
 def place_of(assets: list[Any]) -> str | None:

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -97,6 +97,11 @@ class Trace:
     warnings: list[str] = field(default_factory=list)
     # New editorial passes sit beside the legacy stage adapter until Task 14.
     editorial_passes: list[PassTrace] = field(default_factory=list)
+    requests: list[RequestTrace] = field(default_factory=list)
+
+    def record_request(self, request_trace: RequestTrace) -> None:
+        """Record one planned visual request and every wire outcome it caused."""
+        self.requests.append(request_trace)
 
     def record_editorial_pass(self, pass_trace: PassTrace) -> None:
         """Record one immutable editorial pass and its conservation result."""
@@ -311,6 +316,7 @@ class Trace:
             "editorial_passes": [
                 _editorial_pass_dict(pass_trace) for pass_trace in self.editorial_passes
             ],
+            "requests": [_request_dict(request) for request in self.requests],
             "clips": self.clips,
         }
 
@@ -377,6 +383,26 @@ def _request_dict(request: RequestTrace) -> dict:
     return {
         "provenance": _provenance_dict(request.provenance),
         "attached_sheet_hashes": list(request.attached_sheet_hashes),
+        "planned_calls": request.planned_calls,
+        "actual_calls": request.actual_calls,
+        "cache_hit": request.cache_hit,
+        "tile_count": request.tile_count,
+        "provider": request.provider,
+        "model": request.model,
+        "attempts": [
+            {
+                "attempt": attempt.attempt,
+                "outcome": attempt.outcome,
+                "status_code": attempt.status_code,
+                "adaptation": attempt.adaptation,
+            }
+            for attempt in request.attempts
+        ],
+        "original_provenance": (
+            None
+            if request.original_provenance is None
+            else _provenance_dict(request.original_provenance)
+        ),
     }
 
 

--- a/src/immich_memories/analysis/selection_trace.py
+++ b/src/immich_memories/analysis/selection_trace.py
@@ -15,10 +15,17 @@ from __future__ import annotations
 
 import json
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from immich_memories.analysis.editorial_contracts import (
+    ConservationCheck,
+    DecisionProvenance,
+    PassTrace,
+    RequestTrace,
+    TraceDecision,
+)
 from immich_memories.analysis.selection_coverage import AnalysisCoverage
 
 if TYPE_CHECKING:
@@ -29,6 +36,10 @@ _active: ContextVar[Trace | None] = ContextVar("selection_trace", default=None)
 
 # How many dropped clips to name per stage before summarising the rest.
 _ACCOUNT_LIMIT = 12
+
+
+# A trace is complete in JSON. Markdown names a useful sample and points to it.
+_EDITORIAL_DECISION_LIMIT = 12
 
 
 @dataclass(frozen=True)
@@ -84,6 +95,16 @@ class Trace:
     # could not run is the one this exists for: "0 dropped" has meant both
     # "approved" and "never answered" for as long as the review has existed.
     warnings: list[str] = field(default_factory=list)
+    # New editorial passes sit beside the legacy stage adapter until Task 14.
+    editorial_passes: list[PassTrace] = field(default_factory=list)
+
+    def record_editorial_pass(self, pass_trace: PassTrace) -> None:
+        """Record one immutable editorial pass and its conservation result."""
+        conservation = _check_conservation(pass_trace)
+        recorded = replace(pass_trace, conservation=conservation)
+        self.editorial_passes.append(recorded)
+        if not conservation.valid:
+            self.warnings.append(f"conservation failure in {pass_trace.name}")
 
     def record(
         self,
@@ -96,8 +117,9 @@ class Trace:
         """Note that `name` turned `before` into `after`."""
         before_list, after_list = list(before), list(after)
         before_ids = {_asset_id(item) for item in before_list}
-        after_ids = {_asset_id(item) for item in after_list}
-        lost = [item for item in before_list if _asset_id(item) not in after_ids]
+        kept_ids = tuple(_asset_id(item) for item in after_list)
+        after_id_set = set(kept_ids)
+        lost = [item for item in before_list if _asset_id(item) not in after_id_set]
         self._remember(before_list)
         self._remember(after_list)
         self.stages.append(
@@ -109,9 +131,9 @@ class Trace:
                 favorites_out=sum(_is_favorite(i) for i in after_list),
                 reasons=reasons or [],
                 notes=dict(notes or {}),
-                kept_ids=tuple(sorted(after_ids)),
+                kept_ids=kept_ids,
                 lost_ids=tuple(_asset_id(i) for i in lost),
-                gained_ids=tuple(sorted(after_ids - before_ids)),
+                gained_ids=tuple(asset_id for asset_id in kept_ids if asset_id not in before_ids),
             )
         )
 
@@ -171,9 +193,9 @@ class Trace:
 
     def report(self) -> str:
         """The funnel, as text — widest column is where the pool went."""
-        if not self.stages:
+        if not self.stages and not self.editorial_passes:
             return "No selection stages were recorded.\n"
-        width = max(len(s.name) for s in self.stages)
+        width = max((len(s.name) for s in self.stages), default=len("stage"))
         lines = [
             *self._warning_lines(),
             *self._coverage_lines(),
@@ -193,7 +215,28 @@ class Trace:
                 f"{favorites:>12}{marker}"
             )
             lines.extend(f"{' ' * width}    - {reason}" for reason in stage.reasons)
-        return "\n".join([*lines, *self._account_lines()]) + "\n"
+        return "\n".join([*lines, *self._editorial_pass_lines(), *self._account_lines()]) + "\n"
+
+    def _editorial_pass_lines(self) -> list[str]:
+        if not self.editorial_passes:
+            return []
+        lines = ["", "editorial passes", "-" * 16]
+        for pass_trace in self.editorial_passes:
+            decisions = [*pass_trace.rejected, *pass_trace.unresolved]
+            lines.append(
+                f"  {pass_trace.name}: {len(pass_trace.kept_ids)} kept, "
+                f"{len(pass_trace.rejected)} rejected, {len(pass_trace.unresolved)} unresolved"
+            )
+            lines.extend(
+                f"      {decision.asset_id} — {decision.reason}"
+                for decision in decisions[:_EDITORIAL_DECISION_LIMIT]
+            )
+            if len(decisions) > _EDITORIAL_DECISION_LIMIT:
+                lines.append(
+                    f"      showing {_EDITORIAL_DECISION_LIMIT} of {len(decisions)}; "
+                    "full list in JSON"
+                )
+        return lines
 
     def _account_lines(self) -> list[str]:
         """Why each clip is in the cut, and why the rest are not."""
@@ -265,8 +308,89 @@ class Trace:
                 }
                 for s in self.stages
             ],
+            "editorial_passes": [
+                _editorial_pass_dict(pass_trace) for pass_trace in self.editorial_passes
+            ],
             "clips": self.clips,
         }
+
+
+def _check_conservation(pass_trace: PassTrace) -> ConservationCheck:
+    fates = (
+        *pass_trace.kept_ids,
+        *(decision.asset_id for decision in pass_trace.rejected),
+        *(decision.asset_id for decision in pass_trace.unresolved),
+    )
+    fate_counts: dict[str, int] = {}
+    for asset_id in fates:
+        fate_counts[asset_id] = fate_counts.get(asset_id, 0) + 1
+    input_ids = _unique_ids(pass_trace.input_ids)
+    missing_ids = tuple(asset_id for asset_id in input_ids if asset_id not in fate_counts)
+    duplicate_ids = tuple(asset_id for asset_id in input_ids if fate_counts.get(asset_id, 0) > 1)
+    unexpected_ids = tuple(
+        asset_id for asset_id in _unique_ids(fates) if asset_id not in set(input_ids)
+    )
+    return ConservationCheck(
+        valid=not missing_ids and not duplicate_ids and not unexpected_ids,
+        missing_ids=missing_ids,
+        duplicate_ids=duplicate_ids,
+        unexpected_ids=unexpected_ids,
+    )
+
+
+def _unique_ids(asset_ids: tuple[str, ...]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for asset_id in asset_ids:
+        if asset_id not in seen:
+            unique.append(asset_id)
+            seen.add(asset_id)
+    return tuple(unique)
+
+
+def _editorial_pass_dict(pass_trace: PassTrace) -> dict:
+    conservation = pass_trace.conservation or _check_conservation(pass_trace)
+    return {
+        "name": pass_trace.name,
+        "input_ids": list(pass_trace.input_ids),
+        "kept_ids": list(pass_trace.kept_ids),
+        "rejected": [_decision_dict(decision) for decision in pass_trace.rejected],
+        "unresolved": [_decision_dict(decision) for decision in pass_trace.unresolved],
+        "duration_before": pass_trace.duration_before,
+        "duration_after": pass_trace.duration_after,
+        "provenance": _provenance_dict(pass_trace.provenance),
+        "request_traces": [_request_dict(request) for request in pass_trace.request_traces],
+        "conservation": {
+            "valid": conservation.valid,
+            "missing_ids": list(conservation.missing_ids),
+            "duplicate_ids": list(conservation.duplicate_ids),
+            "unexpected_ids": list(conservation.unexpected_ids),
+        },
+    }
+
+
+def _decision_dict(decision: TraceDecision) -> dict:
+    return {"asset_id": decision.asset_id, "reason": decision.reason}
+
+
+def _request_dict(request: RequestTrace) -> dict:
+    return {
+        "provenance": _provenance_dict(request.provenance),
+        "attached_sheet_hashes": list(request.attached_sheet_hashes),
+    }
+
+
+def _provenance_dict(provenance: DecisionProvenance) -> dict:
+    return {
+        "pass_name": provenance.pass_name,
+        "pass_version": provenance.pass_version,
+        "schema_version": provenance.schema_version,
+        "model_identity": provenance.model_identity,
+        "input_ids": list(provenance.input_ids),
+        "sheet_hashes": list(provenance.sheet_hashes),
+        "request_key": provenance.request_key,
+        "cache_hit": provenance.cache_hit,
+    }
 
 
 def _asset_id(item: object) -> str:
@@ -346,16 +470,22 @@ def active() -> Trace | None:
 
 
 def record(
-    name: str,
-    before: Iterable,
-    after: Iterable,
+    name: str | PassTrace,
+    before: Iterable | None = None,
+    after: Iterable | None = None,
     reasons: list[str] | None = None,
     notes: dict[str, str] | None = None,
 ) -> None:
-    """Record a stage when tracing is on; do nothing when it is not."""
+    """Record a legacy stage or editorial pass when tracing is on."""
     trace = _active.get()
-    if trace is not None:
-        trace.record(name, before, after, reasons, notes)
+    if trace is None:
+        return
+    if isinstance(name, PassTrace):
+        trace.record_editorial_pass(name)
+        return
+    if before is None or after is None:
+        raise TypeError("legacy selection stages require both before and after candidates")
+    trace.record(name, before, after, reasons, notes)
 
 
 def warn(message: str) -> None:

--- a/src/immich_memories/analysis/thumbnail_prefetch.py
+++ b/src/immich_memories/analysis/thumbnail_prefetch.py
@@ -35,6 +35,11 @@ logger = logging.getLogger(__name__)
 THUMBNAIL_SIZE = "preview"
 
 
+def cached_preview_bytes(thumbnail_cache: ThumbnailCache, asset_id: str) -> bytes | None:
+    """Read an already-fetched preview without turning atlas construction into a network call."""
+    return thumbnail_cache.get(asset_id, THUMBNAIL_SIZE)
+
+
 class ThumbnailPrefetcher:
     """Best-effort preview fetcher; failures degrade de-dup, never abort the run."""
 

--- a/src/immich_memories/analysis/visual_atlas.py
+++ b/src/immich_memories/analysis/visual_atlas.py
@@ -1,0 +1,172 @@
+"""Local visual evidence that can be reused across editorial contact sheets."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Literal
+
+from immich_memories.analysis.thumbnail_prefetch import cached_preview_bytes
+from immich_memories.processing.frame_sampling import probe_duration, sample_segment_frames
+
+FILMSTRIP_FRAME_COUNT = 3
+FILMSTRIP_WIDTH = 360
+
+
+@dataclass(frozen=True)
+class AtlasSource:
+    """One source asset and the locally available pixels that represent it."""
+
+    asset: Any
+    preview_jpeg: bytes | None = None
+    motion_path: Path | None = None
+    proposed_segment: tuple[float, float] | None = None
+
+
+@dataclass(frozen=True)
+class AtlasTile:
+    """One stable visual tile, including an explicit unavailable state."""
+
+    entity_id: str
+    kind: Literal["photo", "filmstrip", "unavailable"]
+    jpeg_bytes: bytes | None
+    sha256: str | None
+    frame_count: int
+    unavailable_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class VisualAtlas:
+    """Chronological tiles that derived contact sheets can reuse without new reads."""
+
+    tiles: tuple[AtlasTile, ...]
+
+    def tile_for(self, entity_id: str) -> AtlasTile:
+        """Return the tile for one source entity."""
+        for tile in self.tiles:
+            if tile.entity_id == entity_id:
+                return tile
+        raise KeyError(entity_id)
+
+
+def build_visual_atlas(
+    sources: tuple[AtlasSource, ...] | list[AtlasSource],
+    *,
+    frame_cache_dir: Path | None,
+    thumbnail_cache: Any | None = None,
+) -> VisualAtlas:
+    """Build one local visual tile per source, preserving input order exactly."""
+    entity_ids = tuple(_entity_id(source) for source in sources)
+    if len(set(entity_ids)) != len(entity_ids):
+        raise ValueError("visual atlas sources must have unique entity IDs")
+    atlas = VisualAtlas(
+        tuple(_tile_for(source, frame_cache_dir, thumbnail_cache) for source in sources)
+    )
+    for entity_id in entity_ids:
+        atlas.tile_for(entity_id)
+    return atlas
+
+
+def _entity_id(source: AtlasSource) -> str:
+    entity_id = getattr(source.asset, "id", None)
+    if not isinstance(entity_id, str) or not entity_id:
+        raise ValueError("visual atlas sources need a non-empty asset ID")
+    return entity_id
+
+
+def _tile_for(
+    source: AtlasSource, frame_cache_dir: Path | None, thumbnail_cache: Any | None
+) -> AtlasTile:
+    entity_id = _entity_id(source)
+    if _has_motion(source):
+        filmstrip = _filmstrip_for(source, frame_cache_dir)
+        if filmstrip is not None:
+            return AtlasTile(
+                entity_id=entity_id,
+                kind="filmstrip",
+                jpeg_bytes=filmstrip[0],
+                sha256=sha256(filmstrip[0]).hexdigest(),
+                frame_count=filmstrip[1],
+            )
+    preview_jpeg = source.preview_jpeg or _cached_preview(thumbnail_cache, entity_id)
+    if preview_jpeg is not None and _is_jpeg(preview_jpeg):
+        return AtlasTile(
+            entity_id=entity_id,
+            kind="photo",
+            jpeg_bytes=preview_jpeg,
+            sha256=sha256(preview_jpeg).hexdigest(),
+            frame_count=1,
+        )
+    return AtlasTile(
+        entity_id=entity_id,
+        kind="unavailable",
+        jpeg_bytes=None,
+        sha256=None,
+        frame_count=0,
+        unavailable_reason="no usable local preview or motion frames",
+    )
+
+
+def _cached_preview(thumbnail_cache: Any | None, entity_id: str) -> bytes | None:
+    if thumbnail_cache is None:
+        return None
+    return cached_preview_bytes(thumbnail_cache, entity_id)
+
+
+def _has_motion(source: AtlasSource) -> bool:
+    return source.motion_path is not None and bool(getattr(source.asset, "is_video", False))
+
+
+def _filmstrip_for(source: AtlasSource, frame_cache_dir: Path | None) -> tuple[bytes, int] | None:
+    assert source.motion_path is not None
+    start, end = source.proposed_segment or (0.0, probe_duration(source.motion_path))
+    if end <= start:
+        return None
+    frame_paths = sample_segment_frames(
+        source.motion_path,
+        start_time=start,
+        end_time=end,
+        count=FILMSTRIP_FRAME_COUNT,
+        width=FILMSTRIP_WIDTH,
+        cache_dir=frame_cache_dir,
+    )
+    frames = [_open_jpeg(path) for path in frame_paths]
+    usable = [frame for frame in frames if frame is not None]
+    if not usable:
+        return None
+    return _compose_filmstrip(usable), len(usable)
+
+
+def _open_jpeg(path: Path):
+    from PIL import Image
+
+    try:
+        with Image.open(path) as image:
+            return image.convert("RGB")
+    except OSError:
+        return None
+
+
+def _is_jpeg(data: bytes) -> bool:
+    from PIL import Image
+
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            image.verify()
+    except OSError:
+        return False
+    return True
+
+
+def _compose_filmstrip(frames: list[Any]) -> bytes:
+    from PIL import Image, ImageOps
+
+    panel = FILMSTRIP_WIDTH // len(frames)
+    strip = Image.new("RGB", (FILMSTRIP_WIDTH, panel), (18, 18, 18))
+    for index, frame in enumerate(frames):
+        strip.paste(ImageOps.fit(frame, (panel, panel)), (index * panel, 0))
+    buffer = io.BytesIO()
+    strip.save(buffer, "JPEG", quality=85)
+    return buffer.getvalue()

--- a/src/immich_memories/analysis/visual_atlas.py
+++ b/src/immich_memories/analysis/visual_atlas.py
@@ -116,7 +116,9 @@ def _cached_preview(thumbnail_cache: Any | None, entity_id: str) -> bytes | None
 
 
 def _has_motion(source: AtlasSource) -> bool:
-    return source.motion_path is not None and bool(getattr(source.asset, "is_video", False))
+    return source.motion_path is not None and bool(
+        getattr(source.asset, "is_video", False) or getattr(source.asset, "is_live_photo", False)
+    )
 
 
 def _filmstrip_for(source: AtlasSource, frame_cache_dir: Path | None) -> tuple[bytes, int] | None:

--- a/src/immich_memories/analysis/visual_request_planner.py
+++ b/src/immich_memories/analysis/visual_request_planner.py
@@ -1,0 +1,86 @@
+"""Pure planning for bounded visual editorial requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage
+
+__all__ = ["SheetGroup", "VisionRequestLimits", "VisualRequestPlan", "plan_visual_requests"]
+
+
+@dataclass(frozen=True)
+class VisionRequestLimits:
+    """The empirically approved limits for one endpoint and model."""
+
+    max_pages_per_request: int = 1
+
+    def __post_init__(self) -> None:
+        if self.max_pages_per_request < 1:
+            raise ValueError("max_pages_per_request must be at least one")
+
+
+@dataclass(frozen=True)
+class SheetGroup:
+    """One ordered editorial unit that must not be silently separated."""
+
+    group_id: str
+    pages: tuple[ContactSheetPage, ...]
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("sheet groups need an ID")
+        if not self.pages:
+            raise ValueError("sheet groups need at least one page")
+
+
+@dataclass(frozen=True)
+class VisualRequestPlan:
+    """One request and the explicit continuation it represents, if any."""
+
+    group_ids: tuple[str, ...]
+    pages: tuple[ContactSheetPage, ...]
+    continuation_number: int = 1
+    continuation_count: int = 1
+
+
+def plan_visual_requests(
+    *, groups: tuple[SheetGroup, ...], limits: VisionRequestLimits
+) -> tuple[VisualRequestPlan, ...]:
+    """Plan ordered group requests without assuming any provider capability."""
+    plans: list[VisualRequestPlan] = []
+    pending_groups: list[str] = []
+    pending_pages: list[ContactSheetPage] = []
+    for group in groups:
+        if len(group.pages) <= limits.max_pages_per_request:
+            if (
+                pending_pages
+                and len(pending_pages) + len(group.pages) > limits.max_pages_per_request
+            ):
+                plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+                pending_groups, pending_pages = [], []
+            pending_groups.append(group.group_id)
+            pending_pages.extend(group.pages)
+            continue
+        if pending_pages:
+            plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+            pending_groups, pending_pages = [], []
+        chunks = _page_chunks(group.pages, limits.max_pages_per_request)
+        for number, pages in enumerate(chunks, start=1):
+            plans.append(
+                VisualRequestPlan(
+                    group_ids=(group.group_id,),
+                    pages=pages,
+                    continuation_number=number,
+                    continuation_count=len(chunks),
+                )
+            )
+    if pending_pages:
+        plans.append(VisualRequestPlan(tuple(pending_groups), tuple(pending_pages)))
+    return tuple(plans)
+
+
+def _page_chunks(
+    pages: tuple[ContactSheetPage, ...], maximum: int
+) -> tuple[tuple[ContactSheetPage, ...], ...]:
+    return tuple(pages[index : index + maximum] for index in range(0, len(pages), maximum))

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -18,8 +18,10 @@ file can be deleted at any time and costs only the calls it saved.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,61 @@ CREATE TABLE IF NOT EXISTS judgments (
     answered_at TEXT NOT NULL DEFAULT (datetime('now'))
 )
 """
+
+_VISUAL_SCHEMA = """
+CREATE TABLE IF NOT EXISTS visual_judgments (
+    key TEXT PRIMARY KEY,
+    answer TEXT NOT NULL,
+    original_provenance TEXT NOT NULL,
+    answered_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+@dataclass(frozen=True)
+class VisualJudgmentIdentity:
+    """All evidence and request settings that could change a visual answer."""
+
+    page_bytes: tuple[bytes, ...]
+    ordered_input_ids: tuple[str, ...]
+    ordered_group_ids: tuple[str, ...]
+    annotations: tuple[str, ...]
+    model: str | None
+    thinking: bool
+    image_detail: str
+    pass_name: str
+    prompt_version: str
+    schema_version: str
+    render_version: str
+    layout_versions: tuple[str, ...]
+    upstream_material: tuple[str, ...]
+    request_limits: tuple[str, ...]
+    continuation_identity: tuple[int, int]
+    endpoint: str = ""
+
+    def key(self) -> str:
+        """Return the deterministic key without including credentials or paths."""
+        material = {
+            "version": "visual1",
+            "page_hashes": [hashlib.sha256(page).hexdigest() for page in self.page_bytes],
+            "ordered_input_ids": self.ordered_input_ids,
+            "ordered_group_ids": self.ordered_group_ids,
+            "annotations": self.annotations,
+            "model": self.model or "",
+            "thinking": self.thinking,
+            "image_detail": self.image_detail,
+            "pass_name": self.pass_name,
+            "prompt_version": self.prompt_version,
+            "schema_version": self.schema_version,
+            "render_version": self.render_version,
+            "layout_versions": self.layout_versions,
+            "upstream_material": self.upstream_material,
+            "request_limits": self.request_limits,
+            "continuation_identity": self.continuation_identity,
+            "endpoint": self.endpoint,
+        }
+        encoded = json.dumps(material, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
 
 
 def judgment_key(*, model: str | None, prompt: str, thinking: bool) -> str:
@@ -106,5 +163,57 @@ class JudgmentCache:
             conn.commit()
         except sqlite3.Error as exc:
             logger.debug("Judgment cache unwritable (%s): the answer is not kept", exc)
+        finally:
+            conn.close()
+
+
+class VisualJudgmentCache:
+    """A visual-answer cache independent of the legacy prompt-only table."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.execute(_VISUAL_SCHEMA)
+        return conn
+
+    def answer_for(self, key: str) -> tuple[str, str] | None:
+        """Return a banked answer and its original provenance, if available."""
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Visual judgment cache unreadable (%s): asking again", exc)
+            return None
+        try:
+            row = conn.execute(
+                "SELECT answer, original_provenance FROM visual_judgments WHERE key = ?", (key,)
+            ).fetchone()
+        except sqlite3.Error as exc:
+            logger.debug("Visual judgment cache unreadable (%s): asking again", exc)
+            return None
+        finally:
+            conn.close()
+        return (str(row[0]), str(row[1])) if row else None
+
+    def remember(self, key: str, answer: str, original_provenance: str) -> None:
+        """Bank a complete visual answer with the decision that first produced it."""
+        if not answer:
+            return
+        try:
+            conn = self._connect()
+        except (OSError, sqlite3.Error) as exc:
+            logger.debug("Visual judgment cache unwritable (%s): answer not kept", exc)
+            return
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO visual_judgments (key, answer, original_provenance) "
+                "VALUES (?, ?, ?)",
+                (key, answer, original_provenance),
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.debug("Visual judgment cache unwritable (%s): answer not kept", exc)
         finally:
             conn.close()

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -60,6 +60,7 @@ class VisualJudgmentIdentity:
     thinking: bool
     image_detail: str
     pass_name: str
+    pass_version: str
     prompt_version: str
     schema_version: str
     render_version: str
@@ -81,6 +82,7 @@ class VisualJudgmentIdentity:
             "thinking": self.thinking,
             "image_detail": self.image_detail,
             "pass_name": self.pass_name,
+            "pass_version": self.pass_version,
             "prompt_version": self.prompt_version,
             "schema_version": self.schema_version,
             "render_version": self.render_version,

--- a/src/immich_memories/cache/judgment_cache.py
+++ b/src/immich_memories/cache/judgment_cache.py
@@ -201,7 +201,7 @@ class VisualJudgmentCache:
 
     def remember(self, key: str, answer: str, original_provenance: str) -> None:
         """Bank a complete visual answer with the decision that first produced it."""
-        if not answer:
+        if not answer.strip():
             return
         try:
             conn = self._connect()

--- a/src/immich_memories/processing/frame_sampling.py
+++ b/src/immich_memories/processing/frame_sampling.py
@@ -24,6 +24,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _FALLBACK_DURATION_SECONDS = 60.0
+SEGMENT_RENDER_VERSION = "1"
 
 
 def even_timestamps(duration: float, count: int) -> list[float]:
@@ -90,20 +91,6 @@ def _extract_one(video: Path, timestamp: float, width: int, out_path: Path) -> b
     return out_path.exists()
 
 
-def _key_for(video: Path, count: int, width: int) -> str:
-    """What identifies these frames: which video, how many, how wide.
-
-    Size and mtime stand in for content — hashing gigabytes to decide whether
-    to skip a decode would cost more than the decode.
-    """
-    try:
-        stat = video.stat()
-        identity = f"{video.name}:{stat.st_size}:{int(stat.st_mtime)}"
-    except OSError:
-        identity = video.name
-    return hashlib.sha256(f"{identity}:{count}:{width}".encode()).hexdigest()[:16]
-
-
 def sample_frames(
     video: Path,
     *,
@@ -117,23 +104,90 @@ def sample_frames(
     nothing returns an empty list rather than raising: a caller that cannot see
     the pictures should degrade, not fail.
     """
-    target = _prepared_dir(cache_dir, _key_for(video, count, width))
+    duration = probe_duration(video)
+    return list(
+        sample_segment_frames(
+            video,
+            start_time=0.0,
+            end_time=duration if duration > 0 else _FALLBACK_DURATION_SECONDS,
+            count=count,
+            width=width,
+            cache_dir=cache_dir,
+        )
+    )
+
+
+def sample_segment_frames(
+    video: Path,
+    *,
+    start_time: float,
+    end_time: float,
+    count: int,
+    width: int,
+    cache_dir: Path | None,
+    render_version: str | None = None,
+) -> tuple[Path, ...]:
+    """Sample a bounded video segment, caching only complete usable frame sets."""
+    if count <= 0 or width <= 0 or end_time <= start_time or not _usable_video(video):
+        return ()
+    version = render_version or SEGMENT_RENDER_VERSION
+    key = _segment_key_for(video, start_time, end_time, count, width, version)
+    target = _prepared_dir(cache_dir, key)
     if target is not None:
-        cached = sorted(target.glob("frame_*.jpg"))
+        cached = _usable_cached_frames(target, count)
         if len(cached) == count:
-            logger.debug("Reusing %d cached frame(s) for %s", count, video.name)
-            return cached
+            logger.debug("Reusing %d segment frame(s) for %s", count, video.name)
+            return tuple(cached)
 
     out_dir = target if target is not None else _scratch_dir(video)
     if out_dir is None:
-        return []
-
-    frames = []
-    for index, timestamp in enumerate(even_timestamps(probe_duration(video), count)):
+        return ()
+    timestamps = [start_time + moment for moment in even_timestamps(end_time - start_time, count)]
+    frames: list[Path] = []
+    for index, timestamp in enumerate(timestamps):
         out_path = out_dir / f"frame_{index:03d}.jpg"
-        if _extract_one(video, timestamp, width, out_path):
+        if _extract_one(video, timestamp, width, out_path) or (
+            timestamp != start_time and _extract_one(video, start_time, width, out_path)
+        ):
             frames.append(out_path)
-    return frames
+    return tuple(frames)
+
+
+def _segment_key_for(
+    video: Path,
+    start_time: float,
+    end_time: float,
+    count: int,
+    width: int,
+    render_version: str,
+) -> str:
+    """Identify pixels by resolved source metadata and every rendering choice."""
+    try:
+        stat = video.stat()
+        identity = f"{video.resolve()}:{stat.st_size}:{stat.st_mtime_ns}"
+    except OSError:
+        identity = str(video.resolve())
+    payload = f"{identity}:{start_time:.9f}:{end_time:.9f}:{count}:{width}:{render_version}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _usable_video(video: Path) -> bool:
+    """Reject incomplete downloads and empty inputs before invoking FFmpeg."""
+    try:
+        return video.is_file() and video.suffix != ".part" and video.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _usable_cached_frames(target: Path, count: int) -> list[Path]:
+    frames: list[Path] = []
+    for frame in sorted(target.glob("frame_*.jpg")):
+        try:
+            if frame.is_file() and frame.suffix != ".part" and frame.stat().st_size > 0:
+                frames.append(frame)
+        except OSError:
+            continue
+    return frames if len(frames) == count else []
 
 
 def _prepared_dir(cache_dir: Path | None, key: str) -> Path | None:

--- a/tests/test_contact_sheets.py
+++ b/tests/test_contact_sheets.py
@@ -55,3 +55,14 @@ def test_contact_sheets_reject_duplicate_entity_ids(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unique entity IDs"):
         build_contact_sheets((_tile("same", "red"), _tile("same", "blue")), "scope", tmp_path)
+
+
+@pytest.mark.parametrize("per_sheet", (0, -1, 121))
+def test_contact_sheets_reject_per_sheet_outside_the_visual_evidence_limit(
+    tmp_path: Path, per_sheet: int
+) -> None:
+    """Every public override keeps pages positive and at most 120 numbered tiles."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    with pytest.raises(ValueError, match="between 1 and 120"):
+        build_contact_sheets((_tile("asset-1", "red"),), "scope", tmp_path, per_sheet=per_sheet)

--- a/tests/test_contact_sheets.py
+++ b/tests/test_contact_sheets.py
@@ -1,0 +1,57 @@
+"""Encoded contact sheets preserve their exact evidence bytes and references."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from immich_memories.analysis.visual_atlas import AtlasTile
+
+
+def _tile(entity_id: str, colour: str) -> AtlasTile:
+    image = Image.new("RGB", (32, 24), colour)
+    buffer = BytesIO()
+    image.save(buffer, "JPEG")
+    jpeg = buffer.getvalue()
+    return AtlasTile(entity_id, "photo", jpeg, sha256(jpeg).hexdigest(), 1)
+
+
+def test_contact_sheet_writes_and_exposes_the_same_encoded_jpeg_bytes(tmp_path: Path) -> None:
+    """Disk, hash, attachment bytes, and chronological tile references cannot drift."""
+    from immich_memories.analysis.contact_sheets import TileRef, build_contact_sheets
+
+    tiles = tuple(
+        _tile(f"asset-{number}", colour) for number, colour in enumerate(("red", "green"))
+    )
+    page = build_contact_sheets(tiles, scope_id="episode-1", output_dir=tmp_path)[0]
+
+    assert page.path.read_bytes() == page.jpeg_bytes
+    assert sha256(page.jpeg_bytes).hexdigest() == page.sha256
+    assert page.tile_refs == tuple(TileRef(i + 1, tile.entity_id) for i, tile in enumerate(tiles))
+
+
+def test_contact_sheets_preserve_an_unavailable_asset_as_a_numbered_tile(tmp_path: Path) -> None:
+    """Missing pixels must not shift the number of every later visual decision."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    tiles = (
+        _tile("before", "red"),
+        AtlasTile("unavailable", "unavailable", None, None, 0, "no thumbnail"),
+        _tile("after", "blue"),
+    )
+
+    page = build_contact_sheets(tiles, scope_id="episode-1", output_dir=tmp_path)[0]
+
+    assert [ref.entity_id for ref in page.tile_refs] == ["before", "unavailable", "after"]
+
+
+def test_contact_sheets_reject_duplicate_entity_ids(tmp_path: Path) -> None:
+    """A numbered tile can point at exactly one stable entity."""
+    from immich_memories.analysis.contact_sheets import build_contact_sheets
+
+    with pytest.raises(ValueError, match="unique entity IDs"):
+        build_contact_sheets((_tile("same", "red"), _tile("same", "blue")), "scope", tmp_path)

--- a/tests/test_editorial_contracts.py
+++ b/tests/test_editorial_contracts.py
@@ -1,0 +1,53 @@
+"""Editorial pass records are safe to hand from one pass to the next."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from immich_memories.analysis.editorial_contracts import (
+    ConservationCheck,
+    DecisionProvenance,
+    PassTrace,
+    RequestTrace,
+    TraceDecision,
+)
+
+
+def test_editorial_contracts_cannot_rewrite_a_previous_pass() -> None:
+    """A later pass cannot mutate the inputs, fate, or request it inherited."""
+    provenance = DecisionProvenance(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="1",  # noqa: S106 - test-only pass identity
+        schema_version="1",
+        model_identity="test-model",
+        input_ids=("first", "second"),
+        sheet_hashes=("sheet-hash",),
+        request_key="request-key",
+        cache_hit=False,
+    )
+    decision = TraceDecision("second", "unusable exposure")
+    pass_trace = PassTrace(
+        name="cull",
+        input_ids=("first", "second"),
+        kept_ids=("first",),
+        rejected=(decision,),
+        unresolved=(),
+        duration_before=8.0,
+        duration_after=4.0,
+        provenance=provenance,
+    )
+    request = RequestTrace(provenance=provenance, attached_sheet_hashes=("sheet-hash",))
+    conservation = ConservationCheck(valid=True, missing_ids=(), duplicate_ids=())
+
+    with pytest.raises(FrozenInstanceError):
+        provenance.input_ids = ("replacement",)  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        decision.reason = "replacement"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        pass_trace.kept_ids = ()  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        request.attached_sheet_hashes = ()  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        conservation.valid = False  # type: ignore[misc]

--- a/tests/test_editorial_gateway.py
+++ b/tests/test_editorial_gateway.py
@@ -4,6 +4,8 @@ from hashlib import sha256
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
 from immich_memories.analysis.selection_trace import Trace
 from immich_memories.analysis.visual_request_planner import VisionRequestLimits
@@ -153,3 +155,23 @@ def test_gateway_traces_each_null_content_retry_as_a_wire_attempt(tmp_path) -> N
         "null_content",
         "response",
     ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_works_inside_an_active_event_loop(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+
+    async def _answer(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return "complete"
+
+    # WHY: query_llm is the provider boundary; the active loop is the behavior under test.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        assert gateway.ask(_request(_page())).raw_text == "complete"

--- a/tests/test_editorial_gateway.py
+++ b/tests/test_editorial_gateway.py
@@ -157,6 +157,56 @@ def test_gateway_traces_each_null_content_retry_as_a_wire_attempt(tmp_path) -> N
     ]
 
 
+def test_gateway_rejects_whitespace_without_banking_the_real_post(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+    from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    async def _whitespace(*_args, **kwargs):
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return " \n\t"
+
+    # WHY: a completed transport with blank editorial content must still be traceable, not banked.
+    with (
+        patch("immich_memories.analysis.editorial_gateway.query_llm", new=_whitespace),
+        pytest.raises(ValueError, match="nonblank"),
+    ):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 1
+    assert request_trace["attempts"][0]["outcome"] == "response"
+    assert gateway.cache.answer_for(request_trace["provenance"]["request_key"]) is None
+
+
+def test_gateway_traces_an_invalid_provider_response_as_one_real_post(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: malformed provider content arrives after a real POST and must not look like a free failure.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(ValueError, match="not json"),
+    ):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 1
+    assert [attempt["outcome"] for attempt in request_trace["attempts"]] == ["invalid_response"]
+    assert gateway.cache.answer_for(request_trace["provenance"]["request_key"]) is None
+
+
 @pytest.mark.asyncio
 async def test_gateway_works_inside_an_active_event_loop(tmp_path) -> None:
     from immich_memories.analysis.editorial_gateway import VisualEditorialGateway

--- a/tests/test_editorial_gateway.py
+++ b/tests/test_editorial_gateway.py
@@ -1,0 +1,155 @@
+"""The visual gateway banks exact contact-sheet evidence."""
+
+from hashlib import sha256
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
+from immich_memories.analysis.selection_trace import Trace
+from immich_memories.analysis.visual_request_planner import VisionRequestLimits
+from immich_memories.config_models_llm import LLMConfig
+
+
+def _page() -> ContactSheetPage:
+    jpeg = b"exact sheet jpeg"
+    return ContactSheetPage(
+        sheet_id="episode-001",
+        path=Path("/private-sheet.jpg"),
+        jpeg_bytes=jpeg,
+        sha256=sha256(jpeg).hexdigest(),
+        tile_refs=(TileRef(1, "asset-a"), TileRef(2, "asset-b")),
+        layout_version="layout-1",
+    )
+
+
+def _request(page: ContactSheetPage):
+    from immich_memories.analysis.editorial_gateway import VisualEditorialRequest
+
+    return VisualEditorialRequest(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="pass-1",  # noqa: S106 - test-only pass identity
+        prompt="name only clear failures",
+        prompt_version="prompt-1",
+        schema_version="schema-1",
+        pages=(page,),
+        ordered_input_ids=("asset-a", "asset-b"),
+        ordered_group_ids=("episode",),
+        grounded_annotations=("known place",),
+        upstream_material=("insight-1",),
+        render_version="render-1",
+        limits=VisionRequestLimits(),
+    )
+
+
+def test_gateway_attaches_exact_page_bytes_and_traces_the_same_hash(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    page = _page()
+    captured: dict[str, object] = {}
+
+    async def _answer(prompt, config, **kwargs):
+        from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+        captured["images"] = kwargs["images"]
+        kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"rejected": []}'
+
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: query_llm is the sole external provider transport this gateway may use.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        answer = gateway.ask(_request(page))
+
+    assert sha256(captured["images"][0]).hexdigest() == page.sha256
+    assert answer.raw_text == '{"rejected": []}'
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["attached_sheet_hashes"] == [page.sha256]
+    assert request_trace["tile_count"] == 2
+    assert request_trace["actual_calls"] == 1
+
+
+def test_gateway_reuses_banked_answer_with_original_and_reuse_provenance(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    page = _page()
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    calls: list[None] = []
+
+    async def _answer(*_args, **_kwargs):
+        from immich_memories.analysis.llm_query import LLMTransportAttempt
+
+        calls.append(None)
+        _kwargs["transport_observer"](LLMTransportAttempt(1, "response", 200))
+        return '{"rejected": []}'
+
+    # WHY: query_llm is the sole external provider transport this gateway may use.
+    with patch("immich_memories.analysis.editorial_gateway.query_llm", new=_answer):
+        gateway.ask(_request(page))
+        reused = gateway.ask(_request(page))
+
+    assert len(calls) == 1
+    assert reused.provenance.cache_hit is True
+    assert reused.original_provenance.cache_hit is False
+    reuse_trace = trace.as_dict()["requests"][-1]
+    assert reuse_trace["cache_hit"] is True
+    assert reuse_trace["original_provenance"]["cache_hit"] is False
+
+
+def test_gateway_rejects_a_page_whose_digest_does_not_match_its_bytes(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    bad_page = ContactSheetPage(
+        sheet_id="episode-001",
+        path=Path("/private-sheet.jpg"),
+        jpeg_bytes=b"wrong bytes",
+        sha256="not-a-real-digest",
+        tile_refs=(TileRef(1, "asset-a"),),
+        layout_version="layout-1",
+    )
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"),
+        cache_path=tmp_path / "judgments.db",
+        trace=Trace(),
+    )
+
+    import pytest
+
+    with pytest.raises(ValueError, match="digest"):
+        gateway.ask(_request(bad_page))
+
+
+def test_gateway_traces_each_null_content_retry_as_a_wire_attempt(tmp_path) -> None:
+    from immich_memories.analysis.editorial_gateway import VisualEditorialGateway
+
+    response = AsyncMock(status_code=200)
+    response.raise_for_status = lambda: None
+    response.json = MagicMock(
+        return_value={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    )
+    null = AsyncMock(status_code=200)
+    null.raise_for_status = lambda: None
+    null.json = MagicMock(
+        return_value={"choices": [{"message": {"content": None}, "finish_reason": "stop"}]}
+    )
+    trace = Trace()
+    gateway = VisualEditorialGateway(
+        llm_config=LLMConfig(model="vision-test"), cache_path=tmp_path / "judgments.db", trace=trace
+    )
+
+    # WHY: the LLM server is the external boundary; this verifies its retry ledger.
+    with patch("httpx.AsyncClient.post", side_effect=[null, response]):
+        gateway.ask(_request(_page()))
+
+    request_trace = trace.as_dict()["requests"][0]
+    assert request_trace["actual_calls"] == 2
+    assert [attempt["outcome"] for attempt in request_trace["attempts"]] == [
+        "null_content",
+        "response",
+    ]

--- a/tests/test_editorial_trace.py
+++ b/tests/test_editorial_trace.py
@@ -1,0 +1,128 @@
+"""Editorial decision tracing stays complete without changing chronology."""
+
+from __future__ import annotations
+
+from immich_memories.analysis.editorial_contracts import (
+    DecisionProvenance,
+    PassTrace,
+    TraceDecision,
+)
+from immich_memories.analysis.selection_trace import Trace, record, tracing
+
+
+def _provenance(input_ids: tuple[str, ...]) -> DecisionProvenance:
+    return DecisionProvenance(
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="1",  # noqa: S106 - test-only pass identity
+        schema_version="1",
+        model_identity="test-model",
+        input_ids=input_ids,
+        sheet_hashes=("sheet-hash",),
+        request_key="request-key",
+        cache_hit=False,
+    )
+
+
+def test_editorial_pass_keeps_chronology_and_conserves_every_input() -> None:
+    """A pass preserves the editor's order while accounting for every input."""
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=("late", "early", "middle"),
+            kept_ids=("late", "middle"),
+            rejected=(TraceDecision("early", "unusable exposure"),),
+            unresolved=(),
+            duration_before=12.0,
+            duration_after=8.0,
+            provenance=_provenance(("late", "early", "middle")),
+        )
+    )
+
+    payload = trace.as_dict()
+
+    assert payload["editorial_passes"][0]["kept_ids"] == ["late", "middle"]
+    assert payload["editorial_passes"][0]["conservation"]["valid"] is True
+
+
+def test_active_trace_accepts_an_editorial_pass_through_the_existing_adapter() -> None:
+    """The module adapter remains the one trace entry point during migration."""
+    with tracing() as trace:
+        record(
+            PassTrace(
+                name="cull",
+                input_ids=("first",),
+                kept_ids=("first",),
+                rejected=(),
+                unresolved=(),
+                duration_before=4.0,
+                duration_after=4.0,
+                provenance=_provenance(("first",)),
+            )
+        )
+
+    assert trace.as_dict()["editorial_passes"][0]["name"] == "cull"
+
+
+def test_editorial_pass_reports_duplicate_and_missing_fates() -> None:
+    """A bad pass is visible rather than silently losing an editorial input."""
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=("kept-twice", "missing", "rejected"),
+            kept_ids=("kept-twice",),
+            rejected=(
+                TraceDecision("kept-twice", "also rejected"),
+                TraceDecision("rejected", "unusable exposure"),
+            ),
+            unresolved=(),
+            duration_before=12.0,
+            duration_after=4.0,
+            provenance=_provenance(("kept-twice", "missing", "rejected")),
+        )
+    )
+
+    payload = trace.as_dict()
+
+    assert payload["editorial_passes"][0]["conservation"] == {
+        "valid": False,
+        "missing_ids": ["missing"],
+        "duplicate_ids": ["kept-twice"],
+        "unexpected_ids": [],
+    }
+    assert "!! conservation failure" in trace.report()
+
+
+def test_editorial_report_marks_abbreviated_decisions_as_display_only() -> None:
+    """Markdown samples long decisions while JSON keeps every named fate."""
+    input_ids = tuple(f"reject-{number}" for number in range(13))
+    trace = Trace()
+
+    trace.record_editorial_pass(
+        PassTrace(
+            name="cull",
+            input_ids=input_ids,
+            kept_ids=(),
+            rejected=tuple(
+                TraceDecision(asset_id, f"reason {number}")
+                for number, asset_id in enumerate(input_ids)
+            ),
+            unresolved=(),
+            duration_before=52.0,
+            duration_after=0.0,
+            provenance=_provenance(input_ids),
+        )
+    )
+
+    report = trace.report()
+    payload = trace.as_dict()
+
+    assert "showing 12 of 13; full list in JSON" in report
+    assert "reject-12 — reason 12" not in report
+    assert payload["editorial_passes"][0]["rejected"][-1] == {
+        "asset_id": "reject-12",
+        "reason": "reason 12",
+    }

--- a/tests/test_frame_extraction.py
+++ b/tests/test_frame_extraction.py
@@ -10,7 +10,11 @@ run re-decoded the same video forever.
 from pathlib import Path
 from unittest.mock import patch
 
-from immich_memories.processing.frame_sampling import even_timestamps, sample_frames
+from immich_memories.processing.frame_sampling import (
+    even_timestamps,
+    sample_frames,
+    sample_segment_frames,
+)
 
 
 def test_frames_are_spread_evenly_across_the_video() -> None:
@@ -61,6 +65,73 @@ def test_a_different_width_is_a_different_ask(tmp_path) -> None:
         sample_frames(video, count=2, width=320, cache_dir=tmp_path / "frames")
 
     assert len({w for _, w in calls}) == 2, "one width served the other's frames"
+
+
+def test_segment_cache_identity_changes_for_bounds_and_render_version(tmp_path) -> None:
+    """Filmstrip frames never survive a change to the portion or pixel recipe."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    calls: list[float] = []
+
+    def _fake_extract(_video, timestamp, _width, out_path):
+        calls.append(timestamp)
+        out_path.write_bytes(b"jpeg")
+        return True
+
+    # WHY: FFmpeg extraction is external; cache identity is the behavior under test.
+    with patch("immich_memories.processing.frame_sampling._extract_one", new=_fake_extract):
+        first = sample_segment_frames(
+            video, start_time=0, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        same = sample_segment_frames(
+            video, start_time=0, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_segment = sample_segment_frames(
+            video, start_time=1, end_time=2, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_end = sample_segment_frames(
+            video, start_time=0, end_time=3, count=2, width=320, cache_dir=tmp_path / "frames"
+        )
+        changed_render = sample_segment_frames(
+            video,
+            start_time=0,
+            end_time=2,
+            count=2,
+            width=320,
+            cache_dir=tmp_path / "frames",
+            render_version="new-filmstrip",
+        )
+
+    assert first == same
+    assert changed_segment != first
+    assert changed_end != first
+    assert changed_render != first
+    assert len(calls) == 8
+
+
+def test_segment_sampler_rejects_partial_and_empty_video_inputs(tmp_path) -> None:
+    """An in-flight download or empty placeholder must never be sent to FFmpeg."""
+    partial = tmp_path / "clip.mp4.part"
+    empty = tmp_path / "empty.mp4"
+    partial.write_bytes(b"in flight")
+    empty.touch()
+
+    # WHY: FFmpeg is external and must not run for rejected cache entries.
+    with patch("immich_memories.processing.frame_sampling._extract_one") as extract:
+        assert (
+            sample_segment_frames(
+                partial, start_time=0, end_time=1, count=1, width=320, cache_dir=tmp_path
+            )
+            == ()
+        )
+        assert (
+            sample_segment_frames(
+                empty, start_time=0, end_time=1, count=1, width=320, cache_dir=tmp_path
+            )
+            == ()
+        )
+
+    extract.assert_not_called()
 
 
 def test_a_cache_that_cannot_be_written_still_returns_frames(tmp_path) -> None:

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -185,6 +185,7 @@ def test_visual_identity_changes_for_each_piece_of_visual_evidence() -> None:
         thinking=True,
         image_detail="low",
         pass_name="cull",  # noqa: S106 - test-only pass identity
+        pass_version="pass-1",  # noqa: S106 - test-only pass identity
         prompt_version="p1",
         schema_version="s1",
         render_version="r1",
@@ -203,6 +204,7 @@ def test_visual_identity_changes_for_each_piece_of_visual_evidence() -> None:
     assert base.key() != replace(base, render_version="r2").key()
     assert base.key() != replace(base, layout_versions=("l2", "l1")).key()
     assert base.key() != replace(base, upstream_material=("insight-v2",)).key()
+    assert base.key() != replace(base, pass_version="pass-2").key()  # noqa: S106
 
 
 def test_visual_cache_keeps_original_provenance_when_reused(tmp_path) -> None:

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -7,6 +7,7 @@ of the same memory presents them again. In reasoning mode each of those costs
 measured ~15 minutes a memory spent almost entirely here.
 """
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -170,3 +171,44 @@ def test_without_a_cache_path_nothing_is_remembered(tmp_path) -> None:
         review_selection(_selection(), _config())
 
     assert len(calls) == 2
+
+
+def test_visual_identity_changes_for_each_piece_of_visual_evidence() -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentIdentity
+
+    base = VisualJudgmentIdentity(
+        page_bytes=(b"first", b"second"),
+        ordered_input_ids=("a", "b"),
+        ordered_group_ids=("g",),
+        annotations=("known place",),
+        model="vision-a",
+        thinking=True,
+        image_detail="low",
+        pass_name="cull",  # noqa: S106 - test-only pass identity
+        prompt_version="p1",
+        schema_version="s1",
+        render_version="r1",
+        layout_versions=("l1", "l1"),
+        upstream_material=("insight-v1",),
+        request_limits=("pages=1",),
+        continuation_identity=(1, 1),
+    )
+
+    assert base.key() != replace(base, page_bytes=(b"changed", b"second")).key()
+    assert base.key() != replace(base, page_bytes=(b"second", b"first")).key()
+    assert base.key() != replace(base, annotations=("other place",)).key()
+    assert base.key() != replace(base, model="vision-b").key()
+    assert base.key() != replace(base, prompt_version="p2").key()
+    assert base.key() != replace(base, schema_version="s2").key()
+    assert base.key() != replace(base, render_version="r2").key()
+    assert base.key() != replace(base, layout_versions=("l2", "l1")).key()
+    assert base.key() != replace(base, upstream_material=("insight-v2",)).key()
+
+
+def test_visual_cache_keeps_original_provenance_when_reused(tmp_path) -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentCache
+
+    cache = VisualJudgmentCache(tmp_path / "judgments.db")
+    cache.remember("visual-key", "raw answer", '{"request": "original"}')
+
+    assert cache.answer_for("visual-key") == ("raw answer", '{"request": "original"}')

--- a/tests/test_judgment_cache.py
+++ b/tests/test_judgment_cache.py
@@ -214,3 +214,13 @@ def test_visual_cache_keeps_original_provenance_when_reused(tmp_path) -> None:
     cache.remember("visual-key", "raw answer", '{"request": "original"}')
 
     assert cache.answer_for("visual-key") == ("raw answer", '{"request": "original"}')
+
+
+def test_visual_cache_does_not_bank_whitespace_only_answers(tmp_path) -> None:
+    from immich_memories.cache.judgment_cache import VisualJudgmentCache
+
+    cache = VisualJudgmentCache(tmp_path / "judgments.db")
+
+    cache.remember("visual-key", " \n\t", '{"request": "original"}')
+
+    assert cache.answer_for("visual-key") is None

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -783,3 +783,71 @@ async def test_transport_observer_records_invalid_shape_for_each_provider(
     assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
         (1, "invalid_response", 200)
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body", "usage"),
+    [
+        ("ollama", {"prompt_eval_count": 3, "eval_count": 5, "response": []}, (3, 5)),
+        (
+            "anthropic",
+            {"usage": {"input_tokens": 3, "output_tokens": 5}, "content": "not blocks"},
+            (3, 5),
+        ),
+        (
+            "openai-compatible",
+            {
+                "usage": {"prompt_tokens": 3, "completion_tokens": 5},
+                "choices": [{"message": {}}],
+            },
+            (3, 5),
+        ),
+    ],
+)
+async def test_parseable_malformed_content_keeps_legacy_reply_metrics(
+    provider: str, body: dict, usage: tuple[int, int]
+) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.return_value = body
+
+    # WHY: content may be malformed after the provider has supplied billable usage.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        patch("immich_memories.analysis.llm_query.llm_metrics.record_reply") as record_reply,
+        pytest.raises((KeyError, TypeError, AttributeError)),
+    ):
+        await query_llm(
+            "look", LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+        )
+
+    assert record_reply.call_args.kwargs == {
+        "prompt_tokens": usage[0],
+        "completion_tokens": usage[1],
+    }
+    assert record_reply.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_invalid_json_does_not_create_legacy_reply_metrics(provider: str) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+
+    # WHY: a body that cannot be decoded has no trustworthy usage to count.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        patch("immich_memories.analysis.llm_query.llm_metrics.record_reply") as record_reply,
+        pytest.raises(ValueError, match="not json"),
+    ):
+        await query_llm(
+            "look", LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+        )
+
+    record_reply.assert_not_called()

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -554,6 +554,112 @@ async def test_transport_observer_records_each_null_content_wire_retry() -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic"])
+async def test_transport_observer_records_provider_http_failures(provider: str) -> None:
+    import httpx
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=503)
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "503", request=MagicMock(), response=response
+    )
+    attempts = []
+    config = LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+
+    # WHY: a provider's rejected HTTP response is still one real wire attempt.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        await query_llm("look", config, transport_observer=attempts.append)
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "http_error", 503)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_openai_adaptation_and_success() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    rejected = AsyncMock(status_code=400)
+    rejected.json = MagicMock(
+        return_value={"error": {"message": "Unrecognized request argument: chat_template_kwargs"}}
+    )
+    attempts = []
+
+    # WHY: the compatibility retry posts twice, once rejected and once accepted.
+    with (
+        patch("httpx.AsyncClient.post", side_effect=[rejected, _openai_response()]),
+        patch("immich_memories.analysis.llm_query._PARAM_ADAPTATIONS", {}),
+    ):
+        await query_llm("look", _thinking_config(), transport_observer=attempts.append)
+
+    assert [
+        (event.attempt, event.outcome, event.status_code, event.adaptation) for event in attempts
+    ] == [(1, "dialect_adaptation", 400, "no_chat_template_kwargs"), (2, "response", 200, None)]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_connection_errors() -> None:
+    import httpx
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    # WHY: no response object exists when the wire connection itself fails.
+    with (
+        patch("httpx.AsyncClient.post", side_effect=httpx.ConnectError("offline")),
+        pytest.raises(httpx.ConnectError),
+    ):
+        await query_llm("look", _thinking_config(), transport_observer=attempts.append)
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "connection_error", None)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_survives_thinking_fallback() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    # WHY: the fallback owns a new request but must retain the original observer.
+    with patch(
+        "httpx.AsyncClient.post",
+        side_effect=[_openai_response(finish_reason="length"), _openai_response()],
+    ):
+        await query_llm(
+            "judge", _thinking_config(), thinking=True, transport_observer=attempts.append
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "thinking_fallback", 200),
+        (2, "response", 200),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transport_observers_are_isolated_across_concurrent_queries() -> None:
+    import asyncio
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    first: list = []
+    second: list = []
+    # WHY: per-query attempt numbers must not leak between concurrent callers.
+    with patch("httpx.AsyncClient.post", return_value=_openai_response()):
+        await asyncio.gather(
+            query_llm("first", _thinking_config(), transport_observer=first.append),
+            query_llm("second", _thinking_config(), transport_observer=second.append),
+        )
+
+    assert [(event.attempt, event.outcome) for event in first] == [(1, "response")]
+    assert [(event.attempt, event.outcome) for event in second] == [(1, "response")]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
 async def test_each_provider_payload_carries_the_exact_jpeg_bytes(provider: str) -> None:
     import base64
@@ -603,6 +709,7 @@ async def test_visual_completion_mode_rejects_known_truncation(provider: str, bo
     response = AsyncMock(status_code=200)
     response.json = MagicMock(return_value=body)
     response.raise_for_status = lambda: None
+    attempts = []
     # WHY: the provider response status is the external completion boundary.
     with patch("httpx.AsyncClient.post", return_value=response), pytest.raises(ValueError):
         await query_llm(
@@ -610,4 +717,69 @@ async def test_visual_completion_mode_rejects_known_truncation(provider: str, bo
             LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
             images=(b"jpeg",),
             require_complete=True,
+            transport_observer=attempts.append,
         )
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "incomplete", 200)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_transport_observer_records_invalid_json_for_each_provider(provider: str) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+    attempts = []
+
+    # WHY: a successful POST with unparseable provider content still costs one call.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises(ValueError, match="not json"),
+    ):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            transport_observer=attempts.append,
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "invalid_response", 200)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body"),
+    [
+        ("ollama", {"response": []}),
+        ("anthropic", {"content": "not blocks"}),
+        ("openai-compatible", {"choices": "not choices"}),
+    ],
+)
+async def test_transport_observer_records_invalid_shape_for_each_provider(
+    provider: str, body: dict
+) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = MagicMock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.return_value = body
+    attempts = []
+
+    # WHY: a syntactically valid but unusable provider body also spent one wire attempt.
+    with (
+        patch("httpx.AsyncClient.post", return_value=response),
+        pytest.raises((KeyError, TypeError, AttributeError)),
+    ):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            transport_observer=attempts.append,
+        )
+
+    assert [(event.attempt, event.outcome, event.status_code) for event in attempts] == [
+        (1, "invalid_response", 200)
+    ]

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -551,3 +551,63 @@ async def test_transport_observer_records_each_null_content_wire_retry() -> None
         (2, "null_content", 200),
         (3, "response", 200),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ollama", "anthropic", "openai-compatible"])
+async def test_each_provider_payload_carries_the_exact_jpeg_bytes(provider: str) -> None:
+    import base64
+
+    from immich_memories.analysis.llm_query import query_llm
+
+    image = b"exact-contact-sheet"
+    config = LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision")
+    response = _openai_response()
+    if provider == "ollama":
+        response.json = MagicMock(return_value={"response": "ok"})
+    elif provider == "anthropic":
+        response.json = MagicMock(return_value={"content": [{"type": "text", "text": "ok"}]})
+
+    # WHY: the provider is the external boundary; this decodes its real dialect payload.
+    with patch("httpx.AsyncClient.post", return_value=response) as post:
+        await query_llm("look", config, images=(image,))
+
+    payload = post.call_args.kwargs["json"]
+    if provider == "ollama":
+        encoded = payload["images"][0]
+    elif provider == "anthropic":
+        encoded = payload["messages"][0]["content"][0]["source"]["data"]
+    else:
+        encoded = payload["messages"][0]["content"][1]["image_url"]["url"].split(",", 1)[1]
+    assert base64.b64decode(encoded) == image
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "body"),
+    [
+        ("ollama", {"response": "partial", "done_reason": "length"}),
+        (
+            "anthropic",
+            {"content": [{"type": "text", "text": "partial"}], "stop_reason": "max_tokens"},
+        ),
+        (
+            "openai-compatible",
+            {"choices": [{"message": {"content": "partial"}, "finish_reason": "length"}]},
+        ),
+    ],
+)
+async def test_visual_completion_mode_rejects_known_truncation(provider: str, body: dict) -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    response = AsyncMock(status_code=200)
+    response.json = MagicMock(return_value=body)
+    response.raise_for_status = lambda: None
+    # WHY: the provider response status is the external completion boundary.
+    with patch("httpx.AsyncClient.post", return_value=response), pytest.raises(ValueError):
+        await query_llm(
+            "look",
+            LLMConfig(provider=provider, base_url="http://localhost/v1", model="vision"),
+            images=(b"jpeg",),
+            require_complete=True,
+        )

--- a/tests/test_llm_query.py
+++ b/tests/test_llm_query.py
@@ -530,3 +530,24 @@ class TestBulkCallsDoNotThink:
             await query_llm("Describe this photo", _thinking_config(model="picky"))
 
         assert "chat_template_kwargs" not in mock_post.call_args_list[-1][1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_transport_observer_records_each_null_content_wire_retry() -> None:
+    from immich_memories.analysis.llm_query import query_llm
+
+    attempts = []
+    responses = [_openai_response(content=None), _openai_response(content=None), _openai_response()]
+    # WHY: the LLM server is the external boundary; null-content retries happen at its response.
+    with patch("httpx.AsyncClient.post", side_effect=responses):
+        await query_llm(
+            "Describe this",
+            _thinking_config(thinking=False),
+            transport_observer=attempts.append,
+        )
+
+    assert [(attempt.attempt, attempt.outcome, attempt.status_code) for attempt in attempts] == [
+        (1, "null_content", 200),
+        (2, "null_content", 200),
+        (3, "response", 200),
+    ]

--- a/tests/test_moment_reading.py
+++ b/tests/test_moment_reading.py
@@ -202,6 +202,40 @@ class TestReadingAMoment:
         assert reading.about == ""
         assert reading.keep == ()
 
+    def test_legacy_reading_attaches_the_exact_page_bytes_it_records(self, tmp_path) -> None:
+        """The model sees precisely the local JPEG whose trace can later reproduce it."""
+        from datetime import UTC, datetime
+        from hashlib import sha256
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, patch
+
+        from PIL import Image
+
+        from immich_memories.analysis.moment_reading import read_moment
+        from immich_memories.config_models_llm import LLMConfig
+
+        asset = SimpleNamespace(
+            id="asset-1", people=[], file_created_at=datetime(2020, 1, 1, tzinfo=UTC)
+        )
+        pages = []
+        # WHY: the model is external; this test checks its request evidence.
+        with patch(
+            "immich_memories.analysis.llm_query.query_llm",
+            new=AsyncMock(return_value='{"about": "a walk", "subjects": [], "best": [1]}'),
+        ) as asked:
+            read_moment(
+                [asset],
+                {asset.id: Image.new("RGB", (24, 24), "red")},
+                LLMConfig(model="m"),
+                sheet_output_dir=tmp_path,
+                sheet_recorder=pages.append,
+            )
+
+        assert len(pages) == 1
+        assert pages[0].path.read_bytes() == pages[0].jpeg_bytes
+        assert sha256(pages[0].jpeg_bytes).hexdigest() == pages[0].sha256
+        assert asked.await_args.kwargs["images"] == [pages[0].jpeg_bytes]
+
 
 class TestASheetIsLaidOutWide:
     """One image for a whole moment, and wide rather than tall.

--- a/tests/test_selection_accountability.py
+++ b/tests/test_selection_accountability.py
@@ -65,6 +65,17 @@ class TestEveryClipCanAccountForItself:
         assert story.admitted_at == "duration backfill"
 
 
+class TestLegacyTraceSerialization:
+    def test_the_legacy_adapter_keeps_the_selector_order(self):
+        """The old selector cannot reorder material while it remains supported."""
+        late, early = _clip("late"), _clip("early")
+        trace = Trace()
+
+        trace.record("legacy cull", [late, early], [late, early])
+
+        assert trace.as_dict()["stages"][0]["kept_ids"] == ["late", "early"]
+
+
 class TestTheReportShowsIt:
     def test_the_report_accounts_for_each_clip(self):
         report = _traced().report()

--- a/tests/test_visual_atlas.py
+++ b/tests/test_visual_atlas.py
@@ -1,0 +1,59 @@
+"""The reusable visual atlas turns local visual evidence into stable tiles."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from PIL import Image
+
+
+def _jpeg(path: Path, colour: str) -> Path:
+    Image.new("RGB", (48, 32), colour).save(path, "JPEG")
+    return path
+
+
+def test_video_tile_is_one_locally_composed_chronological_filmstrip(tmp_path: Path) -> None:
+    """A video consumes one tile even though its locally decoded frames show motion."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+    frames = tuple(_jpeg(tmp_path / f"{colour}.jpg", colour) for colour in ("red", "green", "blue"))
+    source = AtlasSource(
+        asset=SimpleNamespace(id="video-1", is_video=True),
+        motion_path=tmp_path / "video.mp4",
+        proposed_segment=(0.0, 3.0),
+    )
+
+    # WHY: frame decoding is the FFmpeg boundary; this test specifies atlas composition only.
+    with patch(
+        "immich_memories.analysis.visual_atlas.sample_segment_frames", return_value=frames
+    ) as sample:
+        atlas = build_visual_atlas((source,), frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for("video-1")
+    assert sample.call_count == 1
+    assert tile.kind == "filmstrip"
+    assert tile.frame_count == 3
+    assert tile.sha256 == sha256(tile.jpeg_bytes).hexdigest()
+
+
+def test_photo_tile_reuses_a_cached_preview_without_a_requester(tmp_path: Path) -> None:
+    """Photo evidence is loaded from the local thumbnail cache, never fetched by the atlas."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+    from immich_memories.cache.thumbnail_cache import ThumbnailCache
+
+    preview = _jpeg(tmp_path / "preview.jpg", "purple").read_bytes()
+    cache = ThumbnailCache(tmp_path / "thumbnails")
+    cache.put("photo-1", "preview", preview)
+
+    atlas = build_visual_atlas(
+        (AtlasSource(asset=SimpleNamespace(id="photo-1", is_video=False)),),
+        frame_cache_dir=None,
+        thumbnail_cache=cache,
+    )
+
+    tile = atlas.tile_for("photo-1")
+    assert tile.kind == "photo"
+    assert tile.jpeg_bytes == preview

--- a/tests/test_visual_atlas.py
+++ b/tests/test_visual_atlas.py
@@ -39,6 +39,40 @@ def test_video_tile_is_one_locally_composed_chronological_filmstrip(tmp_path: Pa
     assert tile.sha256 == sha256(tile.jpeg_bytes).hexdigest()
 
 
+def test_live_photo_motion_is_one_locally_composed_chronological_filmstrip(
+    tmp_path: Path,
+) -> None:
+    """A Live Photo uses its local motion companion even though it is not a video asset."""
+    from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas
+
+    frames = tuple(
+        _jpeg(tmp_path / f"live-{colour}.jpg", colour) for colour in ("red", "green", "blue")
+    )
+    motion_path = tmp_path / "live-photo.mov"
+    motion_path.write_bytes(b"motion")
+    source = AtlasSource(
+        asset=SimpleNamespace(
+            id="live-photo-1",
+            is_video=False,
+            is_live_photo=True,
+            live_photo_video_id="motion-asset-1",
+        ),
+        motion_path=motion_path,
+        proposed_segment=(0.0, 3.0),
+    )
+
+    # WHY: frame decoding is the FFmpeg boundary; this test specifies atlas composition only.
+    with patch(
+        "immich_memories.analysis.visual_atlas.sample_segment_frames", return_value=frames
+    ) as sample:
+        atlas = build_visual_atlas((source,), frame_cache_dir=tmp_path / "frames")
+
+    tile = atlas.tile_for("live-photo-1")
+    assert sample.call_count == 1
+    assert tile.kind == "filmstrip"
+    assert tile.frame_count == 3
+
+
 def test_photo_tile_reuses_a_cached_preview_without_a_requester(tmp_path: Path) -> None:
     """Photo evidence is loaded from the local thumbnail cache, never fetched by the atlas."""
     from immich_memories.analysis.visual_atlas import AtlasSource, build_visual_atlas

--- a/tests/test_visual_request_planner.py
+++ b/tests/test_visual_request_planner.py
@@ -1,0 +1,56 @@
+"""Visual-request plans preserve groups before any provider call is made."""
+
+from pathlib import Path
+
+from immich_memories.analysis.contact_sheets import ContactSheetPage, TileRef
+from immich_memories.analysis.visual_request_planner import (
+    SheetGroup,
+    VisionRequestLimits,
+    plan_visual_requests,
+)
+
+
+def _page(group_id: str, number: int = 1) -> ContactSheetPage:
+    data = f"jpeg-{group_id}-{number}".encode()
+    return ContactSheetPage(
+        sheet_id=f"{group_id}-{number}",
+        path=Path(f"/{group_id}-{number}.jpg"),
+        jpeg_bytes=data,
+        sha256=__import__("hashlib").sha256(data).hexdigest(),
+        tile_refs=(TileRef(number, f"{group_id}-{number}"),),
+        layout_version="1",
+    )
+
+
+def _group(group_id: str, pages: int = 1) -> SheetGroup:
+    return SheetGroup(
+        group_id=group_id, pages=tuple(_page(group_id, page) for page in range(1, pages + 1))
+    )
+
+
+def test_request_plan_conserves_groups_without_guessing_provider_limits() -> None:
+    plans = plan_visual_requests(groups=(_group("a"), _group("b")), limits=VisionRequestLimits())
+
+    assert tuple(group_id for plan in plans for group_id in plan.group_ids) == ("a", "b")
+    assert all(len(plan.pages) == 1 for plan in plans)
+
+
+def test_oversized_group_has_explicit_ordered_continuations() -> None:
+    plans = plan_visual_requests(groups=(_group("episode", pages=3),), limits=VisionRequestLimits())
+
+    assert [
+        (plan.group_ids, plan.continuation_number, plan.continuation_count) for plan in plans
+    ] == [
+        (("episode",), 1, 3),
+        (("episode",), 2, 3),
+        (("episode",), 3, 3),
+    ]
+
+
+def test_confirmed_limit_packs_only_complete_ordered_groups() -> None:
+    plans = plan_visual_requests(
+        groups=(_group("a"), _group("b"), _group("c")),
+        limits=VisionRequestLimits(max_pages_per_request=2),
+    )
+
+    assert [plan.group_ids for plan in plans] == [("a", "b"), ("c",)]


### PR DESCRIPTION
## What this slice does

This is the visual foundation for the replacement editor tracked in #764. It targets the long-lived `feature/764-editorial-selection` branch, not `main`.

- adds one immutable editorial trace with pass conservation and complete JSON provenance
- builds a reusable visual atlas: photos reuse cached previews; videos and Live Photo motion become one locally composed chronological filmstrip tile
- builds contact sheets once and reuses the exact JPEG bytes for disk, hash, model attachment, and trace
- adds one-page-default request planning with explicit continuations and no provider-name guesses
- adds a separate visual judgment cache and provider-neutral gateway
- records planned calls, every real wire attempt, retries, cache reuse, attached sheet hashes, and malformed/incomplete replies without changing legacy reply metrics

## Call economy

Filmstrip frames are sampled and composed locally, so a video still costs one visual tile and no extra model request. Production remains at one JPEG per request until a generated-only capability probe proves that multi-page packing preserves every tile and equivalent decisions.

## Compatibility and safety

- the public legacy trace adapter remains available during migration
- legacy `read_moment` keeps one request per page but now consumes the shared atlas/page builder
- existing text-cache semantics are unchanged
- visual answers are banked only when nonblank and provider-complete
- Live Photos use motion only when a local motion component is present; still fallback remains
- public sheet size is hard-capped at 120 tiles / 2100px
- no new editor pass is wired into public selection yet

## Verification

- exact final tree: `make ci`
- 6,053 passed, 9 skipped
- Semgrep: 0 findings
- Task 1 independent review: PASS
- Task 2 independent re-review: PASS after Live Photo and page-boundary fixes
- Task 3 independent final review: PASS after transport, cache, malformed-response, event-loop, and legacy-metric fixes

## Owner review

This PR has no subjective June contact-sheet verdict because it deliberately does not change selection membership yet. Please review the trace, visual evidence, and request-accounting contracts. The first new judgeable private editing sheet arrives with the Pass 0/1 slice.

Do not merge to `main`; this slice should merge only into `feature/764-editorial-selection` after review.
