### PR TITLE
feat(privacy): private-terms gate for diffs, commit messages, and PR bodies

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -147,3 +147,51 @@ jobs:
 
             We'll look into this as soon as possible. If you'd like to help fix this issue,
             feel free to open a PR referencing this issue.
+
+  # Block owner-defined private terms (family names, birth dates, fine GPS,
+  # ...) from a PR's diff, commit messages, title or body. The denylist is a
+  # repository secret, never a file in this repo, so a fork -- which never
+  # sees secrets -- has nothing to scan against and skips cleanly instead of
+  # failing closed on contributors who can't possibly have the list.
+  private-terms:
+    name: Private terms
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    env:
+      PRIVATE_TERMS: ${{ secrets.PRIVATE_TERMS }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0  # need origin/<base_ref> to diff and walk commit messages against
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          prune-cache: false
+      - run: uv python install "3.13"
+      - run: make dev-ci
+
+      - name: Skip (no PRIVATE_TERMS secret configured)
+        if: env.PRIVATE_TERMS == ''
+        run: |
+          echo "private-terms: PRIVATE_TERMS secret not set, skipping"
+
+      - name: Scan the diff and commit messages against origin/${{ github.base_ref }}
+        if: env.PRIVATE_TERMS != ''
+        run: |
+          uv run python scripts/private_terms_gate.py --terms-env PRIVATE_TERMS \
+            --range "origin/${{ github.base_ref }}..HEAD"
+
+      # PR_TITLE/PR_BODY go through env, never string-interpolated into the
+      # run: script -- a title or body is attacker-controlled text and
+      # interpolating it into shell would be a script-injection hole.
+      - name: Scan the PR title and body
+        if: env.PRIVATE_TERMS != ''
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n' "$PR_TITLE" "$PR_BODY" > "$RUNNER_TEMP/pr.txt"
+          uv run python scripts/private_terms_gate.py --terms-env PRIVATE_TERMS \
+            --text-file "$RUNNER_TEMP/pr.txt"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+# Hooks without an explicit `stages` run only at pre-commit; the commit-msg stage runs
+# only the hooks that ask for it (commitizen, private-terms-commit-msg). Without this,
+# installing the commit-msg hook type would run every gate twice per commit.
+default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   # ~0.1s — Formatting + linting (Rust, fast)
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -37,6 +43,7 @@ repos:
     rev: v4.13.9
     hooks:
       - id: commitizen
+        stages: [commit-msg]
 
 
   # Local hooks using Makefile targets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,25 @@ repos:
     hooks:
       - id: gitleaks
 
+  # Private terms (family names, birth dates, fine GPS, ...). The denylist
+  # lives outside the repo -- see scripts/private_terms_gate.py -- so both
+  # hooks skip cleanly when no denylist is configured on this machine.
+  - repo: local
+    hooks:
+      - id: private-terms
+        name: Private terms (staged diff)
+        entry: make privacy-gate
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      - id: private-terms-commit-msg
+        name: Private terms (commit message)
+        entry: uv run python scripts/private_terms_gate.py --commit-msg
+        language: system
+        stages: [commit-msg]
+        pass_filenames: true
+
   # ~0.1s — Conventional commits
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.13.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,9 @@ make dead-code
 # Security lint (Bandit)
 make security-lint
 
+# Private terms gate (family names, birth dates, fine GPS; denylist lives outside the repo)
+make privacy-gate
+
 # Cognitive complexity gate (complexipy ≤15)
 make cognitive-complexity
 
@@ -96,7 +99,7 @@ make check
 # Full CI pipeline (all checks + advanced quality gates)
 make ci
 
-# Pre-commit hooks (runs all local hooks: lint, format, mypy, gitleaks, commitizen, file-length, complexity, dead-code, security-lint)
+# Pre-commit hooks (runs all local hooks: lint, format, mypy, gitleaks, commitizen, file-length, complexity, dead-code, security-lint, private terms)
 make pre-commit
 
 # Self-critique check for AI code smells

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Uses uv for fast Python package management
 export PYTHONUNBUFFERED=1
 
-.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check docs-config-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams capability-matrix
+.PHONY: help install dev dev-ci dev-test run preflight docs-cli-check docs-config-check test test-extras test-cov test-cov-xml test-integration test-integration-auth test-integration-photos test-integration-audio test-integration-audio-mixing test-integration-titles test-fast benchmark benchmark-perf benchmark-steps benchmark-assembly benchmark-titles benchmark-titles-json benchmark-pipeline benchmark-json benchmark-submit lint format typecheck check launch-check clean clean-cache clean-all build build-check docker docker-run docker-shell file-length complexity cognitive-complexity security-lint bandit-ci semgrep dead-code duplication refurb dep-check arch-check diff-cover diff-cover-ci integration-coverage-for-diff ci critique ensure-dev commitlint privacy-gate pip-audit docs-install docs-dev docs-build docs-check docs-cli demo-video playwright-install e2e e2e-full screenshots diagrams capability-matrix
 
 # Default target
 help:
@@ -35,6 +35,7 @@ help:
 	@echo "  complexity   Check cyclomatic complexity (Xenon grade C)"
 	@echo "  dead-code    Detect dead code (Vulture)"
 	@echo "  security-lint Run Bandit security linter"
+	@echo "  privacy-gate Scan the staged diff for private terms (denylist lives outside the repo)"
 	@echo "  commitlint   Validate commit messages (conventional commits)"
 	@echo "  pip-audit    Check dependencies for known vulnerabilities"
 	@echo "  check        Run all checks (lint + format + type + length + complexity + test)"
@@ -404,6 +405,12 @@ bandit-ci:
 	high=[i for i in r['results'] if i['issue_severity']=='HIGH']; \
 	[print(f\"  {i['filename']}:{i['line_number']} [{i['test_id']}] {i['issue_text']}\") for i in high]; \
 	sys.exit(len(high))"
+
+# Private terms gate: the denylist itself lives outside the repo (see
+# scripts/private_terms_gate.py), so this only ever scans -- it never commits
+# or prints the terms it matches against.
+privacy-gate:  ## Scan the staged diff for private terms (denylist lives outside the repo)
+	uv run python scripts/private_terms_gate.py --staged
 
 # Commit message lint (Commitizen conventional commits)
 commitlint:

--- a/docs-site/docs/contribute/development-setup.md
+++ b/docs-site/docs/contribute/development-setup.md
@@ -81,6 +81,14 @@ make diff-cover-local                # merges them with unit coverage, same as C
 
 If diff-cover still fails after that, the uncovered lines are not reachable from an integration suite and do need unit tests. Subprocess boundaries can be stubbed rather than run for real: `tests/test_ffmpeg_pipe.py` shows the pattern.
 
+## Private terms gate
+
+`make privacy-gate` (and two pre-commit hooks: one on the staged diff, one on the commit message) blocks owner-defined private terms — family names, birth dates, fine-grained GPS coordinates, anything the maintainer doesn't want landing in a diff, commit message, or PR title/body — using `scripts/private_terms_gate.py`.
+
+The denylist itself never lives in this repo. It resolves from, in order: `--terms-file`, an env var named by `--terms-env` (how CI reads it from the `PRIVATE_TERMS` repository secret), `$IMMICH_MEMORIES_PRIVATE_TERMS` (a path), or `~/.config/immich-memories/private-terms.txt`. One term per line; `#` comments and blank lines are ignored; a line starting with `re:` is a regex. If none of those resolve to anything, the gate prints a notice and exits clean — most contributors have no denylist configured, and that isn't a failure.
+
+Every reported match is masked to its first character, so a hit report never contains the term it found. Forks never see the `PRIVATE_TERMS` secret, so the PR-automation job that scans title/body/diff skips there too.
+
 ## Project structure
 
 ```

--- a/scripts/private_terms_gate.py
+++ b/scripts/private_terms_gate.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Mechanically block owner-defined private terms from entering diffs, commit
+messages, or PR text.
+
+The denylist (family names, birth dates, fine GPS, etc.) lives OUTSIDE this
+repo -- a local file, an env var, or a CI secret -- and this script never
+echoes it back: every reported hit is masked to its first character. Most
+contributors have no denylist configured at all, so that is not a failure --
+the gate prints a notice and exits clean. Only the owner's own automation
+passes --require-terms to turn "nothing configured" into a hard error.
+
+Usage:
+    python scripts/private_terms_gate.py --staged
+    python scripts/private_terms_gate.py --range origin/main..HEAD
+    python scripts/private_terms_gate.py --commit-msg .git/COMMIT_EDITMSG
+    python scripts/private_terms_gate.py --text-file - < pr-body.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+DEFAULT_TERMS_ENV_VAR = "IMMICH_MEMORIES_PRIVATE_TERMS"
+DEFAULT_TERMS_PATH = Path("~/.config/immich-memories/private-terms.txt")
+
+EXIT_OK = 0
+EXIT_HITS_FOUND = 1
+EXIT_MISCONFIGURED = 2
+
+# A commit message read from a file (not from `git log`) has no sha to label
+# it with -- it is always the sole message being scanned, so index 0.
+_UNCOMMITTED_MESSAGE_LABEL = "commit message 0"
+
+_COMMIT_RECORD_SEP = "\x1e"
+_COMMIT_FIELD_SEP = "\x1f"
+
+
+@dataclass(frozen=True)
+class Term:
+    """One compiled denylist entry. `index` is its 1-based position in the file."""
+
+    index: int
+    pattern: re.Pattern[str]
+
+
+@dataclass(frozen=True)
+class Hit:
+    """A masked match, plus where it was found. `location` is filled in by the caller."""
+
+    term_index: int
+    masked: str
+    location: str = ""
+
+
+def mask(term_or_match: str) -> str:
+    """First character plus `***` -- the reported form never contains the term itself."""
+    return f"{term_or_match[0]}***" if term_or_match else "***"
+
+
+def _compile_term(index: int, raw_line: str) -> Term:
+    if raw_line.startswith("re:"):
+        pattern = re.compile(raw_line[len("re:") :], re.IGNORECASE)
+    else:
+        pattern = re.compile(rf"(?<!\w){re.escape(raw_line)}(?!\w)", re.IGNORECASE)
+    return Term(index=index, pattern=pattern)
+
+
+def _parse_terms(content: str) -> list[Term]:
+    terms = []
+    index = 1
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        terms.append(_compile_term(index, stripped))
+        index += 1
+    return terms
+
+
+def load_terms(terms_file: str | None = None, terms_env: str | None = None) -> list[Term]:
+    """Resolve the denylist through the priority chain and parse it.
+
+    Priority: --terms-file > --terms-env > $IMMICH_MEMORIES_PRIVATE_TERMS path >
+    the default config path. An explicit --terms-file that can't be read raises;
+    every other tier resolving to nothing just means "no denylist here" -- the
+    caller decides whether that is fatal (--require-terms) or a clean skip.
+    """
+    if terms_file:
+        return _parse_terms(Path(terms_file).read_text(encoding="utf-8"))
+    if terms_env:
+        value = os.environ.get(terms_env, "")
+        return _parse_terms(value) if value.strip() else []
+    configured_path = os.environ.get(DEFAULT_TERMS_ENV_VAR, "")
+    path = Path(configured_path) if configured_path else DEFAULT_TERMS_PATH.expanduser()
+    return _parse_terms(path.read_text(encoding="utf-8")) if path.is_file() else []
+
+
+def scan_text(text: str, terms: Sequence[Term]) -> list[Hit]:
+    """Every match of every term in `text`, masked. Caller fills in `location`."""
+    return [
+        Hit(term_index=term.index, masked=mask(match.group(0)))
+        for term in terms
+        for match in term.pattern.finditer(text)
+    ]
+
+
+def added_lines(diff_text: str) -> Iterator[tuple[str, str]]:
+    """Yield (path, line) for each `+` line of a unified diff, skipping `+++` headers."""
+    current_path = "?"
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ "):
+            current_path = _diff_target_path(raw_line)
+        elif raw_line.startswith("+") and not raw_line.startswith("+++ "):
+            yield current_path, raw_line[1:]
+
+
+def _diff_target_path(header: str) -> str:
+    target = header[len("+++ ") :].strip()
+    return target[2:] if target.startswith("b/") else target
+
+
+def _located(hits: Iterable[Hit], location: str) -> list[Hit]:
+    return [replace(hit, location=location) for hit in hits]
+
+
+def scan_diff(diff_text: str, terms: Sequence[Term]) -> list[Hit]:
+    """Every hit on an added line of a unified diff, each located to its file."""
+    hits = []
+    for path, line in added_lines(diff_text):
+        hits.extend(_located(scan_text(line, terms), f"{path} (added line)"))
+    return hits
+
+
+def _run_git(args: list[str]) -> str:
+    # Fixed argv, no shell -- CI passes a caller-controlled --range value straight
+    # through as one argument, never through a shell where it could be injected.
+    # GIT_* vars are stripped: this script's own pre-commit hook runs it from
+    # inside a `git commit`, which sets GIT_DIR/GIT_WORK_TREE for that commit's
+    # repo. Inheriting them would let a nested git call be redirected there
+    # instead of discovering the repo from the current working directory.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    result = subprocess.run(["git", *args], check=True, capture_output=True, text=True, env=env)
+    return result.stdout
+
+
+def _commit_messages_in_range(range_spec: str) -> list[tuple[str, str]]:
+    """(short_sha, body) for every commit in A..B, using ASCII separators a message can't contain."""
+    output = _run_git(["log", f"--format=%h{_COMMIT_FIELD_SEP}%B{_COMMIT_RECORD_SEP}", range_spec])
+    pairs = []
+    for record in output.split(_COMMIT_RECORD_SEP):
+        if not record.strip("\n"):
+            continue
+        sha, _, body = record.partition(_COMMIT_FIELD_SEP)
+        pairs.append((sha, body))
+    return pairs
+
+
+def _scan_staged(terms: Sequence[Term]) -> list[Hit]:
+    diff_text = _run_git(["diff", "--cached", "-U0", "--no-color"])
+    return scan_diff(diff_text, terms)
+
+
+def _scan_range(range_spec: str, terms: Sequence[Term]) -> list[Hit]:
+    diff_text = _run_git(["diff", range_spec, "-U0", "--no-color"])
+    hits = scan_diff(diff_text, terms)
+    for sha, body in _commit_messages_in_range(range_spec):
+        hits.extend(_located(scan_text(body, terms), f"commit message {sha}"))
+    return hits
+
+
+def _scan_commit_msg_file(path_str: str, terms: Sequence[Term]) -> list[Hit]:
+    text = Path(path_str).read_text(encoding="utf-8")
+    return _located(scan_text(text, terms), _UNCOMMITTED_MESSAGE_LABEL)
+
+
+def _scan_text_file(path_str: str, terms: Sequence[Term]) -> list[Hit]:
+    if path_str == "-":
+        return _located(scan_text(sys.stdin.read(), terms), "stdin")
+    text = Path(path_str).read_text(encoding="utf-8")
+    return _located(scan_text(text, terms), path_str)
+
+
+def _format_hit(hit: Hit) -> str:
+    return f"private-terms: term#{hit.term_index} ({hit.masked}) found in {hit.location}"
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--staged", action="store_true", help="scan `git diff --cached -U0`")
+    parser.add_argument(
+        "--range", metavar="A..B", help="scan the diff and every commit message between two refs"
+    )
+    parser.add_argument("--commit-msg", metavar="PATH", help="scan a commit message file")
+    parser.add_argument("--text-file", metavar="PATH", help="scan a text file ('-' for stdin)")
+    parser.add_argument("--terms-file", metavar="PATH", help="denylist file (highest priority)")
+    parser.add_argument(
+        "--terms-env", metavar="NAME", help="env var holding newline-separated denylist terms"
+    )
+    parser.add_argument(
+        "--require-terms",
+        action="store_true",
+        help="exit 2 instead of skipping when no denylist can be found",
+    )
+    return parser.parse_args(argv)
+
+
+def _collect_hits(args: argparse.Namespace, terms: Sequence[Term]) -> list[Hit]:
+    hits: list[Hit] = []
+    if args.staged:
+        hits.extend(_scan_staged(terms))
+    if args.range:
+        hits.extend(_scan_range(args.range, terms))
+    if args.commit_msg:
+        hits.extend(_scan_commit_msg_file(args.commit_msg, terms))
+    if args.text_file:
+        hits.extend(_scan_text_file(args.text_file, terms))
+    return hits
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        terms = load_terms(terms_file=args.terms_file, terms_env=args.terms_env)
+    except OSError as exc:
+        print(f"private-terms: could not read --terms-file: {exc}")
+        return EXIT_MISCONFIGURED
+
+    if not terms:
+        print("private-terms: no denylist found, skipping")
+        return EXIT_MISCONFIGURED if args.require_terms else EXIT_OK
+
+    hits = _collect_hits(args, terms)
+    for hit in hits:
+        print(_format_hit(hit))
+    print(f"private-terms: {len(hits)} hit(s) found")
+    return EXIT_HITS_FOUND if hits else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_private_terms_gate.py
+++ b/tests/test_private_terms_gate.py
@@ -1,0 +1,370 @@
+"""Behavioral tests for the private-terms gate.
+
+The denylist itself never appears here: every fixture term is a fake word
+(`zorblax`, `quuxley`) chosen only for its shape, never a real name. Git-backed
+tests use a real temp repo instead of mocking `git` -- it is the actual read
+boundary this script has, the same way other tests in this repo exercise real
+FFmpeg rather than stubbing it.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from private_terms_gate import (  # noqa: E402
+    DEFAULT_TERMS_ENV_VAR,
+    EXIT_HITS_FOUND,
+    EXIT_MISCONFIGURED,
+    EXIT_OK,
+    Term,
+    added_lines,
+    load_terms,
+    main,
+    mask,
+    scan_diff,
+    scan_text,
+)
+
+
+def _terms(tmp_path: Path, content: str) -> list[Term]:
+    path = tmp_path / "terms.txt"
+    path.write_text(content)
+    return load_terms(terms_file=str(path))
+
+
+def _clean_git_env() -> dict[str, str]:
+    """Strip inherited GIT_DIR/GIT_INDEX_FILE/etc.
+
+    These tests spin up a throwaway repo under tmp_path. Run under this
+    project's own git hooks (as `make ci`'s pre-commit check does), the
+    outer `git commit` sets those vars for its own repo; git subprocess
+    calls inherit them by default and would git-add into the OUTER
+    worktree's index instead of the tmp_path repo they're meant for.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, env=_clean_git_env(), check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    _run(["git", "init", "-q"], path)
+    _run(["git", "config", "user.email", "test@example.com"], path)
+    _run(["git", "config", "user.name", "Test Bot"], path)
+
+
+# --- mask() ------------------------------------------------------------------
+
+
+def test_mask_returns_first_character_plus_stars() -> None:
+    assert mask("Zorblax") == "Z***"
+
+
+def test_mask_of_empty_string_is_just_stars() -> None:
+    assert mask("") == "***"
+
+
+# --- scan_text() ---------------------------------------------------------------
+
+
+def test_scan_text_matches_whole_word_case_insensitively(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, "zorblax\n")
+
+    hits = scan_text("ZORBLAX showed up in the log", terms)
+
+    assert len(hits) == 1
+    assert hits[0].masked == "Z***"
+
+
+def test_scan_text_does_not_match_a_partial_word(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, "zorblax\n")
+
+    hits = scan_text("zorblaxian visitors arrived", terms)
+
+    assert hits == []
+
+
+def test_scan_text_regex_term_matches_a_birth_date_shape(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, r"re:\b19[0-9]{2}-[0-9]{2}-[0-9]{2}\b" + "\n")
+
+    hits = scan_text("born 1985-03-21 somewhere", terms)
+
+    assert len(hits) == 1
+    assert hits[0].masked == "1***"
+
+
+def test_scan_text_regex_term_matches_a_coordinate_shape(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, r"re:\b5[01]\.[0-9]{5,}\b" + "\n")
+
+    hits = scan_text("saw them near 50.84671, 4.35208", terms)
+
+    assert len(hits) == 1
+
+
+def test_scan_text_masked_output_never_contains_the_original_term(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, "quuxley\n")
+
+    hits = scan_text("QuuXley appears twice: quuxley and QUUXLEY", terms)
+
+    assert len(hits) == 3
+    for hit in hits:
+        assert "quuxley" not in hit.masked.lower()
+
+
+# --- added_lines() -------------------------------------------------------------
+
+_DIFF_TWO_FILES = """diff --git a/alpha.txt b/alpha.txt
+index 111..222 100644
+--- a/alpha.txt
++++ b/alpha.txt
+@@ -1,2 +1,3 @@
+ unchanged context line
+-removed line
++added line in alpha
+diff --git a/beta.txt b/beta.txt
+index 333..444 100644
+--- a/beta.txt
++++ b/beta.txt
+@@ -1 +1,2 @@
++added line in beta
+"""
+
+
+def test_added_lines_ignores_removed_context_and_header_lines() -> None:
+    lines = [line for _, line in added_lines(_DIFF_TWO_FILES)]
+
+    assert "removed line" not in lines
+    assert "unchanged context line" not in lines
+    assert all(not line.startswith(("---", "+++")) for line in lines)
+
+
+def test_added_lines_attributes_hits_to_the_right_file_across_multiple_files() -> None:
+    pairs = list(added_lines(_DIFF_TWO_FILES))
+
+    assert ("alpha.txt", "added line in alpha") in pairs
+    assert ("beta.txt", "added line in beta") in pairs
+
+
+def test_added_line_starting_with_plus_plus_is_not_mistaken_for_a_diff_header(
+    tmp_path: Path,
+) -> None:
+    """A real added line whose content starts with `++` (e.g. `++zorblax;`) is itself
+    prefixed by the diff's own `+` marker, so the raw line reads `+++zorblax;` -- three
+    literal `+` characters, same as a `+++ ` file header's prefix. Only the header has
+    a space right after those three, so that's what must distinguish them."""
+    terms = _terms(tmp_path, "zorblax\n")
+    diff_text = (
+        "diff --git a/counter.py b/counter.py\n"
+        "--- a/counter.py\n"
+        "+++ b/counter.py\n"
+        "@@ -1 +1 @@\n"
+        "-old = 1\n"
+        "+++zorblax\n"
+    )
+
+    hits = scan_diff(diff_text, terms)
+
+    assert len(hits) == 1
+    assert hits[0].location == "counter.py (added line)"
+
+
+# --- scan_diff() -----------------------------------------------------------------
+
+
+def test_scan_diff_combines_added_lines_with_term_matches(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, "quuxley\n")
+    diff_text = (
+        "diff --git a/notes.txt b/notes.txt\n"
+        "--- a/notes.txt\n"
+        "+++ b/notes.txt\n"
+        "@@ -1 +1 @@\n"
+        "-old line\n"
+        "+quuxley was mentioned here\n"
+    )
+
+    hits = scan_diff(diff_text, terms)
+
+    assert len(hits) == 1
+    assert hits[0].location == "notes.txt (added line)"
+    assert "quuxley" not in hits[0].masked
+
+
+# --- load_terms() ----------------------------------------------------------------
+
+
+def test_load_terms_ignores_comments_and_blank_lines(tmp_path: Path) -> None:
+    terms = _terms(tmp_path, "\n# a comment\nzorblax\n\n   \n# another comment\nquuxley\n")
+
+    assert [t.index for t in terms] == [1, 2]
+    assert len(scan_text("zorblax and quuxley both appear", terms)) == 2
+
+
+def test_load_terms_reads_newline_separated_content_from_a_named_env_var(monkeypatch) -> None:
+    monkeypatch.setenv("PRIVATE_TERMS_TEST_VAR", "zorblax\nquuxley\n")
+
+    terms = load_terms(terms_env="PRIVATE_TERMS_TEST_VAR")
+
+    assert len(terms) == 2
+
+
+def test_load_terms_returns_empty_when_nothing_is_configured(tmp_path: Path, monkeypatch) -> None:
+    # No file, no env var, no default path -- HOME is redirected so a real
+    # denylist that happens to exist on the machine running this test can't leak in.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(DEFAULT_TERMS_ENV_VAR, raising=False)
+
+    assert load_terms() == []
+
+
+# --- main() ------------------------------------------------------------------------
+
+
+def test_main_reports_a_skip_notice_and_exits_clean_with_no_denylist(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(DEFAULT_TERMS_ENV_VAR, raising=False)
+
+    exit_code = main([])
+
+    assert exit_code == EXIT_OK
+    assert "no denylist found, skipping" in capsys.readouterr().out
+
+
+def test_main_require_terms_without_a_denylist_exits_with_configuration_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(DEFAULT_TERMS_ENV_VAR, raising=False)
+
+    assert main(["--require-terms"]) == EXIT_MISCONFIGURED
+
+
+def test_main_reports_a_clear_error_when_terms_file_is_missing(tmp_path: Path, capsys) -> None:
+    missing = tmp_path / "does-not-exist.txt"
+
+    exit_code = main(["--terms-file", str(missing)])
+
+    assert exit_code == EXIT_MISCONFIGURED
+    assert "could not read --terms-file" in capsys.readouterr().out
+
+
+def test_main_commit_msg_file_hit_exits_with_hits_found(tmp_path: Path, capsys) -> None:
+    terms_file = tmp_path / "terms.txt"
+    terms_file.write_text("zorblax\n")
+    msg_file = tmp_path / "COMMIT_EDITMSG"
+    msg_file.write_text("feat: mentions zorblax by mistake\n")
+
+    exit_code = main(["--commit-msg", str(msg_file), "--terms-file", str(terms_file)])
+
+    out = capsys.readouterr().out
+    assert exit_code == EXIT_HITS_FOUND
+    assert "zorblax" not in out
+    assert "commit message 0" in out
+
+
+def test_main_text_file_stdin_reads_and_exits_clean_when_nothing_matches(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    terms_file = tmp_path / "terms.txt"
+    terms_file.write_text("zorblax\n")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("nothing sensitive here\n"))
+
+    exit_code = main(["--text-file", "-", "--terms-file", str(terms_file)])
+
+    out = capsys.readouterr().out
+    assert exit_code == EXIT_OK
+    assert "0 hit(s) found" in out
+
+
+def test_main_staged_reports_a_masked_hit_from_the_cached_diff(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "scratch.txt").write_text("hello\n")
+    _run(["git", "add", "scratch.txt"], tmp_path)
+    _run(["git", "commit", "-q", "-m", "init"], tmp_path)
+    (tmp_path / "scratch.txt").write_text("hello\nquuxley was here\n")
+    _run(["git", "add", "scratch.txt"], tmp_path)
+    terms_file = tmp_path / "terms.txt"
+    terms_file.write_text("quuxley\n")
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(["--staged", "--terms-file", str(terms_file)])
+
+    out = capsys.readouterr().out
+    assert exit_code == EXIT_HITS_FOUND
+    assert "scratch.txt (added line)" in out
+    assert "quuxley" not in out
+    assert "q***" in out
+
+
+def test_main_range_scans_both_the_diff_and_the_commit_messages(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "a.txt").write_text("base\n")
+    _run(["git", "add", "a.txt"], tmp_path)
+    _run(["git", "commit", "-q", "-m", "base"], tmp_path)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        env=_clean_git_env(),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (tmp_path / "a.txt").write_text("base\nzorblax lives here\n")
+    _run(["git", "add", "a.txt"], tmp_path)
+    _run(["git", "commit", "-q", "-m", "mentions zorblax in the message"], tmp_path)
+    terms_file = tmp_path / "terms.txt"
+    terms_file.write_text("zorblax\n")
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(["--range", f"{base_sha}..HEAD", "--terms-file", str(terms_file)])
+
+    out = capsys.readouterr().out
+    assert exit_code == EXIT_HITS_FOUND
+    assert "zorblax" not in out
+    assert "a.txt (added line)" in out
+    assert "commit message" in out
+    assert "2 hit(s) found" in out
+
+
+def test_main_staged_is_not_redirected_by_an_inherited_git_dir(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression: this project's own `private-terms` pre-commit hook runs this
+    script from inside a `git commit`, which sets GIT_DIR/GIT_WORK_TREE for ITS
+    repo. A nested git call that inherits those gets redirected there instead of
+    the repo `--staged` is actually meant to scan."""
+    outer_git_dir = subprocess.run(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        cwd=Path(__file__).resolve().parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    _init_repo(tmp_path)
+    (tmp_path / "scratch.txt").write_text("hello\n")
+    _run(["git", "add", "scratch.txt"], tmp_path)
+    _run(["git", "commit", "-q", "-m", "init"], tmp_path)
+    (tmp_path / "scratch.txt").write_text("hello\nquuxley was here\n")
+    _run(["git", "add", "scratch.txt"], tmp_path)
+    terms_file = tmp_path / "terms.txt"
+    terms_file.write_text("quuxley\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GIT_DIR", outer_git_dir)
+
+    exit_code = main(["--staged", "--terms-file", str(terms_file)])
+
+    out = capsys.readouterr().out
+    assert exit_code == EXIT_HITS_FOUND
+    assert "scratch.txt (added line)" in out


### PR DESCRIPTION
Closes #776

## What

A gate that stops owner-defined private terms (family names, birth dates, fine GPS, anything the maintainer lists) from entering diffs, commit messages, or PR titles and bodies. The deny list never enters the repo.

- `scripts/private_terms_gate.py`: pure scanning functions plus a CLI (`--staged`, `--range A..B`, `--commit-msg PATH`, `--text-file PATH`). Terms come from `--terms-file`, `--terms-env NAME`, `$IMMICH_MEMORIES_PRIVATE_TERMS`, or `~/.config/immich-memories/private-terms.txt`. Plain lines match as case-insensitive whole words; `re:` lines are regexes. Every reported hit is masked to its first character.
- Pre-commit: `private-terms` (staged diff, via `make privacy-gate`) and `private-terms-commit-msg` (commit-msg stage). Both print a notice and pass when no deny list is configured, so contributors without one are never blocked.
- CI: a `Private terms` job in `pr-automation.yml` scans the PR diff and every commit message in `origin/<base>..HEAD`, then the PR title and body (passed through `env`, never interpolated into the shell). It reads the `PRIVATE_TERMS` repository secret and skips on forks, which cannot see secrets.
- Git calls use a fixed argv with `GIT_DIR`/`GIT_WORK_TREE` stripped, so the hook cannot be redirected to another repository when it runs inside `git commit`.

## Why

Gitleaks covers secrets only, and nothing scanned commit messages or PR bodies for personal data. The rule existed only as an instruction to the AI assistant, which is not a gate.

## Tests

22 tests in `tests/test_private_terms_gate.py` (whole-word and regex matching, masking, unified-diff parsing across files including added lines that start with `++`, term sources and priority, exit codes, the env-stripping regression). Manual trial of all four hook scenarios in a throwaway repo. Every non-test target of `make ci` green; `make docs-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB3F5TFaL1gfxAPZpQxVZY