### PR TITLE
ci(gates): repair the two gates that fail on their own tooling (#764)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,8 +406,16 @@ bandit-ci:
 	sys.exit(len(high))"
 
 # Commit message lint (Commitizen conventional commits)
+# An empty range is a pass, not a failure: a run that happens after its commits
+# have merged has nothing left to check, and `cz check` exits 3 on "No commit
+# found with range". That made every post-merge re-run unpassable.
 commitlint:
-	uvx --from commitizen cz check --rev-range $${COMMIT_RANGE:-HEAD~1..HEAD}
+	@range="$${COMMIT_RANGE:-HEAD~1..HEAD}"; \
+	if [ -z "$$(git rev-list "$$range" 2>/dev/null)" ]; then \
+		echo "commitlint: no commits in $$range - nothing to check"; \
+	else \
+		uvx --from commitizen cz check --rev-range "$$range"; \
+	fi
 
 # Cognitive complexity (complements cyclomatic complexity)
 # On failure the FAILED list is only the grandfathered backlog — the actual
@@ -445,8 +453,12 @@ refurb:
 # Semgrep SAST (cross-file security analysis)
 # Excludes sqlalchemy-execute-raw-query: our SQL uses ?-parameterized values,
 # column names are hardcoded in code. Semgrep can't distinguish f-string placeholders from injection.
+# Pinned to 3.12 on purpose. semgrep publishes no cp313 manylinux wheel, so on
+# a Linux runner using 3.13 uv builds it from the sdist -- which carries no
+# semgrep-core binary, and the scan dies with "Failed to find semgrep-core".
+# The interpreter running semgrep is unrelated to the project's own.
 semgrep:
-	uvx semgrep scan --config auto --config p/python --error --severity ERROR \
+	uvx --python 3.12 semgrep scan --config auto --config p/python --error --severity ERROR \
 		--exclude-rule python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query \
 		src/
 


### PR DESCRIPTION
Both of these failed on a real run while the code under them was fine, and both would have failed on every branch from here.

**semgrep** publishes no cp313 manylinux wheel. A Linux runner on 3.13 builds it from the sdist instead, and the sdist carries no `semgrep-core` binary, so the scan dies with `Failed to find semgrep-core in PATH or in the semgrep package`. The log gives it away with a `Building semgrep==1.175.0` line where a wheel install has none. Pinned to 3.12 — the interpreter running semgrep has nothing to do with the project's own.

**commitlint** exits 3 on `No commit found with range`. Any run that happens after its commits have merged has an empty range and therefore cannot pass. That is exactly the state a post-merge re-run is in, and it took the whole Quality Gates job down with it — skipping the test matrix, Test Extras, Docker and the package build behind it. An empty range is now a pass.

Neither gate was wrong about the code; they were wrong about themselves.

This also restores real verification for #773, which was merged on local `make ci` because Actions would not trigger for it, leaving the matrix, macOS, Docker and the hermetic launch check unrun.

Refs #764